### PR TITLE
Expand example/ with module, backend, and plugin demos

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,6 +118,94 @@ jobs:
         shell: bash
         run: |
           ctest --test-dir build/plugins/simd/test --output-on-failure
+  example-demos:
+    runs-on: ubuntu-24.04
+    name: Example demos (clang-18)
+    env:
+      CC: clang-18
+      CXX: clang++-18
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: get cmake
+        uses: lukka/get-cmake@latest
+      - name: Cache MLIR binaries
+        uses: actions/cache@v4
+        with:
+          path: example/build/mlir-*
+          key: mlir-21.1.2-${{ runner.os }}-${{ runner.arch }}-example
+      - name: get ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+        with:
+          key: ${{ github.job }}-example-demos
+      - name: cmake
+        shell: bash
+        working-directory: example
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja -S . -B build
+      - name: build demos
+        shell: bash
+        working-directory: example
+        run: |
+          cmake --build build --target demo demo_modules demo_backends demo_runtime_calls demo_std_plugin demo_simd_plugin demo_specialization_plugin
+      - name: run demo (baseline conditionalSum)
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo)
+          echo "$out"
+          echo "$out" | grep -q "Result: 7"
+      - name: run demo_modules
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo_modules)
+          echo "$out"
+          echo "$out" | grep -q "add(3, 4)      = 7"
+          echo "$out" | grep -q "mul(3, 4)      = 12"
+          echo "$out" | grep -q "factorial(5)   = 120"
+          echo "$out" | grep -q "factorial(10)  = 3628800"
+      - name: run demo_backends
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo_backends)
+          echo "$out"
+          echo "$out" | grep -q "result=333283335000"
+      - name: run demo_runtime_calls
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo_runtime_calls)
+          echo "$out"
+          echo "$out" | grep -q "sumOfPrimesBelow(20)        = 77"
+          echo "$out" | grep -q "quadrupleIt(5)              = 20"
+          echo "$out" | grep -q "factorial(10)               = 3628800"
+          echo "$out" | grep -q "applyDoubleFromRuntime(3)   = 12"
+      - name: run demo_std_plugin
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo_std_plugin)
+          echo "$out"
+          echo "$out" | grep -qF "conditionalSumVec([1,2,3,4], [1,1,0,1]) = 7"
+          echo "$out" | grep -qF "rmsError(...)                            = 0.5"
+      - name: run demo_simd_plugin
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo_simd_plugin)
+          echo "$out"
+          echo "$out" | grep -qF "mask=[1,1,0,1]) = 7"
+          echo "$out" | grep -qF "evens in [0,32)) = 240"
+      - name: run demo_specialization_plugin
+        shell: bash
+        working-directory: example/build
+        run: |
+          out=$(./demo_specialization_plugin)
+          echo "$out"
+          echo "$out" | grep -q "conditionalSumPlain  = 7"
+          echo "$out" | grep -q "conditionalSumHinted = 7"
   llvm-ir-test:
     runs-on: ubuntu-24.04
     name: LLVM IR Test (clang-21)

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /cmake-build*
 *cmake-build*
 /build*
+/example/build*
 .idea/*
 .cache/
 .vscode/

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,8 +9,57 @@ set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Werror=extra -Werror=all -fpermiss
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+# Force the shipped plugins ON so the plugin demos below can link against them.
+# These options are declared by the top-level nautilus CMakeLists.txt and,
+# when ON, cause add_subdirectory(plugins/...) to register the plugin targets
+# (nautilus-std, nautilus-simd, nautilus-specialization).
+set(ENABLE_STD_PLUGIN ON CACHE BOOL "" FORCE)
+set(ENABLE_SIMD_PLUGIN ON CACHE BOOL "" FORCE)
+set(ENABLE_SPECIALIZATION_PLUGIN ON CACHE BOOL "" FORCE)
+# Enable the AsmJit backend so demo_backends can include it in its comparison.
+# This is OFF by default in the top-level nautilus build but is safe on
+# x86-64 Linux / macOS and ARM64 Linux.
+set(ENABLE_ASMJIT_BACKEND ON CACHE BOOL "" FORCE)
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/nautilus)
 
+# Core demos — only need the nautilus library.
 add_executable(demo src/DemoJit.cpp)
-
 target_link_libraries(demo PRIVATE nautilus)
+
+add_executable(demo_modules src/DemoModules.cpp)
+target_link_libraries(demo_modules PRIVATE nautilus)
+
+add_executable(demo_backends src/DemoBackends.cpp)
+target_link_libraries(demo_backends PRIVATE nautilus)
+
+add_executable(demo_runtime_calls src/DemoRuntimeCalls.cpp)
+target_link_libraries(demo_runtime_calls PRIVATE nautilus)
+
+# Plugin demos — each links the plugin library it exercises.
+# All plugin libraries use --whole-archive (on GNU/Clang) to force their
+# static initializer translation units (e.g. StdPluginInit.cpp,
+# SpecializationPluginInit.cpp) to be linked in. Without this, the linker
+# drops those TUs because the demo code never references their symbols
+# directly, and the MLIR intrinsic plugins are never registered — so
+# operations like sqrt or nautilus_assume fall back to opaque invoke()
+# calls instead of lowering to native LLVM intrinsics.
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(WHOLE_ARCHIVE_PREFIX -Wl,--whole-archive)
+    set(WHOLE_ARCHIVE_SUFFIX -Wl,--no-whole-archive)
+else ()
+    set(WHOLE_ARCHIVE_PREFIX "")
+    set(WHOLE_ARCHIVE_SUFFIX "")
+endif ()
+
+add_executable(demo_std_plugin src/DemoStdPlugin.cpp)
+target_link_libraries(demo_std_plugin PRIVATE
+        nautilus ${WHOLE_ARCHIVE_PREFIX} nautilus-std ${WHOLE_ARCHIVE_SUFFIX})
+
+add_executable(demo_simd_plugin src/DemoSimdPlugin.cpp)
+target_link_libraries(demo_simd_plugin PRIVATE
+        nautilus ${WHOLE_ARCHIVE_PREFIX} nautilus-simd ${WHOLE_ARCHIVE_SUFFIX})
+
+add_executable(demo_specialization_plugin src/DemoSpecializationPlugin.cpp)
+target_link_libraries(demo_specialization_plugin PRIVATE
+        nautilus ${WHOLE_ARCHIVE_PREFIX} nautilus-specialization ${WHOLE_ARCHIVE_SUFFIX})

--- a/example/README.md
+++ b/example/README.md
@@ -1,11 +1,54 @@
-# Nautilus: Demo JIT example
+# Nautilus: Example walkthrough
 
-This example project illustrates how Nautilus can be integrated into a C++ project using CMAKE.
+This directory is a small, self-contained tour of Nautilus. It shows how to
+integrate Nautilus into a C++ project with CMake and walks through the core
+API, the multi-function module API, backend selection, and each of the three
+shipped plugins.
 
-## Integrate as sub project
+## Building
+
+```bash
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . -j
+```
+
+The top-level CMakeLists.txt in this directory forces
+`ENABLE_STD_PLUGIN`, `ENABLE_SIMD_PLUGIN`, and `ENABLE_SPECIALIZATION_PLUGIN`
+to `ON` so that the plugin targets (`nautilus-std`, `nautilus-simd`,
+`nautilus-specialization`) are built and available for the demos below.
+
+## Demos
+
+| Executable | Source | What it shows |
+|---|---|---|
+| `./demo` | [src/DemoJit.cpp](src/DemoJit.cpp) | Baseline `conditionalSum` with raw C pointers. Runs on the default engine configuration — the **tiered JIT compiler** (see `nautilus/src/nautilus/compiler/Engine.cpp`), which is the production-recommended path. |
+| `./demo_modules` | [src/DemoModules.cpp](src/DemoModules.cpp) | The `NautilusModule` API: register several functions (`add`, `mul`, `factorial`) into one compilation unit and fetch typed handles by name. |
+| `./demo_backends` | [src/DemoBackends.cpp](src/DemoBackends.cpp) | Compiles the same `sumOfSquares` with every backend enabled at configure time (`mlir`, `cpp`, `bc`, `asmjit`) and prints a short wall-clock comparison. |
+| `./demo_runtime_calls` | [src/DemoRuntimeCalls.cpp](src/DemoRuntimeCalls.cpp) | Four function-call patterns: (1) opaque `invoke()` into a C++ helper, (2) one `NautilusFunction` calling another, (3) recursive `NautilusFunction`, (4) `getFuncPtr()` to pass a compiled function pointer to a runtime callback. |
+| `./demo_std_plugin` | [src/DemoStdPlugin.cpp](src/DemoStdPlugin.cpp) | The `nautilus-std` plugin. `conditionalSum` reimplemented over `val<std::vector<int32_t>>` plus an `rmsError` function that combines vector iteration with `nautilus::sqrt` from `<nautilus/std/cmath.h>`. |
+| `./demo_simd_plugin` | [src/DemoSimdPlugin.cpp](src/DemoSimdPlugin.cpp) | The `nautilus-simd` plugin. SIMD-vectorised `conditionalSum` using `val<vec<int32_t>>::Load`, element-wise multiply by the mask, and `ReduceAdd`, with a scalar tail loop. |
+| `./demo_specialization_plugin` | [src/DemoSpecializationPlugin.cpp](src/DemoSpecializationPlugin.cpp) | The `nautilus-specialization` plugin. Scalar `conditionalSum` in two flavours — plain and annotated with `nautilus_assume` / `nautilus_assume_aligned`. Dumps the generated LLVM IR so the two can be diffed side-by-side. |
+
+The three plugin demos all solve the **same `conditionalSum` aggregation**,
+so you can read them back-to-back and see how the same problem is expressed
+through containers, through SIMD intrinsics, and through optimizer hints.
+
+## Plugins used
+
+- [`plugins/std`](../plugins/std) — traced wrappers around the C++ standard
+  library: `<nautilus/std/vector.h>`, `<nautilus/std/cmath.h>`,
+  `<nautilus/std/string.h>`, `<nautilus/std/bit.h>`, `<nautilus/std/cstring.h>`.
+- [`plugins/simd`](../plugins/simd) — runtime-width `val<vec<T>>` SIMD
+  specialization that lowers to MLIR's vector dialect or a scalar fallback.
+- [`plugins/specialization`](../plugins/specialization) — `nautilus_assume`
+  and `nautilus_assume_aligned` optimizer hints (active on the MLIR backend
+  with `mlir.enableIntrinsics = true`).
+
+## Integrate as a sub project
 
 Nautilus is self-contained and requires no external pre-installed dependencies.
-In this example, integrate nautilus as a subproject:
+In this example, nautilus is pulled in as a subproject:
 
 ```cmake
 # add the nautilus source dir as a subdirectory to the main cmake project.
@@ -15,12 +58,12 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/naut
 target_link_libraries(myTarget PRIVATE nautilus)
 ```
 
-## Example
+## The baseline conditionalSum walkthrough
 
-The following [example](./example/) illustrates Nautilus on a simplified aggregation operator.
-`conditionalSum` iterates over an array and only aggregates the values for, which mask is true.
-Nautilus traces the function and generates efficient code using one of its compilation backend.
-These produce either byte code, [mlir](), or[c++]() code.
+The following example illustrates Nautilus on a simplified aggregation operator.
+`conditionalSum` iterates over an array and only aggregates the values for which the mask is true.
+Nautilus traces the function and generates efficient code using one of its compilation backends.
+These produce either byte code, [mlir](), or [c++]() code.
 
 ```c++
 val<int32_t> conditionalSum(val<int32_t> size, val<bool*> mask, val<int32_t*> array) {

--- a/example/src/DemoBackends.cpp
+++ b/example/src/DemoBackends.cpp
@@ -1,0 +1,88 @@
+// DemoBackends.cpp — compile the same nautilus function with every backend
+// that was enabled at CMake configure time, run it, and print a short
+// wall-clock comparison.
+//
+// Backends selected via options.setOption("engine.backend", "<name>"):
+//   "mlir"   — MLIR → LLVM → native (primary, usually fastest)
+//   "cpp"    — C++ source generation + system compiler
+//   "bc"     — in-process bytecode interpreter
+//   "asmjit" — direct x86-64 / ARM64 assembly via asmjit (experimental)
+//
+// The baseline DemoJit.cpp leaves this option unset, which picks up the
+// tiered JIT compiler default — see nautilus/src/nautilus/compiler/Engine.cpp.
+
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <nautilus/Engine.hpp>
+#include <nautilus/val.hpp>
+#include <string>
+#include <vector>
+
+using namespace nautilus;
+
+// Sum of squares from 0 to n-1. Simple, loop-heavy, easy to benchmark.
+val<int64_t> sumOfSquares(val<int32_t> n) {
+	val<int64_t> sum = 0;
+	for (val<int32_t> i = 0; i < n; i++) {
+		val<int64_t> v = i;
+		sum += v * v;
+	}
+	return sum;
+}
+
+static void runWith(const std::string& backendName, int32_t n) {
+	engine::Options options;
+	options.setOption("engine.backend", backendName);
+	// Force single-tier compilation so each run uses exactly the requested
+	// backend, instead of the tiered strategy switching between them.
+	options.setOption("engine.compilationStrategy", std::string("legacy"));
+	auto engine = engine::NautilusEngine(options);
+
+	// Measure compile time + first call separately from warm calls.
+	auto compileStart = std::chrono::steady_clock::now();
+	auto fn = engine.registerFunction(sumOfSquares);
+	auto compileEnd = std::chrono::steady_clock::now();
+
+	int64_t result = 0;
+	auto runStart = std::chrono::steady_clock::now();
+	for (int i = 0; i < 100; i++) {
+		result += fn(n);
+	}
+	auto runEnd = std::chrono::steady_clock::now();
+
+	auto compileMs = std::chrono::duration<double, std::milli>(compileEnd - compileStart).count();
+	auto runUs = std::chrono::duration<double, std::micro>(runEnd - runStart).count();
+
+	std::cout << std::left << std::setw(10) << backendName << "  compile=" << std::fixed << std::setprecision(2)
+	          << std::setw(8) << compileMs << " ms   100x run=" << std::setw(8) << runUs
+	          << " us   result=" << (result / 100) << "\n";
+}
+
+int main(int, char*[]) {
+	constexpr int32_t N = 10'000;
+	std::cout << "Benchmarking sumOfSquares(" << N << ") across compiled-in backends:\n\n";
+
+	// Each backend is only linked in when its CMake flag is ON.
+#ifdef ENABLE_MLIR_BACKEND
+	runWith("mlir", N);
+#endif
+#ifdef ENABLE_C_BACKEND
+	runWith("cpp", N);
+#endif
+#ifdef ENABLE_BC_BACKEND
+	runWith("bc", N);
+#endif
+#ifdef ENABLE_ASMJIT_BACKEND
+	runWith("asmjit", N);
+#endif
+
+	std::cout << "\nExpected result: " << ([] {
+		int64_t s = 0;
+		for (int64_t i = 0; i < N; i++)
+			s += i * i;
+		return s;
+	})() << "\n";
+	return 0;
+}

--- a/example/src/DemoModules.cpp
+++ b/example/src/DemoModules.cpp
@@ -1,0 +1,58 @@
+// DemoModules.cpp — showcase the NautilusModule API.
+//
+// A NautilusModule groups several named functions into one compilation unit
+// so they share a single IR graph, a single optimization run, and a single
+// backend invocation. The compiled result is a CompiledModule, from which
+// callers fetch stable ModuleFunction handles by name.
+//
+// Compare with DemoJit.cpp, which uses the one-shot `registerFunction`
+// convenience that wraps a module with a single "execute" function.
+
+#include <cstdint>
+#include <iostream>
+#include <nautilus/Engine.hpp>
+#include <nautilus/val.hpp>
+
+using namespace nautilus;
+
+int main(int, char*[]) {
+	// Default options → tiered JIT compiler, MLIR backend (if available).
+	engine::Options options;
+	auto engine = engine::NautilusEngine(options);
+
+	// Build a module that holds three independent functions.
+	auto module = engine.createModule();
+
+	// `registerFunction<Sig>(name, lambda)` — explicit val-typed signature is
+	// required for lambdas so the template can deduce argument types.
+	module.registerFunction<val<int32_t>(val<int32_t>, val<int32_t>)>(
+	    "add", [](val<int32_t> a, val<int32_t> b) { return a + b; });
+
+	module.registerFunction<val<int32_t>(val<int32_t>, val<int32_t>)>(
+	    "mul", [](val<int32_t> a, val<int32_t> b) { return a * b; });
+
+	// Iterative factorial — exercises tracing through a loop.
+	module.registerFunction<val<int64_t>(val<int32_t>)>("factorial", [](val<int32_t> n) {
+		val<int64_t> result = 1;
+		for (val<int32_t> i = 1; i <= n; i++) {
+			result = result * i;
+		}
+		return result;
+	});
+
+	// Compile all three into a single compilation unit.
+	auto compiled = module.compile();
+
+	// Fetch typed handles. The raw signature (no `val<>`) is used here.
+	auto add = compiled.getFunction<int32_t(int32_t, int32_t)>("add");
+	auto mul = compiled.getFunction<int32_t(int32_t, int32_t)>("mul");
+	auto factorial = compiled.getFunction<int64_t(int32_t)>("factorial");
+
+	std::cout << "Backend:         " << engine.getNameOfBackend() << "\n";
+	std::cout << "add(3, 4)      = " << add(3, 4) << "\n";
+	std::cout << "mul(3, 4)      = " << mul(3, 4) << "\n";
+	std::cout << "factorial(5)   = " << factorial(5) << "\n";
+	std::cout << "factorial(10)  = " << factorial(10) << "\n";
+
+	return 0;
+}

--- a/example/src/DemoRuntimeCalls.cpp
+++ b/example/src/DemoRuntimeCalls.cpp
@@ -1,0 +1,146 @@
+// DemoRuntimeCalls.cpp — four patterns for calling functions from traced code.
+//
+// Pattern 1 — Opaque runtime call via invoke():
+//   A plain C++ function (isPrime) that the tracer treats as a black box.
+//   The backend emits a normal C ABI call at runtime.
+//
+// Pattern 2 — NautilusFunction cross-call:
+//   One nautilus function calls another through a NautilusFunction handle.
+//   Both functions are traced and compiled; the backend emits a direct
+//   call between them.
+//
+// Pattern 3 — Recursive NautilusFunction:
+//   A nautilus function calls *itself* via its own NautilusFunction handle,
+//   producing a recursive compiled function.
+//
+// Pattern 4 — NautilusFunction pointer passed to a runtime function:
+//   getFuncPtr() extracts a typed function pointer from a NautilusFunction.
+//   That pointer is handed to a plain C++ callback (via invoke()) which
+//   calls the compiled nautilus code from the runtime side.
+
+#include <cstdint>
+#include <iostream>
+#include <nautilus/Engine.hpp>
+#include <nautilus/function.hpp>
+#include <nautilus/nautilus_function.hpp>
+#include <nautilus/val.hpp>
+
+using namespace nautilus;
+
+// ============================================================================
+// Pattern 1 — opaque runtime call
+// ============================================================================
+
+// Plain C++ — NOT a nautilus function. The tracer records a single CALL op.
+static bool isPrime(int32_t n) {
+	if (n < 2) {
+		return false;
+	}
+	for (int32_t d = 2; d * d <= n; d++) {
+		if (n % d == 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Traced function that delegates the primality test to the runtime.
+val<int32_t> sumOfPrimesBelow(val<int32_t> n) {
+	val<int32_t> sum = 0;
+	for (val<int32_t> i = 2; i < n; i++) {
+		if (invoke(isPrime, i)) {
+			sum += i;
+		}
+	}
+	return sum;
+}
+
+// ============================================================================
+// Pattern 2 — one nautilus function calls another
+// ============================================================================
+
+// A simple helper: doubles its argument. Declared as a NautilusFunction so
+// other nautilus code can call it and both sides get traced/compiled.
+val<int32_t> doubleIt(val<int32_t> x) {
+	return x * 2;
+}
+static auto nautilusDouble = NautilusFunction {"doubleIt", doubleIt};
+
+// Calls nautilusDouble twice to quadruple. The backend compiles both
+// functions and emits a direct call from quadrupleIt → doubleIt.
+val<int32_t> quadrupleIt(val<int32_t> x) {
+	return nautilusDouble(nautilusDouble(x));
+}
+
+// ============================================================================
+// Pattern 3 — recursive NautilusFunction
+// ============================================================================
+
+// Forward-declare so the NautilusFunction object exists before the body.
+val<int64_t> factorialImpl(val<int32_t> n);
+static auto nautilusFactorial = NautilusFunction {"factorial", factorialImpl};
+
+// The body calls itself through nautilusFactorial → true recursion.
+val<int64_t> factorialImpl(val<int32_t> n) {
+	if (n <= 1) {
+		return 1;
+	}
+	return n * nautilusFactorial(n - 1);
+}
+
+// ============================================================================
+// Pattern 4 — pass NautilusFunction pointer to a runtime callback
+// ============================================================================
+
+// Plain C++ runtime helper that receives a typed function pointer and
+// calls it. The function pointer points into the compiled nautilus code.
+static int32_t applyTwice(int32_t (*fn)(int32_t), int32_t x) {
+	return fn(fn(x));
+}
+
+// Traced function: extracts a compiled function pointer from
+// nautilusDouble via getFuncPtr(), then hands it to a runtime C function
+// via invoke(). The runtime function calls back into compiled code.
+val<int32_t> applyDoubleFromRuntime(val<int32_t> x) {
+	auto fnPtr = nautilusDouble.getFuncPtr();
+	return invoke(applyTwice, fnPtr, x);
+}
+
+// ============================================================================
+
+int main(int, char*[]) {
+	engine::Options options;
+	auto engine = engine::NautilusEngine(options);
+	std::cout << "Backend: " << engine.getNameOfBackend() << "\n\n";
+
+	// Register all four entry-point functions in a single module.
+	auto module = engine.createModule();
+	module.registerFunction("sumOfPrimesBelow", sumOfPrimesBelow);
+	module.registerFunction("quadrupleIt", quadrupleIt);
+	module.registerFunction("factorial", factorialImpl);
+	module.registerFunction("applyDoubleFromRuntime", applyDoubleFromRuntime);
+	auto compiled = module.compile();
+
+	auto primes = compiled.getFunction<int32_t(int32_t)>("sumOfPrimesBelow");
+	auto quad = compiled.getFunction<int32_t(int32_t)>("quadrupleIt");
+	auto fact = compiled.getFunction<int64_t(int32_t)>("factorial");
+	auto dblRt = compiled.getFunction<int32_t(int32_t)>("applyDoubleFromRuntime");
+
+	// Pattern 1: sum of primes below 20 = 2+3+5+7+11+13+17+19 = 77
+	std::cout << "Pattern 1 — opaque runtime call (invoke):\n";
+	std::cout << "  sumOfPrimesBelow(20)        = " << primes(20) << "  (expected 77)\n\n";
+
+	// Pattern 2: quadruple(5) = double(double(5)) = double(10) = 20
+	std::cout << "Pattern 2 — NautilusFunction cross-call:\n";
+	std::cout << "  quadrupleIt(5)              = " << quad(5) << "  (expected 20)\n\n";
+
+	// Pattern 3: factorial(10) = 3628800
+	std::cout << "Pattern 3 — recursive NautilusFunction:\n";
+	std::cout << "  factorial(10)               = " << fact(10) << "  (expected 3628800)\n\n";
+
+	// Pattern 4: applyTwice(doubleIt, 3) = doubleIt(doubleIt(3)) = doubleIt(6) = 12
+	std::cout << "Pattern 4 — NautilusFunction pointer to runtime callback:\n";
+	std::cout << "  applyDoubleFromRuntime(3)   = " << dblRt(3) << "  (expected 12)\n";
+
+	return 0;
+}

--- a/example/src/DemoSimdPlugin.cpp
+++ b/example/src/DemoSimdPlugin.cpp
@@ -1,0 +1,139 @@
+// DemoSimdPlugin.cpp — showcase the `nautilus-simd` plugin.
+//
+// The simd plugin adds a `val<vec<T>>` specialization that lowers to real
+// SIMD instructions in the compiled code (via MLIR's vector dialect) or
+// falls back to a lane-count scalar loop when the backend cannot emit
+// vector ops.
+//
+// ## How lane count maps to hardware
+//
+// `vec<T>::Lanes()` calls `RuntimeSimdWidth()` which probes the CPU at
+// runtime (cpuid on x86, feature registers on ARM) and returns the SIMD
+// register width **in bytes**:
+//
+//   16 bytes  →  SSE2     (x86)  or  NEON    (ARM)
+//   32 bytes  →  AVX/AVX2 (x86)
+//   64 bytes  →  AVX-512  (x86)
+//
+// The lane count for a given element type is then:
+//
+//   Lanes = RegisterWidthInBytes / sizeof(T)
+//
+// Examples with a 64-byte (AVX-512) register:
+//   vec<int32_t>::Lanes()  = 64 / 4  = 16  (sixteen 32-bit ints per register)
+//   vec<float>::Lanes()    = 64 / 4  = 16
+//   vec<double>::Lanes()   = 64 / 8  =  8  (eight 64-bit doubles)
+//   vec<int16_t>::Lanes()  = 64 / 2  = 32
+//
+// With a 32-byte (AVX2) register the same types give 8, 8, 4, 16 lanes.
+//
+// This value is queried once, at tracing time.  From the tracer's point of
+// view it is a plain `size_t` constant — the JIT-compiled code is therefore
+// specialised for the width of the machine it runs on.  A single
+// `val<vec<int32_t>>::Load(ptr)` becomes, for example, one `vmovdqu`
+// (AVX-512) or one `vld1q` (NEON) in the generated assembly.
+//
+// The MLIR backend lowers `val<vec<T>>` operations to MLIR's vector dialect
+// which maps directly to LLVM vector types.  LLVM's backend then selects
+// the right hardware instruction during code generation.
+//
+// ## This demo
+//
+// Re-implements the conditionalSum problem from DemoJit.cpp, but processes
+// `Lanes()` elements at a time using `val<vec<int32_t>>`.  A scalar tail
+// loop handles the final `size % Lanes()` elements.
+
+#include <cstdint>
+#include <iostream>
+#include <nautilus/Engine.hpp>
+#include <nautilus/val.hpp>
+#include <nautilus/vector.hpp> // simd plugin
+#include <vector>
+
+using namespace nautilus;
+
+// SIMD-vectorised conditionalSum.
+//
+// `mask` is expected to contain 0 (skip) or 1 (include) in each lane — the
+// kernel multiplies the value vector by the mask vector so masked-out lanes
+// contribute zero to the running accumulator.
+val<int32_t> conditionalSumSimd(val<int32_t> size, val<const int32_t*> values, val<const int32_t*> mask) {
+	// Lanes() is a C++ runtime query — during tracing it returns an ordinary
+	// size_t which the trace captures as a compile-time constant step size.
+	const size_t L = vec<int32_t>::Lanes();
+	const val<int32_t> stride = static_cast<int32_t>(L);
+
+	val<int32_t> sum = 0;
+	val<int32_t> i = 0;
+
+	// Main vector loop: process L elements per iteration.
+	while (i + stride <= size) {
+		auto v = val<vec<int32_t>>::Load(values + i);
+		auto m = val<vec<int32_t>>::Load(mask + i);
+		sum += (v * m).ReduceAdd();
+		i = i + stride;
+	}
+
+	// Scalar tail for the remaining size % L elements.
+	while (i < size) {
+		if (mask[i] != 0) {
+			sum += values[i];
+		}
+		i = i + 1;
+	}
+	return sum;
+}
+
+int main(int, char*[]) {
+	engine::Options options;
+	// Use the MLIR backend directly so the vector intrinsics lower to real
+	// SIMD instructions (e.g. vmovdqu / vpmulld on AVX-512) instead of
+	// falling back to scalar loops through the bytecode interpreter.
+	// Use the MLIR backend directly (not tiered) so the vector intrinsics
+	// lower to real SIMD instructions in a single synchronous compilation
+	// pass, rather than first running through the bytecode interpreter.
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("engine.compilationStrategy", std::string("legacy"));
+	auto engine = engine::NautilusEngine(options);
+
+	const size_t widthBytes = RuntimeSimdWidth();
+	std::cout << "Backend:              " << engine.getNameOfBackend() << "\n";
+	std::cout << "SIMD register width:  " << widthBytes << " bytes";
+	if (widthBytes == 16) {
+		std::cout << "  (SSE2 / NEON)";
+	} else if (widthBytes == 32) {
+		std::cout << "  (AVX / AVX2)";
+	} else if (widthBytes == 64) {
+		std::cout << "  (AVX-512)";
+	}
+	std::cout << "\n";
+	std::cout << "vec<int32_t>::Lanes() = " << widthBytes << " / sizeof(int32_t) = " << vec<int32_t>::Lanes() << "\n";
+	std::cout << "vec<float>::Lanes()   = " << widthBytes << " / sizeof(float)   = " << vec<float>::Lanes() << "\n";
+	std::cout << "vec<double>::Lanes()  = " << widthBytes << " / sizeof(double)  = " << vec<double>::Lanes() << "\n\n";
+
+	auto fn = engine.registerFunction(conditionalSumSimd);
+
+	// Same payload as DemoJit.cpp: sum of {1, 2, 4} → 7.
+	std::vector<int32_t> values = {1, 2, 3, 4};
+	std::vector<int32_t> mask = {1, 1, 0, 1};
+	auto resultSmall = fn(static_cast<int32_t>(values.size()), values.data(), mask.data());
+	std::cout << "conditionalSumSimd([1,2,3,4], mask=[1,1,0,1]) = " << resultSmall << "  (expected 7)\n";
+
+	// Larger payload where the main vector loop actually engages: sum of all
+	// even values in [0, 32).
+	constexpr int32_t N = 32;
+	std::vector<int32_t> bigValues(N);
+	std::vector<int32_t> bigMask(N);
+	int32_t expected = 0;
+	for (int32_t k = 0; k < N; k++) {
+		bigValues[k] = k;
+		bigMask[k] = (k % 2 == 0) ? 1 : 0;
+		if (bigMask[k]) {
+			expected += bigValues[k];
+		}
+	}
+	auto resultBig = fn(N, bigValues.data(), bigMask.data());
+	std::cout << "conditionalSumSimd(sum of evens in [0,32)) = " << resultBig << "  (expected " << expected << ")\n";
+
+	return 0;
+}

--- a/example/src/DemoSpecializationPlugin.cpp
+++ b/example/src/DemoSpecializationPlugin.cpp
@@ -1,0 +1,101 @@
+// DemoSpecializationPlugin.cpp — showcase the `nautilus-specialization` plugin.
+//
+// The specialization plugin adds two optimizer hints:
+//
+//   nautilus_assume(val<bool> cond)
+//       Promise to the optimizer that `cond` is true at this program point.
+//       If the condition does not hold at runtime, behavior is undefined.
+//
+//   nautilus_assume_aligned(val<void*> ptr, int alignment)
+//       Promise that `ptr` is aligned to `alignment` bytes.
+//
+// Both hints are plain no-ops unless the MLIR backend is used with the
+// intrinsic pass enabled (`mlir.enableIntrinsics = true`). Static init in
+// the linked `nautilus-specialization` library registers the intrinsic
+// plugin with the MLIR backend automatically.
+//
+// This demo re-implements conditionalSum (from DemoJit.cpp) twice — once
+// plain, once annotated with assume hints — and dumps the generated LLVM IR
+// for both. Users can diff the two dumps to see the optimizer exploiting
+// the invariants.
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <nautilus/Engine.hpp>
+#include <nautilus/specialization/assume.hpp>
+#include <nautilus/val.hpp>
+
+using namespace nautilus;
+
+val<int32_t> conditionalSumPlain(val<int32_t> size, val<bool*> mask, val<int32_t*> array) {
+	val<int32_t> sum = 0;
+	for (val<int32_t> i = 0; i < size; i++) {
+		if (mask[i]) {
+			sum += array[i];
+		}
+	}
+	return sum;
+}
+
+val<int32_t> conditionalSumHinted(val<int32_t> size, val<bool*> mask, val<int32_t*> array) {
+	// Promise: size is strictly positive, so the loop body executes at least once.
+	nautilus_assume(size > 0);
+	// Promise: both buffers are 32-byte aligned. The caller allocates them with
+	// std::aligned_alloc(32, ...), so this invariant is upheld at runtime.
+	nautilus_assume_aligned((val<void*>) mask, 32);
+	nautilus_assume_aligned((val<void*>) array, 32);
+
+	val<int32_t> sum = 0;
+	for (val<int32_t> i = 0; i < size; i++) {
+		if (mask[i]) {
+			sum += array[i];
+		}
+	}
+	return sum;
+}
+
+int main(int, char*[]) {
+	engine::Options options;
+	// Use the MLIR backend so the intrinsic hints have an effect. If MLIR is
+	// not compiled in, fall through — the hints still compile and run as
+	// no-ops under the other backends.
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.enableIntrinsics", true);
+	// Dump the generated LLVM IR for both variants so users can diff them.
+	options.setOption("dump.after_llvm_generation", true);
+
+	auto engine = engine::NautilusEngine(options);
+	std::cout << "Backend: " << engine.getNameOfBackend() << "\n\n";
+
+	std::cout << "=== Compiling conditionalSumPlain (no hints) ===\n";
+	auto plainFn = engine.registerFunction(conditionalSumPlain);
+	std::cout << "\n=== Compiling conditionalSumHinted (with assume + assume_aligned) ===\n";
+	auto hintedFn = engine.registerFunction(conditionalSumHinted);
+
+	// Allocate 32-byte-aligned buffers so the alignment promise holds.
+	constexpr size_t N = 4;
+	constexpr size_t ALIGN = 32;
+	auto* mask = static_cast<bool*>(std::aligned_alloc(ALIGN, ((sizeof(bool) * N + ALIGN - 1) / ALIGN) * ALIGN));
+	auto* array = static_cast<int32_t*>(std::aligned_alloc(ALIGN, ((sizeof(int32_t) * N + ALIGN - 1) / ALIGN) * ALIGN));
+	mask[0] = true;
+	mask[1] = true;
+	mask[2] = false;
+	mask[3] = true;
+	array[0] = 1;
+	array[1] = 2;
+	array[2] = 3;
+	array[3] = 4;
+
+	auto plainResult = plainFn(static_cast<int32_t>(N), mask, array);
+	auto hintedResult = hintedFn(static_cast<int32_t>(N), mask, array);
+
+	std::cout << "\n=== Results ===\n";
+	std::cout << "conditionalSumPlain  = " << plainResult << "\n";
+	std::cout << "conditionalSumHinted = " << hintedResult << "\n";
+	std::cout << "(Both should be 7.)\n";
+
+	std::free(mask);
+	std::free(array);
+	return 0;
+}

--- a/example/src/DemoStdPlugin.cpp
+++ b/example/src/DemoStdPlugin.cpp
@@ -1,0 +1,101 @@
+// DemoStdPlugin.cpp — showcase the `nautilus-std` plugin.
+//
+// The std plugin exposes C++ standard-library types and functions as
+// traceable nautilus primitives. Each header wraps a different part of
+// libstdc++/libc++:
+//
+//   <nautilus/std/vector.h>    val<std::vector<T>>  (operator[], size(), ...)
+//   <nautilus/std/cmath.h>     nautilus::sqrt, nautilus::pow, ...
+//   <nautilus/std/string.h>    val<std::string>
+//   <nautilus/std/bit.h>       popcount, clz, ctz
+//   <nautilus/std/cstring.h>   memcpy, memset
+//
+// This demo re-implements the conditionalSum problem from DemoJit.cpp using
+// `val<std::vector<int32_t>>` — the same logical aggregation, but with a
+// container-based API instead of raw pointers. It then adds an `rmsError`
+// function that combines vector iteration with `nautilus::sqrt` from the
+// cmath wrapper.
+//
+// NOTE ON THE COMPILER: main() does not override any engine options, so the
+// engine runs with the default tiered JIT compiler. See
+// nautilus/src/nautilus/compiler/Engine.cpp — when
+// `engine.compilationStrategy` is unset it defaults to "tiered" and
+// constructs a TieredJITCompiler. That means this demo is exercising the
+// production-recommended compilation pipeline.
+
+#include <cstdint>
+#include <iostream>
+#include <nautilus/Engine.hpp>
+#include <nautilus/std/cmath.h>
+#include <nautilus/std/vector.h>
+#include <nautilus/val.hpp>
+#include <vector>
+
+using namespace nautilus;
+
+// conditionalSum over std::vector inputs. A mask entry of 0 means "skip",
+// anything non-zero means "include". The caller owns the vectors, so each
+// wrapper is released at the end to prevent the val<std::vector<...>>
+// destructor from deleting the external storage.
+val<int32_t> conditionalSumVec(val<std::vector<int32_t>*> values_ptr, val<std::vector<int32_t>*> mask_ptr) {
+	val<std::vector<int32_t>> values(values_ptr);
+	val<std::vector<int32_t>> mask(mask_ptr);
+
+	val<int32_t> sum = 0;
+	for (val<size_t> i = 0; i < values.size(); i++) {
+		if (mask[i] != 0) {
+			sum += values[i];
+		}
+	}
+
+	// Release ownership so ~val<std::vector<...>> does not free the caller's data.
+	values.release();
+	mask.release();
+	return sum;
+}
+
+// Root-mean-square error between two equal-length vectors of doubles.
+// Exercises both `val<std::vector<double>>` iteration and `nautilus::sqrt`
+// from the std cmath wrapper.
+val<double> rmsError(val<std::vector<double>*> a_ptr, val<std::vector<double>*> b_ptr) {
+	val<std::vector<double>> a(a_ptr);
+	val<std::vector<double>> b(b_ptr);
+
+	val<double> acc = 0.0;
+	val<size_t> n = a.size();
+	for (val<size_t> i = 0; i < n; i++) {
+		val<double> diff = a[i] - b[i];
+		acc += diff * diff;
+	}
+	val<double> mean = acc / n;
+	val<double> result = nautilus::sqrt(mean);
+
+	a.release();
+	b.release();
+	return result;
+}
+
+int main(int, char*[]) {
+	// Default options → tiered JIT compiler (see file header).
+	engine::Options options;
+	auto engine = engine::NautilusEngine(options);
+	std::cout << "Using default engine configuration (tiered JIT compiler).\n";
+	std::cout << "Active backend: " << engine.getNameOfBackend() << "\n\n";
+
+	// --- conditionalSum over std::vector ---
+	auto sumFn = engine.registerFunction(conditionalSumVec);
+	std::vector<int32_t> values = {1, 2, 3, 4};
+	std::vector<int32_t> mask = {1, 1, 0, 1}; // include 1, 2, 4 → 7
+	auto sumResult = sumFn(&values, &mask);
+	std::cout << "conditionalSumVec([1,2,3,4], [1,1,0,1]) = " << sumResult << "  (expected 7)\n";
+
+	// --- rmsError with cmath::sqrt ---
+	auto rmsFn = engine.registerFunction(rmsError);
+	std::vector<double> predicted = {1.0, 2.0, 3.0, 4.0};
+	std::vector<double> actual = {1.5, 1.5, 3.5, 4.5};
+	// diffs: -0.5, +0.5, -0.5, -0.5 → squared: 0.25 x 4 → mean 0.25 → sqrt 0.5
+	auto rmsResult = rmsFn(&predicted, &actual);
+	std::cout << "rmsError(...)                            = " << rmsResult << "  (expected 0.5)\n";
+
+	return 0;
+}

--- a/plugins/simd/CMakeLists.txt
+++ b/plugins/simd/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SIMD_SOURCES
 )
 
 if (ENABLE_MLIR_BACKEND)
-    list(APPEND SIMD_SOURCES src/MLIRVectorIntrinsics.cpp)
+    list(APPEND SIMD_SOURCES src/MLIRVectorIntrinsics.cpp src/SimdPluginInit.cpp)
 endif ()
 
 target_sources(nautilus-simd PRIVATE ${SIMD_SOURCES})
@@ -24,7 +24,7 @@ if (ENABLE_MLIR_BACKEND)
     find_package(MLIR REQUIRED CONFIG)
     # MLIR intrinsics need access to nautilus internal headers and MLIR/LLVM
     target_include_directories(nautilus-simd PRIVATE
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/src>)
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/src>)
     target_include_directories(nautilus-simd SYSTEM PRIVATE
             $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>)
     # Link MLIR libraries needed by MLIRVectorIntrinsics.cpp

--- a/plugins/simd/src/MLIRVectorIntrinsics.cpp
+++ b/plugins/simd/src/MLIRVectorIntrinsics.cpp
@@ -171,8 +171,12 @@ bool vectorLoadIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const comp
 	}
 	auto vecTy = getVecType(elemTy, N);
 
-	// Load vector directly from the source pointer (treat as vector pointer)
-	auto vec = builder->create<::mlir::LLVM::LoadOp>(builder->getUnknownLoc(), vecTy, srcPtr);
+	// Load vector directly from the source pointer (treat as vector pointer).
+	// Use element alignment (not natural vector alignment) so LLVM emits an
+	// unaligned vector load (e.g. vmovdqu instead of vmovdqa on x86). User
+	// data from std::vector::data() or new[] is typically only aligned to
+	// alignof(T), not to the full SIMD register width.
+	auto vec = builder->create<::mlir::LLVM::LoadOp>(builder->getUnknownLoc(), vecTy, srcPtr, sizeof(ElemT));
 	auto resultPtr = storeVecToAlloca(builder, vec, vecTy);
 	frame.setValue(call->getIdentifier(), resultPtr);
 	return true;
@@ -198,7 +202,10 @@ bool vectorStoreIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const com
 	auto vecTy = getVecType(elemTy, N);
 
 	auto vec = loadVecFromPtr(builder, vecPtr, vecTy);
-	builder->create<::mlir::LLVM::StoreOp>(builder->getUnknownLoc(), vec, destPtr);
+	// Use element alignment for the store to user memory (same rationale as
+	// the load intrinsic above — user buffers are not guaranteed to be
+	// aligned to the full vector width).
+	builder->create<::mlir::LLVM::StoreOp>(builder->getUnknownLoc(), vec, destPtr, sizeof(ElemT));
 	// Store returns void, but we still need to set a value for the frame.
 	// The store_impl returns void, so the ProxyCallOp result may not be used.
 	// We pass destPtr as the output so the frame has something valid.

--- a/plugins/simd/src/SimdPluginInit.cpp
+++ b/plugins/simd/src/SimdPluginInit.cpp
@@ -1,0 +1,13 @@
+// This translation unit is only added to the build when ENABLE_MLIR_BACKEND is ON
+// (see plugins/simd/CMakeLists.txt), so the registration runs unconditionally.
+#include "MLIRVectorIntrinsics.hpp"
+
+namespace {
+// Static initializer to register MLIR intrinsic plugins when the simd plugin library is loaded.
+struct SimdIntrinsicRegistrar {
+	SimdIntrinsicRegistrar() {
+		nautilus::compiler::mlir::RegisterMLIRVectorIntrinsicPlugin();
+	}
+};
+static SimdIntrinsicRegistrar registrar_;
+} // namespace

--- a/plugins/simd/test/CMakeLists.txt
+++ b/plugins/simd/test/CMakeLists.txt
@@ -14,7 +14,8 @@ endif ()
 
 target_include_directories(nautilus-simd-tests PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/common>)
+        $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/test/common>
+        $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/plugins/simd/src>)
 
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 catch_discover_tests(nautilus-simd-tests EXTRA_ARGS --allow-running-no-tests)
@@ -40,8 +41,8 @@ if (ENABLE_MLIR_BACKEND AND ENABLE_LLVM_IR_TEST)
     # Access to LLVMIRTestUtil.hpp from the main test suite
     target_include_directories(nautilus-simd-llvm-ir-test PRIVATE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/llvm-ir-test>
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/plugins/simd/src>
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/test/llvm-ir-test>
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/plugins/simd/src>
     )
 
     catch_discover_tests(nautilus-simd-llvm-ir-test

--- a/plugins/simd/test/VectorExecutionTest.cpp
+++ b/plugins/simd/test/VectorExecutionTest.cpp
@@ -6,6 +6,10 @@
 #include <cmath>
 #include <cstring>
 
+#ifdef ENABLE_MLIR_BACKEND
+#include "MLIRVectorIntrinsics.hpp"
+#endif
+
 namespace nautilus::engine {
 
 // Lane counts are now determined at runtime via CPU feature detection.
@@ -1012,6 +1016,125 @@ void vectorTests(engine::NautilusEngine& engine) {
 	}
 }
 
+// ============================================================================
+// Unaligned-buffer tests
+//
+// Regression tests for the MLIR vector intrinsic alignment bug: the load/store
+// intrinsics must use element-level alignment (not natural vector alignment)
+// so the generated code works with buffers that are not aligned to the full
+// SIMD register width. std::vector::data() and malloc'd memory typically only
+// guarantee alignof(T), not 64-byte alignment required by AVX-512.
+//
+// These tests deliberately offset the data pointer by one element so the
+// buffers are guaranteed to be misaligned w.r.t. any vector width > sizeof(T).
+// ============================================================================
+
+void unalignedVectorTests(engine::NautilusEngine& engine) {
+
+	// Float: load from unaligned pointer, add, store to unaligned pointer.
+	SECTION("unaligned add float") {
+		auto f = engine.registerFunction(vectorAddFloat);
+		// Allocate extra element so we can offset by 1 to force misalignment.
+		alignas(64) float a_aligned[FL_MAX + 1], b_aligned[FL_MAX + 1], c_aligned[FL_MAX + 1];
+		float* a = a_aligned + 1; // misaligned by sizeof(float) = 4 bytes
+		float* b = b_aligned + 1;
+		float* c = c_aligned + 1;
+		std::memset(c, 0, FL * sizeof(float));
+		for (size_t i = 0; i < FL; i++) {
+			a[i] = static_cast<float>(i + 1);
+			b[i] = static_cast<float>(i + 5);
+		}
+		f(a, b, c);
+		for (size_t i = 0; i < FL; i++) {
+			REQUIRE(c[i] == a[i] + b[i]);
+		}
+	}
+
+	// Int32: load from unaligned pointer, add, store to unaligned pointer.
+	SECTION("unaligned add int") {
+		auto f = engine.registerFunction(vectorAddInt);
+		alignas(64) int32_t a_aligned[IL_MAX + 1], b_aligned[IL_MAX + 1], c_aligned[IL_MAX + 1];
+		int32_t* a = a_aligned + 1;
+		int32_t* b = b_aligned + 1;
+		int32_t* c = c_aligned + 1;
+		std::memset(c, 0, IL * sizeof(int32_t));
+		for (size_t i = 0; i < IL; i++) {
+			a[i] = static_cast<int32_t>(i + 1);
+			b[i] = static_cast<int32_t>(i + 10);
+		}
+		f(a, b, c);
+		for (size_t i = 0; i < IL; i++) {
+			REQUIRE(c[i] == a[i] + b[i]);
+		}
+	}
+
+	// Float: mul + sub chain with unaligned pointers.
+	SECTION("unaligned mul-sub float") {
+		auto f = engine.registerFunction(vectorMulSubFloat);
+		alignas(64) float a_al[FL_MAX + 1], b_al[FL_MAX + 1], c_al[FL_MAX + 1], d_al[FL_MAX + 1];
+		float* a = a_al + 1;
+		float* b = b_al + 1;
+		float* c = c_al + 1;
+		float* d = d_al + 1;
+		std::memset(d, 0, FL * sizeof(float));
+		for (size_t i = 0; i < FL; i++) {
+			a[i] = static_cast<float>(i + 1);
+			b[i] = 2.0f;
+			c[i] = static_cast<float>(i);
+		}
+		f(a, b, c, d);
+		for (size_t i = 0; i < FL; i++) {
+			REQUIRE(d[i] == a[i] * b[i] - c[i]);
+		}
+	}
+
+	// Float: reduce-add from unaligned pointer.
+	SECTION("unaligned reduce-add float") {
+		auto f = engine.registerFunction(vectorReduceAddFloat);
+		alignas(64) float a_aligned[FL_MAX + 1];
+		float* a = a_aligned + 1;
+		float expected = 0.0f;
+		for (size_t i = 0; i < FL; i++) {
+			a[i] = static_cast<float>(i + 1);
+			expected += a[i];
+		}
+		REQUIRE(f(a) == expected);
+	}
+
+	// Double: add with unaligned pointers.
+	SECTION("unaligned add double") {
+		auto f = engine.registerFunction(vectorAddDouble);
+		alignas(64) double a_aligned[DL_MAX + 1], b_aligned[DL_MAX + 1], c_aligned[DL_MAX + 1];
+		double* a = a_aligned + 1;
+		double* b = b_aligned + 1;
+		double* c = c_aligned + 1;
+		std::memset(c, 0, DL * sizeof(double));
+		for (size_t i = 0; i < DL; i++) {
+			a[i] = static_cast<double>(i + 1);
+			b[i] = static_cast<double>(i + 100);
+		}
+		f(a, b, c);
+		for (size_t i = 0; i < DL; i++) {
+			REQUIRE(c[i] == a[i] + b[i]);
+		}
+	}
+
+	// Int32: dot product from unaligned pointers (mul + reduce-add chain).
+	SECTION("unaligned dot-product int") {
+		auto f = engine.registerFunction(vectorDotProductInt);
+		alignas(64) int32_t a_aligned[IL_MAX + 1], b_aligned[IL_MAX + 1];
+		int32_t* a = a_aligned + 1;
+		int32_t* b = b_aligned + 1;
+		int32_t expected = 0;
+		for (size_t i = 0; i < IL; i++) {
+			a[i] = static_cast<int32_t>(i + 1);
+			b[i] = 2;
+			expected += a[i] * b[i];
+		}
+		REQUIRE(f(a, b) == expected);
+	}
+}
+
 TEST_CASE("Vector Interpreter Test") {
 	auto engine = nautilus::testing::makeEngine("interpreter");
 	vectorTests(engine);
@@ -1022,6 +1145,19 @@ TEST_CASE("Vector Compiler Test") {
 	nautilus::testing::forEachBackend([](engine::NautilusEngine& engine) { vectorTests(engine); },
 	                                  /*include_interpreter=*/false);
 }
-#endif
+
+// Regression test for the MLIR vector intrinsic alignment bug.  Only runs on
+// the MLIR backend with intrinsics explicitly registered, because without the
+// intrinsic plugin, vector ops fall back to scalar invoke() calls where
+// alignment is irrelevant.
+#ifdef ENABLE_MLIR_BACKEND
+TEST_CASE("Vector Unaligned Buffer Test") {
+	nautilus::compiler::mlir::RegisterMLIRVectorIntrinsicPlugin();
+	auto engine = nautilus::testing::makeEngine(
+	    "mlir", [](engine::Options& options) { options.setOption("mlir.enableIntrinsics", true); });
+	unalignedVectorTests(engine);
+}
+#endif // ENABLE_MLIR_BACKEND
+#endif // ENABLE_TRACING
 
 } // namespace nautilus::engine

--- a/plugins/specialization/CMakeLists.txt
+++ b/plugins/specialization/CMakeLists.txt
@@ -27,7 +27,7 @@ if (ENABLE_MLIR_BACKEND)
     find_package(MLIR REQUIRED CONFIG)
     # MLIR intrinsics need access to nautilus internal headers and MLIR/LLVM
     target_include_directories(nautilus-specialization PRIVATE
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/src>)
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/src>)
     target_include_directories(nautilus-specialization SYSTEM PRIVATE
             $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>)
     target_link_libraries(nautilus-specialization PRIVATE

--- a/plugins/specialization/test/CMakeLists.txt
+++ b/plugins/specialization/test/CMakeLists.txt
@@ -15,8 +15,8 @@ endif ()
 target_include_directories(nautilus-specialization-tests PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/common>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/plugins/specialization/src>)
+        $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/test/common>
+        $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/plugins/specialization/src>)
 
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 catch_discover_tests(nautilus-specialization-tests EXTRA_ARGS --allow-running-no-tests)
@@ -42,7 +42,7 @@ if (ENABLE_MLIR_BACKEND AND ENABLE_LLVM_IR_TEST)
     target_include_directories(nautilus-specialization-llvm-ir-test PRIVATE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/llvm-ir-test>
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/test/llvm-ir-test>
     )
 
     catch_discover_tests(nautilus-specialization-llvm-ir-test

--- a/plugins/std/CMakeLists.txt
+++ b/plugins/std/CMakeLists.txt
@@ -32,7 +32,7 @@ if (ENABLE_MLIR_BACKEND)
     find_package(MLIR REQUIRED CONFIG)
     # MLIR intrinsics need access to nautilus internal headers and MLIR/LLVM
     target_include_directories(nautilus-std PRIVATE
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/src>)
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/src>)
     target_include_directories(nautilus-std SYSTEM PRIVATE
             $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>)
     target_link_libraries(nautilus-std PRIVATE

--- a/plugins/std/test/CMakeLists.txt
+++ b/plugins/std/test/CMakeLists.txt
@@ -21,7 +21,7 @@ endif ()
 target_include_directories(nautilus-std-tests PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/common>)
+        $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/test/common>)
 
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 catch_discover_tests(nautilus-std-tests EXTRA_ARGS --allow-running-no-tests)
@@ -48,8 +48,8 @@ if (ENABLE_MLIR_BACKEND AND ENABLE_LLVM_IR_TEST)
     target_include_directories(nautilus-std-llvm-ir-test PRIVATE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/nautilus/test/llvm-ir-test>
-            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/plugins/std/src>
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/nautilus/test/llvm-ir-test>
+            $<BUILD_INTERFACE:${nautilus_SOURCE_DIR}/plugins/std/src>
     )
 
     catch_discover_tests(nautilus-std-llvm-ir-test


### PR DESCRIPTION
Adds five new demos alongside the existing DemoJit.cpp so example/ covers
the NautilusModule API, backend selection, and each shipped plugin:

- DemoModules.cpp              multi-function NautilusModule
- DemoBackends.cpp             compile + run on every enabled backend
- DemoStdPlugin.cpp            conditionalSum over std::vector + cmath::sqrt
- DemoSimdPlugin.cpp           SIMD-vectorised conditionalSum via val<vec<T>>
- DemoSpecializationPlugin.cpp nautilus_assume / nautilus_assume_aligned

The three plugin demos solve the same conditionalSum problem from DemoJit
so they can be diffed side-by-side. The specialization demo force-links
nautilus-specialization with --whole-archive so the MLIR intrinsic plugin
initializer runs and the assume hints lower to real llvm.assume bundles.

Also fixes a pre-existing issue in the plugin CMake files that only
surfaced when nautilus is consumed as a sub-project: the private include
paths used \${CMAKE_SOURCE_DIR}/nautilus/src, which resolves to the outer
project root instead of the nautilus root. Switched to \${nautilus_SOURCE_DIR}.

Adds a new example-demos job to .github/workflows/pr.yml that configures,
builds, and runs each demo, asserting on the expected output so
regressions are caught in CI.