### PR TITLE
improve cast and const ptr support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,6 @@ jobs:
       - name: test
         shell: bash
         run: |
-          cd nautilus && ctest --test-dir=nautilus --output-on-failure
+          cd nautilus && ctest --test-dir nautilus --output-on-failure
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,6 @@ jobs:
       - name: test
         shell: bash
         run: |
-          cd nautilus && ctest --test-dir nautilus --output-on-failure
+          ctest --test-dir nautilus --output-on-failure
 
 

--- a/nautilus/include/nautilus/val_ptr.hpp
+++ b/nautilus/include/nautilus/val_ptr.hpp
@@ -108,6 +108,12 @@ template <is_ptr ValuePtrType>
 class val<ValuePtrType> : public base_ptr_val<ValuePtrType> {
 public:
 	using base_ptr_val<ValuePtrType>::base_ptr_val;
+
+	// enable cast to type T
+	template <class T>
+	operator val<T*>() const {
+		return val<T*>((T*)this->value, this->state);
+	}
 };
 
 template <is_arithmetic_ptr ValuePtrType>

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -405,12 +405,13 @@ void MLIRLoweringProvider::generateMLIR(ir::ConstIntOperation* constIntOp, Value
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ConstPtrOperation* , ValueFrame& ) {
-	//builder->create<mlir::LLVM::C>(getNameLoc("location"), mlir::LLVM::LLVMPointerType, constPtrOperation->getValue());
-
-	//frame.setValue(constPtrOperation->getIdentifier(),
-	//               getConstInt("ConstantOp", constIntOp->getStamp(), constIntOp->getValue()));
-
+void MLIRLoweringProvider::generateMLIR(ir::ConstPtrOperation* constPtr, ValueFrame& frame) {
+	int64_t val = (int64_t) constPtr->getValue();
+	auto constInt = builder->create<mlir::arith::ConstantOp>(getNameLoc("location"), builder->getI64Type(),
+	                                                         builder->getIntegerAttr(builder->getI64Type(), val));
+	auto elementAddress = builder->create<mlir::LLVM::IntToPtrOp>(getNameLoc("fieldAccess"),
+	                                                              mlir::LLVM::LLVMPointerType::get(context), constInt);
+	frame.setValue(constPtr->getIdentifier(), elementAddress);
 }
 
 void MLIRLoweringProvider::generateMLIR(ir::ConstFloatOperation* constFloatOp, ValueFrame& frame) {

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -521,7 +521,6 @@ void pointerExecutionTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(values, (int32_t) 1) == 2);
 		REQUIRE(f(values, (int32_t) 8) == 9);
 	}
-	/*
 	SECTION("loadConst") {
 	    globalPtr = values[0];
 	    auto f = engine.registerFunction(loadConst);
@@ -531,7 +530,6 @@ void pointerExecutionTest(engine::NautilusEngine& engine) {
 	    globalPtr = values[2];
 	    REQUIRE(f() == 3);
 	}
-	*/
 	SECTION("sumArray") {
 		auto f = engine.registerFunction(sumArray);
 		val<int> r = f(values, (int32_t) 10);

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -483,6 +483,37 @@ void functionCallExecutionTest(engine::NautilusEngine& engine) {
 void pointerExecutionTest(engine::NautilusEngine& engine) {
 	int* values = new int[10] {1, 2, 3, 4, 5, 6, 7, 8, 9};
 	// int* ptr = &values;
+	SECTION("castVoidInt8") {
+		auto f = engine.registerFunction(castPtrAndGetValue<void, int8_t>);
+		int x = 42;
+		REQUIRE(f((void*) &x) == (int8_t) 42);
+	}
+	SECTION("castVoidInt16") {
+		auto f = engine.registerFunction(castPtrAndGetValue<void, int16_t>);
+		int x = 42;
+		REQUIRE(f((void*) &x) == (int16_t) 42);
+	}
+	SECTION("castVoidInt32") {
+		auto f = engine.registerFunction(castPtrAndGetValue<void, int32_t>);
+		int x = 42;
+		REQUIRE(f((void*) &x) == (int32_t) 42);
+	}
+	SECTION("castVoidInt64") {
+		auto f = engine.registerFunction(castPtrAndGetValue<void, int64_t>);
+		int64_t x = 42;
+		REQUIRE(f((void*) &x) == *((int64_t*) &x));
+	}
+	SECTION("castVoidFloat") {
+		auto f = engine.registerFunction(castPtrAndGetValue<void, float>);
+		int64_t x = 42;
+		REQUIRE(f((void*) &x) == *((float*) &x));
+	}
+	SECTION("castVoidFloat") {
+		auto f = engine.registerFunction(castPtrAndGetValue<void, double>);
+		int64_t x = 42;
+		REQUIRE(f((void*) &x) == *((double*) &x));
+	}
+
 	SECTION("load") {
 		auto f = engine.registerFunction(load);
 
@@ -521,9 +552,17 @@ void pointerExecutionTest(engine::NautilusEngine& engine) {
 		int x = 42;
 		REQUIRE(f((void*) &x) == 42);
 	}
-	SECTION("passCustomStruct") {
-		auto f = engine.registerFunction(passCustomStruct);
-		CustomStruct x = {.x = 42};
+	SECTION("castCustomClass") {
+		auto f = engine.registerFunction(castCustomClass);
+		CustomClass x;
+		x.x = 42;
+		BaseClass* BaseClass = &x;
+		REQUIRE(f(BaseClass) == 42);
+	}
+	SECTION("passCustomClass") {
+		auto f = engine.registerFunction(passCustomClass);
+		CustomClass x;
+		x.x = 42;
 		REQUIRE(f(&x) == 42);
 	}
 	SECTION("specializeType") {

--- a/nautilus/test/execution-tests/PointerFunctions.hpp
+++ b/nautilus/test/execution-tests/PointerFunctions.hpp
@@ -21,6 +21,12 @@ val<int32_t> castVoidPtr(val<void*> array) {
 	return intPtr[0];
 }
 
+template <typename A, typename B>
+val<B> castPtrAndGetValue(val<A*> array) {
+	auto intPtr = static_cast<val<B*>>(array);
+	return intPtr[0];
+}
+
 val<int32_t> sumArray(val<int32_t*> array, val<int32_t> length) {
 	val<int32_t> sum = val<int32_t>(0);
 	for (val<int32_t> i = 0; i < length; i = i + 1) {
@@ -39,17 +45,25 @@ void addArray(val<T*> array, val<T*> array2, val<T> length) {
 	}
 }
 
-
 void callMemcpy(val<int32_t*> src, val<int32_t*> dest) {
 	memcpy(dest, src, 0);
 }
 
-struct CustomStruct {
+class BaseClass {};
+
+class CustomClass : public BaseClass {
+public:
 	int x;
 };
 
-val<int32_t> passCustomStruct(val<CustomStruct*> customStructPtr) {
-	return invoke<>(+[](CustomStruct* ptr) { return ptr->x; }, customStructPtr);
+val<int32_t> passCustomClass(val<CustomClass*> customClassPtr) {
+	return invoke<>(+[](CustomClass* ptr) { return ptr->x; }, customClassPtr);
+}
+
+val<int32_t> castCustomClass(val<BaseClass*> voidPtr) {
+	// cast base struct to custom struct
+	auto resultPtr = static_cast<val<CustomClass*>>(voidPtr);
+	return invoke<>(+[](CustomClass* ptr) { return ptr->x; }, resultPtr);
 }
 
 struct CustomStruct2 {
@@ -68,8 +82,8 @@ public:
 	}
 };
 
-val<int32_t> specializeType(val<CustomStruct2*> customStructPtr) {
-	return customStructPtr.getX();
+val<int32_t> specializeType(val<CustomStruct2*> customClassPtr) {
+	return customClassPtr.getX();
 }
 
 class WrapperType {

--- a/nautilus/test/execution-tests/TracingTest.cpp
+++ b/nautilus/test/execution-tests/TracingTest.cpp
@@ -206,7 +206,7 @@ TEST_CASE("Loop Trace Test") {
 	    {"addArrayInt32", details::createFunctionWrapper(addArray<int32_t>)},
 	    {"simpleDirectCall", details::createFunctionWrapper(simpleDirectCall)},
 	    {"loopDirectCall", details::createFunctionWrapper(loopDirectCall)},
-	    {"passCustomStruct", details::createFunctionWrapper(passCustomStruct)},
+	    {"passCustomStruct", details::createFunctionWrapper(passCustomClass)},
 	    {"specializeType", details::createFunctionWrapper(specializeType)},
 	    {"useWrapper", details::createFunctionWrapper(useWrapper)},
 	    {"voidFuncCall", details::createFunctionWrapper(voidFuncCall)}};


### PR DESCRIPTION
This change improves the casting  and const support for val pointer objects.

The following casts are supported:
```c++
// void* -> primitive
static_cast<val<int64_t*>>(arg);

// primitive* -> primitive*
static_cast<val<int32_t*>>(arg);

// void* -> class*
static_cast<val<CustomStruct*>>(arg);

// base_class* -> derived_class*
val<BaseClass*>> base = ...;
static_cast<val<CustomStruct*>>(base);
```