### PR TITLE
feat(Val): Made it possible to specialize the val<> by using structs instead of template methods

### DIFF
--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -19,7 +19,7 @@ namespace details {
  */
 template <typename ArgValueType, size_t I>
 auto createTraceableArgument() {
-	auto type = tracing::to_type<typename ArgValueType::raw_type>();
+	auto type = tracing::TypeResolver<typename ArgValueType::raw_type>::to_type();
 	auto valueRef = tracing::registerFunctionArgument(type, I);
 	return val<typename ArgValueType::raw_type>(valueRef);
 }
@@ -35,7 +35,7 @@ std::function<void()> createFunctionWrapper(std::index_sequence<Indices...>, std
 			tracing::traceReturnOperation(Type::v, tracing::TypedValueRef());
 		} else {
 			auto returnValue = func(details::createTraceableArgument<FunctionArguments, Indices>()...);
-			auto type = tracing::to_type<typename decltype(returnValue)::raw_type>();
+			auto type = tracing::TypeResolver<typename decltype(returnValue)::raw_type>::to_type();
 			tracing::traceReturnOperation(type, returnValue.state);
 		}
 	};
@@ -78,7 +78,7 @@ public:
 		// no executable is defined, call the underling function directly and convert all arguments to val objects
 		if (executable == nullptr) {
 			auto result = func(make_value((args))...);
-			return nautilus::details::getRawValue(result);
+			return nautilus::details::RawValueResolver<typename R::raw_type>::getRawValue(result);
 		}
 		auto callable = this->executable->template getInvocableMember<typename R::raw_type, FunctionArguments...>("execute");
 		return callable(args...);

--- a/nautilus/include/nautilus/function.hpp
+++ b/nautilus/include/nautilus/function.hpp
@@ -13,7 +13,7 @@ auto getArgumentReferences(const ValueArguments&... arguments) {
 	std::vector<tracing::TypedValueRef> functionArgumentReferences;
 	if constexpr (sizeof...(ValueArguments) > 0) {
 		functionArgumentReferences.reserve(sizeof...(ValueArguments));
-		for (const tracing::TypedValueRef& p : {details::getState(arguments)...}) {
+		for (const tracing::TypedValueRef& p : {details::StateResolver<const ValueArguments&>::getState(arguments)...}) {
 			functionArgumentReferences.emplace_back(p);
 		}
 	}
@@ -32,11 +32,11 @@ public:
 #ifdef ENABLE_TRACING
 		if (tracing::inTracer()) {
 			auto functionArgumentReferences = getArgumentReferences(std::forward<FunctionArgumentsRaw>(args)...);
-			auto resultRef = tracing::traceCall(reinterpret_cast<void*>(fnptr), tracing::to_type<R>(), functionArgumentReferences);
+			auto resultRef = tracing::traceCall(reinterpret_cast<void*>(fnptr), tracing::TypeResolver<R>::to_type(), functionArgumentReferences);
 			return val<R>(resultRef);
 		}
 #endif
-		return val<R>(fnptr(details::getRawValue(std::forward<FunctionArgumentsRaw>(args))...));
+		return val<R>(fnptr(details::RawValueResolver<FunctionArguments>::getRawValue(std::forward<FunctionArgumentsRaw>(args))...));
 	}
 
 	template <typename... FunctionArgumentsRaw>
@@ -49,7 +49,7 @@ public:
 			return;
 		}
 #endif
-		fnptr(details::getRawValue(std::forward<FunctionArgumentsRaw>(args))...);
+		(fnptr(details::RawValueResolver<FunctionArguments>::getRawValue(std::forward<FunctionArgumentsRaw>(args))...));
 	}
 
 	template <is_integral... FunctionArgumentsRaw>

--- a/nautilus/include/nautilus/std/string_view.h
+++ b/nautilus/include/nautilus/std/string_view.h
@@ -25,15 +25,15 @@ public:
 
 	val(val<const CharT*> s, val<size_type> count) : data_ptr(nullptr) {
 		// call new on val<base_type *>
-		auto raw_s = details::getRawValue(s);
-		auto raw_count = details::getRawValue(count);
+		auto raw_s = details::RawValueResolver<const CharT*>::getRawValue(s);
+		auto raw_count = details::RawValueResolver<size_type>::getRawValue(count);
 		auto string_vew = new std::basic_string_view<CharT, Traits>(raw_s, raw_count);
 		data_ptr = val<base_type*>(string_vew);
 	}
 
 	val(val<const CharT*> s) : data_ptr(nullptr) {
 		// call new on val<base_type *>
-		// auto raw_s = details::getRawValue(s);
+		// auto raw_s = details::RawValueResolver<typename std::remove_cvref_t<decltype((s))>::raw_type>::getRawValue(s);
 		// auto string_vew = new std::basic_string_view<CharT, Traits>(raw_s);
 		auto ptr = invoke(
 		    +[](const CharT* s) -> auto { return new std::basic_string_view<CharT, Traits>(s); }, s);

--- a/nautilus/include/nautilus/tracing/TracingUtil.hpp
+++ b/nautilus/include/nautilus/tracing/TracingUtil.hpp
@@ -23,9 +23,9 @@ TypedValueRef& traceConstant(Type type, const ConstantLiteral& value);
 template <typename T>
 TypedValueRef traceConstant(T&& value) {
 	if (inTracer()) {
-		return traceConstant(to_type<T>(), createConstLiteral(value));
+		return traceConstant(TypeResolver<T>::to_type(), createConstLiteral(value));
 	}
-	return {0, to_type<T>()};
+	return {0, TypeResolver<T>::to_type()};
 }
 
 void traceAssignment(const TypedValueRef& target, const TypedValueRef& source, Type resultType);

--- a/nautilus/include/nautilus/tracing/Types.hpp
+++ b/nautilus/include/nautilus/tracing/Types.hpp
@@ -33,37 +33,42 @@ constexpr ConstantLiteral createConstLiteral(T&& t) noexcept {
  * @tparam T
  * @return Type
  */
+template <typename T>
+struct TypeResolver {};
+
 template <is_compatible_val_type T>
-constexpr Type to_type() {
-	using type = std::remove_cvref_t<T>;
-	if constexpr (std::is_same_v<type, bool>) {
-		return Type::b;
-	} else if constexpr (std::is_same_v<type, int8_t> || (std::is_same_v<type, char>) ) {
-		return Type::i8;
-	} else if constexpr (std::is_same_v<type, int16_t>) {
-		return Type::i16;
-	} else if constexpr (std::is_same_v<type, int32_t>) {
-		return Type::i32;
-	} else if constexpr (std::is_same_v<type, int64_t>) {
-		return Type::i64;
-	} else if constexpr (std::is_same_v<type, uint8_t>) {
-		return Type::ui8;
-	} else if constexpr (std::is_same_v<type, uint16_t>) {
-		return Type::ui16;
-	} else if constexpr (std::is_same_v<type, uint32_t>) {
-		return Type::ui32;
-	} else if constexpr (std::is_same_v<type, uint64_t> || std::is_same_v<type, size_t>) {
-		return Type::ui64;
-	} else if constexpr (std::is_same_v<type, float>) {
-		return Type::f32;
-	} else if constexpr (std::is_same_v<type, double>) {
-		return Type::f64;
-	} else if constexpr (std::is_pointer_v<type>) {
-		return Type::ptr;
-	} else {
-		return Type::v;
+struct TypeResolver<T> {
+    [[nodiscard]] static constexpr Type to_type() {
+		using type = std::remove_cvref_t<T>;
+		if constexpr (std::is_same_v<type, bool>) {
+			return Type::b;
+		} else if constexpr (std::is_same_v<type, int8_t> || (std::is_same_v<type, char>) ) {
+			return Type::i8;
+		} else if constexpr (std::is_same_v<type, int16_t>) {
+			return Type::i16;
+		} else if constexpr (std::is_same_v<type, int32_t>) {
+			return Type::i32;
+		} else if constexpr (std::is_same_v<type, int64_t>) {
+			return Type::i64;
+		} else if constexpr (std::is_same_v<type, uint8_t>) {
+			return Type::ui8;
+		} else if constexpr (std::is_same_v<type, uint16_t>) {
+			return Type::ui16;
+		} else if constexpr (std::is_same_v<type, uint32_t>) {
+			return Type::ui32;
+		} else if constexpr (std::is_same_v<type, uint64_t> || std::is_same_v<type, size_t>) {
+			return Type::ui64;
+		} else if constexpr (std::is_same_v<type, float>) {
+			return Type::f32;
+		} else if constexpr (std::is_same_v<type, double>) {
+			return Type::f64;
+		} else if constexpr (std::is_pointer_v<type>) {
+			return Type::ptr;
+		} else {
+			return Type::v;
+		}
 	}
-}
+};
 } // namespace tracing
 
 constexpr const char* toString(Type type) {

--- a/nautilus/include/nautilus/val_enum.hpp
+++ b/nautilus/include/nautilus/val_enum.hpp
@@ -24,14 +24,19 @@ public:
 #ifdef ENABLE_TRACING
 	template <T>
 	    requires std::is_enum_v<T> && (!std::is_convertible_v<T, std::underlying_type_t<T>>)
-	val(T val) : state(tracing::traceConstant(static_cast<std::underlying_type_t<T>>(val))), value(static_cast<std::underlying_type_t<T>>(val)) {
+	val(T val)
+	    : state(tracing::traceConstant(static_cast<std::underlying_type_t<T>>(val))),
+	      value(static_cast<std::underlying_type_t<T>>(val)) {
 	}
 
 	template <T>
 	    requires std::is_enum_v<T> && (!std::is_convertible_v<T, std::underlying_type_t<T>>)
-	val(val<T>& val) : state(tracing::traceConstant(static_cast<std::underlying_type_t<T>>(val))), value(static_cast<std::underlying_type_t<T>>(val)) {
+	val(val<T>& val)
+	    : state(tracing::traceConstant(static_cast<std::underlying_type_t<T>>(val))),
+	      value(static_cast<std::underlying_type_t<T>>(val)) {
 	}
-	val(val<underlying_type_t> t) : state(t.state), value((T) details::getRawValue(t)) {
+	val(val<underlying_type_t> t)
+	    : state(t.state), value((T) details::RawValueResolver<underlying_type_t>::getRawValue(t)) {
 	}
 	val(val<T>& t) : state(tracing::traceCopy(t.state)), value(t.value) {
 	}
@@ -50,14 +55,13 @@ public:
 	val(val<T>& val) : value(static_cast<std::underlying_type_t<T>>(val)) {
 	}
 
-	val(val<underlying_type_t> t) : value((T) details::getRawValue(t)) {
+	val(val<underlying_type_t> t) : value((T) details::RawValueResolver<underlying_type_t>::getRawValue(t)) {
 	}
 	val(val<T>& t) : value(t.value) {
 	}
 	val(T val) : value(val) {
 	}
 #endif
-
 
 	val<bool> operator==(val<T>& other) const {
 #ifdef ENABLE_TRACING
@@ -100,7 +104,7 @@ public:
 	val<T>& operator=(const val<T>& other) {
 #ifdef ENABLE_TRACING
 		if (tracing::inTracer()) {
-			tracing::traceAssignment(state, other.state, tracing::to_type<underlying_type_t>());
+			tracing::traceAssignment(state, other.state, tracing::TypeResolver<underlying_type_t>::to_type());
 		}
 #endif
 		this->value = other.value;
@@ -112,12 +116,12 @@ public:
 #endif
 
 private:
-	friend T details::getRawValue<T>(const val<T>& left);
+	friend details::RawValueResolver<T>;
 	const T value;
 };
 
 template <typename Type>
-requires std::is_enum_v<Type>
+    requires std::is_enum_v<Type>
 auto inline make_value(const Type& value) {
 	return val<Type>(value);
 }

--- a/nautilus/include/nautilus/val_ptr.hpp
+++ b/nautilus/include/nautilus/val_ptr.hpp
@@ -42,8 +42,8 @@ public:
 			return;
 		}
 #endif
-		auto rawPtr = details::getRawValue(ptr);
-		*rawPtr = details::getRawValue(value);
+		auto rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((ptr))>::raw_type>::getRawValue(ptr);
+		*rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((value))>::raw_type>::getRawValue(value);
 	}
 
 	template <class T>
@@ -56,19 +56,19 @@ public:
 			return;
 		}
 #endif
-		auto rawPtr = details::getRawValue(ptr);
-		*rawPtr = details::getRawValue(other);
+		auto rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((ptr))>::raw_type>::getRawValue(ptr);
+		*rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((other))>::raw_type>::getRawValue(other);
 	}
 
 	operator val<baseType>() {
 		// load
 #ifdef ENABLE_TRACING
 		if (tracing::inTracer()) {
-			auto& ref = tracing::traceUnaryOp(tracing::LOAD, tracing::to_type<ValueType>(), ptr.state);
+			auto& ref = tracing::traceUnaryOp(tracing::LOAD, tracing::TypeResolver<ValueType>::to_type(), ptr.state);
 			return val<baseType>(ref);
 		}
 #endif
-		auto rawPtr = details::getRawValue(ptr);
+		auto rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((ptr))>::raw_type>::getRawValue(ptr);
 		return val<baseType>(*rawPtr);
 	}
 
@@ -126,7 +126,7 @@ public:
 	val<ValuePtrType>& operator=(const val<ValuePtrType>& other) {
 #ifdef ENABLE_TRACING
 		if (tracing::inTracer()) {
-			tracing::traceAssignment(this->state, other.state, tracing::to_type<ValuePtrType>());
+			tracing::traceAssignment(this->state, other.state, tracing::TypeResolver<ValuePtrType>::to_type());
 		}
 #endif
 		this->value = other.value;
@@ -203,7 +203,7 @@ public:
 	val<ValuePtrType>& operator=(const val<ValuePtrType>& other) {
 #ifdef ENABLE_TRACING
 		if (tracing::inTracer()) {
-			tracing::traceAssignment(this->state, other.state, tracing::to_type<ValuePtrType>());
+			tracing::traceAssignment(this->state, other.state, tracing::TypeResolver<ValuePtrType>::to_type());
 		}
 #endif
 		this->value = other.value;
@@ -229,11 +229,11 @@ val<ValueType> inline operator+(val<ValueType> left, IndexType offset) {
 	auto offsetBytes = offsetValue * size;
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::ADD, tracing::to_type<ValueType>(), left.state, offsetBytes.state);
+		auto tc = tracing::traceBinaryOp(tracing::ADD, tracing::TypeResolver<ValueType>::to_type(), left.state, offsetBytes.state);
 		return val<ValueType>(tc);
 	}
 #endif
-	auto newPtr = (ValueType) (((uint8_t*) left.value) + details::getRawValue(offsetBytes));
+	auto newPtr = (ValueType) (((uint8_t*) left.value) + details::RawValueResolver<typename std::remove_cvref_t<decltype((offsetBytes))>::raw_type>::getRawValue(offsetBytes));
 	return val<ValueType>(newPtr);
 }
 
@@ -254,7 +254,7 @@ auto inline operator==(val<ValueType> left, val<ValueType> right) {
 
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::EQ, tracing::to_type<bool>(), left.state, right.state);
+		auto tc = tracing::traceBinaryOp(tracing::EQ, tracing::TypeResolver<bool>::to_type(), left.state, right.state);
 		return val<bool>(tc);
 	}
 #endif
@@ -280,7 +280,7 @@ template <typename ValueType>
 auto inline operator<=(val<ValueType> left, val<ValueType> right) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::LTE, tracing::to_type<bool>(), left.state, right.state);
+		auto tc = tracing::traceBinaryOp(tracing::LTE, tracing::TypeResolver<bool>::to_type(), left.state, right.state);
 		return val<bool>(tc);
 	}
 #endif
@@ -292,7 +292,7 @@ template <typename ValueType>
 auto inline operator<(val<ValueType> left, val<ValueType> right) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::LT, tracing::to_type<bool>(), left.state, right.state);
+		auto tc = tracing::traceBinaryOp(tracing::LT, tracing::TypeResolver<bool>::to_type(), left.state, right.state);
 		return val<bool>(tc);
 	}
 #endif
@@ -304,7 +304,7 @@ template <typename ValueType>
 auto inline operator>(val<ValueType> left, val<ValueType> right) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::GT, tracing::to_type<bool>(), left.state, right.state);
+		auto tc = tracing::traceBinaryOp(tracing::GT, tracing::TypeResolver<bool>::to_type(), left.state, right.state);
 		return val<bool>(tc);
 	}
 #endif
@@ -316,7 +316,7 @@ template <typename ValueType>
 auto inline operator>=(val<ValueType> left, val<ValueType> right) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::GTE, tracing::to_type<bool>(), left.state, right.state);
+		auto tc = tracing::traceBinaryOp(tracing::GTE, tracing::TypeResolver<bool>::to_type(), left.state, right.state);
 		return val<bool>(tc);
 	}
 #endif
@@ -328,7 +328,7 @@ template <typename ValueType>
 auto inline operator!=(val<ValueType> left, val<ValueType> right) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
-		auto tc = tracing::traceBinaryOp(tracing::NEQ, tracing::to_type<bool>(), left.state, right.state);
+		auto tc = tracing::traceBinaryOp(tracing::NEQ, tracing::TypeResolver<bool>::to_type(), left.state, right.state);
 		return val<bool>(tc);
 	}
 #endif
@@ -383,8 +383,8 @@ public:
 			return;
 		}
 #endif
-		auto rawPtr = details::getRawValue(ptr);
-		*rawPtr = details::getRawValue(value);
+		auto rawPtr = details::RawValueResolver<bool*>::getRawValue(ptr);
+		*rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((value))>::raw_type>::getRawValue(value);
 	}
 
 	template <class T>
@@ -397,19 +397,19 @@ public:
 			return;
 		}
 #endif
-		auto rawPtr = details::getRawValue(ptr);
-		*rawPtr = details::getRawValue(other);
+		auto rawPtr = details::RawValueResolver<bool*>::getRawValue(ptr);
+		*rawPtr = details::RawValueResolver<typename std::remove_cvref_t<decltype((other))>::raw_type>::getRawValue(other);
 	}
 
 	operator val<baseType>() {
 		// load
 #ifdef ENABLE_TRACING
 		if (tracing::inTracer()) {
-			auto& ref = tracing::traceUnaryOp(tracing::LOAD, tracing::to_type<baseType>(), ptr.state);
+			auto& ref = tracing::traceUnaryOp(tracing::LOAD, tracing::TypeResolver<baseType>::to_type(), ptr.state);
 			return val<baseType>(ref);
 		}
 #endif
-		auto rawPtr = details::getRawValue(ptr);
+		auto rawPtr = details::RawValueResolver<bool*>::getRawValue(ptr);
 		return val<baseType>(*rawPtr);
 	}
 

--- a/nautilus/test/common/TracingUtil.hpp
+++ b/nautilus/test/common/TracingUtil.hpp
@@ -17,7 +17,7 @@ std::function<void()> createFunctionWrapper(std::index_sequence<Indices...>, R (
 			tracing::traceReturnOperation(Type::v, tracing::TypedValueRef());
 		} else {
 			auto returnValue = fnptr(details::createTraceableArgument<FunctionArguments, Indices>()...);
-			auto type = tracing::to_type<typename decltype(returnValue)::basic_type>();
+			auto type = tracing::TypeResolver<typename decltype(returnValue)::basic_type>::to_type();
 			tracing::traceReturnOperation(type, returnValue.state);
 		}
 	};

--- a/nautilus/test/execution-tests/TracingTest.cpp
+++ b/nautilus/test/execution-tests/TracingTest.cpp
@@ -39,7 +39,7 @@ std::function<void()> createFunctionWrapper(std::index_sequence<Indices...>, R (
 			tracing::traceReturnOperation(Type::v, tracing::TypedValueRef());
 		} else {
 			auto returnValue = fnptr(details::createTraceableArgument<FunctionArguments, Indices>()...);
-			auto type = tracing::to_type<typename decltype(returnValue)::raw_type>();
+			auto type = tracing::TypeResolver<typename decltype(returnValue)::raw_type>::to_type();
 			tracing::traceReturnOperation(type, returnValue.state);
 		}
 	};

--- a/nautilus/test/val-tests/FloatValTypeTest.cpp
+++ b/nautilus/test/val-tests/FloatValTypeTest.cpp
@@ -46,21 +46,21 @@ TEMPLATE_TEST_CASE("Float Val Operation Test", "[value][template]", float, doubl
 			auto f1 = val<TestType>(static_cast<TestType>(42.5));
 			auto f2 = val<TestType>(static_cast<TestType>(42.2));
 			auto res = f1 - f2;
-			auto x = details::getRawValue(res);
+			auto x = details::RawValueResolver<typename std::remove_cvref_t<decltype((res))>::raw_type>::getRawValue(res);
 			REQUIRE(x == Catch::Approx(0.3));
 		}
 		SECTION("*") {
 			auto f1 = val<TestType>(static_cast<TestType>(5.5));
 			auto f2 = val<TestType>(static_cast<TestType>(5.5));
 			auto res = f1 * f2;
-			auto x = details::getRawValue(res);
+			auto x = details::RawValueResolver<typename std::remove_cvref_t<decltype((res))>::raw_type>::getRawValue(res);
 			REQUIRE(x == Catch::Approx(30.25));
 		}
 		SECTION("/") {
 			auto f1 = val<TestType>(static_cast<TestType>(21.1));
 			auto f2 = val<TestType>(static_cast<TestType>(7));
 			auto res = f1 / f2;
-			auto x = details::getRawValue(res);
+			auto x = details::RawValueResolver<typename std::remove_cvref_t<decltype((res))>::raw_type>::getRawValue(res);
 			REQUIRE(x == Catch::Approx(3.0142857143));
 		}
 	}


### PR DESCRIPTION
Made it possible to specialize the val<>, e.g., `template <typename T, typename Tag, T Invalid, T Initial>
class val<NES::NESStrongType<T, Tag, Invalid, Initial>>`. 

