### PR TITLE
Fix SessionStart hook timing out on Claude Code web

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,10 +36,12 @@
 	"hooks": {
 		"SessionStart": [
 			{
+				"matcher": "startup",
 				"hooks": [
 					{
 						"type": "command",
-						"command": "$CLAUDE_PROJECT_DIR/.claude/setup.sh"
+						"command": "$CLAUDE_PROJECT_DIR/.claude/setup.sh",
+						"timeout": 900
 					}
 				]
 			}

--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
-# SessionStart hook for Claude Code on the web
-# Ensures Clang 21 is installed and the project is configured for building.
+# SessionStart hook for Claude Code on the web.
+# Ensures Clang 21 and basic build tools are available, then configures CMake.
+# The actual `cmake --build` is intentionally NOT run here — it would blow past
+# the SessionStart hook timeout. Let Claude run the build on demand instead.
 set -euo pipefail
 
+LOG_FILE="${CLAUDE_PROJECT_DIR:-$(pwd)}/.claude/setup.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "==> $(date -u +%Y-%m-%dT%H:%M:%SZ) setup.sh starting"
+
+# Only run the apt-get install path on Debian/Ubuntu (i.e. the web sandbox).
+# On macOS and other hosts, assume the developer has clang-21 installed already.
+if [ ! -f /etc/debian_version ]; then
+	echo "==> Not a Debian/Ubuntu host, skipping apt install."
+	exit 0
+fi
+
 NEED_INSTALL=false
-
-# Check if clang-21 is available
-if ! command -v clang++-21 &>/dev/null; then
-	NEED_INSTALL=true
-fi
-
-# Check if clang-format-21 is available
-if ! command -v clang-format-21 &>/dev/null; then
-	NEED_INSTALL=true
-fi
+if ! command -v clang++-21 &>/dev/null; then NEED_INSTALL=true; fi
+if ! command -v clang-format-21 &>/dev/null; then NEED_INSTALL=true; fi
 
 if [ "$NEED_INSTALL" = true ]; then
 	echo "==> Installing Clang 21 toolchain..."
@@ -50,7 +56,7 @@ if ! dpkg -s binutils-dev &>/dev/null 2>&1; then
 	sudo apt-get install -y -qq binutils-dev libdw-dev
 fi
 
-# Configure and build if no build directory exists
+# Configure CMake once; skip if a build dir already exists.
 if [ ! -f build/build.ninja ]; then
 	echo "==> Configuring CMake build..."
 	mkdir -p build
@@ -61,10 +67,9 @@ if [ ! -f build/build.ninja ]; then
 		-G Ninja \
 		..
 	cd ..
+else
+	echo "==> build/build.ninja already present, skipping CMake configure."
 fi
-
-echo "==> Building nautilus..."
-cmake --build build --target nautilus -j"$(nproc)"
 
 echo "==> Setup complete. Clang 21 is the default compiler."
 clang++-21 --version | head -1

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .vscode/
 compile_commands.json
 Testing/
+.claude/setup.log
+.claude/settings.local.json


### PR DESCRIPTION
The SessionStart hook was running a full `cmake --build` of nautilus, which exceeds the default 10-minute hook timeout on a fresh sandbox and leaves the environment half-configured. Drop the build from the hook and let Claude run it on demand instead.

- Remove `cmake --build` from setup.sh; keep toolchain install and CMake configure only.
- Add `"matcher": "startup"` and `"timeout": 900` to the hook config so it only runs on fresh sessions and has headroom for the one-time apt install on a cold sandbox.
- Early-exit setup.sh on non-Debian hosts via /etc/debian_version so the apt branch is a clean no-op on macOS.
- Tee all output to .claude/setup.log so hook failures on the web are debuggable.
- Gitignore .claude/setup.log and .claude/settings.local.json.