### PR TITLE
fix(ExecutionTrace): fixed unintentional override of currentOp in get…

### DIFF
--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -133,13 +133,11 @@ void ExecutionTrace::nextOperation() {
 }
 
 TraceOperation& ExecutionTrace::getCurrentOperation() {
-	auto& currentOp = getCurrentBlock().operations[currentOperationIndex];
-	while (currentOp.op == JMP) {
-		auto& nextBlock = std::get<BlockRef>(currentOp.input[0]);
+	while (getCurrentBlock().operations[currentOperationIndex].op == JMP) {
+		auto& nextBlock = std::get<BlockRef>(getCurrentBlock().operations[currentOperationIndex].input[0]);
 		setCurrentBlock(nextBlock.block);
-		currentOp = getCurrentBlock().operations[currentOperationIndex];
 	}
-	return currentOp;
+	return getCurrentBlock().operations[currentOperationIndex];
 }
 
 uint16_t ExecutionTrace::createBlock() {


### PR DESCRIPTION
Prior, we declared currentOp as a mutable reference (`auto& currentOp = getCurrentBlock().operations[currentOperationIndex];`) and assigned to the reference of currentOp in the while loop (`currentOp = getCurrentBlock().operations[currentOperationIndex];`).
This caused an ugly, hard to pin-down bug where we would override operations of blocks with operations of their nextBlocks. 