### PR TITLE
Add per-phase compiler stats logging via existing log infrastructure

### DIFF
--- a/example/src/DemoBackends.cpp
+++ b/example/src/DemoBackends.cpp
@@ -38,6 +38,8 @@ static void runWith(const std::string& backendName, int32_t n) {
 	// Force single-tier compilation so each run uses exactly the requested
 	// backend, instead of the tiered strategy switching between them.
 	options.setOption("engine.compilationStrategy", std::string("legacy"));
+	// Enable per-phase compilation stats logging.
+	options.setOption("engine.compilationStats", true);
 	auto engine = engine::NautilusEngine(options);
 
 	// Measure compile time + first call separately from warm calls.
@@ -78,6 +80,7 @@ int main(int, char*[]) {
 	runWith("asmjit", N);
 #endif
 
+	std::cout << "\n(Per-phase compilation stats are logged above by the nautilus library)\n";
 	std::cout << "\nExpected result: " << ([] {
 		int64_t s = 0;
 		for (int64_t i = 0; i < N; i++)

--- a/example/src/DemoJit.cpp
+++ b/example/src/DemoJit.cpp
@@ -22,6 +22,7 @@ val<int32_t> conditionalSum(val<int32_t> size, val<bool*> mask, val<int32_t*> ar
 int main(int, char*[]) {
 	engine::Options options;
 	options.setOption("engine.backend", "cpp");
+	options.setOption("engine.compilationStats", true);
 	// options.setOption("engine.Compilation", false);
 	auto engine = engine::NautilusEngine(options);
 	auto function = engine.registerFunction(conditionalSum);

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
@@ -85,24 +85,34 @@ std::unique_ptr<Executable> LegacyCompiler::compile(JITCompiler::wrapper_functio
 std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFunction>& functions) const {
 	const CompilationUnitID compilationId = createCompilationUnitID();
 	auto dumpHandler = DumpHandler(options, compilationId);
+	auto statsLogger =
+	    log::CompilationStatsLogger(options.getOptionOrDefault("engine.compilationStats", false), compilationId);
+	auto tTotal = log::now();
 
+	auto t0 = log::now();
 	auto traceMode = options.getOptionOrDefault(TRACE_MODE_OPTION, std::string(TRACE_MODE_LAZY));
 	std::shared_ptr<tracing::TraceModule> traceModule =
 	    (traceMode == TRACE_MODE_LAZY) ? tracing::LazyTraceContext::Trace(functions, options)
 	                                   : tracing::ExceptionBasedTraceContext::Trace(functions, options);
+	statsLogger.logTiming(t0, "Tracing completed");
 	dumpHandler.dump("after_tracing", "trace", [&]() { return traceModule->toString(); });
 
+	auto t1 = log::now();
 	auto ssaCreationPhase = tracing::SSACreationPhase();
 	auto afterSSAModule = ssaCreationPhase.apply(std::move(traceModule));
+	statsLogger.logTiming(t1, "SSA creation completed");
 	dumpHandler.dump("after_ssa", "trace", [&]() { return afterSSAModule->toString(); });
 
+	auto t2 = log::now();
 	auto irGenerationPhase = tracing::TraceToIRConversionPhase();
 	auto ir = irGenerationPhase.apply(afterSSAModule, compilationId);
+	statsLogger.logTiming(t2, "IR generation completed");
 	dumpHandler.dump("after_ir_creation", "ir", [&]() { return ir->toString(); });
 	if (options.getOptionOrDefault("dump.graph", false)) {
 		ir::createGraphVizFromIr(ir, options, dumpHandler);
 	}
 
+	statsLogger.logTiming(tTotal, "Frontend (trace + SSA + IR) completed");
 	return ir;
 }
 
@@ -110,9 +120,13 @@ std::unique_ptr<Executable> LegacyCompiler::compileIR(const std::shared_ptr<ir::
                                                       const std::string& backendName) const {
 	const CompilationUnitID compilationId = createCompilationUnitID();
 	auto dumpHandler = DumpHandler(options, compilationId);
+	auto statsLogger =
+	    log::CompilationStatsLogger(options.getOptionOrDefault("engine.compilationStats", false), compilationId);
 
+	auto t0 = log::now();
 	const auto backend = backends->getBackend(backendName);
 	auto executable = backend->compile(ir, dumpHandler, options);
+	statsLogger.logTiming(t0, "Backend compilation ({}) completed", backendName);
 	executable->setGeneratedFiles(dumpHandler.getGeneratedFiles());
 	return executable;
 }

--- a/nautilus/src/nautilus/compiler/TieredCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.cpp
@@ -79,7 +79,11 @@ void TieredJITCompiler::promoteAsync(std::weak_ptr<engine::details::ModuleState>
 			auto compilationId = createPromotionUnitID();
 			auto dumpHandler = DumpHandler(options, compilationId);
 
+			auto statsLogger = log::CompilationStatsLogger(options.getOptionOrDefault("engine.compilationStats", false),
+			                                               compilationId);
+			auto t0 = log::now();
 			auto tier1Executable = backend->compile(ir, dumpHandler, options);
+			statsLogger.logTiming(t0, "Tier 1 promotion ({}) completed", config.tier1.backend);
 			tier1Executable->setGeneratedFiles(dumpHandler.getGeneratedFiles());
 
 			if (auto s = weakState.lock()) {

--- a/nautilus/src/nautilus/logging.hpp
+++ b/nautilus/src/nautilus/logging.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <chrono>
 #include <nautilus/config.hpp>
+#include <string>
 #ifdef ENABLE_LOGGING
 #include <spdlog/spdlog.h>
 #endif
@@ -37,6 +39,38 @@ void error([[maybe_unused]] const char* fmt, [[maybe_unused]] Args&&... args) {
 	spdlog::error("{}", fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...));
 #endif
 }
+
+inline std::chrono::steady_clock::time_point now() {
+#ifdef ENABLE_LOGGING
+	return std::chrono::steady_clock::now();
+#else
+	return {};
+#endif
+}
+
+class CompilationStatsLogger {
+public:
+	CompilationStatsLogger(bool enabled, const std::string& compilationId)
+	    : enabled_(enabled), compilationId_(compilationId) {
+	}
+
+	template <typename... Args>
+	void logTiming([[maybe_unused]] std::chrono::steady_clock::time_point start, [[maybe_unused]] const char* fmt,
+	               [[maybe_unused]] Args&&... args) const {
+#ifdef ENABLE_LOGGING
+		if (enabled_ && spdlog::should_log(spdlog::level::info)) {
+			auto end = std::chrono::steady_clock::now();
+			auto ms = std::chrono::duration<double, std::milli>(end - start).count();
+			auto msg = fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...);
+			spdlog::info("[nautilus] [{}] {} in {:.2f} ms", compilationId_, msg, ms);
+		}
+#endif
+	}
+
+private:
+	[[maybe_unused]] bool enabled_;
+	[[maybe_unused]] const std::string& compilationId_;
+};
 
 namespace options {
 


### PR DESCRIPTION
Add log::now() and log::logTiming() helpers to logging.hpp and instrument
the compilation pipeline in LegacyCompiler and TieredCompiler. Each phase
(tracing, SSA creation, IR generation, backend compilation) is timed and
logged at info level with the compilation unit ID for correlation. Stats
appear automatically in demo output since ENABLE_LOGGING is ON by default.

https://claude.ai/code/session_012Kiz2tWUstqhGYg8SgpzZJ