### PR TITLE
Add ValueProfile and specialize() helper for argument value specialization

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,6 +118,10 @@ jobs:
         shell: bash
         run: |
           ctest --test-dir build/plugins/simd/test --output-on-failure
+      - name: test specialization plugin
+        shell: bash
+        run: |
+          ctest --test-dir build/plugins/specialization/test --output-on-failure
   llvm-ir-test:
     runs-on: ubuntu-24.04
     name: LLVM IR Test (clang-21)
@@ -156,7 +160,7 @@ jobs:
       - name: build
         shell: bash
         run: |
-          cmake --build build --target nautilus-llvm-ir-test nautilus-std-llvm-ir-test nautilus-simd-llvm-ir-test
+          cmake --build build --target nautilus-llvm-ir-test nautilus-std-llvm-ir-test nautilus-simd-llvm-ir-test nautilus-specialization-llvm-ir-test
       - name: test core LLVM IR
         shell: bash
         run: |
@@ -169,3 +173,7 @@ jobs:
         shell: bash
         run: |
           ctest --test-dir build/plugins/simd/test -L "llvm" --output-on-failure
+      - name: test specialization plugin LLVM IR
+        shell: bash
+        run: |
+          ctest --test-dir build/plugins/specialization/test -L "llvm" --output-on-failure

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -531,6 +531,13 @@ void MLIRLoweringProvider::generateMLIR(ir::AndOperation* andOperation, ValueFra
 void MLIRLoweringProvider::generateFunction(mlir::func::FuncOp& mlirFunction, const ir::FunctionOperation& functionOp,
                                             ValueFrame& frame) {
 
+	// Block identifiers (Block_0, Block_1, ...) are only unique *within* a
+	// function, so the mapping must be reset between functions. Otherwise
+	// control-flow ops in a later function would resolve their successor
+	// blocks to blocks defined in an earlier function's region, which MLIR
+	// verification rejects as "reference to block defined in another region".
+	blockMapping.clear();
+
 	// add entry block for the function
 	mlirFunction.addEntryBlock();
 

--- a/plugins/specialization/include/nautilus/specialization/specialize.hpp
+++ b/plugins/specialization/include/nautilus/specialization/specialize.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "nautilus/specialization/profile.hpp"
+#include "nautilus/val.hpp"
+#include <cstdint>
+
+namespace nautilus {
+
+/// Runtime value profile for a single function argument.
+///
+/// `ValueProfile<T>` is the value-specialization counterpart of
+/// `ConditionProfile`: instead of tracking how often a boolean is taken,
+/// it tracks the most-recently-seen value of an integral argument and the
+/// number of times that value reoccurred. The profile is *read* at trace
+/// time by `SpecializedNautilusFunction` to decide which dispatcher
+/// variant to emit, and *written* at runtime via the `profile()` proxy
+/// call that the dispatcher injects into the generic path.
+///
+/// The implementation is intentionally tiny (last value + hit count + total
+/// count) so that the per-call profiling overhead is two stores and one
+/// compare. A "stable" profile is one where the dominant value's hit ratio
+/// exceeds `threshold` after at least `min_samples` total samples.
+template <class T>
+class ValueProfile {
+	static_assert(std::is_integral_v<T>, "ValueProfile only supports integral types in v1");
+
+public:
+	/// Runtime profiling hook. Registered as a proxy call by
+	/// `SpecializedNautilusFunction`. Mirrors `ConditionProfile::profile`.
+	static void profile(ValueProfile<T>* p, T value) {
+		if (p->total_ == 0 || p->last_ != value) {
+			p->last_ = value;
+			p->hits_ = 1;
+		} else {
+			p->hits_++;
+		}
+		p->total_++;
+	}
+
+	/// True if the dominant value has been observed often enough to be
+	/// worth specializing on. Read at trace time only.
+	bool isStable(double threshold = 0.95, std::uint64_t min_samples = 1024) const {
+		if (total_ < min_samples) {
+			return false;
+		}
+		return static_cast<double>(hits_) / static_cast<double>(total_) >= threshold;
+	}
+
+	/// The current dominant value. Only meaningful when `isStable()` is true.
+	T dominant() const {
+		return last_;
+	}
+
+private:
+	T last_ = T {};
+	std::uint64_t hits_ = 0;
+	std::uint64_t total_ = 0;
+};
+
+} // namespace nautilus

--- a/plugins/specialization/include/nautilus/specialization/specialized_function.hpp
+++ b/plugins/specialization/include/nautilus/specialization/specialized_function.hpp
@@ -1,0 +1,338 @@
+#pragma once
+
+#include "nautilus/nautilus_function.hpp"
+#include "nautilus/specialization/specialize.hpp"
+#include "nautilus/val.hpp"
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+
+namespace nautilus {
+
+namespace detail {
+
+/// True if `I` appears in the pack `Idxs...`.
+template <std::size_t I, std::size_t... Idxs>
+constexpr bool isSpecializedIndex() {
+	return ((I == Idxs) || ...);
+}
+
+/// N-th element of a `std::size_t` pack (C++20-friendly replacement for
+/// C++26 pack indexing).
+template <std::size_t N, std::size_t First, std::size_t... Rest>
+constexpr std::size_t nthInPack() {
+	if constexpr (N == 0) {
+		return First;
+	} else {
+		return nthInPack<N - 1, Rest...>();
+	}
+}
+
+/// Index of `I` within the pack `Idxs...` (assuming it is present). Used
+/// to pick the matching constant out of the per-index constants tuple.
+template <std::size_t I, std::size_t First, std::size_t... Rest>
+constexpr std::size_t indexOfInPack() {
+	if constexpr (I == First) {
+		return 0;
+	} else {
+		return 1 + indexOfInPack<I, Rest...>();
+	}
+}
+
+/// Pick one argument when calling into the original user function from
+/// the reduced specialized variant. `nsTup` holds only the
+/// non-specialized arguments (in `NonSpecIdxs...` order), while
+/// `consts` holds the specialized constants (in `Idxs...` order).
+///
+/// For a position `I` that is specialized, returns a fresh
+/// `val<T>(const)` — which traces as a local constant op, not as a
+/// function parameter. For a non-specialized position, forwards the
+/// corresponding element of `nsTup`.
+template <std::size_t I, class NsTup, class ConstTup, std::size_t... Idxs, std::size_t... NonSpecIdxs>
+decltype(auto) pickReducedArg(NsTup& nsTup, const ConstTup& consts, std::index_sequence<Idxs...>,
+                              std::index_sequence<NonSpecIdxs...>) {
+	if constexpr (isSpecializedIndex<I, Idxs...>()) {
+		constexpr std::size_t pos = indexOfInPack<I, Idxs...>();
+		using T = std::tuple_element_t<pos, ConstTup>;
+		return val<T>(std::get<pos>(consts));
+	} else {
+		constexpr std::size_t pos = indexOfInPack<I, NonSpecIdxs...>();
+		return std::get<pos>(nsTup);
+	}
+}
+
+template <class F, class NsTup, class ConstTup, std::size_t... Is, std::size_t... Idxs, std::size_t... NonSpecIdxs>
+decltype(auto) callWithReducedArgs(F& f, NsTup& nsTup, const ConstTup& consts, std::index_sequence<Is...>,
+                                   std::index_sequence<Idxs...> specIdxs,
+                                   std::index_sequence<NonSpecIdxs...> nonSpecIdxs) {
+	return f(pickReducedArg<Is>(nsTup, consts, specIdxs, nonSpecIdxs)...);
+}
+
+/// Append `I` to an existing `std::index_sequence`.
+template <std::size_t I, class Seq>
+struct appendIndex;
+template <std::size_t I, std::size_t... As>
+struct appendIndex<I, std::index_sequence<As...>> {
+	using type = std::index_sequence<As..., I>;
+};
+
+/// Compute the index-subsequence of `[0..N)` that is **not** in the
+/// specialized pack `Idxs...`. Drives the reduced argument list of the
+/// specialized variant so that specialized positions disappear from
+/// the function signature entirely.
+template <std::size_t I, std::size_t N, class Acc, std::size_t... Idxs>
+struct filterNonSpec {
+	static constexpr bool is_spec = ((I == Idxs) || ...);
+	using acc_next = std::conditional_t<is_spec, Acc, typename appendIndex<I, Acc>::type>;
+	using type = typename filterNonSpec<I + 1, N, acc_next, Idxs...>::type;
+};
+template <std::size_t N, class Acc, std::size_t... Idxs>
+struct filterNonSpec<N, N, Acc, Idxs...> {
+	using type = Acc;
+};
+template <std::size_t N, std::size_t... Idxs>
+using nonSpecIndicesT = typename filterNonSpec<0, N, std::index_sequence<>, Idxs...>::type;
+
+/// Slice a tuple by index sequence: `tupleSlice<tuple<A, B, C>, seq<0, 2>>::type == tuple<A, C>`.
+template <class Tuple, class Seq>
+struct tupleSlice;
+template <class Tuple, std::size_t... Is>
+struct tupleSlice<Tuple, std::index_sequence<Is...>> {
+	using type = std::tuple<std::tuple_element_t<Is, Tuple>...>;
+};
+
+/// Turn a tuple of argument types into a `std::function<R(Ts...)>`.
+template <class R, class Tuple>
+struct funcFromTuple;
+template <class R, class... Ts>
+struct funcFromTuple<R, std::tuple<Ts...>> {
+	using type = std::function<R(Ts...)>;
+};
+
+} // namespace detail
+
+/// Argument-value-specialized wrapper around `NautilusFunction`.
+///
+/// `SpecializedNautilusFunction<Signature, Idxs...>` holds two internal
+/// `NautilusFunction`s:
+///
+/// - `generic_` — wraps the user's callable unchanged. Always exists.
+/// - `specialized_` — wraps a lambda that forwards to the user's
+///   callable with every argument at a position in `Idxs...` replaced
+///   by a freshly-traced `val<T>` constant. Built lazily the first time
+///   **all** of the per-index profiles have become stable.
+///
+/// When called from inside a traced scope, `operator()` emits a
+/// dispatcher into the caller's trace:
+///
+/// - **Any profile still unstable.** Emits `invoke(&ValueProfile<T>::profile,
+///   ...)` proxy calls for the still-unstable indexes and forwards to
+///   `generic_`.
+/// - **All profiles stable.** Emits a conjunction of equality tests
+///   `arg_i0 == c0 && arg_i1 == c1 && ...` and a traced `if/else` that
+///   calls `specialized_` on the then-branch and `generic_` on the
+///   else-branch.
+///
+/// Typical usage:
+///
+/// ```cpp
+/// static nautilus::ValueProfile<int64_t> g_base_profile;
+/// static nautilus::ValueProfile<int64_t> g_exp_profile;
+///
+/// SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 0, 1>
+///     pow_spec{"pow", pow_kernel, &g_base_profile, &g_exp_profile};
+/// ```
+template <class Signature, std::size_t... Idxs>
+class SpecializedNautilusFunction;
+
+template <class R, class... Args, std::size_t... Idxs>
+class SpecializedNautilusFunction<R(Args...), Idxs...> {
+	static_assert(sizeof...(Idxs) >= 1, "SpecializedNautilusFunction: at least one specialized index required");
+	static_assert(((Idxs < sizeof...(Args)) && ...), "SpecializedNautilusFunction: Idx out of range");
+
+	using UserFn = std::function<R(Args...)>;
+	using ArgsTuple = std::tuple<Args...>;
+
+	// Raw (unwrapped) type at specialized position `I`.
+	template <std::size_t I>
+	using RawAt = typename std::tuple_element_t<I, ArgsTuple>::raw_type;
+
+	using ConstTuple = std::tuple<RawAt<Idxs>...>;
+	using ProfileTuple = std::tuple<ValueProfile<RawAt<Idxs>>...>;
+
+	// Index sequence of the non-specialized argument positions, the
+	// corresponding argument-types tuple, and the reduced
+	// `std::function` type used for the specialized variant. The
+	// specialized `NautilusFunction` is built with this reduced
+	// signature so that specialized arguments disappear from the IR
+	// altogether instead of lingering as dead parameters.
+	using NonSpecSeq = detail::nonSpecIndicesT<sizeof...(Args), Idxs...>;
+	using NonSpecArgsTuple = typename detail::tupleSlice<ArgsTuple, NonSpecSeq>::type;
+	using SpecFnType = typename detail::funcFromTuple<R, NonSpecArgsTuple>::type;
+
+public:
+	SpecializedNautilusFunction(std::string name, UserFn f)
+	    : userFn_(std::move(f)), generic_(std::make_unique<NautilusFunction<UserFn>>(name + "__generic", userFn_)),
+	      baseName_(name) {
+		// Build the dispatcher's user-fn: a lambda that closes over
+		// `this` (stable — the class is non-copyable) and contains the
+		// profile-update / generic-vs-specialized branching logic. The
+		// lambda body runs at the moment the dispatcher itself gets
+		// traced; from the parent trace's point of view all of this is
+		// hidden behind a single `traceNautilusCall` to the dispatcher
+		// symbol.
+		UserFn dispatchBody = [this](Args... args) -> R {
+			return this->traceDispatchBody(args...);
+		};
+		dispatcher_ = std::make_unique<NautilusFunction<UserFn>>(std::move(name), std::move(dispatchBody));
+	}
+
+	SpecializedNautilusFunction(const SpecializedNautilusFunction&) = delete;
+	SpecializedNautilusFunction& operator=(const SpecializedNautilusFunction&) = delete;
+	SpecializedNautilusFunction(SpecializedNautilusFunction&&) = delete;
+	SpecializedNautilusFunction& operator=(SpecializedNautilusFunction&&) = delete;
+
+	const std::string& name() const noexcept {
+		return baseName_;
+	}
+
+	/// Access the internally-owned `ValueProfile` for the `P`-th entry
+	/// in the specialized-index pack `Idxs...`. Useful for tests that
+	/// want to prime the profile directly without driving it via calls.
+	template <std::size_t P>
+	auto& profile() noexcept {
+		static_assert(P < sizeof...(Idxs), "profile<P>: P out of range");
+		return std::get<P>(profiles_);
+	}
+
+	/// External call entry point. Forwards to the dispatcher
+	/// `NautilusFunction`, which from inside a tracer emits exactly one
+	/// `traceNautilusCall` to the dispatcher symbol — the same shape a
+	/// caller sees for any other `NautilusFunction`. The dispatch logic
+	/// (profile update / specialized vs generic) lives inside the
+	/// dispatcher's own traced body.
+	R operator()(Args... args) {
+		return (*dispatcher_)(args...);
+	}
+
+private:
+	/// The dispatcher's traced body. Runs under the tracer when the
+	/// pipeline traces the dispatcher `NautilusFunction`. Reads the
+	/// current profile state at C++ level and emits either the
+	/// profile-update + generic path or a traced if/else into the two
+	/// child `NautilusFunction`s.
+	R traceDispatchBody(Args... args) {
+		maybeBuildSpecialized();
+
+		R result;
+		if (specialized_) {
+			auto tup = std::forward_as_tuple(args...);
+			if (buildPredicate(tup, std::index_sequence_for<Args...> {})) {
+				result = callSpecializedVariant(tup, NonSpecSeq {});
+			} else {
+				result = (*generic_)(args...);
+			}
+		} else {
+			if (ProfilingContext::shouldCollectProfile()) {
+				auto tup = std::forward_as_tuple(args...);
+				emitProfileUpdates(tup, std::make_index_sequence<sizeof...(Idxs)> {});
+			}
+			result = (*generic_)(args...);
+		}
+		return result;
+	}
+
+	template <class Tup, std::size_t... Is>
+	val<bool> buildPredicate(Tup& tup, std::index_sequence<Is...>) {
+		// (arg_i0 == c0) && (arg_i1 == c1) && ...
+		return (... && eqAt<Is>(tup));
+	}
+
+	// Compare the original argument at position `I` against the cached
+	// constant stored for `I`. Only called for `I \in Idxs...`.
+	template <std::size_t I, class Tup>
+	val<bool> eqAt(Tup& tup) {
+		if constexpr (detail::isSpecializedIndex<I, Idxs...>()) {
+			constexpr std::size_t pos = detail::indexOfInPack<I, Idxs...>();
+			using T = RawAt<detail::nthInPack<pos, Idxs...>()>;
+			return std::get<I>(tup) == val<T>(std::get<pos>(cachedConsts_));
+		} else {
+			return val<bool>(true);
+		}
+	}
+
+	template <class Tup, std::size_t... Ps>
+	void emitProfileUpdates(Tup& tup, std::index_sequence<Ps...>) {
+		(emitOneProfileUpdate<Ps>(tup), ...);
+	}
+
+	template <std::size_t P, class Tup>
+	void emitOneProfileUpdate(Tup& tup) {
+		constexpr std::size_t I = detail::nthInPack<P, Idxs...>();
+		using T = RawAt<I>;
+		auto* profile = &std::get<P>(profiles_);
+		if (profile->isStable()) {
+			return;
+		}
+		invoke(&ValueProfile<T>::profile, val<ValueProfile<T>*>(profile), static_cast<val<T>>(std::get<I>(tup)));
+	}
+
+	void maybeBuildSpecialized() {
+		if (specialized_) {
+			return;
+		}
+		if (!allStable(std::make_index_sequence<sizeof...(Idxs)> {})) {
+			return;
+		}
+		cachedConsts_ = captureConsts(std::make_index_sequence<sizeof...(Idxs)> {});
+		buildSpecializedVariant(NonSpecSeq {});
+	}
+
+	/// Build the specialized `NautilusFunction` with a reduced
+	/// signature. The lambda takes only the non-specialized arguments
+	/// (`NonSpecIdxs...`); constants for the specialized positions are
+	/// materialised inside the lambda body as `val<T>(c)` and thus
+	/// become local `arith.constant` ops in the traced body rather than
+	/// dead formal parameters.
+	template <std::size_t... NonSpecIdxs>
+	void buildSpecializedVariant(std::index_sequence<NonSpecIdxs...>) {
+		auto userFn = userFn_;
+		auto consts = cachedConsts_;
+		SpecFnType specLambda = [userFn, consts](std::tuple_element_t<NonSpecIdxs, ArgsTuple>... nsArgs) mutable -> R {
+			auto nsTup = std::forward_as_tuple(nsArgs...);
+			return detail::callWithReducedArgs(userFn, nsTup, consts, std::index_sequence_for<Args...> {},
+			                                   std::index_sequence<Idxs...> {}, std::index_sequence<NonSpecIdxs...> {});
+		};
+		specialized_ =
+		    std::make_unique<NautilusFunction<SpecFnType>>(baseName_ + "__specialized", std::move(specLambda));
+	}
+
+	/// Forward the non-specialized subset of the dispatcher's traced
+	/// arguments to the specialized variant.
+	template <class Tup, std::size_t... NonSpecIdxs>
+	R callSpecializedVariant(Tup& tup, std::index_sequence<NonSpecIdxs...>) {
+		return (*specialized_)(std::get<NonSpecIdxs>(tup)...);
+	}
+
+	template <std::size_t... Ps>
+	bool allStable(std::index_sequence<Ps...>) const {
+		return (... && std::get<Ps>(profiles_).isStable());
+	}
+
+	template <std::size_t... Ps>
+	ConstTuple captureConsts(std::index_sequence<Ps...>) const {
+		return ConstTuple {std::get<Ps>(profiles_).dominant()...};
+	}
+
+	UserFn userFn_;
+	ProfileTuple profiles_;
+	std::unique_ptr<NautilusFunction<UserFn>> generic_;
+	std::unique_ptr<NautilusFunction<SpecFnType>> specialized_;
+	std::unique_ptr<NautilusFunction<UserFn>> dispatcher_;
+	ConstTuple cachedConsts_ {};
+	std::string baseName_;
+};
+
+} // namespace nautilus

--- a/plugins/specialization/test/CMakeLists.txt
+++ b/plugins/specialization/test/CMakeLists.txt
@@ -3,6 +3,8 @@ include(Catch)
 
 add_executable(nautilus-specialization-tests
         AssumeExecutionTest.cpp
+        SpecializationTest.cpp
+        SpecializedNautilusFunctionBackendTest.cpp
 )
 
 nautilus_inline(nautilus-specialization-tests)
@@ -43,6 +45,7 @@ if (ENABLE_MLIR_BACKEND AND ENABLE_LLVM_IR_TEST)
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
             $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/llvm-ir-test>
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/plugins/specialization/src>
     )
 
     catch_discover_tests(nautilus-specialization-llvm-ir-test

--- a/plugins/specialization/test/LLVMIRAssumeTest.cpp
+++ b/plugins/specialization/test/LLVMIRAssumeTest.cpp
@@ -6,6 +6,22 @@
 #include <filesystem>
 #include <string>
 
+// Register MLIR assume intrinsics so the compiler emits llvm.assume instead
+// of generic runtime calls. The static initializer in
+// SpecializationPluginInit.cpp lives in its own TU with no externally
+// referenced symbols, so the linker drops it from the static archive — we
+// must therefore force the registration from inside the test executable.
+#include "MLIRAssumeIntrinsics.hpp"
+
+namespace {
+struct SpecializationIntrinsicRegistrar {
+	SpecializationIntrinsicRegistrar() {
+		nautilus::compiler::mlir::RegisterMLIRAssumeIntrinsicPlugin();
+	}
+};
+static SpecializationIntrinsicRegistrar registrar_;
+} // namespace
+
 namespace nautilus::engine {
 
 using nautilus::engine::assumeAlignedFunction;

--- a/plugins/specialization/test/SpecializationTest.cpp
+++ b/plugins/specialization/test/SpecializationTest.cpp
@@ -1,0 +1,326 @@
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include <catch2/catch_all.hpp>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#if defined(ENABLE_MLIR_BACKEND) && !defined(__APPLE__)
+#include "nautilus/specialization/specialize.hpp"
+#include "nautilus/specialization/specialized_function.hpp"
+
+namespace nautilus::engine {
+
+// ---------------------------------------------------------------------------
+// ValueProfile<T> — runtime counter that SpecializedNautilusFunction reads
+// at trace time to decide which dispatcher variant to emit.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("ValueProfile::profile updates hits and total") {
+	ValueProfile<int64_t> p;
+	REQUIRE_FALSE(p.isStable(0.5, 4));
+	ValueProfile<int64_t>::profile(&p, 5);
+	ValueProfile<int64_t>::profile(&p, 5);
+	ValueProfile<int64_t>::profile(&p, 5);
+	ValueProfile<int64_t>::profile(&p, 5);
+	REQUIRE(p.isStable(0.5, 4));
+	REQUIRE(p.dominant() == 5);
+
+	// A different value resets the hit streak but keeps total growing.
+	ValueProfile<int64_t>::profile(&p, 7);
+	REQUIRE(p.dominant() == 7);
+}
+
+TEST_CASE("ValueProfile: non-dominant values keep profile unstable") {
+	ValueProfile<int64_t> p;
+	for (int i = 0; i < 2048; ++i) {
+		ValueProfile<int64_t>::profile(&p, i % 2);
+	}
+	REQUIRE_FALSE(p.isStable());
+	REQUIRE_FALSE(p.isStable(0.01, 1024));
+}
+
+TEST_CASE("ValueProfile: min_samples gate") {
+	ValueProfile<int32_t> p;
+	for (int i = 0; i < 16; ++i) {
+		ValueProfile<int32_t>::profile(&p, 42);
+	}
+	REQUIRE_FALSE(p.isStable());   // default 1024 samples required
+	REQUIRE(p.isStable(0.95, 16)); // lowered gate -> stable
+	REQUIRE(p.dominant() == 42);
+}
+
+// ---------------------------------------------------------------------------
+// IR-dump helper. We deliberately do not use the reference-file comparison
+// harness because the dispatcher bakes profile pointers into the IR as
+// `inttoptr (i64 N to ptr)` literals, and `N` changes across runs.
+// ---------------------------------------------------------------------------
+
+struct CompiledDumps {
+	std::string mlir;
+	std::string llvm;
+};
+
+static CompiledDumps readCompiledIR(const std::string& tag, auto kernel) {
+	auto dumpPath = (std::filesystem::temp_directory_path() / ("nautilus-specialize-ir-" + tag)).string();
+	std::filesystem::remove_all(dumpPath);
+	std::filesystem::create_directories(dumpPath);
+
+	engine::Options options;
+	options.setOption("engine.backend", "mlir");
+	options.setOption("dump.after_llvm_generation", true);
+	options.setOption("dump.after_mlir_generation", true);
+	options.setOption("dump.all", true);
+	options.setOption("dump.path", dumpPath);
+	options.setOption("engine.normalizeFunctionNames", true);
+	options.setOption("mlir.enableIntrinsics", true);
+	options.setOption("mlir.enableMultithreading", false);
+
+	auto engine = engine::NautilusEngine(options);
+	auto function = engine.registerFunction(kernel);
+
+	auto slurp = [](std::string_view path) {
+		std::ifstream in {std::string {path}};
+		std::stringstream buf;
+		buf << in.rdbuf();
+		return buf.str();
+	};
+
+	auto mlirFile = function.getExecutable()->getGeneratedFile("after_mlir_generation");
+	auto llvmFile = function.getExecutable()->getGeneratedFile("after_llvm_generation");
+	REQUIRE(!mlirFile.empty());
+	REQUIRE(!llvmFile.empty());
+	return {slurp(mlirFile), slurp(llvmFile)};
+}
+
+// ---------------------------------------------------------------------------
+// SpecializedNautilusFunction: wraps a user kernel and exposes itself as a
+// regular NautilusFunction. The dispatch logic (profile-update vs traced
+// if/else into __specialized / __generic) lives inside the dispatcher
+// symbol's own traced body, so a parent trace sees exactly one
+// `traceNautilusCall` to the dispatcher.
+// ---------------------------------------------------------------------------
+
+static val<int64_t> specNF_pow(val<int64_t> base, val<int64_t> exp) {
+	val<int64_t> r = 1;
+	for (val<int64_t> i = 0; i < exp; i = i + 1) {
+		r = r * base;
+	}
+	return r;
+}
+
+TEST_CASE("SpecializedNautilusFunction: profile empty -> generic path + profile update") {
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"specnf_pow", specNF_pow};
+
+	auto engine = nautilus::testing::makeEngine("mlir", [&](engine::Options& options) {
+		options.setOption("mlir.enableIntrinsics", true);
+		options.setOption("mlir.enableMultithreading", false);
+	});
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+	auto fn = engine.registerFunction(wrapper);
+
+	REQUIRE(fn(2, 5) == 32);
+	REQUIRE(fn(3, 4) == 81);
+	REQUIRE(fn(7, 0) == 1);
+	for (int i = 0; i < 2048; ++i) {
+		REQUIRE(fn(2, 5) == 32);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+	REQUIRE(spec.profile<0>().dominant() == 5);
+}
+
+TEST_CASE("SpecializedNautilusFunction: stable profile -> dispatcher picks specialized/generic") {
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"specnf_pow_stable", specNF_pow};
+	for (int i = 0; i < 2048; ++i) {
+		ValueProfile<int64_t>::profile(&spec.profile<0>(), 5);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+
+	auto engine = nautilus::testing::makeEngine("mlir", [&](engine::Options& options) {
+		options.setOption("mlir.enableIntrinsics", true);
+		options.setOption("mlir.enableMultithreading", false);
+	});
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+	auto fn = engine.registerFunction(wrapper);
+
+	// Specialized branch (exp == 5).
+	REQUIRE(fn(2, 5) == 32);
+	REQUIRE(fn(3, 5) == 243);
+	REQUIRE(fn(-2, 5) == -32);
+	REQUIRE(fn(1, 5) == 1);
+	// Generic branch (exp != 5).
+	REQUIRE(fn(2, 10) == 1024);
+	REQUIRE(fn(3, 4) == 81);
+	REQUIRE(fn(5, 0) == 1);
+	REQUIRE(fn(7, 1) == 7);
+}
+
+TEST_CASE("SpecializedNautilusFunction IR: dispatcher hides cond_br + variant calls") {
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"specnf_ir", specNF_pow};
+	for (int i = 0; i < 2048; ++i) {
+		ValueProfile<int64_t>::profile(&spec.profile<0>(), 5);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+	const auto dumps = readCompiledIR("specnf", wrapper);
+	INFO("== Pre-opt MLIR for SpecializedNautilusFunction (stable):\n" << dumps.mlir);
+
+	// Externally a SpecializedNautilusFunction looks like a regular
+	// NautilusFunction: the parent `execute` contains exactly one call
+	// to the dispatcher symbol `@specnf_ir`. The dispatch logic
+	// (cond_br + nested calls into the two variants) lives in the
+	// dispatcher's own `func.func @specnf_ir` body, not in `execute`.
+	REQUIRE(dumps.mlir.find("func.func @execute") != std::string::npos);
+	REQUIRE(dumps.mlir.find("call @specnf_ir(") != std::string::npos);
+	REQUIRE(dumps.mlir.find("func.func @specnf_ir(") != std::string::npos);
+	REQUIRE(dumps.mlir.find("func.func @specnf_ir__generic(") != std::string::npos);
+	REQUIRE(dumps.mlir.find("func.func @specnf_ir__specialized(") != std::string::npos);
+	REQUIRE(dumps.mlir.find("call @specnf_ir__generic(") != std::string::npos);
+	REQUIRE(dumps.mlir.find("call @specnf_ir__specialized(") != std::string::npos);
+	REQUIRE(dumps.mlir.find("cf.cond_br") != std::string::npos);
+
+	// The specialized variant must have a *reduced* signature: the
+	// specialized index (1 = `exp`) is dropped, so only `base` (one
+	// i64) remains. The dominant value 5 becomes a local constant
+	// inside the specialized body, not a dead function parameter.
+	REQUIRE(dumps.mlir.find("func.func @specnf_ir__specialized(%arg0: i64) ->") != std::string::npos);
+	REQUIRE(dumps.mlir.find("func.func @specnf_ir__generic(%arg0: i64, %arg1: i64) ->") != std::string::npos);
+
+	// The cond_br and the two variant calls must live inside the
+	// dispatcher function, not inside `execute`.
+	const auto executeStart = dumps.mlir.find("func.func @execute");
+	const auto executeEnd = dumps.mlir.find("func.func @", executeStart + 1);
+	REQUIRE(executeStart != std::string::npos);
+	const std::string executeBody = dumps.mlir.substr(executeStart, executeEnd - executeStart);
+	REQUIRE(executeBody.find("cf.cond_br") == std::string::npos);
+	REQUIRE(executeBody.find("call @specnf_ir__generic") == std::string::npos);
+	REQUIRE(executeBody.find("call @specnf_ir__specialized") == std::string::npos);
+	REQUIRE(executeBody.find("call @specnf_ir(") != std::string::npos);
+}
+
+TEST_CASE("SpecializedNautilusFunction: multi-index specialization over (base, exp)") {
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 0, 1> spec {"specnf_multi", specNF_pow};
+	for (int i = 0; i < 2048; ++i) {
+		ValueProfile<int64_t>::profile(&spec.profile<0>(), 2);
+		ValueProfile<int64_t>::profile(&spec.profile<1>(), 5);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+	REQUIRE(spec.profile<1>().isStable());
+
+	auto engine = nautilus::testing::makeEngine("mlir", [&](engine::Options& options) {
+		options.setOption("mlir.enableIntrinsics", true);
+		options.setOption("mlir.enableMultithreading", false);
+	});
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+	auto fn = engine.registerFunction(wrapper);
+
+	// Fully-specialized path: both args match.
+	REQUIRE(fn(2, 5) == 32);
+	// Only base matches -> generic.
+	REQUIRE(fn(2, 4) == 16);
+	// Only exp matches -> generic.
+	REQUIRE(fn(3, 5) == 243);
+	// Neither matches -> generic.
+	REQUIRE(fn(4, 3) == 64);
+	REQUIRE(fn(7, 0) == 1);
+}
+
+TEST_CASE("SpecializedNautilusFunction IR: multi-index drops all specialized args from signature") {
+	// Fully specialized over both arguments: the specialized variant
+	// should have a zero-parameter signature because every argument is
+	// replaced by a local constant inside the body.
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 0, 1> spec {"specnf_full", specNF_pow};
+	for (int i = 0; i < 2048; ++i) {
+		ValueProfile<int64_t>::profile(&spec.profile<0>(), 2);
+		ValueProfile<int64_t>::profile(&spec.profile<1>(), 5);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+	REQUIRE(spec.profile<1>().isStable());
+
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+	const auto dumps = readCompiledIR("specnf_full", wrapper);
+	INFO("== Pre-opt MLIR for fully-specialized SpecializedNautilusFunction:\n" << dumps.mlir);
+
+	// The specialized variant now takes *no* arguments.
+	REQUIRE(dumps.mlir.find("func.func @specnf_full__specialized() ->") != std::string::npos);
+	// Dispatcher calls it with an empty arg list.
+	REQUIRE(dumps.mlir.find("call @specnf_full__specialized() :") != std::string::npos);
+	// Generic variant still has the original two-parameter signature.
+	REQUIRE(dumps.mlir.find("func.func @specnf_full__generic(%arg0: i64, %arg1: i64) ->") != std::string::npos);
+}
+
+TEST_CASE("SpecializedNautilusFunction: multi-index unstable profile emits two profile updates") {
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 0, 1> spec {"specnf_multi_empty", specNF_pow};
+
+	auto engine = nautilus::testing::makeEngine("mlir", [&](engine::Options& options) {
+		options.setOption("mlir.enableIntrinsics", true);
+		options.setOption("mlir.enableMultithreading", false);
+	});
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+	auto fn = engine.registerFunction(wrapper);
+
+	for (int i = 0; i < 2048; ++i) {
+		REQUIRE(fn(2, 5) == 32);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+	REQUIRE(spec.profile<0>().dominant() == 2);
+	REQUIRE(spec.profile<1>().isStable());
+	REQUIRE(spec.profile<1>().dominant() == 5);
+}
+
+TEST_CASE("SpecializedNautilusFunction: re-register after profile stabilizes emits specialized variant") {
+	SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"specnf_reg", specNF_pow};
+
+	auto engine = nautilus::testing::makeEngine("mlir", [&](engine::Options& options) {
+		options.setOption("mlir.enableIntrinsics", true);
+		options.setOption("mlir.enableMultithreading", false);
+	});
+	std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+		return spec(b, e);
+	};
+
+	// First registration: profile is empty, the dispatcher body goes
+	// through the profile-update + generic path. Driving the kernel with
+	// a dominant `exp` value makes the profile stable.
+	auto fn1 = engine.registerFunction(wrapper);
+	REQUIRE_FALSE(spec.profile<0>().isStable());
+	for (int i = 0; i < 4096; ++i) {
+		REQUIRE(fn1(2, 5) == 32);
+	}
+	REQUIRE(spec.profile<0>().isStable());
+	REQUIRE(spec.profile<0>().dominant() == 5);
+
+	// Second registration: the profile is now stable, so re-tracing the
+	// dispatcher picks up the if/else into the specialized variant. The
+	// compiled module should expose a `__specialized` symbol that the
+	// first compilation did not have.
+	const auto dumps = readCompiledIR("specnf_reg", wrapper);
+	INFO("== Pre-opt MLIR for re-registered SpecializedNautilusFunction:\n" << dumps.mlir);
+	REQUIRE(dumps.mlir.find("specnf_reg__generic") != std::string::npos);
+	REQUIRE(dumps.mlir.find("specnf_reg__specialized") != std::string::npos);
+	REQUIRE(dumps.mlir.find("call @specnf_reg__specialized") != std::string::npos);
+	REQUIRE(dumps.mlir.find("call @specnf_reg__generic") != std::string::npos);
+	REQUIRE(dumps.mlir.find("cf.cond_br") != std::string::npos);
+
+	auto fn2 = engine.registerFunction(wrapper);
+	REQUIRE(fn2(2, 5) == 32);  // specialized branch
+	REQUIRE(fn2(3, 5) == 243); // specialized branch
+	REQUIRE(fn2(3, 4) == 81);  // generic branch
+	REQUIRE(fn2(7, 0) == 1);   // generic branch
+}
+
+} // namespace nautilus::engine
+#endif

--- a/plugins/specialization/test/SpecializedNautilusFunctionBackendTest.cpp
+++ b/plugins/specialization/test/SpecializedNautilusFunctionBackendTest.cpp
@@ -1,0 +1,207 @@
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <functional>
+
+#ifdef ENABLE_TRACING
+#include "nautilus/specialization/specialize.hpp"
+#include "nautilus/specialization/specialized_function.hpp"
+
+namespace nautilus::engine {
+
+// Backend-parameterized behavioural tests for SpecializedNautilusFunction.
+//
+// These tests mirror the patterns used by the generic execution tests in
+// `nautilus/test/common/ExecutionTest.hpp`: every test case iterates over all
+// enabled code-gen backends via `forEachBackend`, plus the interpreter when
+// applicable. IR-shape inspection (cond_br placement, dispatcher symbol names)
+// stays in `SpecializationTest.cpp` since it is inherently MLIR-only.
+//
+// Backend variations / notes:
+// - The interpreter (`engine.Compilation=false`) executes the dispatcher
+//   lambda directly without compiling. The traced if/else still evaluates as
+//   regular C++ control flow, so both the specialized and generic branches
+//   produce correct results. Numeric outputs match the compiled backends.
+// - All compiled backends (mlir / cpp / bc / asmjit) go through the same
+//   tracing dispatcher path and must produce identical numeric results.
+
+namespace {
+
+val<int64_t> specBackendPow(val<int64_t> base, val<int64_t> exp) {
+	val<int64_t> r = 1;
+	for (val<int64_t> i = 0; i < exp; i = i + 1) {
+		r = r * base;
+	}
+	return r;
+}
+
+val<int32_t> specBackendMulAdd(val<int32_t> x, val<int32_t> k) {
+	return x * k + k;
+}
+
+} // namespace
+
+TEST_CASE("SpecializedNautilusFunction backends: empty profile / generic path") {
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"spec_be_empty",
+		                                                                                   specBackendPow};
+		    std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+			    return spec(b, e);
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    REQUIRE(fn(2, 5) == 32);
+		    REQUIRE(fn(3, 4) == 81);
+		    REQUIRE(fn(7, 0) == 1);
+		    REQUIRE(fn(-2, 3) == -8);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+TEST_CASE("SpecializedNautilusFunction backends: stable profile dispatches both branches") {
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"spec_be_stable",
+		                                                                                   specBackendPow};
+		    for (int i = 0; i < 2048; ++i) {
+			    ValueProfile<int64_t>::profile(&spec.profile<0>(), 5);
+		    }
+		    REQUIRE(spec.profile<0>().isStable());
+		    std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+			    return spec(b, e);
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    // Specialized branch (exp == 5).
+		    REQUIRE(fn(2, 5) == 32);
+		    REQUIRE(fn(3, 5) == 243);
+		    REQUIRE(fn(-2, 5) == -32);
+		    REQUIRE(fn(1, 5) == 1);
+		    // Generic branch (exp != 5).
+		    REQUIRE(fn(2, 10) == 1024);
+		    REQUIRE(fn(3, 4) == 81);
+		    REQUIRE(fn(5, 0) == 1);
+		    REQUIRE(fn(7, 1) == 7);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+TEST_CASE("SpecializedNautilusFunction backends: multi-index specialization") {
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 0, 1> spec {"spec_be_multi",
+		                                                                                      specBackendPow};
+		    for (int i = 0; i < 2048; ++i) {
+			    ValueProfile<int64_t>::profile(&spec.profile<0>(), 2);
+			    ValueProfile<int64_t>::profile(&spec.profile<1>(), 5);
+		    }
+		    REQUIRE(spec.profile<0>().isStable());
+		    REQUIRE(spec.profile<1>().isStable());
+		    std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+			    return spec(b, e);
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    // Both match -> specialized.
+		    REQUIRE(fn(2, 5) == 32);
+		    // Partial / no matches -> generic.
+		    REQUIRE(fn(2, 4) == 16);
+		    REQUIRE(fn(3, 5) == 243);
+		    REQUIRE(fn(4, 3) == 64);
+		    REQUIRE(fn(7, 0) == 1);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+TEST_CASE("SpecializedNautilusFunction backends: edge dominant value zero") {
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"spec_be_zero",
+		                                                                                   specBackendPow};
+		    for (int i = 0; i < 2048; ++i) {
+			    ValueProfile<int64_t>::profile(&spec.profile<0>(), 0);
+		    }
+		    REQUIRE(spec.profile<0>().isStable());
+		    REQUIRE(spec.profile<0>().dominant() == 0);
+		    std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+			    return spec(b, e);
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    // Specialized branch (exp == 0): pow returns 1 for any base.
+		    REQUIRE(fn(2, 0) == 1);
+		    REQUIRE(fn(99, 0) == 1);
+		    // Generic branch.
+		    REQUIRE(fn(2, 5) == 32);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+TEST_CASE("SpecializedNautilusFunction backends: edge dominant value negative (int32)") {
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int32_t>(val<int32_t>, val<int32_t>), 1> spec {"spec_be_neg",
+		                                                                                   specBackendMulAdd};
+		    for (int i = 0; i < 2048; ++i) {
+			    ValueProfile<int32_t>::profile(&spec.profile<0>(), -3);
+		    }
+		    REQUIRE(spec.profile<0>().isStable());
+		    std::function<val<int32_t>(val<int32_t>, val<int32_t>)> wrapper = [&](val<int32_t> x, val<int32_t> k) {
+			    return spec(x, k);
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    // Specialized branch (k == -3): x * -3 + -3.
+		    REQUIRE(fn(10, -3) == -33);
+		    REQUIRE(fn(0, -3) == -3);
+		    // Generic branch.
+		    REQUIRE(fn(4, 5) == 25);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+TEST_CASE("SpecializedNautilusFunction backends: multiple call sites in same parent") {
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"spec_be_multi_call",
+		                                                                                   specBackendPow};
+		    for (int i = 0; i < 2048; ++i) {
+			    ValueProfile<int64_t>::profile(&spec.profile<0>(), 3);
+		    }
+		    REQUIRE(spec.profile<0>().isStable());
+		    std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> a, val<int64_t> b) {
+			    // Two call sites: both must dedup to the same dispatcher symbol.
+			    auto x = spec(a, 3); // specialized
+			    auto y = spec(b, 4); // generic
+			    return x + y;
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    // 2^3 + 5^4 = 8 + 625 = 633
+		    REQUIRE(fn(2, 5) == 633);
+		    // 4^3 + 2^4 = 64 + 16 = 80
+		    REQUIRE(fn(4, 2) == 80);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+TEST_CASE("SpecializedNautilusFunction backends: profile drives stabilization through compiled calls") {
+	// Drives the profile via real compiled calls (rather than priming it
+	// directly), ensuring the profile-update proxy call lowers correctly on
+	// each backend.
+	nautilus::testing::forEachBackend(
+	    [](engine::NautilusEngine& engine) {
+		    SpecializedNautilusFunction<val<int64_t>(val<int64_t>, val<int64_t>), 1> spec {"spec_be_drive",
+		                                                                                   specBackendPow};
+		    std::function<val<int64_t>(val<int64_t>, val<int64_t>)> wrapper = [&](val<int64_t> b, val<int64_t> e) {
+			    return spec(b, e);
+		    };
+		    auto fn = engine.registerFunction(wrapper);
+		    REQUIRE_FALSE(spec.profile<0>().isStable());
+		    for (int i = 0; i < 2048; ++i) {
+			    REQUIRE(fn(2, 5) == 32);
+		    }
+		    REQUIRE(spec.profile<0>().isStable());
+		    REQUIRE(spec.profile<0>().dominant() == 5);
+	    },
+	    /*include_interpreter=*/true);
+}
+
+} // namespace nautilus::engine
+#endif


### PR DESCRIPTION
Introduces a header-only API in the specialization plugin that lets a
traced kernel mark arguments for value specialization. specialize(arg, p)
emits a profile-update proxy call when the profile is empty, and a
traced 'if (arg == c) { nautilus_assume(arg == c); arg = c; }'
dispatcher once the profile has stabilized so that downstream uses of
the argument can be const-folded by ConstantPropagationPhase + LLVM.