### PR TITLE
Harden the inlining plugin: registry thread-safety, JIT hook safety, tests

### DIFF
--- a/plugins/inlining/cmake/NautilusInline.cmake
+++ b/plugins/inlining/cmake/NautilusInline.cmake
@@ -15,7 +15,10 @@ include_guard(GLOBAL)
 
 option(ENABLE_INLINING_PASS "Enable building inlining llvm pass" ON)
 
-function(is_inlining_supported result_var)
+# Runs the host/toolchain detection and writes the result to ${result_var}
+# in the parent scope. Prefer the cached value in NAUTILUS_INLINE_SUPPORTED
+# once it has been populated by the top-level include below.
+function(_detect_inlining_support result_var)
     if(NOT ENABLE_INLINING_PASS)
         set(${result_var} FALSE PARENT_SCOPE)
         return()
@@ -44,6 +47,19 @@ function(is_inlining_supported result_var)
     set(${result_var} TRUE PARENT_SCOPE)
 endfunction()
 
+# Cached detector: run detection exactly once per configure and stash the
+# result in an INTERNAL cache variable so every subsequent
+# `nautilus_inline(...)` invocation is a cheap read (and so the toolchain
+# warnings above are emitted only once).
+function(is_inlining_supported result_var)
+    if(NOT DEFINED NAUTILUS_INLINE_SUPPORTED_CACHED)
+        _detect_inlining_support(_nautilus_inline_detected)
+        set(NAUTILUS_INLINE_SUPPORTED_CACHED "${_nautilus_inline_detected}" CACHE INTERNAL
+            "Whether the Nautilus inlining plugin is supported on this host/toolchain")
+    endif ()
+    set(${result_var} "${NAUTILUS_INLINE_SUPPORTED_CACHED}" PARENT_SCOPE)
+endfunction()
+
 
 is_inlining_supported(NAUTILUS_INLINE_SUPPORTED)
 
@@ -56,7 +72,14 @@ function(nautilus_inline target)
                     "-fpass-plugin=$<TARGET_FILE:InliningPass>"
             )
         else ()
-            message(WARNING "nautilus_inline(${target}) called but the InliningPass target is not available. Enable ENABLE_INLINING_PLUGIN to build it. Skipping.")
+            # The toolchain supports inlining but the pass library isn't a
+            # target in this configure. The most common cause is that the
+            # top-level ENABLE_INLINING_PLUGIN gate is OFF (the gate that
+            # actually add_subdirectory()'s plugins/inlining), not the
+            # local ENABLE_INLINING_PASS in this file. Both gates must be
+            # ON for the pass to be built. Warn rather than FATAL so that
+            # callers like the demo can degrade gracefully.
+            message(WARNING "nautilus_inline(${target}) called but the InliningPass target is not available. Enable both ENABLE_INLINING_PLUGIN (top-level) and ENABLE_INLINING_PASS (plugin-local) to build it. Skipping.")
         endif ()
     else ()
         message(WARNING "Function inlining requires clang 19-21 during compilation.")

--- a/plugins/inlining/include/nautilus/inline.hpp
+++ b/plugins/inlining/include/nautilus/inline.hpp
@@ -1,13 +1,25 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 // use this macro in front of a function to mark it as a candidate function for nautilus to inline
 // e.g. NAUTILUS_INLINE int foo(int bar) {...}
-// this marker is used by an LLVM pass to detect those functions and extract LLVM IR code for them
-// increment version counter whenever the pass is updated to force re-compilation
+// this marker is used by an LLVM pass to detect those functions and extract LLVM IR code for them.
+//
+// Version counter: bump the `_v0001` suffix whenever any of the following
+// change, so ccache / build caches re-run the pass over existing TUs:
+//   - the ABI of `registerBitcodePleaseIgnoreThisThanks` /
+//     `registerSymbolPleaseIgnoreThisThanks`
+//   - the bitcode serialization format produced by
+//     `serializeFunctionWithDependencySymbols`
+//   - the convention used for the "is_target" function attribute or the
+//     hex-encoded symbol names used at JIT time
+// The pass uses `starts_with("nautilus_inline")` so multiple versions can
+// coexist in one build, but bumping is what forces a recompile.
 #if defined(__clang__)
 #define NAUTILUS_INLINE __attribute__((annotate("nautilus_inline_v0001")))
 #else
@@ -33,12 +45,24 @@ class InlineFunctionRegistry {
 public:
 	static InlineFunctionRegistry& instance(); // get the static singleton instance of the registry
 
-	const std::string& getBitcode(void* fn) const; // retrieve the bitcode of a target function address
-	bool
-	containsFunctionBitcode(void* fn) const; // look up whether the registry contains the bitcode for a function address
-	void* getSymbolAddress(std::string& symbolName) const; // look up the runtime address of a symbol by name
+	// Retrieve the bitcode of a target function address. Returns std::nullopt
+	// if no bitcode has been registered for `fn`. Returning by value (rather
+	// than by reference) keeps the caller safe: the snapshot remains valid
+	// even if the registry is mutated concurrently after the call returns.
+	std::optional<std::string> getBitcode(void* fn) const;
 
-	const std::unordered_map<std::string, void*>& getSymbolTable();
+	// Look up whether the registry contains the bitcode for a function address.
+	bool containsFunctionBitcode(void* fn) const;
+
+	// Look up the runtime address of a symbol by name. Returns nullptr if
+	// the symbol is not registered.
+	void* getSymbolAddress(std::string_view symbolName) const;
+
+	// Returns a snapshot copy of the (name -> address) symbol table. A copy
+	// is intentional: the JIT-time callers iterate the table outside the
+	// registry's mutex, so a snapshot avoids tearing against shared-object
+	// ctors that may still be running `addSymbol`.
+	std::unordered_map<std::string, void*> getSymbolTable() const;
 
 private:
 	mutable std::mutex mutex_;
@@ -47,7 +71,7 @@ private:
 
 	// those functions should normally not be used in nautilus, and are used by the llvm pass only
 	int addBitcode(void* fn, std::string bitcode);
-	int addSymbol(std::string& symbolName, void* ptr);
+	int addSymbol(std::string_view symbolName, void* ptr);
 
 	friend int ::registerBitcodePleaseIgnoreThisThanks(void* fn, const char* bitcodePtr, uint64_t bitcodeLen);
 	friend int ::registerSymbolPleaseIgnoreThisThanks(const char* symbolStringPtr, uint64_t symbolNameLength,

--- a/plugins/inlining/pass/CMakeLists.txt
+++ b/plugins/inlining/pass/CMakeLists.txt
@@ -26,7 +26,4 @@ if (NAUTILUS_INLINE_SUPPORTED)
     add_custom_target(InliningPassDependency
             DEPENDS $<TARGET_FILE:InliningPass>
     )
-    set_target_properties(InliningPass PROPERTIES
-            INTERFACE_ ${ENABLE_INLINING_PASS}
-    )
 endif ()

--- a/plugins/inlining/pass/FunctionInliningPass.cpp
+++ b/plugins/inlining/pass/FunctionInliningPass.cpp
@@ -13,6 +13,13 @@
 
 namespace nautilus::passes {
 
+// Lowest allowed ctor priority (65535): ensures the generated
+// `M.ir_ctor` that populates `InlineFunctionRegistry` runs AFTER the
+// function-local static inside `InlineFunctionRegistry::instance()` has been
+// initialized in any reachable TU ordering. Do not lower without first
+// switching `instance()` to use an explicit `std::call_once` guard.
+constexpr uint32_t NAUTILUS_INLINE_CTOR_PRIORITY = 65535;
+
 class NautilusInlineRegistrationPass : public llvm::PassInfoMixin<NautilusInlineRegistrationPass> {
 public:
 	static llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager& MAM) {
@@ -43,21 +50,25 @@ public:
 					}
 				}
 				if (toInline) {
-					// catch errors so that non-inlinable functions dont completely break compilation
+					// Catch errors so that non-inlinable functions don't completely
+					// break compilation. Two orthogonal failure modes are tracked:
+					//   crashFree:  RunSafely returns false if the lambda SIGSEGVs
+					//               (malformed bitcode, etc). We just log and skip.
+					//   serialized: set inside the lambda iff the result was stored
+					//               into `bitcodes`. A missing optional result is a
+					//               soft failure — we log but don't abort compilation.
+					bool serialized = false;
 					llvm::CrashRecoveryContext CRC;
-					bool success = CRC.RunSafely([&] {
-						// Serialize function to LLVM IR bitcode
+					const bool crashFree = CRC.RunSafely([&] {
 						auto result = serializeFunctionWithDependencySymbols(F, symbolMap);
-						if (!result.has_value()) {
-							CRC.HandleExit(1);
+						if (result.has_value()) {
+							bitcodes.insert({&F, std::move(*result)});
+							serialized = true;
 						}
-						bitcodes.insert({&F, *result});
-						success = true;
 					});
-					if (!success) {
+					if (!crashFree || !serialized) {
 						llvm::errs() << "Failed to serialize inline function. To get rid of this warning, remove the "
-						                "NAUT_INLINE "
-						                "tag from this function: "
+						                "NAUTILUS_INLINE tag from this function: "
 						             << F.getName() << "\n";
 					}
 				}
@@ -79,7 +90,7 @@ public:
 			insertSymbolRegistryCalls(ctorBuilder, symbolRegistrationFunction, symbolMap);
 
 			ctorBuilder->CreateRetVoid();
-			appendToGlobalCtors(M, ctor, 65535);
+			appendToGlobalCtors(M, ctor, NAUTILUS_INLINE_CTOR_PRIORITY);
 		}
 		return llvm::PreservedAnalyses::all();
 	}

--- a/plugins/inlining/pass/InliningUtils.cpp
+++ b/plugins/inlining/pass/InliningUtils.cpp
@@ -22,6 +22,10 @@
 
 namespace nautilus::passes {
 
+// Generates a 128-bit-ish hex string used to disambiguate extracted symbol
+// names. Thread-safety: the static RNG state is only touched from within a
+// single LLVM pass invocation, which the pass manager runs serially per
+// module, so no external synchronisation is required here.
 std::string getUUIDString() {
 	static std::random_device rd;
 	static std::mt19937 gen(rd());
@@ -91,7 +95,18 @@ std::optional<std::string> serializeFunctionWithDependencySymbols(llvm::Function
 	StripDebugInfo(*wrapperModule); // to suppress some llvm warning messages for invalid debug info
 
 	for (auto& globalVariable : wrapperModule->globals()) {
-		auto originalGV = dyn_cast<llvm::GlobalValue>(v2vInverted[&globalVariable]);
+		// ExtractGVPass may introduce fresh globals that were not present in
+		// the original module; those are absent from v2vInverted. Skipping
+		// them is safe: without a runtime address in the registry they
+		// can't be rewritten anyway.
+		auto it = v2vInverted.find(&globalVariable);
+		if (it == v2vInverted.end()) {
+			continue;
+		}
+		auto* originalGV = llvm::dyn_cast<llvm::GlobalValue>(it->second);
+		if (!originalGV) {
+			continue;
+		}
 		auto uniqueName = getUniqueName(originalGV, symbolMap, originalModule);
 		globalVariable.setName(uniqueName);
 		globalVariable.setInitializer(nullptr);
@@ -101,13 +116,21 @@ std::optional<std::string> serializeFunctionWithDependencySymbols(llvm::Function
 	}
 
 	for (auto& function : wrapperModule->functions()) {
-		if (&function != clonedTarget && !function.isIntrinsic()) {
-			auto originalFunction = dyn_cast<llvm::GlobalValue>(v2vInverted[&function]);
-			auto uniqueName = getUniqueName(originalFunction, symbolMap, originalModule);
-			function.setName(uniqueName);
-			function.deleteBody();
-			function.setLinkage(llvm::GlobalValue::ExternalLinkage);
+		if (&function == clonedTarget || function.isIntrinsic()) {
+			continue;
 		}
+		auto it = v2vInverted.find(&function);
+		if (it == v2vInverted.end()) {
+			continue;
+		}
+		auto* originalFunction = llvm::dyn_cast<llvm::GlobalValue>(it->second);
+		if (!originalFunction) {
+			continue;
+		}
+		auto uniqueName = getUniqueName(originalFunction, symbolMap, originalModule);
+		function.setName(uniqueName);
+		function.deleteBody();
+		function.setLinkage(llvm::GlobalValue::ExternalLinkage);
 	}
 
 	// serialize wrapperModule to bitcode string

--- a/plugins/inlining/pass/InliningUtils.hpp
+++ b/plugins/inlining/pass/InliningUtils.hpp
@@ -2,14 +2,18 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
-#include <map>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 
 namespace nautilus::passes {
 
-using SymbolMap = std::map<llvm::GlobalValue*, std::string>;
+// Pointer-keyed map of extracted globals/functions to the randomized unique
+// names used in the serialized bitcode. Unordered since iteration order is
+// irrelevant — names are UUID-randomized and the bitcode writer does not
+// depend on key order.
+using SymbolMap = std::unordered_map<llvm::GlobalValue*, std::string>;
 
 void insertBitcodeRegistryCall(std::shared_ptr<llvm::IRBuilder<>> builder, llvm::Function* bitcodeRegistrationFunction,
                                llvm::Function& targetFunction, std::string& bitcodeStr);

--- a/plugins/inlining/src/InlineFunctionRegistry.cpp
+++ b/plugins/inlining/src/InlineFunctionRegistry.cpp
@@ -8,21 +8,23 @@ InlineFunctionRegistry& InlineFunctionRegistry::instance() {
 
 int InlineFunctionRegistry::addBitcode(void* fn, std::string bitcode) {
 	std::lock_guard<std::mutex> lock(mutex_);
-	bitcodeRegistry_[fn] = bitcode;
+	bitcodeRegistry_[fn] = std::move(bitcode);
 	return 0;
 }
 
-int InlineFunctionRegistry::addSymbol(std::string& symbolName, void* ptr) {
+int InlineFunctionRegistry::addSymbol(std::string_view symbolName, void* ptr) {
 	std::lock_guard<std::mutex> lock(mutex_);
-	symbolRegistry_[symbolName] = ptr;
+	symbolRegistry_[std::string(symbolName)] = ptr;
 	return 0;
 }
 
-const std::string& InlineFunctionRegistry::getBitcode(void* fn) const {
-	static std::string empty {};
+std::optional<std::string> InlineFunctionRegistry::getBitcode(void* fn) const {
 	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = bitcodeRegistry_.find(fn);
-	return it != bitcodeRegistry_.end() ? it->second : empty;
+	if (it == bitcodeRegistry_.end()) {
+		return std::nullopt;
+	}
+	return it->second;
 }
 
 bool InlineFunctionRegistry::containsFunctionBitcode(void* fn) const {
@@ -30,13 +32,16 @@ bool InlineFunctionRegistry::containsFunctionBitcode(void* fn) const {
 	return bitcodeRegistry_.contains(fn);
 }
 
-void* InlineFunctionRegistry::getSymbolAddress(std::string& symbolName) const {
+void* InlineFunctionRegistry::getSymbolAddress(std::string_view symbolName) const {
 	std::lock_guard<std::mutex> lock(mutex_);
-	auto it = symbolRegistry_.find(symbolName);
+	// Heterogeneous lookup is not available for std::unordered_map in C++20,
+	// so materialize the name into a std::string for the find() call.
+	auto it = symbolRegistry_.find(std::string(symbolName));
 	return it != symbolRegistry_.end() ? it->second : nullptr;
 }
 
-const std::unordered_map<std::string, void*>& InlineFunctionRegistry::getSymbolTable() {
+std::unordered_map<std::string, void*> InlineFunctionRegistry::getSymbolTable() const {
+	std::lock_guard<std::mutex> lock(mutex_);
 	return symbolRegistry_;
 }
 
@@ -45,6 +50,5 @@ int registerBitcodePleaseIgnoreThisThanks(void* fn, const char* bitcodePtr, uint
 }
 
 int registerSymbolPleaseIgnoreThisThanks(const char* symbolStringPtr, uint64_t symbolNameLength, void* ptr) {
-	auto symbolName = std::string(symbolStringPtr, symbolNameLength);
-	return InlineFunctionRegistry::instance().addSymbol(symbolName, ptr);
+	return InlineFunctionRegistry::instance().addSymbol(std::string_view(symbolStringPtr, symbolNameLength), ptr);
 }

--- a/plugins/inlining/src/InliningPluginInit.cpp
+++ b/plugins/inlining/src/InliningPluginInit.cpp
@@ -15,7 +15,6 @@
 #include "LLVMInliningUtils.hpp"
 #include "nautilus/compiler/backends/mlir/LLVMBackendHooks.hpp"
 #include <llvm/IR/Module.h>
-#include <sstream>
 #endif
 
 int registerInliningHooksPleaseIgnoreThisThanks() {
@@ -38,7 +37,9 @@ struct InliningPluginRegistrar {
 		// Hook 2: contribute the inline registry's (name -> address) pairs
 		// to the JIT's ORC symbol map. The symbol names are hex-formatted
 		// runtime addresses, matching the names used by the rewritten
-		// inlinable functions.
+		// inlinable functions. NOTE: this iterates a snapshot of the table
+		// at hook-call time; symbols registered later (e.g. via a late
+		// dlopen) will not appear until the next JIT compile.
 		hooks.jitSymbolContributor = [](const nautilus::compiler::mlir::SymbolContributor& contribute) {
 			for (const auto& [key, value] : InlineFunctionRegistry::instance().getSymbolTable()) {
 				auto hexStr = nautilus::compiler::mlir::ptrToHex(value);
@@ -48,14 +49,16 @@ struct InliningPluginRegistrar {
 
 		// Hook 3: when lowering an external proxy call whose target has
 		// registered bitcode, emit the hex-formatted pointer address as the
-		// MLIR function name so the JIT-time inliner can pick it up.
+		// MLIR function name so the JIT-time inliner can pick it up. The
+		// name must match the format produced by `ptrToHex` elsewhere in
+		// the plugin so that `hexToPtr` round-trips and `jitSymbolContributor`
+		// resolves the same symbol — using `ptrToHex` here keeps those
+		// formats in lock-step.
 		hooks.proxyCallNameOverride = [](void* functionPtr) -> std::optional<std::string> {
 			if (!InlineFunctionRegistry::instance().containsFunctionBitcode(functionPtr)) {
 				return std::nullopt;
 			}
-			std::stringstream ss;
-			ss << functionPtr;
-			return ss.str();
+			return nautilus::compiler::mlir::ptrToHex(functionPtr);
 		};
 	}
 };

--- a/plugins/inlining/src/LLVMInliningUtils.cpp
+++ b/plugins/inlining/src/LLVMInliningUtils.cpp
@@ -1,7 +1,7 @@
 #include "LLVMInliningUtils.hpp"
 #include "fmt/format.h"
-#include "nautilus/exceptions/RuntimeException.hpp"
 #include "nautilus/inline.hpp"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Linker/Linker.h"
@@ -29,62 +29,61 @@ std::string ptrToHex(const void* ptr) {
 }
 
 // look up invoked function in the bitcode registry and retrieve if available
-std::optional<std::unique_ptr<llvm::Module>> loadBitcodeIfAvailable(void* fnPtr, llvm::LLVMContext& ctx) {
+std::optional<std::unique_ptr<llvm::Module>>
+loadBitcodeIfAvailable(void* fnPtr, llvm::LLVMContext& ctx, const std::unordered_map<std::string, void*>& symbolTable) {
 	// look up the function pointer in the bitcode registry
 	auto bitcodeStr = InlineFunctionRegistry::instance().getBitcode(fnPtr);
-	if (bitcodeStr.empty()) {
+	if (!bitcodeStr.has_value()) {
 		return std::nullopt; // function not found in registry, cant inline
 	}
 
 	// deserialize bitcode module
-	auto buffer = llvm::MemoryBuffer::getMemBuffer(llvm::StringRef(bitcodeStr.data(), bitcodeStr.size()), "", false);
+	auto buffer = llvm::MemoryBuffer::getMemBuffer(llvm::StringRef(bitcodeStr->data(), bitcodeStr->size()), "", false);
 	llvm::Expected<std::unique_ptr<llvm::Module>> moduleOrErr = llvm::parseBitcodeFile(buffer->getMemBufferRef(), ctx);
 	if (!moduleOrErr) {
 		logAllUnhandledErrors(moduleOrErr.takeError(), llvm::errs(), "Bitcode parse error: ");
 		return std::nullopt; // if deserialization fails, fall back to regular invocation
 	}
 
-	// rewrite names of function dependencies to runtime addresses for linkage + recursive inlining
-	for (auto& func : *moduleOrErr.get()) {
-		if (func.isDeclaration() && !func.isIntrinsic()) {
-			auto it = InlineFunctionRegistry::instance().getSymbolTable().find(func.getName().str());
-			if (it != InlineFunctionRegistry::instance().getSymbolTable().end()) {
-				auto hexStr = ptrToHex(it->second);
+	auto& inlineModule = **moduleOrErr;
 
-				auto* existingFunc = moduleOrErr.get()->getFunction(hexStr);
-				if (!existingFunc) {
-					func.setName(hexStr);
-				} else {
-					func.replaceAllUsesWith(existingFunc);
-					func.removeFromParent();
-				}
-			} else {
-				llvm::errs() << "Symbol registry error. Undefined function " << func.getName()
-				             << " not contained in symbol registry.\n";
-				return std::nullopt;
-			}
+	// rewrite names of function dependencies to runtime addresses for linkage + recursive inlining
+	for (auto& func : inlineModule) {
+		if (!func.isDeclaration() || func.isIntrinsic()) {
+			continue;
+		}
+		auto it = symbolTable.find(func.getName().str());
+		if (it == symbolTable.end()) {
+			llvm::errs() << "Symbol registry error. Undefined function " << func.getName()
+			             << " not contained in symbol registry.\n";
+			return std::nullopt;
+		}
+		auto hexStr = ptrToHex(it->second);
+		if (auto* existingFunc = inlineModule.getFunction(hexStr)) {
+			func.replaceAllUsesWith(existingFunc);
+			func.removeFromParent();
+		} else {
+			func.setName(hexStr);
 		}
 	}
 
 	// same for external global variables
-	for (auto& globalVar : moduleOrErr.get()->globals()) {
-		if (globalVar.isDeclaration()) {
-			auto it = InlineFunctionRegistry::instance().getSymbolTable().find(globalVar.getName().str());
-			if (it != InlineFunctionRegistry::instance().getSymbolTable().end()) {
-				auto hexStr = ptrToHex(it->second);
-
-				auto* existingGV = moduleOrErr.get()->getGlobalVariable(hexStr);
-				if (!existingGV) {
-					globalVar.setName(hexStr);
-				} else {
-					globalVar.replaceAllUsesWith(existingGV);
-					globalVar.removeFromParent();
-				}
-			} else {
-				llvm::errs() << "Symbol registry error. Global variable " << globalVar.getName()
-				             << " not contained in symbol registry.\n";
-				return std::nullopt;
-			}
+	for (auto& globalVar : inlineModule.globals()) {
+		if (!globalVar.isDeclaration()) {
+			continue;
+		}
+		auto it = symbolTable.find(globalVar.getName().str());
+		if (it == symbolTable.end()) {
+			llvm::errs() << "Symbol registry error. Global variable " << globalVar.getName()
+			             << " not contained in symbol registry.\n";
+			return std::nullopt;
+		}
+		auto hexStr = ptrToHex(it->second);
+		if (auto* existingGV = inlineModule.getGlobalVariable(hexStr)) {
+			globalVar.replaceAllUsesWith(existingGV);
+			globalVar.removeFromParent();
+		} else {
+			globalVar.setName(hexStr);
 		}
 	}
 
@@ -97,25 +96,56 @@ void fixFunctionNameConflicts(const llvm::Module& moduleToOptimize, llvm::Module
 	 * If that's the case, we need to update function names to avoid conflicts
 	 * target functions that refer to the same host function are correctly deduplicated before using the function ptr
 	 */
+	// Snapshot the host module's function names once. Each subsequent rename
+	// checks the set in O(1); with n `is_target` functions this replaces the
+	// previous O(n * hostFnCount) scan.
+	llvm::StringSet<> hostFunctionNames;
+	for (const auto& func : moduleToOptimize) {
+		hostFunctionNames.insert(func.getName());
+	}
+
 	for (auto& func1 : inlineModule) {
 		if (!func1.hasFnAttribute("is_target")) {
 			continue;
 		}
-		int i = 0;
+		if (!hostFunctionNames.contains(func1.getName())) {
+			continue;
+		}
 		auto originalName = func1.getName().str();
-		while (moduleToOptimize.getFunction(func1.getName())) {
-			auto newName = originalName + "_" + std::to_string(i++);
-			func1.setName(newName);
+		for (int i = 0;; ++i) {
+			auto newName = originalName + "_" + std::to_string(i);
+			if (!hostFunctionNames.contains(newName)) {
+				func1.setName(newName);
+				break;
+			}
 		}
 	}
 }
 
+// Safety cap for the fixed-point inlining loop below. Recursive inlining
+// converges in practice well under this bound; if it doesn't, we prefer to
+// emit a diagnostic and fall back to the partially-inlined state rather
+// than hang the JIT.
+constexpr int MAX_INLINE_ITERATIONS = 32;
+
 void inlineFunctions(llvm::Module& moduleToOptimize) {
+	// Snapshot the symbol table once per inlining call: the table is
+	// populated by static initializers at program startup and by
+	// `dlopen`-loaded shared object ctors; snapshotting avoids holding the
+	// registry mutex across llvm::Linker and keeps repeated lookups cheap.
+	const auto symbolTable = InlineFunctionRegistry::instance().getSymbolTable();
+
 	// repeat until module wasnt modified during an iteration
 	// this is key for recursive inlining, where inlinable candidates may appear later during processing
 	std::unordered_map<void*, llvm::Function*> inlinedFunctions {};
 	bool doAnotherIteration; // true if there could still be inlinable functions
+	int iteration = 0;
 	do {
+		if (++iteration > MAX_INLINE_ITERATIONS) {
+			llvm::errs() << "inlineFunctions: fixed-point iteration cap (" << MAX_INLINE_ITERATIONS
+			             << ") reached; aborting further inlining\n";
+			break;
+		}
 		doAnotherIteration = false;
 		std::vector<llvm::Function*> functionListView;
 		for (auto& F : moduleToOptimize) {
@@ -143,7 +173,7 @@ void inlineFunctions(llvm::Module& moduleToOptimize) {
 			}
 
 			// try to load bitcode for the current function
-			auto optInlineModule = loadBitcodeIfAvailable(fnPtr, moduleToOptimize.getContext());
+			auto optInlineModule = loadBitcodeIfAvailable(fnPtr, moduleToOptimize.getContext(), symbolTable);
 			if (!optInlineModule.has_value()) {
 				continue;
 			}
@@ -165,8 +195,12 @@ void inlineFunctions(llvm::Module& moduleToOptimize) {
 			inlineModule->setDataLayout(moduleToOptimize.getDataLayout().getStringRepresentation());
 
 			if (moduleToOptimize.getFunction(inlinableFunctionFName) != nullptr) {
-				// this should never happen if the deduplication logic works correctly
-				throw RuntimeException("Inlining error: symbol '" + inlinableFunctionFName + "' doubly defined");
+				// Should not happen if fixFunctionNameConflicts did its job,
+				// but if it does we prefer to skip this candidate (falling
+				// back to the non-inlined proxy-call path) rather than abort
+				// the entire JIT compile by throwing out of this hook.
+				llvm::errs() << "Inlining skipped: symbol '" << inlinableFunctionFName << "' doubly defined.\n";
+				continue;
 			}
 
 			// link original module with the inline function module (merges two llvm modules)

--- a/plugins/inlining/test/CMakeLists.txt
+++ b/plugins/inlining/test/CMakeLists.txt
@@ -4,6 +4,7 @@ include(Catch)
 add_executable(nautilus-inlining-tests
         InliningExecutionTest.cpp
         FunctionPtrInliningTest.cpp
+        RegistryThreadSafetyTest.cpp
 )
 
 nautilus_inline(nautilus-inlining-tests)

--- a/plugins/inlining/test/InliningExecutionTest.cpp
+++ b/plugins/inlining/test/InliningExecutionTest.cpp
@@ -1,9 +1,10 @@
 #include "ExecutionTest.hpp"
-#include "RunctimeCallFunctions.hpp"
+#include "RuntimeCallFunctions.hpp"
 #include "nautilus/Engine.hpp"
 #include <catch2/catch_all.hpp>
 
 #if defined(ENABLE_TRACING) && defined(ENABLE_MLIR_BACKEND)
+#include "InliningTestAnchors.hpp"
 #include "nautilus/compiler/backends/mlir/LLVMBackendHooks.hpp"
 #include "nautilus/inline.hpp"
 #endif
@@ -16,13 +17,20 @@ TEST_CASE("Inlining plugin: linkable", "[inlining][smoke]") {
 
 #if defined(ENABLE_TRACING) && defined(ENABLE_MLIR_BACKEND)
 
-// Static anchors so the NAUTILUS_INLINE-annotated helper functions referenced
-// by the test body are actually emitted into the test binary (and thus end
-// up in the InlineFunctionRegistry at program startup when the Clang pass
-// plugin runs over the plugin test TU).
-[[maybe_unused]] static auto* anchor_add = &add;
-[[maybe_unused]] static auto* anchor_sub = &sub;
-[[maybe_unused]] static Derived d;
+// A host is expected to actually exercise the inlining pass when:
+//   1. the compiler is Clang in the supported 19-21 range, AND
+//   2. the host is not ARM/aarch64.
+// On such hosts the pass plugin is always loaded via `nautilus_inline()`
+// in the test CMakeLists, so the registry MUST be populated by the time
+// the test binary starts running. On any other host we expect the
+// registry to be empty. Historically we conditionally asserted "sub is
+// registered IFF add is registered", which allowed a silent-skip failure
+// mode where the pass ran but added nothing.
+#if defined(__clang__) && __clang_major__ >= 19 && __clang_major__ < 22 && !defined(__aarch64__) && !defined(__arm__)
+#define NAUTILUS_INLINING_EXPECTED_ACTIVE 1
+#else
+#define NAUTILUS_INLINING_EXPECTED_ACTIVE 0
+#endif
 
 // Defense-in-depth smoke test: if inlining is actually active, the Clang
 // pass plugin registered bitcode for the annotated helpers at program load
@@ -40,19 +48,22 @@ TEST_CASE("InlineFunctionRegistry contains annotated helpers", "[inlining][smoke
 	// and the Clang pass finds them during compilation of the test binary.
 	REQUIRE(add(1, 2) == 3);
 	REQUIRE(sub(5, 2) == 3);
-	// When the pass ran, it populated the registry with bitcode for these
-	// helpers — look them up by address.
 	const bool haveAddBitcode =
 	    InlineFunctionRegistry::instance().containsFunctionBitcode(reinterpret_cast<void*>(&add));
 	const bool haveSubBitcode =
 	    InlineFunctionRegistry::instance().containsFunctionBitcode(reinterpret_cast<void*>(&sub));
-	// These must be true on hosts where the pass is supported (Clang 19 on
-	// non-ARM). On other hosts, the test binary is still built and run but
-	// the registry will be empty. Only assert strictly when we know inlining
-	// is active.
-	if (haveAddBitcode) {
-		REQUIRE(haveSubBitcode);
-	}
+#if NAUTILUS_INLINING_EXPECTED_ACTIVE
+	// On a supported toolchain both must be present — a partial registry
+	// indicates the pass ran but dropped entries silently.
+	REQUIRE(haveAddBitcode);
+	REQUIRE(haveSubBitcode);
+#else
+	// On other hosts the pass didn't run, and the registry is expected to
+	// be empty for these helpers. Don't require emptiness though — a user
+	// could have linked in a supported-toolchain archive.
+	(void) haveAddBitcode;
+	(void) haveSubBitcode;
+#endif
 }
 
 // Drives the annotated helper functions through the engine, exercising the
@@ -67,7 +78,7 @@ static void inlinedFunctionCallTests(engine::NautilusEngine& engine) {
 
 	SECTION("dynCastCall") {
 		auto f = engine.registerFunction(dynCastCall);
-		REQUIRE(f(&d) == 0);
+		REQUIRE(f(&detail::inlining_anchor_derived) == 0);
 	}
 
 	SECTION("directCallWithNestedCalls") {
@@ -128,6 +139,75 @@ TEST_CASE("Inlined Function Call Test") {
 		opts.setOption("mlir.inline_invoke_calls", true);
 	});
 	inlinedFunctionCallTests(engine);
+}
+
+// --------------------------------------------------------------------------
+// Additional coverage tests added in the plugin hardening pass.
+// --------------------------------------------------------------------------
+
+// The `proxyCallNameOverride` hook installed by the inlining plugin must
+// produce a distinct, hex-formatted name per input pointer, and must return
+// nullopt for pointers whose bitcode isn't registered. This is the contract
+// the MLIR backend relies on when deciding whether to route a call through
+// the JIT-time inliner.
+TEST_CASE("proxyCallNameOverride hook returns stable hex names", "[inlining][unit]") {
+	const auto& hooks = nautilus::compiler::mlir::getLLVMBackendHooks();
+	REQUIRE(static_cast<bool>(hooks.proxyCallNameOverride));
+
+	// An on-stack object cannot be a registered function pointer, so the
+	// hook must decline to rename it.
+	int localStackObject = 0;
+	void* unknownPtr = reinterpret_cast<void*>(&localStackObject);
+	REQUIRE_FALSE(hooks.proxyCallNameOverride(unknownPtr).has_value());
+
+#if NAUTILUS_INLINING_EXPECTED_ACTIVE
+	// For a registered helper the hook must return a stable, non-empty
+	// hex-formatted string that round-trips via repeated calls (i.e. the
+	// name is deterministic for the same pointer — format drift between
+	// call sites would break JIT inlining silently).
+	void* addAddr = reinterpret_cast<void*>(&add);
+	auto overriddenAdd = hooks.proxyCallNameOverride(addAddr);
+	REQUIRE(overriddenAdd.has_value());
+	REQUIRE(!overriddenAdd->empty());
+	REQUIRE(overriddenAdd->rfind("0x", 0) == 0); // starts with "0x"
+	REQUIRE(*overriddenAdd == *hooks.proxyCallNameOverride(addAddr));
+
+	// Distinct registered functions must yield distinct names (address
+	// uniqueness must survive the hex encoding).
+	void* subAddr = reinterpret_cast<void*>(&sub);
+	auto overriddenSub = hooks.proxyCallNameOverride(subAddr);
+	REQUIRE(overriddenSub.has_value());
+	REQUIRE(*overriddenAdd != *overriddenSub);
+#endif
+}
+
+// The registry must distinguish "not registered" from "registered as empty
+// bitcode" — previously both returned the same `static std::string empty`
+// sentinel, which masked genuine miss cases. An unknown pointer must yield
+// `std::nullopt`.
+TEST_CASE("InlineFunctionRegistry reports misses distinctly", "[inlining][unit]") {
+	// Use a stack address that will never be a registered function pointer.
+	int localStackObject = 0;
+	void* unknownPtr = reinterpret_cast<void*>(&localStackObject);
+	const auto bitcode = InlineFunctionRegistry::instance().getBitcode(unknownPtr);
+	REQUIRE_FALSE(bitcode.has_value());
+	REQUIRE_FALSE(InlineFunctionRegistry::instance().containsFunctionBitcode(unknownPtr));
+}
+
+// When `mlir.inline_invoke_calls` is disabled, the engine must still be
+// able to compile and execute the same traced functions — falling back to
+// the opaque proxy-call path. This is the path that H2 (replacing the
+// throw with a skip) protects against: even on the inlining path, any
+// per-candidate failure should degrade to this same behaviour.
+TEST_CASE("Inlining disabled path still executes correctly", "[inlining][unit]") {
+	auto engine = nautilus::testing::makeEngine("mlir", [](engine::Options& opts) {
+		opts.setOption("engine.Compilation", true);
+		opts.setOption("mlir.enableMultithreading", false);
+		opts.setOption("mlir.inline_invoke_calls", false);
+	});
+	auto f = engine.registerFunction(simpleDirectCall);
+	REQUIRE(f(10, 10) == 20);
+	REQUIRE(f(1, 2) == 3);
 }
 
 #endif

--- a/plugins/inlining/test/LLVMIRInliningTest.cpp
+++ b/plugins/inlining/test/LLVMIRInliningTest.cpp
@@ -8,8 +8,9 @@
 // start matching the non-inlined core reference IR, the JIT-time inliner has
 // silently regressed.
 
+#include "InliningTestAnchors.hpp"
 #include "LLVMIRTestUtil.hpp"
-#include "common/RunctimeCallFunctions.hpp"
+#include "common/RuntimeCallFunctions.hpp"
 #include "nautilus/Engine.hpp"
 #include "nautilus/inline.hpp"
 #include <catch2/catch_all.hpp>
@@ -17,6 +18,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <regex>
 #include <string>
 
 namespace nautilus::engine {
@@ -29,13 +31,6 @@ using nautilus::engine::loopDirectCall2;
 using nautilus::engine::simpleDirectCall;
 using nautilus::engine::sub;
 
-// Static anchors so the NAUTILUS_INLINE-annotated helper functions referenced
-// by the test body are actually emitted into the test binary (and thus end up
-// in the InlineFunctionRegistry at program startup when the Clang pass plugin
-// runs over the plugin test TU).
-[[maybe_unused]] static auto* anchor_add = &add;
-[[maybe_unused]] static auto* anchor_sub = &sub;
-
 // Returns true if the Clang inlining pass plugin actually ran over the test
 // binary at compile time and populated the registry with bitcode for the
 // annotated helpers. On hosts where the pass is unsupported (e.g. non-Clang,
@@ -45,6 +40,69 @@ using nautilus::engine::sub;
 static bool inliningPassActive() {
 	return InlineFunctionRegistry::instance().containsFunctionBitcode(reinterpret_cast<void*>(&add));
 }
+
+// RAII guard that cleans up a filesystem path on destruction. Using this
+// rather than manual `remove_all` at test end ensures cleanup runs even if
+// a REQUIRE aborts the test body.
+namespace {
+struct TempPathGuard {
+	std::filesystem::path path;
+	explicit TempPathGuard(std::filesystem::path p) : path(std::move(p)) {
+		std::filesystem::remove_all(path);
+		std::filesystem::create_directories(path);
+	}
+	~TempPathGuard() {
+		std::error_code ec;
+		std::filesystem::remove_all(path, ec);
+	}
+	TempPathGuard(const TempPathGuard&) = delete;
+	TempPathGuard& operator=(const TempPathGuard&) = delete;
+};
+
+// Checks that the generated LLVM IR contains neither a `declare` of any
+// `runtimeFuncN` (the opaque-proxy-call names the MLIR backend emits for
+// unresolved helper calls) nor a call instruction targeting one. These
+// regex patterns are stricter than substring matches: they tolerate
+// differing return types and avoid false matches on tokens like
+// `@runtimeFuncPrinterShim` that may appear in future backend changes.
+void assertNoRuntimeFuncCall(const std::string& ir) {
+	static const std::regex declarePattern(R"(\bdeclare\s+\S+\s+@runtimeFunc\w*)");
+	static const std::regex callPattern(R"(\b(?:tail\s+)?call\s+\S+\s+@runtimeFunc\w*)");
+	INFO("Unexpected @runtimeFunc reference left in IR after inlining");
+	REQUIRE_FALSE(std::regex_search(ir, declarePattern));
+	REQUIRE_FALSE(std::regex_search(ir, callPattern));
+}
+
+// Recompile a Nautilus-traced function with the inlining options that the
+// reference-IR tests use, then read the generated LLVM IR back as a string
+// so callers can run custom assertions over it. Cleans up the temp dump
+// directory automatically via RAII.
+template <typename Func>
+std::string dumpInlinedIR(const std::string& label, Func func) {
+	auto dumpPath = std::filesystem::temp_directory_path() / ("nautilus-inlining-ir-smoke-" + label);
+	TempPathGuard guard(dumpPath);
+
+	engine::Options options;
+	options.setOption("engine.backend", "mlir");
+	options.setOption("dump.after_llvm_generation", true);
+	options.setOption("dump.all", true);
+	options.setOption("dump.console", false);
+	options.setOption("dump.path", dumpPath.string());
+	options.setOption("engine.normalizeFunctionNames", true);
+	options.setOption("mlir.enableIntrinsics", true);
+	options.setOption("mlir.inline_invoke_calls", true);
+	options.setOption("mlir.enableMultithreading", false);
+
+	auto engine = engine::NautilusEngine(options);
+	auto function = engine.registerFunction(func);
+	auto generatedLLVMFile = function.getExecutable()->getGeneratedFile("after_llvm_generation");
+	REQUIRE_FALSE(generatedLLVMFile.empty());
+
+	std::ifstream in(std::string {generatedLLVMFile});
+	REQUIRE(in.good());
+	return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+} // namespace
 
 // Wrapper for testLLVMIR that drops the generated module into the plugin's
 // own `inlining-ir/` reference directory and turns on JIT-time inlining via
@@ -84,53 +142,37 @@ TEST_CASE("Inlining LLVM IR: loopDirectCall2 (inlined)", "[inlining][llvm-ir]") 
 	testInliningLLVMIR("loopDirectCall2_inlined", loopDirectCall2);
 }
 
-// End-to-end defense-in-depth: recompile `simpleDirectCall` with the same
-// options that `testInliningLLVMIR` uses, then scan the dumped IR by hand to
-// assert that the annotated `add` helper was actually folded into `execute`.
-// If the reference `.ll` files ever start matching the non-inlined variants,
-// this test fails loudly rather than silently rubber-stamping a regression.
-TEST_CASE("Inlining LLVM IR: generated IR does not contain runtimeFunc declare", "[inlining][llvm-ir][smoke]") {
+// End-to-end defense-in-depth: recompile each annotated helper with the
+// same options that `testInliningLLVMIR` uses, then scan the dumped IR by
+// hand to assert that no opaque `@runtimeFunc` proxy call survives. If the
+// reference `.ll` files ever start matching the non-inlined variants, this
+// test fails loudly rather than silently rubber-stamping a regression. In
+// addition, for `simpleDirectCall` we assert the inlined `add` body made
+// it into `execute` by looking for a raw `add` instruction.
+TEST_CASE("Inlining LLVM IR: no runtimeFunc left after inlining", "[inlining][llvm-ir][smoke]") {
 	if (!inliningPassActive()) {
 		SKIP("Clang inlining pass plugin is not active on this host — cannot verify inlining.");
 	}
 
-	std::string dumpPath =
-	    (std::filesystem::temp_directory_path() / "nautilus-inlining-ir-smoke-simpleDirectCall").string();
-	std::filesystem::remove_all(dumpPath);
-	std::filesystem::create_directories(dumpPath);
-
-	engine::Options options;
-	options.setOption("engine.backend", "mlir");
-	options.setOption("dump.after_llvm_generation", true);
-	options.setOption("dump.all", true);
-	options.setOption("dump.console", false);
-	options.setOption("dump.path", dumpPath);
-	options.setOption("engine.normalizeFunctionNames", true);
-	options.setOption("mlir.enableIntrinsics", true);
-	options.setOption("mlir.inline_invoke_calls", true);
-	options.setOption("mlir.enableMultithreading", false);
-
-	auto engine = engine::NautilusEngine(options);
-	auto function = engine.registerFunction(simpleDirectCall);
-	auto generatedLLVMFile = function.getExecutable()->getGeneratedFile("after_llvm_generation");
-	REQUIRE(!generatedLLVMFile.empty());
-
-	std::ifstream in(std::string {generatedLLVMFile});
-	REQUIRE(in.good());
-	std::string ir((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-
-	// After inlining, the `add` helper body must be merged into `execute`:
-	// there should be no `declare i32 @runtimeFunc0(i32, i32)` left, and no
-	// `call` / `tail call` to `@runtimeFunc0`. The IR must still define
-	// `execute`, and it should contain an `add` instruction — that's the
-	// inlined helper body.
-	REQUIRE(ir.find("define") != std::string::npos);
-	REQUIRE(ir.find("@execute") != std::string::npos);
-	REQUIRE(ir.find("declare i32 @runtimeFunc") == std::string::npos);
-	REQUIRE(ir.find("call i32 @runtimeFunc") == std::string::npos);
-	REQUIRE(ir.find("= add ") != std::string::npos);
-
-	std::filesystem::remove_all(dumpPath);
+	SECTION("simpleDirectCall") {
+		auto ir = dumpInlinedIR("simpleDirectCall", simpleDirectCall);
+		REQUIRE(ir.find("define") != std::string::npos);
+		REQUIRE(ir.find("@execute") != std::string::npos);
+		assertNoRuntimeFuncCall(ir);
+		REQUIRE(ir.find("= add ") != std::string::npos); // inlined `add` body
+	}
+	SECTION("directCallWithNestedCalls") {
+		assertNoRuntimeFuncCall(dumpInlinedIR("directCallWithNestedCalls", directCallWithNestedCalls));
+	}
+	SECTION("callTwoFunctions") {
+		assertNoRuntimeFuncCall(dumpInlinedIR("callTwoFunctions", callTwoFunctions));
+	}
+	SECTION("loopDirectCall") {
+		assertNoRuntimeFuncCall(dumpInlinedIR("loopDirectCall", loopDirectCall));
+	}
+	SECTION("loopDirectCall2") {
+		assertNoRuntimeFuncCall(dumpInlinedIR("loopDirectCall2", loopDirectCall2));
+	}
 }
 
 } // namespace nautilus::engine

--- a/plugins/inlining/test/RegistryThreadSafetyTest.cpp
+++ b/plugins/inlining/test/RegistryThreadSafetyTest.cpp
@@ -1,0 +1,85 @@
+// Thread-safety smoke test for InlineFunctionRegistry.
+//
+// The registry is normally populated by static ctors at program startup,
+// but shared objects loaded later via dlopen can register additional
+// entries while the JIT has already started reading the table via
+// `getSymbolTable()` / `getBitcode()`. Prior to the hardening changes the
+// non-const `getSymbolTable()` returned a live reference while holding no
+// mutex, and `getBitcode()` returned a reference that escaped the lock.
+//
+// This test drives the registry through 4 threads (2 writers, 2 readers)
+// for ~1k iterations each and asserts that no invariant is violated.
+// It isn't a stress test — it's a regression guard to ensure the snapshot
+// semantics stay intact when the APIs evolve. Run under TSAN for maximum
+// effect: `cmake -DSAN=thread ..`.
+#include "nautilus/inline.hpp"
+#include <atomic>
+#include <catch2/catch_all.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace nautilus {
+
+TEST_CASE("InlineFunctionRegistry concurrent readers and writers", "[inlining][threading]") {
+	auto& registry = InlineFunctionRegistry::instance();
+
+	constexpr int iters = 1000;
+	std::atomic<bool> start {false};
+
+	// Two writer threads register distinct (fake) bitcodes and symbol
+	// mappings. The bitcode keys are derived from stable stack-free
+	// integer values to avoid colliding with any real registrations the
+	// inlining pass may have populated.
+	auto writer = [&](int base) {
+		while (!start.load(std::memory_order_acquire)) {
+		}
+		for (int i = 0; i < iters; ++i) {
+			auto* fakeFn = reinterpret_cast<void*>(static_cast<uintptr_t>(0xC0FFEE0000ULL) +
+			                                       static_cast<uintptr_t>(base * iters + i));
+			registerBitcodePleaseIgnoreThisThanks(fakeFn, "bc", 2);
+
+			auto symName = "sym_" + std::to_string(base) + "_" + std::to_string(i);
+			registerSymbolPleaseIgnoreThisThanks(symName.data(), symName.size(), fakeFn);
+		}
+	};
+
+	// Two reader threads take snapshots and look up known-missing pointers.
+	// The invariants checked here are:
+	//   1. getBitcode returns nullopt (not an empty-string sentinel) for
+	//      entirely fresh addresses.
+	//   2. getSymbolTable is safe to call concurrently and returns a
+	//      plain-value snapshot that doesn't tear.
+	auto reader = [&]() {
+		while (!start.load(std::memory_order_acquire)) {
+		}
+		int unknown_stack {};
+		for (int i = 0; i < iters; ++i) {
+			auto snapshot = registry.getSymbolTable();
+			(void) snapshot.size(); // touch the snapshot to defeat optimisation
+			auto bc = registry.getBitcode(&unknown_stack);
+			REQUIRE_FALSE(bc.has_value());
+		}
+	};
+
+	std::vector<std::thread> threads;
+	threads.emplace_back(writer, 0);
+	threads.emplace_back(writer, 1);
+	threads.emplace_back(reader);
+	threads.emplace_back(reader);
+
+	start.store(true, std::memory_order_release);
+	for (auto& t : threads) {
+		t.join();
+	}
+
+	// After all writers are done the snapshot must include a stable number
+	// of entries corresponding to what both writers inserted. We don't
+	// assert the exact count because other tests may have registered
+	// additional symbols, but the table must have grown by at least the
+	// number we inserted.
+	auto finalTable = registry.getSymbolTable();
+	REQUIRE(finalTable.size() >= static_cast<size_t>(2 * iters));
+}
+
+} // namespace nautilus

--- a/plugins/inlining/test/common/InliningTestAnchors.hpp
+++ b/plugins/inlining/test/common/InliningTestAnchors.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+// Static anchors for the NAUTILUS_INLINE-annotated helpers referenced by
+// the plugin test binaries. Taking the address of each helper with
+// `[[maybe_unused]] static auto*` ensures the function symbols are actually
+// emitted into each test TU, which in turn lets the Clang inlining pass
+// plugin (running at compile time over the test binary) discover them and
+// populate `InlineFunctionRegistry` at program startup.
+//
+// Including this header from every plugin test TU that exercises the
+// registry keeps the anchor list in one place, avoiding the drift that
+// occurred when InliningExecutionTest.cpp and LLVMIRInliningTest.cpp each
+// declared their own (initially identical, now easy to diverge) anchors.
+
+#include "RuntimeCallFunctions.hpp"
+
+namespace nautilus::engine::detail {
+
+[[maybe_unused]] static auto* inlining_anchor_add = &add;
+[[maybe_unused]] static auto* inlining_anchor_sub = &sub;
+[[maybe_unused]] static Derived inlining_anchor_derived;
+
+} // namespace nautilus::engine::detail

--- a/plugins/inlining/test/common/RuntimeCallFunctions.hpp
+++ b/plugins/inlining/test/common/RuntimeCallFunctions.hpp
@@ -133,7 +133,7 @@ val<int32_t> loopDirectCall(val<int32_t> c, val<int32_t> x) {
 	return sum;
 }
 
-inline int32_t get42() {
+NAUTILUS_INLINE int32_t get42() {
 	return 42;
 }
 

--- a/plugins/inlining/test/inlining-ir/callTwoFunctions_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/callTwoFunctions_inlined.ll
@@ -1,0 +1,65 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = shl i32 %0, 1
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = shl i32 %0, 1
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = getelementptr i8, ptr %0, i64 16
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = getelementptr i8, ptr %0, i64 16
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine3addEii(i32 noundef %0, i32 noundef %1) local_unnamed_addr #2 {
+  %3 = add nsw i32 %1, %0
+  ret i32 %3
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine3subEii(i32 noundef %0, i32 noundef %1) local_unnamed_addr #2 {
+  %3 = sub nsw i32 %0, %1
+  ret i32 %3
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+!llvm.ident = !{!6, !6}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 0}
+!3 = !{i32 7, !"PIE Level", i32 2}
+!4 = !{i32 7, !"uwtable", i32 2}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}

--- a/plugins/inlining/test/inlining-ir/directCallWithNestedCalls_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/directCallWithNestedCalls_inlined.ll
@@ -1,0 +1,59 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = shl i32 %0, 1
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = shl i32 %0, 1
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = getelementptr i8, ptr %0, i64 16
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = getelementptr i8, ptr %0, i64 16
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine9addAndSubEii(i32 noundef %0, i32 %1) local_unnamed_addr #2 {
+  %3 = shl i32 %0, 1
+  ret i32 %3
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 0}
+!3 = !{i32 7, !"PIE Level", i32 2}
+!4 = !{i32 7, !"uwtable", i32 2}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}

--- a/plugins/inlining/test/inlining-ir/loopDirectCall2_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/loopDirectCall2_inlined.ll
@@ -1,0 +1,64 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
+  %2 = mul i32 %0, 42
+  ret i32 %2
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
+  %2 = mul i32 %0, 42
+  ret i32 %2
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = mul i32 %3, 42
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = mul i32 %3, 42
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine5get42Ev() local_unnamed_addr #2 {
+  ret i32 42
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine3addEii(i32 noundef %0, i32 noundef %1) local_unnamed_addr #2 {
+  %3 = add nsw i32 %1, %0
+  ret i32 %3
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+!llvm.ident = !{!6, !6}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 0}
+!3 = !{i32 7, !"PIE Level", i32 2}
+!4 = !{i32 7, !"uwtable", i32 2}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}

--- a/plugins/inlining/test/inlining-ir/loopDirectCall_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/loopDirectCall_inlined.ll
@@ -1,0 +1,74 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+._crit_edge:
+  %2 = icmp sgt i32 %0, 0
+  %3 = mul i32 %1, %0
+  %spec.select = select i1 %2, i32 %3, i32 0
+  ret i32 %spec.select
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = icmp sgt i32 %0, 0
+  %4 = mul i32 %1, %0
+  %spec.select.i = select i1 %3, i32 %4, i32 0
+  ret i32 %spec.select.i
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load i32, ptr %5, align 4
+  %7 = icmp sgt i32 %3, 0
+  %8 = mul i32 %6, %3
+  %spec.select.i = select i1 %7, i32 %8, i32 0
+  %9 = getelementptr i8, ptr %0, i64 16
+  %10 = load ptr, ptr %9, align 8
+  store i32 %spec.select.i, ptr %10, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load i32, ptr %5, align 4
+  %7 = icmp sgt i32 %3, 0
+  %8 = mul i32 %6, %3
+  %spec.select.i.i = select i1 %7, i32 %8, i32 0
+  %9 = getelementptr i8, ptr %0, i64 16
+  %10 = load ptr, ptr %9, align 8
+  store i32 %spec.select.i.i, ptr %10, align 4
+  ret void
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine3addEii(i32 noundef %0, i32 noundef %1) local_unnamed_addr #2 {
+  %3 = add nsw i32 %1, %0
+  ret i32 %3
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 0}
+!3 = !{i32 7, !"PIE Level", i32 2}
+!4 = !{i32 7, !"uwtable", i32 2}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}

--- a/plugins/inlining/test/inlining-ir/simpleDirectCall_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/simpleDirectCall_inlined.ll
@@ -1,0 +1,65 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = add nsw i32 %1, %0
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = add nsw i32 %1, %0
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load i32, ptr %5, align 4
+  %7 = add nsw i32 %6, %3
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load i32, ptr %5, align 4
+  %7 = add nsw i32 %6, %3
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+; Function Attrs: alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable
+define dso_local noundef i32 @_ZN8nautilus6engine3addEii(i32 noundef %0, i32 noundef %1) local_unnamed_addr #2 {
+  %3 = add nsw i32 %1, %0
+  ret i32 %3
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 0}
+!3 = !{i32 7, !"PIE Level", i32 2}
+!4 = !{i32 7, !"uwtable", i32 2}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}


### PR DESCRIPTION
Correctness & safety:
- Registry: snapshot-by-value semantics for getSymbolTable(); optional
  return type for getBitcode() so callers distinguish "missing" from
  "empty"; make all accessors const with proper locking; switch
  string params to std::string_view.
- LLVM JIT hook: replace `throw RuntimeException` on duplicate symbol
  with a log+skip so one bad candidate no longer aborts JIT.
- LLVM JIT hook: snapshot symbol table once per inlineFunctions() call;
  cap the fixed-point loop at 32 iterations to prevent infinite loops.
- Pass: null-check v2vInverted lookups so fresh globals introduced by
  ExtractGVPass don't crash in getUniqueName.
- proxyCallNameOverride now uses ptrToHex for format consistency with
  jitSymbolContributor (prevents silent ABI drift).

API hygiene & perf:
- CMake: remove dead `INTERFACE_` property on InliningPass; cache the
  is_inlining_supported() detector; fix misleading warning message.
- Pass: disentangle CrashRecoveryContext success/serialized booleans.
- Pass: name the 65535 ctor priority with a documented constant.
- Pass: SymbolMap is now unordered_map (iteration order was never used).
- Pre-populate a StringSet for fixFunctionNameConflicts (O(n) instead
  of O(n^2)).

Tests:
- Rename RunctimeCallFunctions.hpp -> RuntimeCallFunctions.hpp (typo).
- Extract shared helper anchors into InliningTestAnchors.hpp.
- Generalize the LLVM-IR smoke test across all five test functions
  with regex-based @runtimeFunc detection and RAII temp-dir cleanup.
- Tighten InliningExecutionTest registry assertions: on supported
  toolchains (Clang 19-21, non-ARM) both bitcodes are required.
- Add coverage for proxyCallNameOverride hook, the non-inlined
  fallback path, and miss-semantics of the registry.
- Add RegistryThreadSafetyTest (4-thread reader/writer smoke, TSAN-ready).