### PR TITLE
Fixed wrong data type for initialization

### DIFF
--- a/nautilus/include/nautilus/val.hpp
+++ b/nautilus/include/nautilus/val.hpp
@@ -47,7 +47,7 @@ public:
 	using basic_type = ValueType;
 
 #ifdef ENABLE_TRACING
-	val() : state(tracing::traceConstant(0)) {
+	val() : state(tracing::traceConstant<raw_type>(0)), value(0) {
 	}
 	val(ValueType value) : state(tracing::traceConstant(value)), value(value) {
 	}
@@ -60,7 +60,7 @@ public:
 	val(tracing::TypedValueRef& tc) : state(tc), value() {
 	}
 #else
-	val() {
+	val() : value(0) {
 	}
 	val(ValueType value) : value(value) {
 	}

--- a/nautilus/test/common/ExpressionFunctions.hpp
+++ b/nautilus/test/common/ExpressionFunctions.hpp
@@ -68,6 +68,13 @@ auto subInt8AndInt8(val<int8_t> x, val<int8_t> y) {
 	return result;
 }
 
+auto mulInt64AndNotDefinedI64(val<int64_t> x) {
+	// We want to test, if the default initialization is correct
+	val<int64_t> y;
+	const auto result = x * y;
+	return result;
+}
+
 auto addInt8AndInt32(val<int8_t> x, val<int32_t> y) {
 	const auto result = x + y;
 	return result;

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -252,6 +252,14 @@ void expressionTests(engine::NautilusEngine& engine) {
 		REQUIRE(f((double) -14) == -7);
 	}
 
+	SECTION("mulInt64AndNotDefinedI64") {
+		auto f = engine.registerFunction(mulInt64AndNotDefinedI64);
+		REQUIRE(f((int64_t) 1) == 0);
+		REQUIRE(f((int64_t) -1) == 0);
+		REQUIRE(f((int64_t) 0) == 0);
+		REQUIRE(f((int64_t) 0) == 0);
+	}
+
 	SECTION("subInt8AndInt8") {
 		auto f = engine.registerFunction(subInt8AndInt8);
 		REQUIRE(f((int8_t) 1, (int8_t) 2) == -1);

--- a/nautilus/test/execution-tests/TracingTest.cpp
+++ b/nautilus/test/execution-tests/TracingTest.cpp
@@ -196,6 +196,7 @@ TEST_CASE("Expression Trace Test") {
 	    {"shiftRight_i8", details::createFunctionWrapper(shiftRight<int8_t>)},
 	    {"negate_i8", details::createFunctionWrapper(negate<int8_t>)},
 	    {"logicalNot_bool", details::createFunctionWrapper(logicalNot<bool>)},
+	    {"mulInt64AndNotDefinedI64", details::createFunctionWrapper(mulInt64AndNotDefinedI64)},
 	    {"subInt8AndInt8", details::createFunctionWrapper(subInt8AndInt8)},
 	    {"addInt8AndInt32", details::createFunctionWrapper(addInt8AndInt32)},
 	};


### PR DESCRIPTION
Fixed an error that would result in a tracing error, as the default constructor for `val<>` was defined incorrectly.
The bug was that the call to `tracing::traceConstant(0)` implicitly casted the underling state and value to a i32, regardless if `val<>` was defined with a different data type. 