### PR TITLE
fix: Uninitialized val_ptr

### DIFF
--- a/nautilus/include/nautilus/val_ptr.hpp
+++ b/nautilus/include/nautilus/val_ptr.hpp
@@ -81,12 +81,13 @@ template <is_ptr ValuePtrType>
 class base_ptr_val {
 public:
 	using ValType = std::remove_pointer_t<ValuePtrType>;
+	using raw_no_qualifiers = std::remove_cv_t<ValType>;
 	using raw_type = ValuePtrType;
 	using basic_type = std::remove_pointer_t<ValuePtrType>;
 	using pointer_type = ValuePtrType;
 
 #ifdef ENABLE_TRACING
-	base_ptr_val() : state(tracing::traceConstant(nullptr)), value() {
+	base_ptr_val() : state(tracing::traceConstant<void*>(nullptr)), value() {
 	}
 	base_ptr_val(ValuePtrType ptr) : state(tracing::traceConstant((void*) ptr)), value(ptr) {
 	}

--- a/nautilus/test/val-tests/PtrValTypeTest.cpp
+++ b/nautilus/test/val-tests/PtrValTypeTest.cpp
@@ -74,6 +74,13 @@ TEST_CASE("Ptr Val Test") {
 		val<int> v3 = f1[2];
 		REQUIRE(v3 == 3);
 	}
+
+	SECTION("Uninit") {
+		auto f1 = val<int*>(nullptr);
+		REQUIRE(f1 == nullptr);
+		val<int8_t*> f2;
+		REQUIRE(f2 == nullptr);
+	}
 }
 
 /*


### PR DESCRIPTION
Fixed a bug that would result in a compiler error if `val<int8_t*>` is not initialized. The culprit was that a nullptr is not of type `void` and therefore, `tracing::traceConstant` would not find a constexpr case.