### PR TITLE
Constrain binary operators

### DIFF
--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -308,19 +308,21 @@ LHS inline getRawValue(const val<LHS>& val) {
 	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
 	    requires(CON_VAL<LHS> && CON_VAL<RHS>)                                                                                                                                                                                                 \
 	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
-		return details::FUNC(std::forward<LHS>(left), std::forward<RHS>(right));                                                                                                                                                               \
+		return details::FUNC(std::move(left), std::move(right));                                                                                                                                                               \
 	}                                                                                                                                                                                                                                          \
                                                                                                                                                                                                                                                \
 	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
 	    requires(CON_VAL<LHS> && CON_VALUE<RHS>)                                                                                                                                                                                               \
-	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
-		return details::FUNC(std::forward<LHS>(left), make_value(std::forward<RHS>(right)));                                                                                                                                                   \
+	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                            \
+        auto&& rhsV = make_value(std::forward<RHS>(right));\
+		return details::FUNC(std::move(left),  std::move(rhsV));                                                                                                                                                   \
 	}                                                                                                                                                                                                                                          \
                                                                                                                                                                                                                                                \
 	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
 	    requires(CON_VALUE<LHS> && CON_VAL<RHS>)                                                                                                                                                                                               \
-	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
-		return details::FUNC(make_value(std::forward<LHS>(left)), std::forward<RHS>(right));                                                                                                                                                   \
+	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                            \
+        auto&& lhsV = make_value(std::forward<LHS>(left));\
+		return details::FUNC(std::move(lhsV), std::move(right));                                                                                                                                                   \
 	}
 
 DEFINE_BINARY_OPERATOR(+, add, is_fundamental_val, convertible_to_fundamental)

--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -92,20 +92,29 @@ public:
 	using basic_type = ValueType;
 
 #ifdef ENABLE_TRACING
-	val() : state(tracing::traceConstant(0)) {}
-	val(ValueType value) : state(tracing::traceConstant(value)), value(value) {}
+	val() : state(tracing::traceConstant(0)) {
+	}
+	val(ValueType value) : state(tracing::traceConstant(value)), value(value) {
+	}
 	// copy constructor
-	val(const val<ValueType>& other) : state(tracing::traceCopy(other.state)), value(other.value) {}
+	val(const val<ValueType>& other) : state(tracing::traceCopy(other.state)), value(other.value) {
+	}
 	// move constructor
-	val(const val<ValueType>&& other) noexcept : state(std::move(other.state)), value(other.value) {}
-	val(tracing::value_ref& tc) : state(tc), value() {}
+	val(const val<ValueType>&& other) noexcept : state(std::move(other.state)), value(other.value) {
+	}
+	val(tracing::value_ref& tc) : state(tc), value() {
+	}
 #else
-	val() {}
-	val(ValueType value) : value(value) {}
+	val() {
+	}
+	val(ValueType value) : value(value) {
+	}
 	// copy constructor
-	val(const val<ValueType>& other) : value(other.value) {}
+	val(const val<ValueType>& other) : value(other.value) {
+	}
 	// move constructor
-	val(const val<ValueType>&& other) : value(other.value) {}
+	val(const val<ValueType>&& other) : value(other.value) {
+	}
 #endif
 
 	val<ValueType>& operator=(const val<ValueType>& other) {
@@ -320,22 +329,6 @@ auto&& cast_value(LeftType&& value) {
 namespace details {
 
 #ifdef ENABLE_TRACING
-#define TRAC_BINARY_OP(OP)                                                                                                                                                                                                                     \
-	if (tracing::inTracer()) {                                                                                                                                                                                                                 \
-		auto tc = tracing::traceBinaryOp<tracing::OP, commonType>(lValue.state, rValue.state);                                                                                                                                                 \
-		return val<commonType>(tc);                                                                                                                                                                                                            \
-	}
-
-#define TRAC_BINARY_OP_DIRECT(OP)                                                                                                                                                                                                              \
-	if (tracing::inTracer()) {                                                                                                                                                                                                                 \
-		auto tc = tracing::traceBinaryOp<tracing::OP, commonType>(left.state, right.state);                                                                                                                                                    \
-		return val<commonType>(tc);                                                                                                                                                                                                            \
-	}
-#else
-#define TRAC_OP(OP)
-#endif
-
-#ifdef ENABLE_TRACING
 #define TRAC_LOGICAL_BINARY_OP(OP)                                                                                                                                                                                                             \
 	if (tracing::inTracer()) {                                                                                                                                                                                                                 \
 		auto tc = tracing::traceBinaryOp<tracing::OP, bool>(lValue.state, rValue.state);                                                                                                                                                       \
@@ -410,46 +403,46 @@ LHS inline getRawValue(const val<LHS>& val) {
 
 } // namespace details
 
-#define DEFINE_BINARY_OPERATOR(OP, FUNC)                                                                                                                                                                                                       \
+#define DEFINE_BINARY_OPERATOR(OP, FUNC, CON, CONV_TO)                                                                                                                                                                                         \
 	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
-	    requires(is_fundamental_val<LHS> && (is_fundamental_val<RHS> || convertible_to_fundamental<RHS>)) || ((is_fundamental_val<LHS> || convertible_to_fundamental<LHS>) && is_fundamental_val<RHS>)                                         \
+	    requires(CON<LHS> && (CON<RHS> || CONV_TO<RHS>) ) || ((CON<LHS> || CONV_TO<LHS>) && CON<RHS>)                                                                                                                                          \
 	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
 		auto&& lhsV = make_value(std::forward<LHS>(left));                                                                                                                                                                                     \
 		auto&& rhsV = make_value(std::forward<RHS>(right));                                                                                                                                                                                    \
 		return details::FUNC(std::move(lhsV), std::move(rhsV));                                                                                                                                                                                \
 	}
 
-DEFINE_BINARY_OPERATOR(+, add)
+DEFINE_BINARY_OPERATOR(+, add, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(-, sub)
+DEFINE_BINARY_OPERATOR(-, sub, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(*, mul)
+DEFINE_BINARY_OPERATOR(*, mul, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(/, div)
+DEFINE_BINARY_OPERATOR(/, div, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(%, mod)
+DEFINE_BINARY_OPERATOR(%, mod, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(==, eq)
+DEFINE_BINARY_OPERATOR(==, eq, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(!=, neq)
+DEFINE_BINARY_OPERATOR(!=, neq, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(>, gt)
+DEFINE_BINARY_OPERATOR(>, gt, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(>=, gte)
+DEFINE_BINARY_OPERATOR(>=, gte, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(<, lt)
+DEFINE_BINARY_OPERATOR(<, lt, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(<=, lte)
+DEFINE_BINARY_OPERATOR(<=, lte, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(>>, shr)
+DEFINE_BINARY_OPERATOR(>>, shr, is_integral_val, convertible_to_integral)
 
-DEFINE_BINARY_OPERATOR(<<, shl)
+DEFINE_BINARY_OPERATOR(<<, shl, is_integral_val, convertible_to_integral)
 
-DEFINE_BINARY_OPERATOR(|, bOr)
+DEFINE_BINARY_OPERATOR(|, bOr, is_integral_val, convertible_to_integral)
 
-DEFINE_BINARY_OPERATOR(&, bAnd)
+DEFINE_BINARY_OPERATOR(&, bAnd, is_integral_val, convertible_to_integral)
 
-DEFINE_BINARY_OPERATOR(^, bXOr)
+DEFINE_BINARY_OPERATOR(^, bXOr, is_integral_val, convertible_to_integral)
 
 template <typename LHS>
 auto inline operator~(LHS left) {
@@ -487,30 +480,35 @@ auto& operator%=(val<LHS>& left, RHS right) {
 }
 
 template <typename LHS, typename RHS>
+    requires(is_integral<LHS> && (is_integral_val<RHS> || convertible_to_integral<RHS>) )
 auto& operator|=(val<LHS>& left, RHS right) {
 	left = left | right;
 	return left;
 }
 
 template <typename LHS, typename RHS>
+    requires(is_integral<LHS> && (is_integral_val<RHS> || convertible_to_integral<RHS>) )
 auto& operator^=(val<LHS>& left, RHS right) {
 	left = left ^ right;
 	return left;
 }
 
 template <typename LHS, typename RHS>
+    requires(is_integral<LHS> && (is_integral_val<RHS> || convertible_to_integral<RHS>) )
 auto& operator&=(val<LHS>& left, RHS right) {
 	left = left & right;
 	return left;
 }
 
 template <typename LHS, typename RHS>
+    requires(is_integral<LHS> && (is_integral_val<RHS> || convertible_to_integral<RHS>) )
 auto& operator<<=(val<LHS>& left, RHS right) {
 	left = left << right;
 	return left;
 }
 
 template <typename LHS, typename RHS>
+    requires(is_integral<LHS> && (is_integral_val<RHS> || convertible_to_integral<RHS>) )
 auto& operator>>=(val<LHS>& left, RHS right) {
 	left = left >> right;
 	return left;

--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -17,60 +17,9 @@ namespace details {
 template <typename LHS>
 LHS getRawValue(const val<LHS>& val);
 
-#define COMMON_RETURN_TYPE val<typename std::common_type<typename LHS::basic_type, typename RHS::basic_type>::type>
+#define COMMON_RETURN_TYPE val<typename std::common_type<typename std::remove_cvref_t<LHS>::basic_type, typename std::remove_cvref_t<RHS>::basic_type>::type>
 
 #define INFERED_RETURN_TYPE(OP) val<decltype(getRawValue(left) OP getRawValue(right))>
-
-template <typename LHS, typename RHS>
-COMMON_RETURN_TYPE add(LHS& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE sub(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE mul(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE div(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE mod(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-val<bool> eq(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-val<bool> lt(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-val<bool> gt(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-val<bool> lte(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-val<bool> gte(val<LHS>& left, val<RHS>& right);
-
-val<bool> lAnd(val<bool>& left, val<bool>& right);
-
-val<bool> lOr(val<bool>& left, val<bool>& right);
-
-val<bool> lNot(val<bool>& val);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE bAnd(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE bOr(val<LHS>& left, val<RHS>& right);
-
-template <is_fundamental LHS, is_fundamental RHS>
-COMMON_RETURN_TYPE bXOr(val<LHS>& left, val<RHS>& right);
-
-template <is_integral LHS, is_integral RHS>
-auto shl(val<LHS>& left, val<RHS>& right);
-
-template <is_integral LHS, is_integral RHS>
-auto shr(val<LHS>& left, val<RHS>& right);
 
 template <is_fundamental LHS>
 val<LHS> neg(val<LHS>& val);
@@ -175,60 +124,6 @@ public:
 private:
 	friend ValueType details::getRawValue<ValueType>(const val<ValueType>& left);
 	ValueType value;
-
-	template <is_arithmetic LHS, is_arithmetic RHS>
-	friend COMMON_RETURN_TYPE mul(val<LHS>& left, val<RHS>& right);
-
-	template <is_arithmetic LHS, is_arithmetic RHS>
-	friend COMMON_RETURN_TYPE details::add(val<LHS>& left, val<RHS>& right);
-
-	template <is_arithmetic LHS, is_arithmetic RHS>
-	friend COMMON_RETURN_TYPE details::sub(val<LHS>& left, val<RHS>& right);
-
-	template <is_arithmetic LHS, is_arithmetic RHS>
-	friend COMMON_RETURN_TYPE details::div(val<LHS>& left, val<RHS>& right);
-
-	template <is_arithmetic LHS, is_arithmetic RHS>
-	friend COMMON_RETURN_TYPE details::mod(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend val<bool> details::eq(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend val<bool> details::lt(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend val<bool> details::gt(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend val<bool> details::lte(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend val<bool> details::gte(val<LHS>& left, val<RHS>& right);
-
-	friend val<bool> details::lAnd(val<bool>& left, val<bool>& right);
-
-	friend val<bool> details::lOr(val<bool>& left, val<bool>& right);
-
-	friend val<bool> details::lNot(val<bool>& val);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend COMMON_RETURN_TYPE details::bAnd(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend COMMON_RETURN_TYPE details::bOr(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS, is_fundamental RHS>
-	friend COMMON_RETURN_TYPE details::bXOr(val<LHS>& left, val<RHS>& right);
-
-	template <is_integral LHS, is_integral RHS>
-	friend auto details::shl(val<LHS>& left, val<RHS>& right);
-
-	template <is_integral LHS, is_integral RHS>
-	friend auto details::shr(val<LHS>& left, val<RHS>& right);
-
-	template <is_fundamental LHS>
-	friend auto details::neg(val<LHS>& val);
 };
 
 template <>
@@ -243,21 +138,30 @@ public:
 
 #ifdef ENABLE_TRACING
 
-	val() : state(tracing::traceConstant(0)), value(false) {}
-	val(bool value) : state(tracing::traceConstant(value)), value(value) {}
+	val() : state(tracing::traceConstant(0)), value(false) {
+	}
+	val(bool value) : state(tracing::traceConstant(value)), value(value) {
+	}
 	// copy constructor
-	val(const val<bool>& other) : state(tracing::traceCopy(other.state)), value(other.value) {}
+	val(const val<bool>& other) : state(tracing::traceCopy(other.state)), value(other.value) {
+	}
 	// move constructor
-	val(const val<bool>&& other) : state(other.state), value(other.value) {}
-	val(tracing::value_ref& tc) : state(tc) {}
+	val(const val<bool>&& other) : state(other.state), value(other.value) {
+	}
+	val(tracing::value_ref& tc) : state(tc) {
+	}
 
 #else
-	val() {}
-	val(bool value) : value(value) {}
+	val() {
+	}
+	val(bool value) : value(value) {
+	}
 	// copy constructor
-	val(const val<bool>& other) : value(other.value) {}
+	val(const val<bool>& other) : value(other.value) {
+	}
 	// move constructor
-	val(const val<bool>&& other) : value(other.value) {}
+	val(const val<bool>&& other) : value(other.value) {
+	}
 #endif
 
 	val<bool>& operator=(const val<bool>& other) {
@@ -307,7 +211,7 @@ auto inline make_value(const Type& value) {
 
 template <typename LeftType, is_fundamental RightType>
 auto inline cast_value(LeftType&& value) {
-	typedef typename LeftType::basic_type basic_type;
+	typedef typename std::remove_reference_t<LeftType>::basic_type basic_type;
 	typedef typename std::common_type<basic_type, RightType>::type commonType;
 	if constexpr (std::is_same_v<basic_type, RightType>) {
 		return std::forward<LeftType>(value);
@@ -341,10 +245,10 @@ namespace details {
 #define DEFINE_BINARY_OPERATOR_HELPER(OP, OP_NAME, OP_TRACE, RES_TYPE)                                                                                                                                                                         \
 	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
 	auto inline OP_NAME(LHS&& left, RHS&& right) {                                                                                                                                                                                             \
-		typedef typename std::common_type<typename LHS::basic_type, typename RHS::basic_type>::type commonType;                                                                                                                                \
+		typedef typename std::common_type<typename std::remove_reference_t<LHS>::basic_type, typename std::remove_reference_t<RHS>::basic_type>::type commonType;                                                                              \
 		auto&& lValue = cast_value<LHS, commonType>(std::forward<LHS>(left));                                                                                                                                                                  \
 		auto&& rValue = cast_value<RHS, commonType>(std::forward<RHS>(right));                                                                                                                                                                 \
-		using resultType = decltype(getRawValue(lValue) OP getRawValue(rValue));                                                                                                                                                                  \
+		using resultType = decltype(getRawValue(lValue) OP getRawValue(rValue));                                                                                                                                                               \
 		if SHOULD_TRACE () {                                                                                                                                                                                                                   \
 			auto tc = tracing::traceBinaryOp<tracing::OP_TRACE, resultType>(details::getState(lValue), details::getState(rValue));                                                                                                             \
 			return RES_TYPE(tc);                                                                                                                                                                                                               \
@@ -400,16 +304,25 @@ LHS inline getRawValue(const val<LHS>& val) {
 	return val.value;
 }
 
-
 } // namespace details
 
-#define DEFINE_BINARY_OPERATOR(OP, FUNC, CON, CONV_TO)                                                                                                                                                                                         \
+#define DEFINE_BINARY_OPERATOR(OP, FUNC, CON_VAL, CON_VALUE)                                                                                                                                                                                   \
 	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
-	    requires(CON<LHS> && (CON<RHS> || CONV_TO<RHS>) ) || ((CON<LHS> || CONV_TO<LHS>) && CON<RHS>)                                                                                                                                          \
+	    requires(CON_VAL<LHS> && CON_VAL<RHS>)                                                                                                                                                                                                 \
 	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
-		auto&& lhsV = make_value(std::forward<LHS>(left));                                                                                                                                                                                     \
-		auto&& rhsV = make_value(std::forward<RHS>(right));                                                                                                                                                                                    \
-		return details::FUNC(std::move(lhsV), std::move(rhsV));                                                                                                                                                                                \
+		return details::FUNC(std::forward<LHS>(left), std::forward<RHS>(right));                                                                                                                                                               \
+	}                                                                                                                                                                                                                                          \
+                                                                                                                                                                                                                                               \
+	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
+	    requires(CON_VAL<LHS> && CON_VALUE<RHS>)                                                                                                                                                                                               \
+	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
+		return details::FUNC(std::forward<LHS>(left), make_value(std::forward<RHS>(right)));                                                                                                                                                   \
+	}                                                                                                                                                                                                                                          \
+                                                                                                                                                                                                                                               \
+	template <typename LHS, typename RHS>                                                                                                                                                                                                      \
+	    requires(CON_VALUE<LHS> && CON_VAL<RHS>)                                                                                                                                                                                               \
+	auto inline operator OP(LHS&& left, RHS&& right) {                                                                                                                                                                                         \
+		return details::FUNC(make_value(std::forward<LHS>(left)), std::forward<RHS>(right));                                                                                                                                                   \
 	}
 
 DEFINE_BINARY_OPERATOR(+, add, is_fundamental_val, convertible_to_fundamental)
@@ -432,17 +345,17 @@ DEFINE_BINARY_OPERATOR(>=, gte, is_fundamental_val, convertible_to_fundamental)
 
 DEFINE_BINARY_OPERATOR(<, lt, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(<=, lte, is_fundamental_val, convertible_to_fundamental)
+DEFINE_BINARY_OPERATOR(<=, lte, is_fundamental_val, is_fundamental_convertable)
 
-DEFINE_BINARY_OPERATOR(>>, shr, is_integral_val, convertible_to_integral)
+DEFINE_BINARY_OPERATOR(>>, shr, is_integral_val, is_integral)
 
-DEFINE_BINARY_OPERATOR(<<, shl, is_integral_val, convertible_to_integral)
+DEFINE_BINARY_OPERATOR(<<, shl, is_integral_val, is_integral)
 
-DEFINE_BINARY_OPERATOR(|, bOr, is_integral_val, convertible_to_integral)
+DEFINE_BINARY_OPERATOR(|, bOr, is_integral_val, is_integral)
 
-DEFINE_BINARY_OPERATOR(&, bAnd, is_integral_val, convertible_to_integral)
+DEFINE_BINARY_OPERATOR(&, bAnd, is_integral_val, is_integral)
 
-DEFINE_BINARY_OPERATOR(^, bXOr, is_integral_val, convertible_to_integral)
+DEFINE_BINARY_OPERATOR(^, bXOr, is_integral_val, is_integral)
 
 template <typename LHS>
 auto inline operator~(LHS left) {

--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -345,7 +345,7 @@ DEFINE_BINARY_OPERATOR(>=, gte, is_fundamental_val, convertible_to_fundamental)
 
 DEFINE_BINARY_OPERATOR(<, lt, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(<=, lte, is_fundamental_val, is_fundamental_convertable)
+DEFINE_BINARY_OPERATOR(<=, lte, is_fundamental_val, convertible_to_fundamental)
 
 DEFINE_BINARY_OPERATOR(>>, shr, is_integral_val, is_integral)
 

--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -19,10 +19,7 @@ LHS getRawValue(const val<LHS>& val);
 
 #define COMMON_RETURN_TYPE val<typename std::common_type<typename std::remove_cvref_t<LHS>::basic_type, typename std::remove_cvref_t<RHS>::basic_type>::type>
 
-#define INFERED_RETURN_TYPE(OP) val<decltype(getRawValue(left) OP getRawValue(right))>
-
-template <is_fundamental LHS>
-val<LHS> neg(val<LHS>& val);
+#define DEDUCT_RETURN_TYPE(OP) val<decltype(getRawValue(left) OP getRawValue(right))>
 
 template <typename T>
 tracing::value_ref getState(T&& value) {
@@ -165,7 +162,6 @@ public:
 #endif
 
 	val<bool>& operator=(const val<bool>& other) {
-
 		if SHOULD_TRACE () {
 #ifdef ENABLE_TRACING
 			tracing::traceAssignment(state, other.state, tracing::to_type<bool>());
@@ -186,6 +182,8 @@ public:
 		return value;
 	}
 
+private:
+	friend bool details::getRawValue<bool>(const val<bool>& left);
 	bool value;
 };
 
@@ -278,9 +276,9 @@ DEFINE_BINARY_OPERATOR_HELPER(>, gt, GT, val<bool>)
 
 DEFINE_BINARY_OPERATOR_HELPER(>=, gte, GTE, val<bool>)
 
-DEFINE_BINARY_OPERATOR_HELPER(>>, shr, RSH, INFERED_RETURN_TYPE(>>))
+DEFINE_BINARY_OPERATOR_HELPER(>>, shr, RSH, DEDUCT_RETURN_TYPE(>>))
 
-DEFINE_BINARY_OPERATOR_HELPER(<<, shl, LSH, INFERED_RETURN_TYPE(<<))
+DEFINE_BINARY_OPERATOR_HELPER(<<, shl, LSH, DEDUCT_RETURN_TYPE(<<))
 
 DEFINE_BINARY_OPERATOR_HELPER(&, bAnd, BAND, COMMON_RETURN_TYPE)
 
@@ -288,7 +286,7 @@ DEFINE_BINARY_OPERATOR_HELPER(|, bOr, BOR, COMMON_RETURN_TYPE)
 
 DEFINE_BINARY_OPERATOR_HELPER(^, bXOr, BXOR, COMMON_RETURN_TYPE)
 
-template <is_fundamental LHS>
+template <is_integral LHS>
 val<LHS> neg(val<LHS>& val) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
@@ -435,7 +433,7 @@ val<bool> inline lOr(val<bool>& left, val<bool>& right) {
 		return val<bool> {tc};
 	}
 #endif
-	return left.value || right.value;
+	return getRawValue(left) || getRawValue(right);
 }
 
 val<bool> inline lAnd(val<bool>& left, val<bool>& right) {
@@ -445,7 +443,7 @@ val<bool> inline lAnd(val<bool>& left, val<bool>& right) {
 		return val<bool> {tc};
 	}
 #endif
-	return left.value && right.value;
+	return getRawValue(left) && getRawValue(right);
 }
 
 val<bool> inline lNot(val<bool>& arg) {
@@ -455,7 +453,7 @@ val<bool> inline lNot(val<bool>& arg) {
 		return val<bool> {tc};
 	}
 #endif
-	return !arg.value;
+	return !getRawValue(arg);
 }
 } // namespace details
 

--- a/nautilus/include/nautilus/val_concepts.hpp
+++ b/nautilus/include/nautilus/val_concepts.hpp
@@ -10,20 +10,24 @@ namespace nautilus {
 #define SHOULD_TRACE() constexpr(false)
 #endif
 
-
 template <typename T>
 class val;
 
 template <typename T>
-concept convertible_to_fundamental = (std::is_convertible_v<T, int> || std::is_convertible_v<T, double> || std::is_convertible_v<T, char> || std::is_convertible_v<T, bool> || std::is_convertible_v<T, float> ||
-                                      std::is_convertible_v<T, long> || std::is_convertible_v<T, short> || std::is_convertible_v<T, unsigned long> || std::is_convertible_v<T, unsigned int> || std::is_convertible_v<T, unsigned short> ||
-                                      std::is_convertible_v<T, long long> || std::is_convertible_v<T, unsigned long long>);
+concept convertible_to_integral = (std::is_convertible_v<T, int> || std::is_convertible_v<T, char> || std::is_convertible_v<T, long> || std::is_convertible_v<T, short> || std::is_convertible_v<T, unsigned long> ||
+                                   std::is_convertible_v<T, unsigned int> || std::is_convertible_v<T, unsigned short> || std::is_convertible_v<T, long long> || std::is_convertible_v<T, unsigned long long>);
+
+template <typename T>
+concept convertible_to_fundamental = (convertible_to_integral<T> || std::is_convertible_v<T, float> || std::is_convertible_v<T, double> || std::is_convertible_v<T, bool>);
 
 template <typename T>
 concept is_arithmetic = std::is_arithmetic_v<T>;
 
 template <typename T>
 concept is_fundamental_val = requires(val<T> value) { std::is_fundamental_v<typename std::remove_reference_t<T>::basic_type>; };
+
+template <typename T>
+concept is_integral_val = requires(val<T> value) { std::is_integral_v<typename std::remove_reference_t<T>::basic_type>; };
 
 template <typename T>
 concept is_ptr = std::is_pointer_v<T>;
@@ -82,6 +86,6 @@ concept is_traceable_value = requires(T a) {
 };
 
 template <typename T>
-concept is_compatible_val_type = is_ptr<T>  || is_fundamental<T> || is_fundamental_ref<T> || is_bool<T> || is_bool_ref<T>;
+concept is_compatible_val_type = is_ptr<T> || is_fundamental<T> || is_fundamental_ref<T> || is_bool<T> || is_bool_ref<T>;
 
 } // namespace nautilus

--- a/nautilus/include/nautilus/val_concepts.hpp
+++ b/nautilus/include/nautilus/val_concepts.hpp
@@ -18,16 +18,29 @@ concept convertible_to_integral = (std::is_convertible_v<T, int> || std::is_conv
                                    std::is_convertible_v<T, unsigned int> || std::is_convertible_v<T, unsigned short> || std::is_convertible_v<T, long long> || std::is_convertible_v<T, unsigned long long>);
 
 template <typename T>
-concept convertible_to_fundamental = (convertible_to_integral<T> || std::is_convertible_v<T, float> || std::is_convertible_v<T, double> || std::is_convertible_v<T, bool>);
+concept is_fundamental_val = requires {
+	typename std::remove_reference_t<T>::basic_type; // Ensure T has a member type 'basic_type'
+	requires std::is_fundamental_v<typename std::remove_reference_t<T>::basic_type>; // Ensure 'basic_type' is integral
+};
+
+template <typename T>
+concept convertible_to_fundamental = !is_fundamental_val<T> && (convertible_to_integral<T> || std::is_convertible_v<T, float> || std::is_convertible_v<T, double> || std::is_convertible_v<T, bool>);
 
 template <typename T>
 concept is_arithmetic = std::is_arithmetic_v<T>;
 
-template <typename T>
-concept is_fundamental_val = requires(val<T> value) { std::is_fundamental_v<typename std::remove_reference_t<T>::basic_type>; };
+
 
 template <typename T>
-concept is_integral_val = requires(val<T> value) { std::is_integral_v<typename std::remove_reference_t<T>::basic_type>; };
+concept is_fundamental_convertable = std::is_fundamental_v<std::remove_cvref_t<T>> && !std::is_pointer_v<T>;
+
+
+template <typename T>
+concept is_integral_val = requires {
+	typename std::remove_reference_t<T>::basic_type; // Ensure T has a member type 'basic_type'
+	requires std::is_integral_v<typename std::remove_reference_t<T>::basic_type>; // Ensure 'basic_type' is integral
+};
+
 
 template <typename T>
 concept is_ptr = std::is_pointer_v<T>;
@@ -51,7 +64,7 @@ template <typename T>
 concept is_fundamental_ref = std::is_reference_v<T>;
 
 template <typename T>
-concept is_integral = std::is_integral_v<T>;
+concept is_integral = std::is_integral_v<std::remove_cvref_t<T>>;
 
 template <typename T>
 concept is_bool = std::is_same_v<T, bool>;

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -84,7 +84,6 @@ void expressionTests(engine::NautilusEngine& engine) {
 		REQUIRE(f((char) 1) == (char) -2);
 		REQUIRE(f((char) CHAR_MAX) == (char) CHAR_MIN);
 		REQUIRE(f((char) CHAR_MIN) == (char) CHAR_MAX);
-
 	}
 
 	SECTION("callEnumFunction") {

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -84,6 +84,7 @@ void expressionTests(engine::NautilusEngine& engine) {
 		REQUIRE(f((char) 1) == (char) -2);
 		REQUIRE(f((char) CHAR_MAX) == (char) CHAR_MIN);
 		REQUIRE(f((char) CHAR_MIN) == (char) CHAR_MAX);
+
 	}
 
 	SECTION("callEnumFunction") {

--- a/nautilus/test/val-tests/ValConceptTest.cpp
+++ b/nautilus/test/val-tests/ValConceptTest.cpp
@@ -6,6 +6,15 @@
 
 namespace nautilus {
 
+template <typename LHS, typename RHS>
+bool defineOperator() {
+	if constexpr (requires(LHS l, RHS r) { l & r; }) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 TEMPLATE_TEST_CASE("Val Concept Test", "[value][template]", int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t, size_t, float, double) {
 	SECTION("convertible_to_fundamental") {
 		REQUIRE(convertible_to_fundamental<TestType>);
@@ -47,6 +56,15 @@ TEMPLATE_TEST_CASE("Val Concept Test", "[value][template]", int8_t, int16_t, int
 	SECTION("is_val_type") {
 		REQUIRE(!is_val_type<TestType>);
 		REQUIRE(is_val_type<val<TestType>>);
+	}
+	SECTION("checkOpDefine") {
+		REQUIRE(defineOperator<val<int>, val<int>>());
+		REQUIRE(defineOperator<val<int>&, val<int>>());
+		REQUIRE(defineOperator<val<int>&, val<int>&>());
+		REQUIRE(defineOperator<val<int>&, val<int>&>());
+		REQUIRE(defineOperator<val<int>&, int&>());
+		REQUIRE(defineOperator<val<int>&, int&>());
+		REQUIRE(!defineOperator<val<float>, val<float>>());
 	}
 }
 } // namespace nautilus


### PR DESCRIPTION
Nautilus defines shr, shl, binary and, binary or, binary xor unconstrained for all vals. 
But these operators can't do those operations on floating points.

Currently, in nes we are using an if constexpr (require {operator&(lhs, rhs)}) and unfortunately that finds the implementation for operator&(val<float> a, ...), and that does not compile. Thus we should constrain these operations for std::integral types.