### PR TITLE
fix mlir function type

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -183,10 +183,9 @@ mlir::arith::CmpIPredicate convertToBooleanMLIRComparison(ir::CompareOperation::
 
 mlir::FlatSymbolRefAttr MLIRLoweringProvider::insertExternalFunction(const std::string& name, void* functionPtr,
                                                                      const mlir::Type& resultType,
-                                                                     const std::vector<mlir::Type>& argTypes,
-                                                                     bool varArgs) {
+                                                                     const std::vector<mlir::Type>& argTypes) {
 	// Create function arg & result types (currently only int for result).
-	mlir::LLVM::LLVMFunctionType llvmFnType = mlir::LLVM::LLVMFunctionType::get(resultType, argTypes, varArgs);
+	mlir::LLVM::LLVMFunctionType llvmFnType = mlir::LLVM::LLVMFunctionType::get(resultType, argTypes);
 
 	// The InsertionGuard saves the current insertion point (IP) and restores it
 	// after scope is left.
@@ -543,7 +542,7 @@ void MLIRLoweringProvider::generateMLIR(ir::ProxyCallOperation* proxyCallOp, Val
 	} else {
 		functionRef = insertExternalFunction(proxyCallOp->getFunctionSymbol(), proxyCallOp->getFunctionPtr(),
 		                                     getMLIRType(proxyCallOp->getStamp()),
-		                                     getMLIRType(proxyCallOp->getInputArguments()), true);
+		                                     getMLIRType(proxyCallOp->getInputArguments()));
 	}
 
 	std::vector<mlir::Value> functionArgs;

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -144,10 +144,9 @@ private:
 	 * @param name: Function name.
 	 * @param numResultBits: Number of bits of returned Integer.
 	 * @param argTypes: Argument types of function.
-	 * @param varArgs: Include variable arguments.
 	 * @return FlatSymbolRefAttr: Reference to function used in CallOps.
 	 */
-	::mlir::FlatSymbolRefAttr insertExternalFunction(const std::string& name, void* functionPtr, const ::mlir::Type& resultType, const std::vector<::mlir::Type>& argTypes, bool varArgs);
+	::mlir::FlatSymbolRefAttr insertExternalFunction(const std::string& name, void* functionPtr, const ::mlir::Type& resultType, const std::vector<::mlir::Type>& argTypes);
 
 	/**
 	 * @brief Generates a Name(d)Loc(ation) that is attached to the operation.


### PR DESCRIPTION
This change fixes the function types in the mlir code generation. This is required for the support of llvm 19