### PR TITLE
fix gcc14 compile error with fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_WARNINGS "-Wall -Wextra -pedantic-errors -Werror=extra-semi -Werro
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_WARNINGS "${CMAKE_CXX_WARNINGS} -Wpedantic-macros -Werror=integer-overflow -Werror=return-type -Werror=return-stack-address  -Werror=writable-strings")
 else ()
-    set(CMAKE_CXX_WARNINGS "${CMAKE_CXX_WARNINGS} -Woverflow -Werror=return-type -Werror=return-local-addr  -Werror=write-strings")
+    set(CMAKE_CXX_WARNINGS "${CMAKE_CXX_WARNINGS} -Woverflow -Werror=return-type -Werror=return-local-addr  -Werror=write-strings -Wno-error=stringop-overflow")
 endif ()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_WARNINGS} -fpermissive -fno-omit-frame-pointer")
 


### PR DESCRIPTION
The current `fmt` version (and also the `fmt` version used in NES fails to compile with gcc14 with the following error:

```
/home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/base.h:1213:31: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
 1213 |   while (begin != end) *out++ = static_cast<T>(*begin++);
      |                        ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h: In function ‘OutputIt fmt::v11::detail::write_escaped_string(OutputIt, fmt::v11::basic_string_view<Char>) [with Char = char; OutputIt = fmt::v11::basic_appender<char>]’:
/home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h:676:10: note: at offset 21 into destination object ‘buf’ of size 7
  676 |     char buf[2 * block_size - 1] = {};
      |          ^~~
/home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h:676:10: note: at offset [5, 7] into destination object ‘buf’ of size 7
/home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h:676:10: note: at offset 21 into destination object ‘buf’ of size 7
In function ‘constexpr OutputIt fmt::v11::detail::copy(InputIt, InputIt, OutputIt) [with T = char; InputIt = const char*; OutputIt = char*; typename std::enable_if<(! is_back_insert_iterator<OutputIt>::value), int>::type <anonymous> = 0]’,
    inlined from ‘constexpr void fmt::v11::detail::for_each_codepoint(fmt::v11::string_view, F) [with F = find_escape(const char*, const char*)::<lambda(uint32_t, fmt::v11::string_view)>]’ at /home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h:677:15,
    inlined from ‘fmt::v11::detail::find_escape_result<char> fmt::v11::detail::find_escape(const char*, const char*)’ at /home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h:1794:21,
    inlined from ‘OutputIt fmt::v11::detail::write_escaped_string(OutputIt, fmt::v11::basic_string_view<Char>) [with Char = char; OutputIt = fmt::v11::basic_appender<char>]’ at /home/mgoerdel/nes/nautilus/third_party/fmt/include/fmt/format.h:1886:30:
```

This PR turns the error into a warning.