### PR TITLE
Fix benchmark compilation errors

### DIFF
--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -45,6 +45,28 @@ template <typename R, typename... FunctionArguments>
 std::function<void()> createFunctionWrapper(std::function<R(FunctionArguments...)> func) {
 	return createFunctionWrapper(std::make_index_sequence<sizeof...(FunctionArguments)> {}, func);
 }
+
+// Function pointer overloads for compatibility with benchmark tests
+template <size_t... Indices, typename R, typename... FunctionArguments>
+std::function<void()> createFunctionWrapper(std::index_sequence<Indices...>, R (*fnptr)(FunctionArguments...)) {
+	[[maybe_unused]] std::size_t args = sizeof...(FunctionArguments);
+	auto traceFunc = [=]() {
+		if constexpr (std::is_void_v<R>) {
+			fnptr(details::createTraceableArgument<FunctionArguments, Indices>()...);
+			tracing::traceReturnOperation(Type::v, tracing::TypedValueRef());
+		} else {
+			auto returnValue = fnptr(details::createTraceableArgument<FunctionArguments, Indices>()...);
+			auto type = tracing::TypeResolver<typename decltype(returnValue)::raw_type>::to_type();
+			tracing::traceReturnOperation(type, returnValue.state);
+		}
+	};
+	return traceFunc;
+}
+
+template <typename R, typename... FunctionArguments>
+std::function<void()> createFunctionWrapper(R (*fnptr)(FunctionArguments...)) {
+	return createFunctionWrapper(std::make_index_sequence<sizeof...(FunctionArguments)> {}, fnptr);
+}
 #endif
 } // namespace details
 

--- a/nautilus/test/benchmark/TracingBenchmark.cpp
+++ b/nautilus/test/benchmark/TracingBenchmark.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Tracing Benchmark") {
 		auto func = std::get<1>(test);
 		auto name = std::get<0>(test);
 		Catch::Benchmark::Benchmark("trace_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
-			meter.measure([&func] { return tracing::TraceContext::trace(func); });
+			meter.measure([&func] { return tracing::TraceContext::trace(func, engine::Options()); });
 		});
 	}
 }
@@ -62,7 +62,8 @@ TEST_CASE("SSA Creation Benchmark") {
 		}
 
 		Catch::Benchmark::Benchmark("ssa_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
-			std::shared_ptr<tracing::ExecutionTrace> trace = tracing::TraceContext::trace(func);
+			auto traceUnique = tracing::TraceContext::trace(func, engine::Options());
+			std::shared_ptr<tracing::ExecutionTrace> trace = std::move(traceUnique);
 			meter.measure([&] {
 				auto ssaCreationPhase = tracing::SSACreationPhase();
 				return ssaCreationPhase.apply(trace);
@@ -78,7 +79,8 @@ TEST_CASE("IR Creation Benchmark") {
 		auto name = std::get<0>(test);
 
 		Catch::Benchmark::Benchmark("ir_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
-			std::shared_ptr<tracing::ExecutionTrace> trace = tracing::TraceContext::trace(func);
+			auto traceUnique = tracing::TraceContext::trace(func, engine::Options());
+			std::shared_ptr<tracing::ExecutionTrace> trace = std::move(traceUnique);
 			auto ssaCreationPhase = tracing::SSACreationPhase();
 			trace = ssaCreationPhase.apply(trace);
 
@@ -114,7 +116,8 @@ TEST_CASE("Backend Compilation Benchmark") {
 
 			Catch::Benchmark::Benchmark("comp_" + backend + "_" + name)
 			    .operator=([&func, &registry, backend](Catch::Benchmark::Chronometer meter) {
-				    std::shared_ptr<tracing::ExecutionTrace> trace = tracing::TraceContext::trace(func);
+				    auto traceUnique = tracing::TraceContext::trace(func, engine::Options());
+				    std::shared_ptr<tracing::ExecutionTrace> trace = std::move(traceUnique);
 				    auto ssaCreationPhase = tracing::SSACreationPhase();
 				    trace = ssaCreationPhase.apply(trace);
 				    auto backendBackend = registry->getBackend(backend);

--- a/nautilus/test/common/TracingUtil.hpp
+++ b/nautilus/test/common/TracingUtil.hpp
@@ -5,27 +5,3 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-
-namespace nautilus::engine { namespace details {
-// old tracing functions for functions pointers
-template <size_t... Indices, typename R, typename... FunctionArguments>
-std::function<void()> createFunctionWrapper(std::index_sequence<Indices...>, R (*fnptr)(FunctionArguments...)) {
-	[[maybe_unused]] std::size_t args = sizeof...(FunctionArguments);
-	auto traceFunc = [=]() {
-		if constexpr (std::is_void_v<R>) {
-			fnptr(details::createTraceableArgument<FunctionArguments, Indices>()...);
-			tracing::traceReturnOperation(Type::v, tracing::TypedValueRef());
-		} else {
-			auto returnValue = fnptr(details::createTraceableArgument<FunctionArguments, Indices>()...);
-			auto type = tracing::TypeResolver<typename decltype(returnValue)::basic_type>::to_type();
-			tracing::traceReturnOperation(type, returnValue.state);
-		}
-	};
-	return traceFunc;
-}
-
-template <typename R, typename... FunctionArguments>
-std::function<void()> createFunctionWrapper(R (*fnptr)(FunctionArguments...)) {
-	return createFunctionWrapper(std::make_index_sequence<sizeof...(FunctionArguments)> {}, fnptr);
-}
-}} // namespace nautilus::engine::details


### PR DESCRIPTION
- Add function pointer overloads for createFunctionWrapper in Engine.hpp
- Remove duplicate createFunctionWrapper definitions from test TracingUtil.hpp
- Update TracingBenchmark.cpp to use correct TraceContext::trace() API
- Convert unique_ptr to shared_ptr for SSA and IR conversion phases

This fixes compilation errors where:
1. createFunctionWrapper was redefined in both Engine.hpp and TracingUtil.hpp
2. TraceContext::trace() method signature changed to return unique_ptr
3. Benchmark phases require shared_ptr instead of unique_ptr