### PR TITLE
Constrains modulo operator to integer types

### DIFF
--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -337,7 +337,7 @@ DEFINE_BINARY_OPERATOR(*, mul, is_fundamental_val, convertible_to_fundamental)
 
 DEFINE_BINARY_OPERATOR(/, div, is_fundamental_val, convertible_to_fundamental)
 
-DEFINE_BINARY_OPERATOR(%, mod, is_fundamental_val, convertible_to_fundamental)
+DEFINE_BINARY_OPERATOR(%, mod, is_integral_val, is_integral)
 
 DEFINE_BINARY_OPERATOR(==, eq, is_fundamental_val, convertible_to_fundamental)
 


### PR DESCRIPTION
Modulo (at least using operator%) does not work for floating points. This PR constraints the modulo implementation to `std::integral`.