### PR TITLE
Optimize LLVM initialization

### DIFF
--- a/nautilus/include/nautilus/JITCompiler.hpp
+++ b/nautilus/include/nautilus/JITCompiler.hpp
@@ -25,7 +25,7 @@ public:
 
 private:
 	const engine::Options options;
-	std::unique_ptr<CompilationBackendRegistry> backends;
+	const CompilationBackendRegistry* backends;
 };
 
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/JITCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/JITCompiler.cpp
@@ -10,7 +10,8 @@
 #include <random>
 #include <sstream>
 #include <string>
-#include <utility>
+#include <fmt/core.h>
+#include <fmt/chrono.h>
 
 #ifdef ENABLE_COMPILER
 
@@ -22,11 +23,11 @@
 
 namespace nautilus::compiler {
 
-JITCompiler::JITCompiler() : options(), backends(std::make_unique<CompilationBackendRegistry>()) {
+JITCompiler::JITCompiler() : options(), backends(CompilationBackendRegistry::getInstance()) {
 }
 
 JITCompiler::JITCompiler(engine::Options options)
-    : options(std::move(options)), backends(std::make_unique<CompilationBackendRegistry>()) {
+    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()) {
 }
 
 JITCompiler::~JITCompiler() = default;
@@ -35,13 +36,10 @@ JITCompiler::~JITCompiler() = default;
 
 std::string createCompilationUnitID() {
 	// Get the current time point
-	auto now = std::chrono::system_clock::now();
-	auto time = std::chrono::system_clock::to_time_t(now);
-	auto local_time = *std::localtime(&time);
-
 	// Create a timestamp string from the current time
-	std::ostringstream timestamp;
-	timestamp << std::put_time(&local_time, "%Y-%m-%d_%H-%M-%S");
+	
+	auto now = std::chrono::system_clock::now();
+	std::string timestamp = fmt::format(fmt::runtime("{:%Y-%m-%d_%H-%M-%S}"), now);
 
 	// Create a random device and generator
 	std::random_device rd;
@@ -59,7 +57,7 @@ std::string createCompilationUnitID() {
 	}
 
 	// Concatenate timestamp and UUID
-	return timestamp.str() + "_#" + uuid;
+	return timestamp + "_#" + uuid;
 }
 
 std::unique_ptr<Executable> JITCompiler::compile(JITCompiler::wrapper_function function) const {

--- a/nautilus/src/nautilus/compiler/backends/CompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/CompilationBackend.cpp
@@ -36,11 +36,16 @@ CompilationBackendRegistry::CompilationBackendRegistry() {
 }
 #endif
 
-CompilationBackend* CompilationBackendRegistry::getBackend(const std::string& name) {
+const CompilationBackendRegistry* CompilationBackendRegistry::getInstance() {
+	static auto registry = std::make_unique<CompilationBackendRegistry>(CompilationBackendRegistry());
+	return registry.get();
+}
+
+const CompilationBackend* CompilationBackendRegistry::getBackend(const std::string& name) const {
 	if (!items.contains(name)) {
 		throw RuntimeException("Backend not available");
 	}
-	return items[name].get();
+	return items.at(name).get();
 }
 
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/backends/CompilationBackend.hpp
+++ b/nautilus/src/nautilus/compiler/backends/CompilationBackend.hpp
@@ -19,17 +19,17 @@ public:
 	 * @brief Compiles ir graph to executable.
 	 * @return std::unique_ptr<Executable>
 	 */
-	virtual std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler, const engine::Options& options) = 0;
+	virtual std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler, const engine::Options& options) const = 0;
 
 	virtual ~CompilationBackend();
 };
 
 class CompilationBackendRegistry {
 public:
-	CompilationBackendRegistry();
-	CompilationBackend* getBackend(const std::string& name);
-
+	static const CompilationBackendRegistry* getInstance();
+	const CompilationBackend* getBackend(const std::string& name) const;
 private:
+	CompilationBackendRegistry();
 	std::map<std::string, std::unique_ptr<CompilationBackend>> items = std::map<std::string, std::unique_ptr<CompilationBackend>>();
 };
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -8,7 +8,8 @@
 namespace nautilus::compiler::bc {
 
 std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<ir::IRGraph>& ir,
-                                                          const DumpHandler& dumpHandler, const engine::Options&) {
+                                                          const DumpHandler& dumpHandler,
+                                                          const engine::Options&) const {
 	auto result = BCLoweringProvider().lower(ir);
 	auto code = std::get<0>(result);
 	dumpHandler.dump("after_bc_generation", "bc", [&]() { return code.toString(); });

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.hpp
@@ -9,7 +9,7 @@ namespace nautilus::compiler::bc {
  */
 class BCInterpreterBackend : public CompilationBackend {
 public:
-	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir,const DumpHandler& dumpHandler, const engine::Options& options) override;
+	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir,const DumpHandler& dumpHandler, const engine::Options& options) const override;
 };
 
 } // namespace nautilus::compiler::bc

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPCompilationBackend.cpp
@@ -7,7 +7,8 @@
 namespace nautilus::compiler::cpp {
 
 std::unique_ptr<Executable> CPPCompilationBackend::compile(const std::shared_ptr<ir::IRGraph>& ir,
-                                                           const DumpHandler& dumpHandler, const engine::Options&) {
+                                                           const DumpHandler& dumpHandler,
+                                                           const engine::Options&) const {
 	auto code = CPPLoweringProvider::lower(ir);
 	dumpHandler.dump("after_c_generation", ".c", [&]() { return code; });
 

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPCompilationBackend.hpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPCompilationBackend.hpp
@@ -10,7 +10,7 @@ namespace nautilus::compiler::cpp {
  */
 class CPPCompilationBackend : public CompilationBackend {
 public:
-	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler, const engine::Options& options) override;
+	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler, const engine::Options& options) const override;
 };
 
 } // namespace nautilus::compiler::cpp

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
@@ -26,10 +26,6 @@ JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
 		llvm::errs() << "Failed to emit LLVM IR\n";
 	}
 
-	// Initialize information about the local machine in LLVM.
-	LLVMInitializeNativeTarget();
-	LLVMInitializeNativeAsmPrinter();
-
 	// Create MLIR execution engine (wrapper around LLVM ExecutionEngine).
 	::mlir::ExecutionEngineOptions options;
 	options.jitCodeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
@@ -16,9 +16,15 @@
 
 namespace nautilus::compiler::mlir {
 
+MLIRCompilationBackend::MLIRCompilationBackend() {
+	// Initialize information about the local machine in LLVM.
+	LLVMInitializeNativeTarget();
+	LLVMInitializeNativeAsmPrinter();
+}
+
 std::unique_ptr<Executable> MLIRCompilationBackend::compile(const std::shared_ptr<ir::IRGraph>& ir,
                                                             const DumpHandler& dumpHandler,
-                                                            const engine::Options& options) {
+                                                            const engine::Options& options) const {
 
 	// 1. Create the MLIRLoweringProvider and lower the given NESIR. Return an
 	// MLIR module.

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.hpp
@@ -9,7 +9,8 @@ namespace nautilus::compiler::mlir {
  */
 class MLIRCompilationBackend : public CompilationBackend {
 public:
-	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler, const engine::Options& options) override;
+	MLIRCompilationBackend();
+	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler, const engine::Options& options) const override;
 };
 
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -540,9 +540,9 @@ void MLIRLoweringProvider::generateMLIR(ir::ProxyCallOperation* proxyCallOp, Val
 	if (theModule.lookupSymbol<mlir::LLVM::LLVMFuncOp>(proxyCallOp->getFunctionSymbol())) {
 		functionRef = mlir::SymbolRefAttr::get(context, proxyCallOp->getFunctionSymbol());
 	} else {
-		functionRef = insertExternalFunction(proxyCallOp->getFunctionSymbol(), proxyCallOp->getFunctionPtr(),
-		                                     getMLIRType(proxyCallOp->getStamp()),
-		                                     getMLIRType(proxyCallOp->getInputArguments()));
+		functionRef =
+		    insertExternalFunction(proxyCallOp->getFunctionSymbol(), proxyCallOp->getFunctionPtr(),
+		                           getMLIRType(proxyCallOp->getStamp()), getMLIRType(proxyCallOp->getInputArguments()));
 	}
 
 	std::vector<mlir::Value> functionArgs;

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -120,8 +120,8 @@ struct formatter<nautilus::compiler::ir::IRGraph> : formatter<std::string_view> 
 
 template <>
 struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::OperationIdentifier& op,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::OperationIdentifier& op, format_context& ctx)
+	    -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", op.getId());
 		return out;
@@ -130,8 +130,8 @@ struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::s
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlockInvocation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op, format_context& ctx)
+	    -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "Block_{}(", op.getBlock()->getIdentifier());
 		const auto& args = op.getArguments();
@@ -158,8 +158,8 @@ struct formatter<nautilus::compiler::ir::IfOperation> : formatter<std::string_vi
 
 template <>
 struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op, format_context& ctx)
+	    -> format_context::iterator {
 		auto out = ctx.out();
 
 		if (op.getStamp() != nautilus::Type::v) {
@@ -239,8 +239,8 @@ struct formatter<nautilus::compiler::ir::Operation> : formatter<std::string_view
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlock& block,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlock& block, format_context& ctx)
+	    -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "\nBlock_{}(", block.getIdentifier());
 		const auto& args = block.getArguments();
@@ -261,8 +261,8 @@ struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_vie
 
 template <>
 struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::FunctionOperation& func,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::FunctionOperation& func, format_context& ctx)
+	    -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}(", func.getName());
 		for (const auto& arg : func.getInputArgNames()) {

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -283,8 +283,8 @@ auto formatter<nautilus::tracing::ExecutionTrace>::format(const nautilus::tracin
 	return out;
 }
 
-auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block& block,
-                                                 format_context& ctx) -> format_context::iterator {
+auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block& block, format_context& ctx)
+    -> format_context::iterator {
 	auto out = ctx.out();
 	fmt::format_to(out, "(");
 	for (size_t i = 0; i < block.arguments.size(); i++) {
@@ -306,8 +306,8 @@ auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block&
 
 template <>
 struct formatter<nautilus::tracing::TypedValueRef> : formatter<std::string_view> {
-	static auto format(const nautilus::tracing::TypedValueRef& typeValRef,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(const nautilus::tracing::TypedValueRef& typeValRef, format_context& ctx)
+	    -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", typeValRef.ref);
 		return out;

--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
@@ -18,7 +18,7 @@ TagRecorder::TagRecorder(TagAddress startAddress) : startAddress(startAddress) {
 // check if gnu backtrace is available.
 #if defined(BACKWARD_HAS_BACKTRACE) & !defined(HOST_IS_MUSL)
 TagVector TagRecorder::createBaseTag() {
-        void* tagBuffer[MAX_TAG_SIZE];
+	void* tagBuffer[MAX_TAG_SIZE];
 	int size = backtrace(tagBuffer, MAX_TAG_SIZE);
 	std::vector<TagAddress> addresses;
 	for (int i = 0; i < size; i++) {
@@ -106,16 +106,18 @@ Tag* TagRecorder::createReferenceTag() {
 
 template <size_t StackSize>
 __attribute__((noinline)) void* get_addr(size_t index) {
-    return [&]<std::size_t... ints>(std::index_sequence<ints...>) __attribute__((noinline)) {
-        void* addr = nullptr;
-        (void)((index == ints && (void(addr = __builtin_extract_return_addr(__builtin_return_address(ints + 2))), true)) || ...);
-        return addr;
-    }(std::make_index_sequence<StackSize>{});
+	return [&]<std::size_t... ints>(std::index_sequence<ints...>) __attribute__((noinline)) {
+		void* addr = nullptr;
+		(void) ((index == ints &&
+		         (void(addr = __builtin_extract_return_addr(__builtin_return_address(ints + 2))), true)) ||
+		        ...);
+		return addr;
+	}
+	(std::make_index_sequence<StackSize> {});
 }
 
 static void* getReturnAddress(uint32_t offset) {
 	return get_addr<TagRecorder::MAX_TAG_SIZE>(offset);
 }
-
 
 } // namespace nautilus::tracing


### PR DESCRIPTION
This change ensures that all Nautilus compilation backends are only initialized once. As a result, LLVMInitializeNativeTarget and LLVMInitializeNativeAsmPrinter are only called one time per process.