### PR TITLE
Remove llvm-diff comparison test and related infrastructure

### DIFF
--- a/nautilus/test/llvm-ir-test/CMakeLists.txt
+++ b/nautilus/test/llvm-ir-test/CMakeLists.txt
@@ -41,36 +41,10 @@ catch_discover_tests(nautilus-llvm-ir-test
         LABELS "llvm;ir;regression"
 )
 
-# Add custom test for llvm-diff comparison
-find_program(LLVM_DIFF llvm-diff)
-if(LLVM_DIFF)
-    message(STATUS "Found llvm-diff: ${LLVM_DIFF}")
-
-    # Custom target to run IR comparison
-    add_test(
-        NAME llvm-ir:llvm-diff-comparison
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/compare-ir.sh
-                ${CMAKE_BINARY_DIR}/nautilus-ir-test-output
-    )
-
-    set_tests_properties(llvm-ir:llvm-diff-comparison PROPERTIES
-        LABELS "llvm;ir;regression"
-        DEPENDS nautilus-llvm-ir-test
-    )
-else()
-    message(WARNING "llvm-diff not found - IR comparison tests will be skipped")
-endif()
-
 # Custom target to generate reference IR
 add_custom_target(generate-reference-ir
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/nautilus-llvm-ir-test --generate-reference
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Generating reference LLVM IR files"
     DEPENDS nautilus-llvm-ir-test
-)
-
-# Install test scripts
-install(
-    PROGRAMS compare-ir.sh
-    DESTINATION test/llvm-ir-test
 )


### PR DESCRIPTION
## Summary
This change removes the llvm-diff based IR comparison test infrastructure from the LLVM IR test suite, simplifying the test configuration and removing a dependency on the external `llvm-diff` tool.

## Key Changes
- Removed the custom `llvm-ir:llvm-diff-comparison` test that performed IR comparison using the `llvm-diff` tool
- Removed the `llvm-diff` program detection and conditional test setup logic
- Removed the installation of the `compare-ir.sh` script
- Retained the `generate-reference-ir` custom target for generating reference IR files

## Details
The llvm-diff comparison test was previously optional (only run if `llvm-diff` was found on the system) and served as a regression test for LLVM IR output. This removal simplifies the test configuration by eliminating:
- The external tool dependency check
- The conditional test registration logic
- The shell script wrapper for IR comparison
- The associated installation rules

The reference IR generation capability remains intact for manual comparison or alternative testing approaches.

https://claude.ai/code/session_01Bm7b5DzcEvpG8S7tc4vAik