### PR TITLE
fix(DumpHelper): Only create folder if necessary in the DumpHelper

### DIFF
--- a/nautilus/src/nautilus/compiler/DumpHandler.hpp
+++ b/nautilus/src/nautilus/compiler/DumpHandler.hpp
@@ -13,6 +13,7 @@ public:
 
 private:
 	[[nodiscard]] bool shouldDump(std::string_view dumpName) const;
+	[[nodiscard]] bool shallCreateFolder() const;
 	[[nodiscard]] bool dumpToConsole() const;
 	[[nodiscard]] bool dumpToFile() const;
 	const engine::Options& options;

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(nautilus-execution-tests
         ExecutionTest.cpp
         BoolExecutionTest.cpp
         CastExecutionTest.cpp
+        DumpHelperTest.cpp
 )
 
 target_link_libraries(nautilus-execution-tests PUBLIC nautilus Catch2::Catch2WithMain)
@@ -13,6 +14,9 @@ endif ()
 target_include_directories(nautilus-execution-tests PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<INSTALL_INTERFACE:src/nautilus/>)
+target_include_directories(nautilus-execution-tests PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src/nautilus/compiler/>
+)
 
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 

--- a/nautilus/test/execution-tests/DumpHelperTest.cpp
+++ b/nautilus/test/execution-tests/DumpHelperTest.cpp
@@ -1,0 +1,81 @@
+#include "nautilus/options.hpp"
+#include "nautilus/val.hpp"
+#include "DumpHandler.hpp"
+#include <catch2/catch_all.hpp>
+#include <filesystem>
+#include <iostream>
+
+namespace nautilus {
+
+// Tests if we only create a folder, if we need to
+TEST_CASE("DumpHelperFolderCreationNoDumpToFile") {
+	static const std::string folderName = "test123";
+	const auto path = std::filesystem::temp_directory_path() / "dump" / folderName;
+	if (std::filesystem::exists(path)) {
+		std::filesystem::remove_all(path);
+	}
+
+	nautilus::engine::Options options;
+	options.setOption("dump.toFile", false);
+	const compiler::DumpHandler dumpHandler(options, folderName);
+	dumpHandler.dump("after_ssa", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_ir_creation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_mlir_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_llvm_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_cpp_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_bc_generation", "trace", []() { return "Some fancy text"; });
+
+
+	/// Check that there does not exist any folder test123 under temp_dir/dump
+	const auto dumpFolderExists = std::filesystem::exists(path);
+	REQUIRE(dumpFolderExists == false);
+}
+
+// Tests if we only create a folder, if we need to
+TEST_CASE("DumpHelperFolderCreationNoDumpAll") {
+	static const std::string folderName = "test123";
+	const auto path = std::filesystem::temp_directory_path() / "dump" / folderName;
+	if (std::filesystem::exists(path)) {
+		std::filesystem::remove_all(path);
+	}
+
+	nautilus::engine::Options options;
+	options.setOption("dump.all", false);
+	const compiler::DumpHandler dumpHandler(options, folderName);
+	dumpHandler.dump("after_ssa", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_ir_creation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_mlir_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_llvm_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_cpp_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_bc_generation", "trace", []() { return "Some fancy text"; });
+
+	/// Check that there does not exist any folder test123 under temp_dir/dump
+	const auto dumpFolderExists = std::filesystem::exists(path);
+	REQUIRE(dumpFolderExists == false);
+}
+
+// Tests if we only create a folder, if we need to
+TEST_CASE("DumpHelperFolderCreationDumpAll") {
+	static const std::string folderName = "test123";
+	const auto path = std::filesystem::temp_directory_path() / "dump" / folderName;
+	if (std::filesystem::exists(path)) {
+		std::filesystem::remove_all(path);
+	}
+
+	nautilus::engine::Options options;
+	options.setOption("dump.all", true);
+	options.setOption("dump.after_ssa", true);
+	const compiler::DumpHandler dumpHandler(options, folderName);
+	dumpHandler.dump("after_ssa", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_ir_creation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_mlir_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_llvm_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_cpp_generation", "trace", []() { return "Some fancy text"; });
+	dumpHandler.dump("after_bc_generation", "trace", []() { return "Some fancy text"; });
+
+	/// Check that there does not exist any folder test123 under temp_dir/dump
+	const auto dumpFolderExists = std::filesystem::exists(path);
+	REQUIRE(dumpFolderExists == true);
+}
+
+} // namespace nautilus


### PR DESCRIPTION
We would create a folder in the `DumpHelper` constructor, even though we would not need it. This PR fixes this