### PR TITLE
Add iteration limit warning to static_val and code formatting fixes

### DIFF
--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -86,7 +86,9 @@ public:
 			                    fn(make_value(args)...));
 		                },
 		                [&](compiler::Executable::Invocable<typename R::raw_type, FunctionArguments...>& fn) ->
-		                typename R::raw_type { return fn(args...); }},
+		                typename R::raw_type {
+			                return fn(args...);
+		                }},
 		    func);
 	}
 
@@ -115,7 +117,9 @@ public:
 
 	auto operator()(FunctionArguments... args) {
 		std::visit(overloaded {[&](std::function<void(val<FunctionArguments>...)>& fn) { fn(make_value(args)...); },
-		                       [&](compiler::Executable::Invocable<void, FunctionArguments...>& fn) { fn(args...); }},
+		                       [&](compiler::Executable::Invocable<void, FunctionArguments...>& fn) {
+			                       fn(args...);
+		                       }},
 		           func);
 	}
 

--- a/nautilus/include/nautilus/static.hpp
+++ b/nautilus/include/nautilus/static.hpp
@@ -3,12 +3,15 @@
 #ifdef ENABLE_TRACING
 #include "nautilus/tracing/TracingUtil.hpp"
 #endif
-#include <iostream>
 #include <iterator>
 #include <type_traits>
 #include <vector>
 
 namespace nautilus {
+
+/// Log a warning when a static_val iteration limit is reached.
+/// Defined in static.cpp; uses spdlog when ENABLE_LOGGING is active.
+void WarnStaticValIterationLimit(int64_t limit);
 
 template <typename T>
     requires std::is_integral_v<T>
@@ -100,9 +103,7 @@ public:
 	const auto& operator++() {
 		++value;
 		if (value == MAX_ITERATIONS) {
-			std::cerr << "Warning: static_val exceeded " << MAX_ITERATIONS
-			          << " iterations. This may cause excessive trace sizes and long compilation times. "
-			          << "Consider using a regular val<> loop instead." << std::endl;
+			WarnIterationLimit();
 		}
 		return *this;
 	}
@@ -111,9 +112,7 @@ public:
 		T temp = value;
 		++value;
 		if (value == MAX_ITERATIONS) {
-			std::cerr << "Warning: static_val exceeded " << MAX_ITERATIONS
-			          << " iterations. This may cause excessive trace sizes and long compilation times. "
-			          << "Consider using a regular val<> loop instead." << std::endl;
+			WarnIterationLimit();
 		}
 		return temp;
 	}
@@ -155,6 +154,10 @@ public:
 	}
 
 private:
+	static void WarnIterationLimit() {
+		WarnStaticValIterationLimit(static_cast<int64_t>(MAX_ITERATIONS));
+	}
+
 	T value {};
 #ifdef ENABLE_TRACING
 	bool owns_trace = false;

--- a/nautilus/include/nautilus/static.hpp
+++ b/nautilus/include/nautilus/static.hpp
@@ -95,14 +95,26 @@ public:
 		return t;
 	}
 
+	static constexpr T MAX_ITERATIONS = 1000;
+
 	const auto& operator++() {
 		++value;
+		if (value == MAX_ITERATIONS) {
+			std::cerr << "Warning: static_val exceeded " << MAX_ITERATIONS
+			          << " iterations. This may cause excessive trace sizes and long compilation times. "
+			          << "Consider using a regular val<> loop instead." << std::endl;
+		}
 		return *this;
 	}
 
 	T operator++(int) {
 		T temp = value;
 		++value;
+		if (value == MAX_ITERATIONS) {
+			std::cerr << "Warning: static_val exceeded " << MAX_ITERATIONS
+			          << " iterations. This may cause excessive trace sizes and long compilation times. "
+			          << "Consider using a regular val<> loop instead." << std::endl;
+		}
 		return temp;
 	}
 

--- a/nautilus/include/nautilus/val_ptr.hpp
+++ b/nautilus/include/nautilus/val_ptr.hpp
@@ -77,13 +77,13 @@ public:
 #define BINARY_AND_ASSIGN_OPERATOR(OP)                                                                                 \
 	template <class T>                                                                                                 \
 	    requires std::is_convertible_v<T, baseType>                                                                    \
-	void operator OP## = (T other) noexcept {                                                                          \
+	void operator OP##=(T other) noexcept {                                                                            \
 		val<baseType> value {other};                                                                                   \
 		*this OP## = value;                                                                                            \
 	}                                                                                                                  \
 	template <class T>                                                                                                 \
 	    requires std::is_convertible_v<T, baseType>                                                                    \
-	void operator OP## = (val<T> other) noexcept {                                                                     \
+	void operator OP##=(val<T> other) noexcept {                                                                       \
 		val<baseType> value {other};                                                                                   \
 		*this = *this OP value;                                                                                        \
 	}                                                                                                                  \
@@ -207,7 +207,7 @@ protected:
 };
 
 template <typename T, typename F>
-std::size_t field_offset(F T::* pm) {
+std::size_t field_offset(F T::*pm) {
 	alignas(T) std::byte storage[sizeof(T)] {};
 	T* obj = std::launder(reinterpret_cast<T*>(storage));                       // ← reinterpret_cast: not constexpr
 	return reinterpret_cast<char*>(&(obj->*pm)) - reinterpret_cast<char*>(obj); // ← same
@@ -222,7 +222,7 @@ public:
 
 	template <typename F, typename T = ValType>
 	    requires std::is_class_v<T>
-	auto get(F T::* pm) {
+	auto get(F T::*pm) {
 		auto offset = field_offset(pm);
 		val<uint8_t*> bytePtr = static_cast<val<uint8_t*>>(*this);
 		val<uint8_t*> fieldBytePtr = bytePtr + offset;
@@ -236,14 +236,14 @@ public:
 
 	template <typename F, typename T = ValType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, val<F> value) {
+	void set(F T::*pm, val<F> value) {
 		val<F&> valueRef = get(pm);
 		valueRef = value;
 	}
 
 	template <typename F, typename T = ValType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, F value) {
+	void set(F T::*pm, F value) {
 		val<F&> valueRef = get(pm);
 		valueRef = value;
 	}

--- a/nautilus/include/nautilus/val_std.hpp
+++ b/nautilus/include/nautilus/val_std.hpp
@@ -236,7 +236,7 @@ public:
 	 */
 	template <typename F, typename T = ValueType>
 	    requires std::is_class_v<T>
-	auto get(F T::* pm) {
+	auto get(F T::*pm) {
 		return value_ptr.get(pm);
 	}
 
@@ -248,7 +248,7 @@ public:
 	 */
 	template <typename F, typename T = ValueType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, val<F> value) {
+	void set(F T::*pm, val<F> value) {
 		return value_ptr.set(pm, value);
 	}
 
@@ -263,7 +263,7 @@ public:
 	 */
 	template <typename F, typename T = ValueType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, F value) {
+	void set(F T::*pm, F value) {
 		return value_ptr.set(pm, value);
 	}
 

--- a/nautilus/src/nautilus/CMakeLists.txt
+++ b/nautilus/src/nautilus/CMakeLists.txt
@@ -6,4 +6,4 @@ add_subdirectory(compiler)
 add_subdirectory(api)
 add_subdirectory(llvm-passes)
 
-add_source_files(nautilus logging.cpp)
+add_source_files(nautilus logging.cpp static.cpp)

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -126,8 +126,8 @@ struct formatter<nautilus::compiler::ir::Operation> : formatter<std::string_view
 
 template <>
 struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::OperationIdentifier& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::OperationIdentifier& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", op.getId());
 		return out;
@@ -136,8 +136,8 @@ struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::s
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlockInvocation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "Block_{}(", op.getBlock()->getIdentifier());
 		const auto& args = op.getArguments();
@@ -164,8 +164,8 @@ struct formatter<nautilus::compiler::ir::IfOperation> : formatter<std::string_vi
 
 template <>
 struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 
 		if (op.getStamp() != nautilus::Type::v) {
@@ -245,8 +245,8 @@ auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::c
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlock& block, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlock& block,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "\nBlock_{}(", block.getIdentifier());
 		const auto& args = block.getArguments();
@@ -267,8 +267,8 @@ struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_vie
 
 template <>
 struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::FunctionOperation& func, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::FunctionOperation& func,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}(", func.getName());
 		for (const auto& arg : func.getInputArgNames()) {

--- a/nautilus/src/nautilus/logging.hpp
+++ b/nautilus/src/nautilus/logging.hpp
@@ -32,6 +32,13 @@ void trace([[maybe_unused]] const char* fmt, [[maybe_unused]] Args&&... args) {
 }
 
 template <typename... Args>
+void warn([[maybe_unused]] const char* fmt, [[maybe_unused]] Args&&... args) {
+#ifdef ENABLE_LOGGING
+	spdlog::warn("{}", fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
+#endif
+}
+
+template <typename... Args>
 void error([[maybe_unused]] const char* fmt, [[maybe_unused]] Args&&... args) {
 #ifdef ENABLE_LOGGING
 	spdlog::error("{}", fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));

--- a/nautilus/src/nautilus/static.cpp
+++ b/nautilus/src/nautilus/static.cpp
@@ -1,0 +1,12 @@
+#include "nautilus/logging.hpp"
+#include <nautilus/static.hpp>
+
+namespace nautilus {
+
+void WarnStaticValIterationLimit(int64_t limit) {
+	log::warn("static_val exceeded {} iterations. This may cause excessive trace sizes and long compilation times. "
+	          "Consider using a regular val<> loop instead.",
+	          limit);
+}
+
+} // namespace nautilus

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -307,8 +307,8 @@ auto formatter<nautilus::tracing::ExecutionTrace>::format(const nautilus::tracin
 	return out;
 }
 
-auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block& block, format_context& ctx)
-    -> format_context::iterator {
+auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block& block,
+                                                 format_context& ctx) -> format_context::iterator {
 	auto out = ctx.out();
 	fmt::format_to(out, "(");
 	for (size_t i = 0; i < block.arguments.size(); i++) {
@@ -330,8 +330,8 @@ auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block&
 
 template <>
 struct formatter<nautilus::tracing::TypedValueRef> : formatter<std::string_view> {
-	static auto format(const nautilus::tracing::TypedValueRef& typeValRef, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::tracing::TypedValueRef& typeValRef,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", typeValRef.ref);
 		return out;

--- a/nautilus/src/nautilus/tracing/TracingUtil.cpp
+++ b/nautilus/src/nautilus/tracing/TracingUtil.cpp
@@ -129,8 +129,8 @@ struct formatter<nautilus::ConstantLiteral> : formatter<std::string_view> {
 };
 } // namespace fmt
 
-auto fmt::formatter<nautilus::ConstantLiteral>::format(nautilus::ConstantLiteral lit, format_context& ctx) const
-    -> format_context::iterator {
+auto fmt::formatter<nautilus::ConstantLiteral>::format(nautilus::ConstantLiteral lit,
+                                                       format_context& ctx) const -> format_context::iterator {
 	auto out = ctx.out();
 	std::visit(
 	    [&](auto&& value) {

--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
@@ -112,7 +112,8 @@ __attribute__((noinline)) void* get_addr(size_t index) {
 		         (void(addr = __builtin_extract_return_addr(__builtin_return_address(ints + 2))), true)) ||
 		        ...);
 		return addr;
-	}(std::make_index_sequence<StackSize> {});
+	}
+	(std::make_index_sequence<StackSize> {});
 }
 
 static void* getReturnAddress(uint32_t offset) {

--- a/nautilus/test/common/ExpressionFunctions.hpp
+++ b/nautilus/test/common/ExpressionFunctions.hpp
@@ -212,9 +212,7 @@ val<int32_t> constructComplexReturnObject(val<int32_t> a, val<int32_t> b) {
 
 val<int32_t> constructComplexReturnObject2(val<int32_t> a, val<int32_t> b) {
 	val<int32_t> t = 0;
-	{
-		t = constructComplexReturnObject(a, b);
-	}
+	{ t = constructComplexReturnObject(a, b); }
 	return t + 42;
 }
 


### PR DESCRIPTION
## Summary
This PR adds a warning mechanism to `static_val` when iteration limits are exceeded, and applies consistent code formatting across the codebase.

## Key Changes

- **Add iteration limit warning to static_val**: 
  - Introduced `MAX_ITERATIONS` constant (1000) to `static_val` class
  - Added `WarnStaticValIterationLimit()` function to log warnings when iteration limit is reached
  - Created new `static.cpp` file to implement the warning function using spdlog logging
  - Warnings are triggered in both prefix and postfix increment operators

- **Add warn() logging function**:
  - Implemented `warn()` template function in `logging.hpp` to support warning-level log messages
  - Follows the same pattern as existing `trace()` and `error()` functions with conditional compilation based on `ENABLE_LOGGING`

- **Code formatting improvements**:
  - Fixed spacing in macro-generated operators (e.g., `operator##=` → `operator##=` without space)
  - Reformatted long function signatures to split parameters across multiple lines for better readability
  - Applied consistent formatting to formatter specializations in `IRGraph.cpp`, `ExecutionTrace.cpp`, and `TracingUtil.cpp`
  - Fixed pointer-to-member syntax spacing (e.g., `F T::* pm` → `F T::*pm`)
  - Simplified single-statement block formatting in test code

- **Build system update**:
  - Added `static.cpp` to CMakeLists.txt source files

## Implementation Details

The iteration limit warning helps developers identify when `static_val` loops may be causing excessive trace sizes and long compilation times, encouraging them to use regular `val<>` loops instead. The warning is only emitted once per loop when the limit is first reached.

https://claude.ai/code/session_01DtVn8hcLR2jjfA7dB4A4xy