### PR TITLE
Small ostream fixes

### DIFF
--- a/nautilus/include/nautilus/std/ostream.h
+++ b/nautilus/include/nautilus/std/ostream.h
@@ -81,7 +81,7 @@ public:
 	}
 
 	template <class T>
-	val<std::basic_ostream<CharT, Traits>>& operator<<(val<T>& value) {
+	val<std::basic_ostream<CharT, Traits>>& operator<<(const val<T>& value) {
 		invoke(pipe<T>, stream, value);
 		return *this;
 	}

--- a/nautilus/include/nautilus/std/ostream.h
+++ b/nautilus/include/nautilus/std/ostream.h
@@ -1,7 +1,9 @@
 #pragma once
 #include "nautilus/val_ptr.hpp"
+#include "nautilus/val.hpp"
+#include "nautilus/std/string.h"
 #include <ostream>
-#include <string>
+#include <ios>
 namespace nautilus {
 
 template <class _CharT, class _Traits>
@@ -33,6 +35,39 @@ void callFlush(std::basic_ostream<_CharT, _Traits>* ptr) {
 template <class _CharT, class _Traits>
 val<std::basic_ostream<_CharT, _Traits>>& flush(val<std::basic_ostream<_CharT, _Traits>>& __os) {
 	invoke(callFlush<_CharT, _Traits>, __os.stream);
+	return __os;
+}
+
+template <class _CharT, class _Traits>
+void callHex(std::basic_ostream<_CharT, _Traits>* ptr) {
+	std::hex(*ptr);
+}
+
+template <class _CharT, class _Traits>
+val<std::basic_ostream<_CharT, _Traits>>& hex(val<std::basic_ostream<_CharT, _Traits>>& __os) {
+	invoke(callHex<_CharT, _Traits>, __os.stream);
+	return __os;
+}
+
+template <class _CharT, class _Traits>
+void callDec(std::basic_ostream<_CharT, _Traits>* ptr) {
+	std::dec(*ptr);
+}
+
+template <class _CharT, class _Traits>
+val<std::basic_ostream<_CharT, _Traits>>& dec(val<std::basic_ostream<_CharT, _Traits>>& __os) {
+	invoke(callDec<_CharT, _Traits>, __os.stream);
+	return __os;
+}
+
+template <class _CharT, class _Traits>
+void callOct(std::basic_ostream<_CharT, _Traits>* ptr) {
+	std::oct(*ptr);
+}
+
+template <class _CharT, class _Traits>
+val<std::basic_ostream<_CharT, _Traits>>& oct(val<std::basic_ostream<_CharT, _Traits>>& __os) {
+	invoke(callOct<_CharT, _Traits>, __os.stream);
 	return __os;
 }
 

--- a/nautilus/test/execution-tests/std/OstreamTest.cpp
+++ b/nautilus/test/execution-tests/std/OstreamTest.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/Engine.hpp"
 #include "nautilus/std/iostream.h"
+#include "nautilus/std/ostream.h"
 #include "nautilus/std/sstream.h"
 #include "nautilus/std/string.h"
 #include "nautilus/std/string_view.h"
@@ -25,6 +26,24 @@ val<char> sstreamTest(val<int32_t> value) {
     return ss.view().data()[4];
 }*/
 
+void sstreamHexTest(val<int32_t> value) {
+	// allocates a stringstream, which is managed by the runtime and freed when the object goes out of scope
+	stringstream ss;
+	ss << hex << value << endl;
+}
+
+void sstreamDecTest(val<int32_t> value) {
+	// allocates a stringstream, which is managed by the runtime and freed when the object goes out of scope
+	stringstream ss;
+	ss << dec << value << endl;
+}
+
+void sstreamOctTest(val<int32_t> value) {
+	// allocates a stringstream, which is managed by the runtime and freed when the object goes out of scope
+	stringstream ss;
+	ss << oct << value << endl;
+}
+
 val<char> sstreamToStrTest(val<int32_t> value) {
 	// allocates a stringstream, which is managed by the runtime and freed when the object goes out of scope
 	stringstream ss;
@@ -48,6 +67,24 @@ void runOstreamTest(engine::NautilusEngine& engine) {
 		auto f = engine.registerFunction(cerrTest);
 		f(42);
 		f(44);
+	}
+
+	SECTION("hex") {
+		auto f = engine.registerFunction(sstreamHexTest);
+		f(42);
+		f(23);
+	}
+
+	SECTION("dec") {
+		auto f = engine.registerFunction(sstreamDecTest);
+		f(42);
+		f(23);
+	}
+
+	SECTION("oct") {
+		auto f = engine.registerFunction(sstreamOctTest);
+		f(42);
+		f(23);
 	}
 }
 


### PR DESCRIPTION
This PR adds `std::hex` to be used directly in `nautilus`.