### PR TITLE
cleanup dynamic values

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ jobs:
   benchmark:
     name: Run tracing benchmark
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     env:
       CC: clang
       CXX: clang++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
   build-test:
     runs-on: ${{matrix.os}}
     name: Build on ${{ matrix.os }} with ${{ matrix.cc }} ${{ matrix.flags }}
-    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+# cancel previous runs of same PR / branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-test:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   build-test:
     runs-on: ${{matrix.os}}
     name: Build on ${{ matrix.os }} with ${{ matrix.cc }} ${{ matrix.flags }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   build-test:
     runs-on: ${{matrix.os}}
     name: Build on ${{ matrix.os }} with ${{ matrix.cc }} ${{ matrix.flags }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -7,10 +7,14 @@ on:
   pull_request:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-test:
     runs-on: ${{matrix.os}}
     name: Build on ${{ matrix.os }} with ${{ matrix.cc }} ${{ matrix.flags }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches:
       - main
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   build-test:
     runs-on: ${{matrix.os}}

--- a/nautilus/include/nautilus/common/traceing.hpp
+++ b/nautilus/include/nautilus/common/traceing.hpp
@@ -131,7 +131,8 @@ void traceValueDestruction(value_ref ref);
 
 value_ref traceCast(value_ref state, Type resultType);
 
-std::vector<uint8_t>& getVarRefMap();
+void allocateValRef(ValueRef ref);
+void freeValRef(ValueRef ref);
 
 value_ref traceCall(void* fptn, const std::type_info& ti, Type resultType, const std::vector<tracing::value_ref>& arguments);
 

--- a/nautilus/include/nautilus/common/traceing.hpp
+++ b/nautilus/include/nautilus/common/traceing.hpp
@@ -131,7 +131,7 @@ void traceValueDestruction(value_ref ref);
 
 value_ref traceCast(value_ref state, Type resultType);
 
-std::array<uint8_t, 10240>& getVarRefMap();
+std::vector<uint8_t>& getVarRefMap();
 
 value_ref traceCall(void* fptn, const std::type_info& ti, Type resultType, const std::vector<tracing::value_ref>& arguments);
 

--- a/nautilus/include/nautilus/common/traceing.hpp
+++ b/nautilus/include/nautilus/common/traceing.hpp
@@ -131,14 +131,12 @@ void traceValueDestruction(value_ref ref);
 
 value_ref traceCast(value_ref state, Type resultType);
 
-void allocateValRef(ValueRef ref);
-void freeValRef(ValueRef ref);
-
 value_ref traceCall(void* fptn, const std::type_info& ti, Type resultType, const std::vector<tracing::value_ref>& arguments);
 
 std::ostream& operator<<(std::ostream& os, const Op& operation);
 
 void pushStaticVal(void* ptr);
-
 void popStaticVal();
+void allocateValRef(ValueRef ref);
+void freeValRef(ValueRef ref);
 } // namespace nautilus::tracing

--- a/nautilus/src/nautilus/common/TypedValueRefHolder.cpp
+++ b/nautilus/src/nautilus/common/TypedValueRefHolder.cpp
@@ -18,11 +18,7 @@ TypedValueRefHolder::TypedValueRefHolder(nautilus::tracing::TypedValueRef valueR
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& varRef = tracing::getVarRefMap();
-	if (varRef.size() <= valueRef.ref) {
-		varRef.resize(valueRef.ref+1, 0);
-	}
-	varRef[valueRef.ref]++;
+	tracing::allocateValRef(valueRef.ref);
 #endif
 }
 
@@ -30,11 +26,7 @@ TypedValueRefHolder::TypedValueRefHolder(const nautilus::tracing::TypedValueRefH
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& varRef = tracing::getVarRefMap();
-	if (varRef.size() <= valueRef.ref) {
-		varRef.resize(valueRef.ref+1, 0);
-	}
-	varRef[valueRef.ref]++;
+	tracing::allocateValRef(valueRef.ref);
 #endif
 }
 
@@ -42,28 +34,19 @@ TypedValueRefHolder::TypedValueRefHolder(const nautilus::tracing::TypedValueRefH
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& varRef = tracing::getVarRefMap();
-	if (varRef.size() <= valueRef.ref) {
-		varRef.resize(valueRef.ref+1, 0);
-	}
-	varRef[valueRef.ref]++;
+	tracing::allocateValRef(valueRef.ref);
 #endif
 }
 
 TypedValueRefHolder& TypedValueRefHolder::operator=(const nautilus::tracing::TypedValueRefHolder& other) {
 #ifdef ENABLE_TRACING
-	auto& varRef = tracing::getVarRefMap();
-	if (varRef.size() <= valueRef.ref) {
-		varRef.resize(valueRef.ref+1, 0);
-	}
-	varRef[valueRef.ref]++;
+	tracing::allocateValRef(valueRef.ref);
 #endif
 	valueRef = other.valueRef;
 	return *this;
 }
 
 TypedValueRefHolder& TypedValueRefHolder::operator=(nautilus::tracing::TypedValueRefHolder&& other) {
-
 	valueRef = std::move(other.valueRef);
 	return *this;
 }
@@ -72,14 +55,7 @@ TypedValueRefHolder::~TypedValueRefHolder() {
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& varRef = tracing::getVarRefMap();
-	if (varRef.size() <= valueRef.ref) {
-		varRef.resize(valueRef.ref+1, 0);
-	}
-	auto& refCounter = varRef[valueRef.ref];
-	// the ref counter should always be greater than zero.
-	assert(refCounter > 0);
-	refCounter--;
+	tracing::freeValRef(valueRef.ref);
 #endif
 }
 

--- a/nautilus/src/nautilus/common/TypedValueRefHolder.cpp
+++ b/nautilus/src/nautilus/common/TypedValueRefHolder.cpp
@@ -18,8 +18,11 @@ TypedValueRefHolder::TypedValueRefHolder(nautilus::tracing::TypedValueRef valueR
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& refCounter = tracing::getVarRefMap()[valueRef.ref];
-	refCounter++;
+	auto& varRef = tracing::getVarRefMap();
+	if (varRef.size() <= valueRef.ref) {
+		varRef.resize(valueRef.ref+1, 0);
+	}
+	varRef[valueRef.ref]++;
 #endif
 }
 
@@ -27,8 +30,11 @@ TypedValueRefHolder::TypedValueRefHolder(const nautilus::tracing::TypedValueRefH
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& refCounter = tracing::getVarRefMap()[valueRef.ref];
-	refCounter++;
+	auto& varRef = tracing::getVarRefMap();
+	if (varRef.size() <= valueRef.ref) {
+		varRef.resize(valueRef.ref+1, 0);
+	}
+	varRef[valueRef.ref]++;
 #endif
 }
 
@@ -36,15 +42,21 @@ TypedValueRefHolder::TypedValueRefHolder(const nautilus::tracing::TypedValueRefH
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& refCounter = tracing::getVarRefMap()[valueRef.ref];
-	refCounter++;
+	auto& varRef = tracing::getVarRefMap();
+	if (varRef.size() <= valueRef.ref) {
+		varRef.resize(valueRef.ref+1, 0);
+	}
+	varRef[valueRef.ref]++;
 #endif
 }
 
 TypedValueRefHolder& TypedValueRefHolder::operator=(const nautilus::tracing::TypedValueRefHolder& other) {
 #ifdef ENABLE_TRACING
-	auto& refCounter = tracing::getVarRefMap()[valueRef.ref];
-	refCounter++;
+	auto& varRef = tracing::getVarRefMap();
+	if (varRef.size() <= valueRef.ref) {
+		varRef.resize(valueRef.ref+1, 0);
+	}
+	varRef[valueRef.ref]++;
 #endif
 	valueRef = other.valueRef;
 	return *this;
@@ -60,7 +72,11 @@ TypedValueRefHolder::~TypedValueRefHolder() {
 #ifdef ENABLE_TRACING
 	if (!inTracer())
 		return;
-	auto& refCounter = tracing::getVarRefMap()[valueRef.ref];
+	auto& varRef = tracing::getVarRefMap();
+	if (varRef.size() <= valueRef.ref) {
+		varRef.resize(valueRef.ref+1, 0);
+	}
+	auto& refCounter = varRef[valueRef.ref];
 	// the ref counter should always be greater than zero.
 	assert(refCounter > 0);
 	refCounter--;

--- a/nautilus/src/nautilus/tracing/TraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.cpp
@@ -309,8 +309,8 @@ std::vector<StaticVarHolder>& TraceContext::getStaticVars() {
 }
 
 void TraceContext::allocateValRef(ValueRef ref) {
-	if (dynamicVars.size() <= ref) {
-		dynamicVars.resize(ref+1, 0);
+	while (dynamicVars.size() <= ref) {
+		dynamicVars.emplace_back(0);
 	}
 	dynamicVars.at(ref)++;
 }
@@ -319,7 +319,7 @@ void TraceContext::freeValRef(ValueRef ref) {
 	// the ref counter should always be greater than zero.
 	assert(refCounter > 0);
 	refCounter--;
-	while (!dynamicVars.empty() && dynamicVars.back() == 0){
+	while (!dynamicVars.empty() && dynamicVars.back() == 0) {
 		dynamicVars.pop_back();
 	}
 }
@@ -339,8 +339,6 @@ uint64_t hashStaticVector(const std::vector<StaticVarHolder>& data) {
 uint64_t hashDynamicVector(const DynamicValueMap& data) {
 	size_t hash = offset_basis;
 	for (auto value : data) {
-		//if (value == 0)
-		//	continue;
 		hash ^= value;
 		hash *= fnv_prime;
 	}

--- a/nautilus/src/nautilus/tracing/TraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.cpp
@@ -15,6 +15,7 @@ TraceContext* TraceContext::get() {
 
 TraceContext* TraceContext::initialize(TagRecorder& tagRecorder) {
 	traceContext = new TraceContext(tagRecorder);
+	traceContext->dynamicVars.resize(0, 0);
 	return traceContext;
 }
 
@@ -318,6 +319,9 @@ void TraceContext::freeValRef(ValueRef ref) {
 	// the ref counter should always be greater than zero.
 	assert(refCounter > 0);
 	refCounter--;
+	while (!dynamicVars.empty() && dynamicVars.back() == 0){
+		dynamicVars.pop_back();
+	}
 }
 
 constexpr size_t fnv_prime = 0x100000001b3;
@@ -334,7 +338,9 @@ uint64_t hashStaticVector(const std::vector<StaticVarHolder>& data) {
 
 uint64_t hashDynamicVector(const DynamicValueMap& data) {
 	size_t hash = offset_basis;
-	for (auto& value : data) {
+	for (auto value : data) {
+		//if (value == 0)
+		//	continue;
 		hash ^= value;
 		hash *= fnv_prime;
 	}

--- a/nautilus/src/nautilus/tracing/TraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.cpp
@@ -307,8 +307,17 @@ std::vector<StaticVarHolder>& TraceContext::getStaticVars() {
 	return staticVars;
 }
 
-DynamicValueMap& TraceContext::getDynamicVars() {
-	return dynamicVars;
+void TraceContext::allocateValRef(ValueRef ref) {
+	if (dynamicVars.size() <= ref) {
+		dynamicVars.resize(ref+1, 0);
+	}
+	dynamicVars.at(ref)++;
+}
+void TraceContext::freeValRef(ValueRef ref) {
+	auto& refCounter = dynamicVars.at(ref);
+	// the ref counter should always be greater than zero.
+	assert(refCounter > 0);
+	refCounter--;
 }
 
 constexpr size_t fnv_prime = 0x100000001b3;

--- a/nautilus/src/nautilus/tracing/TraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.cpp
@@ -15,8 +15,14 @@ TraceContext* TraceContext::get() {
 
 TraceContext* TraceContext::initialize(TagRecorder& tagRecorder) {
 	traceContext = new TraceContext(tagRecorder);
-	traceContext->dynamicVars.resize(0, 0);
+	traceContext->dynamicVars.reserve(128);
 	return traceContext;
+}
+
+void TraceContext::resume() {
+	staticVars.clear();
+	dynamicVars.clear();
+	traceContext->dynamicVars.reserve(128);
 }
 
 void TraceContext::terminate() {
@@ -146,7 +152,6 @@ value_ref TraceContext::traceCall(const std::string& functionName, const std::st
 		});
 		auto op = Op::CALL;
 		auto resultRef = executionTrace->addOperationWithResult(tag, op, resultType, std::vector<InputVariant> {functionArguments});
-		//  executionTrace->variableBitset[resultRef] = true;
 		return resultRef;
 	}
 	throw TraceTerminationException();
@@ -208,7 +213,6 @@ void TraceContext::traceReturnOperation(Type type, value_ref ref) {
 	}
 	auto tag = recordSnapshot();
 	executionTrace->addReturn(tag, type, ref);
-	return;
 }
 
 value_ref TraceContext::traceUnaryOperation(nautilus::tracing::Op op, Type resultType, nautilus::tracing::value_ref& inputRef) {
@@ -289,7 +293,6 @@ std::unique_ptr<ExecutionTrace> TraceContext::trace(std::function<void()>& trace
 			traceIteration = traceIteration + 1;
 			log::trace("Trace Iteration {}", traceIteration);
 			log::trace("{}", tc->executionTrace->toString());
-
 			tc->symbolicExecutionContext->next();
 			tc->executionTrace->resetExecution();
 			TraceContext::get()->resume();

--- a/nautilus/src/nautilus/tracing/TraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.hpp
@@ -100,7 +100,7 @@ public:
 	void resume() {
 		staticVars.clear();
 		dynamicVars.clear();
-		dynamicVars.resize(12,0);
+		dynamicVars.resize(0,0);
 	}
 
 	static TraceContext* initialize(TagRecorder& tagRecorder);

--- a/nautilus/src/nautilus/tracing/TraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.hpp
@@ -104,7 +104,7 @@ public:
 	void resume() {
 		staticVars.clear();
 		dynamicVars.clear();
-		dynamicVars.reserve(255);
+		dynamicVars.resize(12,0);
 	}
 
 	static TraceContext* initialize(TagRecorder& tagRecorder);
@@ -112,7 +112,8 @@ public:
 	static std::unique_ptr<ExecutionTrace> trace(std::function<void()>& traceFunction);
 
 	std::vector<StaticVarHolder>& getStaticVars();
-	DynamicValueMap& getDynamicVars();
+	void allocateValRef(ValueRef ref);
+	void freeValRef(ValueRef ref);
 
 private:
 	explicit TraceContext(TagRecorder& tagRecorder);

--- a/nautilus/src/nautilus/tracing/TraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.hpp
@@ -21,7 +21,7 @@ private:
 	friend uint64_t hashStaticVector(const std::vector<StaticVarHolder>& data);
 };
 
-using DynamicValueMap = std::array<uint8_t, 10240>;
+using DynamicValueMap = std::vector<uint8_t>;
 
 /**
  * @brief The trace context manages a thread local instance to record a symbolic execution trace of a given Nautilus
@@ -103,7 +103,8 @@ public:
 
 	void resume() {
 		staticVars.clear();
-		dynamicVars.fill(0);
+		dynamicVars.clear();
+		dynamicVars.reserve(255);
 	}
 
 	static TraceContext* initialize(TagRecorder& tagRecorder);

--- a/nautilus/src/nautilus/tracing/TraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.hpp
@@ -97,10 +97,6 @@ public:
 
 	~TraceContext() = default;
 
-	void pause() {
-		active = false;
-	}
-
 	void resume() {
 		staticVars.clear();
 		dynamicVars.clear();
@@ -124,7 +120,6 @@ private:
 
 	Snapshot recordSnapshot();
 
-	bool active = false;
 	TagRecorder& tagRecorder;
 	std::unique_ptr<ExecutionTrace> executionTrace;
 	std::unique_ptr<SymbolicExecutionContext> symbolicExecutionContext;

--- a/nautilus/src/nautilus/tracing/TraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.hpp
@@ -97,11 +97,7 @@ public:
 
 	~TraceContext() = default;
 
-	void resume() {
-		staticVars.clear();
-		dynamicVars.clear();
-		dynamicVars.resize(0,0);
-	}
+	void resume();
 
 	static TraceContext* initialize(TagRecorder& tagRecorder);
 

--- a/nautilus/src/nautilus/tracing/TracingUtil.cpp
+++ b/nautilus/src/nautilus/tracing/TracingUtil.cpp
@@ -71,8 +71,11 @@ value_ref traceConstant(Type type, std::any&& value) {
 	return TraceContext::get()->traceCast(state, resultType);
 }
 
-DynamicValueMap& getVarRefMap() {
-	return TraceContext::get()->getDynamicVars();
+void allocateValRef(ValueRef ref) {
+	TraceContext::get()->allocateValRef(ref);
+}
+void freeValRef(ValueRef ref) {
+	TraceContext::get()->freeValRef(ref);
 }
 
 [[maybe_unused]] value_ref traceCopy(value_ref state) {


### PR DESCRIPTION
This pr improves the handling of dynamic values. The old implementation used a fixed array, which caused problems in nebulastream. Now we use a dynamic vector, which is preallocated for a certain size, which should reduce the expansion cost at runtime.


