### PR TITLE
Cache Invocable and prevent concurrent access into orc

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -536,6 +536,7 @@ std::any BCInterpreter::invokeGeneric(const std::vector<std::any>& args) {
 		;
 	}
 	assert(false);
+	return nullptr;
 }
 
 int64_t BCInterpreter::execute(RegisterFile& regs) const {

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -59,6 +59,7 @@ std::string CPPLoweringProvider::LoweringContext::getType(const Type& stamp) {
 		return "uint8_t*";
 	}
 	assert(false);
+	return "unknown";
 }
 
 std::stringstream CPPLoweringProvider::LoweringContext::process() {

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.cpp
@@ -6,10 +6,27 @@
 #include <mlir/IR/MLIRContext.h>
 
 namespace nautilus::compiler::mlir {
+static std::mutex llvm_jit_mutex {};
+
 MLIRExecutable::MLIRExecutable(std::unique_ptr<::mlir::ExecutionEngine> engine) : engine(std::move(engine)) {
 }
-
+MLIRExecutable::~MLIRExecutable() {
+	if (engine) {
+		std::scoped_lock lock(llvm_jit_mutex);
+		engine.reset();
+	}
+}
+MLIRExecutable::MLIRExecutable(MLIRExecutable&& other) noexcept
+    : engine(std::move(other.engine)) {
+}
+MLIRExecutable& MLIRExecutable::operator=(MLIRExecutable&& other) noexcept {
+	if (this == &other)
+		return *this;
+	engine = std::move(other.engine);
+	return *this;
+}
 void* MLIRExecutable::getInvocableFunctionPtr(const std::string& member) {
+	std::scoped_lock lock(llvm_jit_mutex);
 	return engine->lookup(member).get();
 }
 bool MLIRExecutable::hasInvocableFunctionPtr() {

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.hpp
@@ -11,6 +11,11 @@ namespace nautilus::compiler::mlir {
 class MLIRExecutable : public Executable {
 public:
 	MLIRExecutable(std::unique_ptr<::mlir::ExecutionEngine> engine);
+	~MLIRExecutable() override;
+	MLIRExecutable(const MLIRExecutable& other) = delete;
+	MLIRExecutable(MLIRExecutable&& other) noexcept;
+	MLIRExecutable& operator=(const MLIRExecutable& other) = delete;
+	MLIRExecutable& operator=(MLIRExecutable&& other) noexcept;
 
 protected:
 	void* getInvocableFunctionPtr(const std::string& member) override;

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -157,6 +157,7 @@ mlir::LLVM::ICmpPredicate convertToLLVMComparison(ir::CompareOperation::Comparat
 		return mlir::LLVM::ICmpPredicate::ne;
 	default:
 		assert(false);
+		return mlir::LLVM::ICmpPredicate::ult;
 	}
 }
 
@@ -178,6 +179,7 @@ mlir::arith::CmpIPredicate convertToBooleanMLIRComparison(ir::CompareOperation::
 		return mlir::arith::CmpIPredicate::sge;
 	default:
 		assert(false);
+		return mlir::arith::CmpIPredicate::sge;
 	}
 }
 

--- a/nautilus/src/nautilus/tracing/TraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/TraceContext.cpp
@@ -55,7 +55,7 @@ bool TraceContext::isFollowing() {
 	return symbolicExecutionContext->getCurrentMode() == SymbolicExecutionContext::MODE::FOLLOW;
 }
 
-TypedValueRef& TraceContext::follow(Op op) {
+TypedValueRef& TraceContext::follow([[maybe_unused]] Op op) {
 	auto& currentOperation = executionTrace->getCurrentOperation();
 	executionTrace->nextOperation();
 	assert(currentOperation.op == op);


### PR DESCRIPTION
Whenever invoked, the `CallableFunction` wrapper locates the executable within the LLVM context.
This makes calling a function not thread-safe as the underlying LLVM implementation is not thread-safe and introduces an unnecessary overhead.

For small functions, this lookup dominates the runtime. Note: This benchmark only measures the invocation. Compilation is done beforehand.

```c++
static nautilus::val<int> smallFunction(nautilus::val<int> i) {
	return i * 2;
}
```

```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
BM_smallFunctionCompiler          1187 ns         1183 ns       565135
BM_smallFunctionInterpreter       62.7 ns         62.5 ns     11918221
```

This PR caches the `Invocable` produced by the Compiler during construction of the `CallableFunction` and thus skips the lookup within the invocation.

```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
BM_smallFunctionCompiler          3.65 ns         3.65 ns    191092600
BM_smallFunctionInterpreter       63.1 ns         63.1 ns     11229368
```

Note: we can remove the release mode and benchmark commit and only pick the relevant commit