### PR TITLE
Add assume_constant, assume_range, assume_nonzero specializations

### DIFF
--- a/plugins/specialization/include/nautilus/specialization/assume.hpp
+++ b/plugins/specialization/include/nautilus/specialization/assume.hpp
@@ -25,4 +25,31 @@ side effects; only its value is used for optimization.
 */
 void nautilus_assume_aligned(val<void*> ptr, int alignment);
 
+/*
+Tells the optimizer that `value` is equal to `expected_value`. Along all
+dominated uses, the optimizer is then free to fold `value` to the literal
+constant, achieving the same code as if the value had been a compile-time
+constant -- without forcing the user to recompile the function per value.
+
+If `value != expected_value` at runtime, behavior is undefined.
+*/
+void nautilus_assume_constant(val<int64_t> value, int64_t expected_value);
+
+/*
+Tells the optimizer that `value` lies within the inclusive interval [lo, hi].
+Enables range-based optimizations: bounds-check elimination, narrower integer
+codegen, division/modulo strength reduction.
+
+If `value` is outside [lo, hi] at runtime, behavior is undefined.
+*/
+void nautilus_assume_range(val<int64_t> value, int64_t lo, int64_t hi);
+
+/*
+Tells the optimizer that `value != 0`. Eliminates undefined-behavior checks
+on division and intrinsics like ctz/clz.
+
+If `value == 0` at runtime, behavior is undefined.
+*/
+void nautilus_assume_nonzero(val<int64_t> value);
+
 } // namespace nautilus

--- a/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
+++ b/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
@@ -19,6 +19,44 @@ public:
 			    return true;
 		    });
 		manager.addIntrinsic(
+		    reinterpret_cast<void*>(&nautilus_assume_constant_stub),
+		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
+		       MLIRLoweringProvider::ValueFrame& frame) -> bool {
+			    auto value = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+			    auto expected = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+			    auto cmp = builder->create<::mlir::arith::CmpIOp>(builder->getUnknownLoc(),
+			                                                      ::mlir::arith::CmpIPredicate::eq, value, expected);
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), cmp);
+			    return true;
+		    });
+		manager.addIntrinsic(
+		    reinterpret_cast<void*>(&nautilus_assume_range_stub),
+		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
+		       MLIRLoweringProvider::ValueFrame& frame) -> bool {
+			    auto value = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+			    auto lo = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+			    auto hi = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+			    auto geLo = builder->create<::mlir::arith::CmpIOp>(builder->getUnknownLoc(),
+			                                                       ::mlir::arith::CmpIPredicate::sge, value, lo);
+			    auto leHi = builder->create<::mlir::arith::CmpIOp>(builder->getUnknownLoc(),
+			                                                       ::mlir::arith::CmpIPredicate::sle, value, hi);
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), geLo);
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), leHi);
+			    return true;
+		    });
+		manager.addIntrinsic(
+		    reinterpret_cast<void*>(&nautilus_assume_nonzero_stub),
+		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
+		       MLIRLoweringProvider::ValueFrame& frame) -> bool {
+			    auto value = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+			    auto zero = builder->create<::mlir::arith::ConstantOp>(builder->getUnknownLoc(), value.getType(),
+			                                                           builder->getIntegerAttr(value.getType(), 0));
+			    auto cmp = builder->create<::mlir::arith::CmpIOp>(builder->getUnknownLoc(),
+			                                                      ::mlir::arith::CmpIPredicate::ne, value, zero);
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), cmp);
+			    return true;
+		    });
+		manager.addIntrinsic(
 		    reinterpret_cast<void*>(&nautilus_assume_aligned_stub),
 		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
 		       [[maybe_unused]] compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) -> bool {

--- a/plugins/specialization/src/assume.cpp
+++ b/plugins/specialization/src/assume.cpp
@@ -21,4 +21,28 @@ void nautilus_assume_aligned(val<void*> ptr, int alignment) {
 	invoke(nautilus_assume_aligned_stub, ptr, val<int8_t>(alignment));
 }
 
+void nautilus_assume_constant_stub(int64_t, int64_t) {
+	// Stub for optimization purposes; does nothing at runtime.
+}
+
+void nautilus_assume_constant(val<int64_t> value, int64_t expected_value) {
+	invoke(nautilus_assume_constant_stub, value, val<int64_t>(expected_value));
+}
+
+void nautilus_assume_range_stub(int64_t, int64_t, int64_t) {
+	// Stub for optimization purposes; does nothing at runtime.
+}
+
+void nautilus_assume_range(val<int64_t> value, int64_t lo, int64_t hi) {
+	invoke(nautilus_assume_range_stub, value, val<int64_t>(lo), val<int64_t>(hi));
+}
+
+void nautilus_assume_nonzero_stub(int64_t) {
+	// Stub for optimization purposes; does nothing at runtime.
+}
+
+void nautilus_assume_nonzero(val<int64_t> value) {
+	invoke(nautilus_assume_nonzero_stub, value);
+}
+
 } // namespace nautilus

--- a/plugins/specialization/src/assume_stubs.hpp
+++ b/plugins/specialization/src/assume_stubs.hpp
@@ -1,6 +1,11 @@
 
 
+#include <cstdint>
+
 namespace nautilus {
 void nautlis_assume_stub(bool);
 void nautilus_assume_aligned_stub(void*, int);
+void nautilus_assume_constant_stub(int64_t, int64_t);
+void nautilus_assume_range_stub(int64_t, int64_t, int64_t);
+void nautilus_assume_nonzero_stub(int64_t);
 } // namespace nautilus

--- a/plugins/specialization/test/AssumeExecutionTest.cpp
+++ b/plugins/specialization/test/AssumeExecutionTest.cpp
@@ -26,6 +26,36 @@ val<int32_t> cfWithAssume(val<int32_t> a) {
 	}
 }
 
+val<int64_t> cfWithAssumeConstant(val<int64_t> a) {
+	nautilus_assume_constant(a, 7);
+	if (a == 7) {
+		return a * 3;
+	} else {
+		invoke<void>(throwExceptions);
+		return 42;
+	}
+}
+
+val<int64_t> cfWithAssumeRange(val<int64_t> a) {
+	nautilus_assume_range(a, 0, 100);
+	if (a >= 0 && a <= 100) {
+		return a + 1;
+	} else {
+		invoke<void>(throwExceptions);
+		return 42;
+	}
+}
+
+val<int64_t> cfWithAssumeNonzero(val<int64_t> a) {
+	nautilus_assume_nonzero(a);
+	if (a != 0) {
+		return a + 5;
+	} else {
+		invoke<void>(throwExceptions);
+		return 42;
+	}
+}
+
 val<int> cfWithAssumeAlignment(val<int32_t*> a) {
 	nautilus_assume_aligned(a, 256);
 	return *a + 10;
@@ -49,6 +79,38 @@ TEST_CASE("MLIR Intrinsic Function Test") {
 					REQUIRE(f(0) == 10);
 				} else {
 					REQUIRE(f(42) == 52);
+					REQUIRE_THROWS(f(0));
+				}
+			}
+			SECTION("cfWithAssumeConstant") {
+				auto f = engine.registerFunction(cfWithAssumeConstant);
+				if (useIntrinsics) {
+					REQUIRE(f(7) == 21);
+					// with intrinsics, the optimizer folds `a` to the asserted constant 7,
+					// so even passing 0 returns 7 * 3 = 21 (undefined behavior is exploited)
+					REQUIRE(f(0) == 21);
+				} else {
+					REQUIRE(f(7) == 21);
+					REQUIRE_THROWS(f(0));
+				}
+			}
+			SECTION("cfWithAssumeRange") {
+				auto f = engine.registerFunction(cfWithAssumeRange);
+				if (useIntrinsics) {
+					REQUIRE(f(50) == 51);
+					REQUIRE(f(-1) == 0);
+				} else {
+					REQUIRE(f(50) == 51);
+					REQUIRE_THROWS(f(-1));
+				}
+			}
+			SECTION("cfWithAssumeNonzero") {
+				auto f = engine.registerFunction(cfWithAssumeNonzero);
+				if (useIntrinsics) {
+					REQUIRE(f(3) == 8);
+					REQUIRE(f(0) == 5);
+				} else {
+					REQUIRE(f(3) == 8);
 					REQUIRE_THROWS(f(0));
 				}
 			}


### PR DESCRIPTION
Extend the specialization plugin with three new compile-time hints for
int64_t values, lowered to arith.cmpi + llvm.intr.assume in the MLIR
backend:

- nautilus_assume_constant(v, k): folds v to k along dominated uses,
  enabling polyvariant-style specialization without per-value recompile
- nautilus_assume_range(v, lo, hi): inclusive range assertion, enables
  bounds-check elimination and narrower codegen
- nautilus_assume_nonzero(v): eliminates UB checks on div/ctz/clz

Adds behavioral tests mirroring cfWithAssume that verify the else
branch becomes unreachable when intrinsics are enabled.