### PR TITLE
Clean up IRGraph: drop dead root op, O(1) function lookup, tidy value types

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -117,7 +117,7 @@ Vec AsmJitLoweringProvider::LoweringContext::toVec(const AsmReg& r) {
 
 // ── Label management ──────────────────────────────────────────────────────────
 
-Label AsmJitLoweringProvider::LoweringContext::getOrCreateLabel(const std::string& blockId) {
+Label AsmJitLoweringProvider::LoweringContext::getOrCreateLabel(ir::BlockIdentifier blockId) {
 	auto it = blockLabels.find(blockId);
 	if (it != blockLabels.end())
 		return it->second;

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
@@ -82,8 +82,8 @@ private:
 		std::shared_ptr<ir::IRGraph> ir;
 		/// Maps Nautilus function name → AsmJit FuncNode (stable label for forward calls).
 		std::unordered_map<std::string, ::asmjit::FuncNode*> funcNodes_;
-		std::unordered_map<std::string, ::asmjit::Label> blockLabels;
-		std::unordered_set<std::string> processedBlocks;
+		std::unordered_map<ir::BlockIdentifier, ::asmjit::Label> blockLabels;
+		std::unordered_set<ir::BlockIdentifier> processedBlocks;
 
 		static ::asmjit::TypeId getTypeId(Type t);
 		static bool isFloatType(Type t);
@@ -94,7 +94,7 @@ private:
 		static ::asmjit::a64::Gp toGp(const AsmReg& r);
 		static ::asmjit::a64::Vec toVec(const AsmReg& r);
 
-		::asmjit::Label getOrCreateLabel(const std::string& blockId);
+		::asmjit::Label getOrCreateLabel(ir::BlockIdentifier blockId);
 		void emitMove(const AsmReg& dst, const AsmReg& src);
 
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -122,7 +122,7 @@ Xmm AsmJitLoweringProvider::LoweringContext::toXmm(const AsmReg& r) {
 
 // ── Label management ──────────────────────────────────────────────────────────
 
-Label AsmJitLoweringProvider::LoweringContext::getOrCreateLabel(const std::string& blockId) {
+Label AsmJitLoweringProvider::LoweringContext::getOrCreateLabel(ir::BlockIdentifier blockId) {
 	auto it = blockLabels.find(blockId);
 	if (it != blockLabels.end())
 		return it->second;

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -82,8 +82,8 @@ private:
 		std::shared_ptr<ir::IRGraph> ir;
 		/// Maps Nautilus function name → AsmJit FuncNode (stable label for forward calls).
 		std::unordered_map<std::string, ::asmjit::FuncNode*> funcNodes_;
-		std::unordered_map<std::string, ::asmjit::Label> blockLabels;
-		std::unordered_set<std::string> processedBlocks;
+		std::unordered_map<ir::BlockIdentifier, ::asmjit::Label> blockLabels;
+		std::unordered_set<ir::BlockIdentifier> processedBlocks;
 
 		static ::asmjit::TypeId getTypeId(Type t);
 		static bool isFloatType(Type t);
@@ -94,7 +94,7 @@ private:
 		static ::asmjit::x86::Gp toGp(const AsmReg& r);
 		static ::asmjit::x86::Xmm toXmm(const AsmReg& r);
 
-		::asmjit::Label getOrCreateLabel(const std::string& blockId);
+		::asmjit::Label getOrCreateLabel(ir::BlockIdentifier blockId);
 		void emitMove(const AsmReg& dst, const AsmReg& src);
 
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
@@ -98,7 +98,7 @@ private:
 		std::unordered_map<std::string, void*> internalFunctionPtrs;
 		std::string targetFunctionName = "execute";
 		RegisterProvider registerProvider;
-		std::unordered_map<std::string, short> activeBlocks;
+		std::unordered_map<ir::BlockIdentifier, short> activeBlocks;
 		std::unordered_map<ir::OperationIdentifier, int> usageCounts;
 		std::unordered_set<ir::OperationIdentifier> functionArgs;
 

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -155,7 +155,7 @@ std::string CPPLoweringProvider::LoweringContext::process(const ir::BasicBlock* 
 			}
 		}
 		// create bytecode block;
-		auto blockName = "Block_" + block->getIdentifier();
+		auto blockName = "Block_" + std::to_string(block->getIdentifier().getId());
 		short blockIndex = blocks.size();
 		auto& currentBlock = blocks.emplace_back();
 		currentBlock << blockName << ":\n";

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
@@ -61,7 +61,7 @@ private:
 		Code functions;
 		std::vector<Code> blocks;
 		std::shared_ptr<ir::IRGraph> ir;
-		std::unordered_map<std::string, std::string> activeBlocks;
+		std::unordered_map<ir::BlockIdentifier, std::string> activeBlocks;
 		std::unordered_set<std::string> functionNames;
 		std::string returnType;
 

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -94,7 +94,8 @@ private:
 	::mlir::Value globalString;
 	::mlir::FlatSymbolRefAttr printfReference;
 	llvm::StringMap<::mlir::Value> printfStrings;
-	std::unordered_map<std::string, ::mlir::Block*> blockMapping; // Keeps track of already created basic blocks.
+	std::unordered_map<ir::BlockIdentifier, ::mlir::Block*>
+	    blockMapping; // Keeps track of already created basic blocks.
 	const engine::Options* options;
 
 	/**

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -27,14 +27,11 @@ namespace nautilus::compiler::ir {
 IRGraph::IRGraph(const compiler::CompilationUnitID& id) : id(id) {
 }
 
-std::unique_ptr<FunctionOperation>& IRGraph::addRootOperation(std::unique_ptr<FunctionOperation> root) {
-	return addFunctionOperation(std::move(root));
-}
-
 std::unique_ptr<FunctionOperation>&
 IRGraph::addFunctionOperation(std::unique_ptr<FunctionOperation> functionOperation) {
-	functionOperations.emplace_back(std::move(functionOperation));
-	return functionOperations.back();
+	auto& slot = functionOperations.emplace_back(std::move(functionOperation));
+	functionOperationsByName.emplace(std::string_view {slot->getName()}, slot.get());
+	return slot;
 }
 
 const std::vector<std::unique_ptr<FunctionOperation>>& IRGraph::getFunctionOperations() const {
@@ -42,12 +39,8 @@ const std::vector<std::unique_ptr<FunctionOperation>>& IRGraph::getFunctionOpera
 }
 
 const FunctionOperation* IRGraph::getFunctionOperation(const std::string& name) const {
-	for (const auto& func : functionOperations) {
-		if (func->getName() == name) {
-			return func.get();
-		}
-	}
-	return nullptr;
+	auto it = functionOperationsByName.find(std::string_view {name});
+	return it != functionOperationsByName.end() ? it->second : nullptr;
 }
 
 const CompilationUnitID& IRGraph::getId() const {
@@ -140,8 +133,8 @@ struct formatter<nautilus::compiler::ir::Operation> : formatter<std::string_view
 
 template <>
 struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::OperationIdentifier& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::OperationIdentifier& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", op.getId());
 		return out;
@@ -149,9 +142,19 @@ struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::s
 };
 
 template <>
+struct formatter<nautilus::compiler::ir::BlockIdentifier> : formatter<std::string_view> {
+	static auto format(nautilus::compiler::ir::BlockIdentifier id,
+	                   format_context& ctx) -> format_context::iterator {
+		auto out = ctx.out();
+		fmt::format_to(out, "{}", id.getId());
+		return out;
+	}
+};
+
+template <>
 struct formatter<nautilus::compiler::ir::BasicBlockInvocation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "Block_{}(", op.getBlock()->getIdentifier());
 		const auto& args = op.getArguments();
@@ -178,8 +181,8 @@ struct formatter<nautilus::compiler::ir::IfOperation> : formatter<std::string_vi
 
 template <>
 struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 
 		if (op.getStamp() != nautilus::Type::v) {
@@ -204,54 +207,106 @@ struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::st
 
 auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::compiler::ir::Operation& op,
                                                                format_context& ctx) -> format_context::iterator {
+	using OpType = nautilus::compiler::ir::Operation::OperationType;
 	auto out = ctx.out();
-	if (auto shiftOp = op.dynCast<ShiftOperation>()) {
-		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), shiftOp->getLeftInput()->getIdentifier(),
-		               shiftOpToString(shiftOp->getType()), shiftOp->getRightInput()->getIdentifier());
-	} else if (auto compOp = op.dynCast<CompareOperation>()) {
-		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), compOp->getLeftInput()->getIdentifier(),
-		               compOpToString(compOp->getComparator()), compOp->getRightInput()->getIdentifier());
-	} else if (auto bcompOp = op.dynCast<BinaryCompOperation>()) {
-		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), bcompOp->getLeftInput()->getIdentifier(),
-		               shiftOpToString(bcompOp->getType()), bcompOp->getRightInput()->getIdentifier());
-	} else if (auto res = op.dynCast<BinaryOperation>()) {
-		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), res->getLeftInput()->getIdentifier(),
-		               binaryOpToString(op.getOperationType()), res->getRightInput()->getIdentifier());
-	} else if (auto ifOp = op.dynCast<IfOperation>()) {
-		fmt::format_to(out, "{}", *ifOp);
-	} else if (auto brOp = op.dynCast<BranchOperation>()) {
-		fmt::format_to(out, "br {}", brOp->getNextBlockInvocation());
-	} else if (auto constBool = op.dynCast<ConstBooleanOperation>()) {
-		fmt::format_to(out, "{} = {}", op.getIdentifier(), constBool->getValue());
-	} else if (auto constInt = op.dynCast<ConstIntOperation>()) {
-		fmt::format_to(out, "{} = {}", op.getIdentifier(), constInt->getValue());
-	} else if (auto constFloat = op.dynCast<ConstFloatOperation>()) {
-		fmt::format_to(out, "{} = {}", op.getIdentifier(), constFloat->getValue());
-	} else if (auto returnOp = op.dynCast<ReturnOperation>()) {
+	switch (op.getOperationType()) {
+	case OpType::ShiftOp: {
+		const auto& shiftOp = *nautilus::compiler::ir::cast<ShiftOperation>(&op);
+		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), shiftOp.getLeftInput()->getIdentifier(),
+		               shiftOpToString(shiftOp.getType()), shiftOp.getRightInput()->getIdentifier());
+		break;
+	}
+	case OpType::CompareOp: {
+		const auto& compOp = *nautilus::compiler::ir::cast<CompareOperation>(&op);
+		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), compOp.getLeftInput()->getIdentifier(),
+		               compOpToString(compOp.getComparator()), compOp.getRightInput()->getIdentifier());
+		break;
+	}
+	case OpType::BinaryComp: {
+		const auto& bcompOp = *nautilus::compiler::ir::cast<BinaryCompOperation>(&op);
+		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), bcompOp.getLeftInput()->getIdentifier(),
+		               shiftOpToString(bcompOp.getType()), bcompOp.getRightInput()->getIdentifier());
+		break;
+	}
+	case OpType::AddOp:
+	case OpType::SubOp:
+	case OpType::MulOp:
+	case OpType::DivOp:
+	case OpType::ModOp:
+	case OpType::AndOp:
+	case OpType::OrOp: {
+		const auto& bin = *nautilus::compiler::ir::cast<BinaryOperation>(&op);
+		fmt::format_to(out, "{} = {} {} {}", op.getIdentifier(), bin.getLeftInput()->getIdentifier(),
+		               binaryOpToString(op.getOperationType()), bin.getRightInput()->getIdentifier());
+		break;
+	}
+	case OpType::IfOp:
+		fmt::format_to(out, "{}", *nautilus::compiler::ir::cast<IfOperation>(&op));
+		break;
+	case OpType::BranchOp:
+		fmt::format_to(out, "br {}", nautilus::compiler::ir::cast<BranchOperation>(&op)->getNextBlockInvocation());
+		break;
+	case OpType::ConstBooleanOp:
+		fmt::format_to(out, "{} = {}", op.getIdentifier(),
+		               nautilus::compiler::ir::cast<ConstBooleanOperation>(&op)->getValue());
+		break;
+	case OpType::ConstIntOp:
+		fmt::format_to(out, "{} = {}", op.getIdentifier(),
+		               nautilus::compiler::ir::cast<ConstIntOperation>(&op)->getValue());
+		break;
+	case OpType::ConstFloatOp:
+		fmt::format_to(out, "{} = {}", op.getIdentifier(),
+		               nautilus::compiler::ir::cast<ConstFloatOperation>(&op)->getValue());
+		break;
+	case OpType::ReturnOp: {
+		const auto* returnOp = nautilus::compiler::ir::cast<ReturnOperation>(&op);
 		fmt::format_to(out, "return");
 		if (returnOp->hasReturnValue()) {
 			fmt::format_to(out, " ({})", returnOp->getReturnValue()->getIdentifier());
 		}
-	} else if (auto constPtr = op.dynCast<ConstPtrOperation>()) {
-		fmt::format_to(out, "{} = *", constPtr->getIdentifier());
-	} else if (auto callOp = op.dynCast<ProxyCallOperation>()) {
-		fmt::format_to(out, "{}", *callOp);
-	} else if (auto castOp = op.dynCast<CastOperation>()) {
-		fmt::format_to(out, "{} = {} cast_to {}", castOp->getIdentifier(), castOp->getInput()->getIdentifier(),
+		break;
+	}
+	case OpType::ConstPtrOp:
+		fmt::format_to(out, "{} = *", op.getIdentifier());
+		break;
+	case OpType::ProxyCallOp:
+		fmt::format_to(out, "{}", *nautilus::compiler::ir::cast<ProxyCallOperation>(&op));
+		break;
+	case OpType::CastOp: {
+		const auto* castOp = nautilus::compiler::ir::cast<CastOperation>(&op);
+		fmt::format_to(out, "{} = {} cast_to {}", op.getIdentifier(), castOp->getInput()->getIdentifier(),
 		               toString(castOp->getStamp()));
-	} else if (auto loadOp = op.dynCast<LoadOperation>()) {
-		fmt::format_to(out, "{} = load({})", loadOp->getIdentifier(), loadOp->getAddress()->getIdentifier());
-	} else if (auto storeOp = op.dynCast<StoreOperation>()) {
+		break;
+	}
+	case OpType::LoadOp: {
+		const auto* loadOp = nautilus::compiler::ir::cast<LoadOperation>(&op);
+		fmt::format_to(out, "{} = load({})", op.getIdentifier(), loadOp->getAddress()->getIdentifier());
+		break;
+	}
+	case OpType::StoreOp: {
+		const auto* storeOp = nautilus::compiler::ir::cast<StoreOperation>(&op);
 		fmt::format_to(out, "store({}, {})", storeOp->getValue()->getIdentifier(),
 		               storeOp->getAddress()->getIdentifier());
-	} else if (auto notOp = op.dynCast<NotOperation>()) {
-		fmt::format_to(out, "{} = !{}", notOp->getIdentifier(), notOp->getInput()->getIdentifier());
-	} else if (auto negateOp = op.dynCast<NegateOperation>()) {
-		fmt::format_to(out, "{} = ~{}", negateOp->getIdentifier(), negateOp->getInput()->getIdentifier());
-	} else if (auto alloca = op.dynCast<AllocaOperation>()) {
-		fmt::format_to(out, "{} = alloca {}b", alloca->getIdentifier(), alloca->getSize());
-	} else {
+		break;
+	}
+	case OpType::NotOp: {
+		const auto* notOp = nautilus::compiler::ir::cast<NotOperation>(&op);
+		fmt::format_to(out, "{} = !{}", op.getIdentifier(), notOp->getInput()->getIdentifier());
+		break;
+	}
+	case OpType::NegateOp: {
+		const auto* negateOp = nautilus::compiler::ir::cast<NegateOperation>(&op);
+		fmt::format_to(out, "{} = ~{}", op.getIdentifier(), negateOp->getInput()->getIdentifier());
+		break;
+	}
+	case OpType::AllocaOp: {
+		const auto* alloca = nautilus::compiler::ir::cast<AllocaOperation>(&op);
+		fmt::format_to(out, "{} = alloca {}b", op.getIdentifier(), alloca->getSize());
+		break;
+	}
+	default:
 		fmt::format_to(out, "{}", op.getIdentifier().toString());
+		break;
 	}
 	fmt::format_to(out, " :{}", toString(op.getStamp()));
 	return out;
@@ -259,8 +314,8 @@ auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::c
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlock& block, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlock& block,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "\nBlock_{}(", block.getIdentifier());
 		const auto& args = block.getArguments();
@@ -281,8 +336,8 @@ struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_vie
 
 template <>
 struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::FunctionOperation& func, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::FunctionOperation& func,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}(", func.getName());
 		for (const auto& arg : func.getInputArgNames()) {

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
@@ -4,6 +4,8 @@
 #include "nautilus/JITCompiler.hpp"
 #include <memory>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 
 namespace nautilus::compiler::ir {
 
@@ -17,8 +19,6 @@ public:
 	IRGraph(const CompilationUnitID& id);
 
 	~IRGraph() = default;
-
-	std::unique_ptr<FunctionOperation>& addRootOperation(std::unique_ptr<FunctionOperation> rootOperation);
 
 	/**
 	 * @brief Adds a function operation to the IR graph
@@ -34,7 +34,7 @@ public:
 	const std::vector<std::unique_ptr<FunctionOperation>>& getFunctionOperations() const;
 
 	/**
-	 * @brief Gets a specific function operation by name
+	 * @brief Gets a specific function operation by name in O(1) via an internal index.
 	 * @param name The name of the function
 	 * @return Pointer to the function operation if found, nullptr otherwise
 	 */
@@ -45,8 +45,10 @@ public:
 	[[nodiscard]] const CompilationUnitID& getId() const;
 
 private:
-	std::unique_ptr<FunctionOperation> rootOperation;
 	std::vector<std::unique_ptr<FunctionOperation>> functionOperations;
+	// Name -> function index. The string_view is backed by the name field owned
+	// by FunctionOperation, which is stable for the lifetime of the graph.
+	std::unordered_map<std::string_view, FunctionOperation*> functionOperationsByName;
 	const CompilationUnitID id;
 };
 

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 namespace nautilus::compiler::ir {
-BasicBlock::BasicBlock(uint32_t identifier, std::vector<std::unique_ptr<BasicBlockArgument>>& arguments)
+BasicBlock::BasicBlock(BlockIdentifier identifier, std::vector<std::unique_ptr<BasicBlockArgument>> arguments)
     : identifier(identifier), operations(), arguments(std::move(arguments)) {
 }
 
@@ -19,16 +19,12 @@ void BasicBlock::addNextBlock(BasicBlock* nextBlock, const std::vector<Operation
 		nextBlockIn.addArgument(op);
 	}
 	addOperation(std::move(branchOp));
-	// add this block as a predecessor to the next block
-	// Todo #3167 : can we use this to replace the addPredecessor pass? (also:
-	// addTrueBlock, and addFalseBlock)
-	// nextBlock->addPredecessor(shared_from_this());
 }
 
 BasicBlock::~BasicBlock() = default;
 
-const std::string BasicBlock::getIdentifier() const {
-	return std::to_string(identifier);
+BlockIdentifier BasicBlock::getIdentifier() const {
+	return identifier;
 }
 
 const std::vector<std::unique_ptr<Operation>>& BasicBlock::getOperations() const {
@@ -64,14 +60,6 @@ void BasicBlock::replaceTerminatorOperation(Operation* loopOperation) {
 BasicBlock* BasicBlock::addOperation(std::unique_ptr<Operation> operation) {
 	operations.emplace_back(std::move(operation));
 	return this;
-}
-
-void BasicBlock::addPredecessor(BasicBlock* predecessor) {
-	this->predecessors.emplace_back(predecessor);
-}
-
-std::vector<BasicBlock*>& BasicBlock::getPredecessors() {
-	return predecessors;
 }
 
 /* void BasicBlock::replaceOperation(size_t operationIndex, Operation

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
@@ -3,10 +3,38 @@
 
 #include "nautilus/compiler/ir/blocks/BasicBlockArgument.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
+#include <compare>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
 namespace nautilus::compiler::ir {
+
+/**
+ * @brief Strong typedef for a BasicBlock id.
+ *
+ * Mirrors `OperationIdentifier`: a `constexpr` value type wrapping a
+ * `uint32_t`, so passing it by value is trivial and raw integer ids
+ * cannot be accidentally mixed with op ids in containers or function
+ * signatures. Implicit construction from `uint32_t` is allowed so
+ * call sites that already hold a raw block-id (e.g. the tracing layer)
+ * don't need per-site conversions.
+ */
+class BlockIdentifier {
+public:
+	constexpr BlockIdentifier(uint32_t id) : id(id) {
+	}
+
+	constexpr auto operator<=>(const BlockIdentifier&) const = default;
+	constexpr bool operator==(const BlockIdentifier&) const = default;
+
+	[[nodiscard]] constexpr uint32_t getId() const {
+		return id;
+	}
+
+private:
+	uint32_t id;
+};
 
 class BasicBlock {
 public:
@@ -15,11 +43,11 @@ public:
 	 * @param Operations: A list of Operations that are executed in the BasicBlock.
 	 * @param nextBlocks : The BasicBlock that is next in the control flow of the execution.
 	 */
-	explicit BasicBlock(uint32_t identifier, std::vector<std::unique_ptr<BasicBlockArgument>>& arguments);
+	explicit BasicBlock(BlockIdentifier identifier, std::vector<std::unique_ptr<BasicBlockArgument>> arguments);
 
 	virtual ~BasicBlock();
 
-	[[nodiscard]] const std::string getIdentifier() const;
+	[[nodiscard]] BlockIdentifier getIdentifier() const;
 
 	[[nodiscard]] const std::vector<std::unique_ptr<Operation>>& getOperations() const;
 
@@ -54,10 +82,6 @@ public:
 
 	void addOperationBefore(Operation* before, std::unique_ptr<Operation>& operation);
 
-	void addPredecessor(BasicBlock* predecessor);
-
-	std::vector<BasicBlock*>& getPredecessors();
-
 	uint64_t getIndexOfArgument(Operation* arg);
 
 	void replaceTerminatorOperation(Operation* newTerminatorOperation);
@@ -65,12 +89,20 @@ public:
 	[[nodiscard]] std::pair<const BasicBlock*, const BasicBlock*> getNextBlocks();
 
 private:
-	uint32_t identifier;
+	BlockIdentifier identifier;
 	std::vector<std::unique_ptr<Operation>> operations;
 	std::vector<std::unique_ptr<BasicBlockArgument>> arguments;
-	std::vector<BasicBlock*> predecessors;
 };
 
 using BasicBlockPtr = std::shared_ptr<BasicBlock>;
 
 } // namespace nautilus::compiler::ir
+
+namespace std {
+template <>
+struct hash<nautilus::compiler::ir::BlockIdentifier> {
+	std::size_t operator()(nautilus::compiler::ir::BlockIdentifier k) const noexcept {
+		return std::hash<uint32_t> {}(k.getId());
+	}
+};
+} // namespace std

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockArgument.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockArgument.cpp
@@ -5,4 +5,8 @@ namespace nautilus::compiler::ir {
 BasicBlockArgument::BasicBlockArgument(const OperationIdentifier identifier, Type stamp)
     : Operation(OperationType::BasicBlockArgument, identifier, stamp) {
 }
+
+bool BasicBlockArgument::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::BasicBlockArgument;
+}
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockArgument.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockArgument.hpp
@@ -14,6 +14,8 @@ public:
 	~BasicBlockArgument() override = default;
 
 	friend std::ostream& operator<<(std::ostream& os, const BasicBlockArgument& argument);
+
+	static bool classof(const Operation* op);
 };
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.cpp
@@ -16,24 +16,24 @@ const BasicBlock* BasicBlockInvocation::getBlock() const {
 }
 
 void BasicBlockInvocation::addArgument(Operation* argument) {
-	this->operations.emplace_back(argument);
+	inputs.emplace_back(argument);
 }
 
 void BasicBlockInvocation::removeArgument(uint64_t argumentIndex) {
-	operations.erase(operations.begin() + argumentIndex);
+	inputs.erase(inputs.begin() + argumentIndex);
 }
 
 void BasicBlockInvocation::replaceArgument(Operation* toReplace, Operation* replaceWith) {
-	std::replace(operations.begin(), operations.end(), toReplace, replaceWith);
+	std::replace(inputs.begin(), inputs.end(), toReplace, replaceWith);
 }
 
 void BasicBlockInvocation::replaceArgument(const Operation* toReplace, Operation* replaceWith) {
-	std::replace(operations.begin(), operations.end(), const_cast<Operation*>(toReplace), replaceWith);
+	std::replace(inputs.begin(), inputs.end(), const_cast<Operation*>(toReplace), replaceWith);
 }
 
 int BasicBlockInvocation::getOperationArgIndex(Operation* arg) {
-	for (uint64_t i = 0; i < operations.size(); i++) {
-		if (operations[i] == arg) {
+	for (uint64_t i = 0; i < inputs.size(); i++) {
+		if (inputs[i] == arg) {
 			return i;
 		}
 	}
@@ -41,7 +41,11 @@ int BasicBlockInvocation::getOperationArgIndex(Operation* arg) {
 }
 
 const std::vector<Operation*>& BasicBlockInvocation::getArguments() const {
-	return operations;
+	return inputs;
+}
+
+bool BasicBlockInvocation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::BlockInvocation;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp
@@ -30,9 +30,13 @@ public:
 	 */
 	int getOperationArgIndex(Operation*);
 
+	static bool classof(const Operation* op);
+
 private:
+	// Arguments are stored in the base Operation::inputs vector — block-argument
+	// edges are real SSA value edges, so generic passes that walk getInputs()
+	// see them automatically without a special case.
 	BasicBlock* basicBlock;
-	std::vector<Operation*> operations;
 };
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.cpp
@@ -13,4 +13,8 @@ size_t AllocaOperation::getSize() const {
 	return allocationSize;
 }
 
+bool AllocaOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::AllocaOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.hpp
@@ -12,6 +12,8 @@ public:
 
 	size_t getSize() const;
 
+	static bool classof(const Operation* op);
+
 private:
 	size_t allocationSize;
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp
@@ -9,6 +9,6 @@ public:
 
 	~AddOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp
@@ -9,6 +9,6 @@ public:
 
 	~DivOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.cpp
@@ -9,7 +9,7 @@ ModOperation::ModOperation(OperationIdentifier identifier, Operation* leftInput,
 }
 
 bool ModOperation::classof(const Operation* Op) {
-	return Op->getOperationType() == OperationType::DivOp;
+	return Op->getOperationType() == OperationType::ModOp;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp
@@ -11,6 +11,6 @@ public:
 
 	~ModOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp
@@ -10,6 +10,6 @@ public:
 
 	~MulOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp
@@ -11,6 +11,6 @@ public:
 
 	~SubOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp
@@ -14,7 +14,7 @@ public:
 
 	~BinaryCompOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 
 	Type getType() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp
@@ -13,6 +13,6 @@ public:
 
 	void setInput(Operation* newInput);
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp
@@ -13,7 +13,7 @@ public:
 
 	~ShiftOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 
 	ShiftType getType() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/CastOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/CastOperation.cpp
@@ -15,4 +15,8 @@ void CastOperation::setInput(Operation* newInput) {
 	this->inputs[0] = newInput;
 }
 
+bool CastOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::CastOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/CastOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/CastOperation.hpp
@@ -14,6 +14,8 @@ public:
 	Operation* getInput() const;
 
 	void setInput(Operation* newInput);
+
+	static bool classof(const Operation* op);
 };
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.cpp
@@ -14,7 +14,7 @@ double ConstFloatOperation::getValue() const {
 }
 
 bool ConstFloatOperation::classof(const Operation* Op) {
-	return Op->getOperationType() == OperationType::ConstIntOp;
+	return Op->getOperationType() == OperationType::ConstFloatOp;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.cpp
@@ -14,8 +14,8 @@ int64_t ConstIntOperation::getValue() const {
 	return constantValue;
 }
 
-bool ConstIntOperation::classof(const Operation*) {
-	return false;
+bool ConstIntOperation::classof(const Operation* Op) {
+	return Op->getOperationType() == OperationType::ConstIntOp;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.cpp
@@ -14,8 +14,8 @@ void* ConstPtrOperation::getValue() const {
 	return constantValue;
 }
 
-bool ConstPtrOperation::classof(const Operation*) {
-	return false;
+bool ConstPtrOperation::classof(const Operation* Op) {
+	return Op->getOperationType() == OperationType::ConstPtrOp;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.cpp
@@ -22,4 +22,8 @@ void* FunctionAddressOfOperation::getFunctionPtr() {
 	return functionPtr;
 }
 
+bool FunctionAddressOfOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::FunctionAddressOfOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp
@@ -19,6 +19,8 @@ public:
 	const std::string& getFunctionName() const;
 	void* getFunctionPtr();
 
+	static bool classof(const Operation* op);
+
 private:
 	const std::string functionSymbol;
 	const std::string functionName;

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.cpp
@@ -4,7 +4,7 @@
 
 namespace nautilus::compiler::ir {
 
-FunctionOperation::FunctionOperation(std::string name, std::vector<std::unique_ptr<BasicBlock>>& functionBasicBlocks,
+FunctionOperation::FunctionOperation(std::string name, std::vector<std::unique_ptr<BasicBlock>> functionBasicBlocks,
                                      std::vector<Type> inputArgs, std::vector<std::string> inputArgNames,
                                      Type outputArg)
     : Operation(OperationType::FunctionOp, outputArg), name(std::move(name)),

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
@@ -7,7 +7,7 @@
 namespace nautilus::compiler::ir {
 class FunctionOperation : public Operation {
 public:
-	explicit FunctionOperation(std::string name, std::vector<std::unique_ptr<BasicBlock>>& functionBasicBlocks,
+	explicit FunctionOperation(std::string name, std::vector<std::unique_ptr<BasicBlock>> functionBasicBlocks,
 	                           std::vector<Type> inputArgs, std::vector<std::string> inputArgNames, Type outputArg);
 
 	~FunctionOperation() override = default;

--- a/nautilus/src/nautilus/compiler/ir/operations/IfOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IfOperation.cpp
@@ -58,4 +58,8 @@ bool IfOperation::hasFalseCase() {
 double IfOperation::getProbability() const {
 	return this->probability;
 }
+
+bool IfOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::IfOp;
+}
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/IfOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IfOperation.hpp
@@ -34,6 +34,8 @@ public:
 
 	double getProbability() const;
 
+	static bool classof(const Operation* op);
+
 private:
 	BasicBlockInvocation trueBlockInvocation;
 	BasicBlockInvocation falseBlockInvocation;

--- a/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.cpp
@@ -26,4 +26,8 @@ const FunctionAttributes& IndirectCallOperation::getFunctionAttributes() const {
 	return fnAttrs;
 }
 
+bool IndirectCallOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::IndirectCallOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.hpp
@@ -27,6 +27,8 @@ public:
 
 	[[nodiscard]] const FunctionAttributes& getFunctionAttributes() const;
 
+	static bool classof(const Operation* op);
+
 private:
 	FunctionAttributes fnAttrs;
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.cpp
@@ -3,12 +3,16 @@
 
 namespace nautilus::compiler::ir {
 
-LoadOperation::LoadOperation(const OperationIdentifier& identifier, Operation* address, Type type)
+LoadOperation::LoadOperation(OperationIdentifier identifier, Operation* address, Type type)
     : Operation(OperationType::LoadOp, identifier, type, {address}) {
 }
 
 const Operation* LoadOperation::getAddress() const {
 	return inputs[0];
+}
+
+bool LoadOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::LoadOp;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.hpp
@@ -5,10 +5,12 @@
 namespace nautilus::compiler::ir {
 class LoadOperation : public Operation {
 public:
-	explicit LoadOperation(const OperationIdentifier& identifier, Operation* address, Type stamp);
+	explicit LoadOperation(OperationIdentifier identifier, Operation* address, Type stamp);
 
 	~LoadOperation() override = default;
 
 	const Operation* getAddress() const;
+
+	static bool classof(const Operation* op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.cpp
@@ -8,7 +8,7 @@ AndOperation::AndOperation(OperationIdentifier identifier, Operation* leftInput,
 }
 
 bool AndOperation::classof(const Operation* Op) {
-	return Op->getOperationType() == OperationType::AddOp;
+	return Op->getOperationType() == OperationType::AndOp;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp
@@ -9,6 +9,6 @@ public:
 
 	~AndOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.cpp
@@ -63,4 +63,8 @@ std::string CompareOperation::getComparatorAsString() {
 	return "";
 }
 
+bool CompareOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::CompareOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp
@@ -38,6 +38,8 @@ public:
 
 	std::string getComparatorAsString();
 
+	static bool classof(const Operation* op);
+
 private:
 	Comparator comparator;
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp
@@ -13,6 +13,6 @@ public:
 
 	void setInput(Operation* newInput);
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.cpp
@@ -8,6 +8,6 @@ OrOperation::OrOperation(OperationIdentifier identifier, Operation* leftInput, O
 }
 
 bool OrOperation::classof(const Operation* Op) {
-	return Op->getOperationType() == OperationType::AddOp;
+	return Op->getOperationType() == OperationType::OrOp;
 }
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp
@@ -9,6 +9,6 @@ public:
 
 	~OrOperation() override = default;
 
-	bool classof(const Operation* Op);
+	static bool classof(const Operation* Op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.cpp
@@ -1,8 +1,9 @@
 
 #include "nautilus/compiler/ir/operations/Operation.hpp"
+#include "nautilus/compiler/ir/operations/OperationProperties.hpp"
 
 namespace nautilus::compiler::ir {
-Operation::Operation(OperationType opType, const OperationIdentifier& identifier, Type stamp,
+Operation::Operation(OperationType opType, OperationIdentifier identifier, Type stamp,
                      const std::vector<Operation*>& inputs)
     : opType(opType), identifier(identifier), stamp(stamp), inputs(inputs) {
 }
@@ -29,51 +30,38 @@ const Type& Operation::getStamp() const {
 	return stamp;
 }
 
-OperationIdentifier::OperationIdentifier(uint32_t ir) : id(ir) {
-}
-
-uint32_t OperationIdentifier::getId() const {
-	return id;
-}
-
-bool OperationIdentifier::operator==(const OperationIdentifier& rhs) const {
-	return id == rhs.id;
-}
-
-bool OperationIdentifier::operator!=(const OperationIdentifier& rhs) const {
-	return !(rhs == *this);
-}
-
 std::string OperationIdentifier::toString() const {
 	return "$" + std::to_string(id);
 }
 
-bool OperationIdentifier::operator<(const OperationIdentifier& rhs) const {
-	if (id < rhs.id)
-		return true;
-	return false;
-}
-
-bool OperationIdentifier::operator>(const OperationIdentifier& rhs) const {
-	return rhs < *this;
-}
-
-bool OperationIdentifier::operator<=(const OperationIdentifier& rhs) const {
-	return !(rhs < *this);
-}
-
-bool OperationIdentifier::operator>=(const OperationIdentifier& rhs) const {
-	return !(*this < rhs);
-}
-
 bool Operation::isConstOperation() const {
-	return opType == OperationType::ConstBooleanOp || opType == OperationType::ConstFloatOp ||
-	       opType == OperationType::ConstIntOp;
+	// Note: historically only the int/float/bool const ops were considered
+	// "const" — ConstPtrOp was not. The property table reports ConstPtrOp as
+	// Constant too, so gate that out here to preserve behavior.
+	return opType != OperationType::ConstPtrOp && isConstantOp(opType);
 }
 
-BinaryOperation::BinaryOperation(OperationType opType, const OperationIdentifier& identifier, Type type,
-                                 Operation* left, Operation* right)
+BinaryOperation::BinaryOperation(OperationType opType, OperationIdentifier identifier, Type type, Operation* left,
+                                 Operation* right)
     : Operation(opType, identifier, type, {left, right}) {
+}
+
+bool BinaryOperation::classof(const Operation* op) {
+	switch (op->getOperationType()) {
+	case OperationType::AddOp:
+	case OperationType::SubOp:
+	case OperationType::MulOp:
+	case OperationType::DivOp:
+	case OperationType::ModOp:
+	case OperationType::AndOp:
+	case OperationType::OrOp:
+	case OperationType::ShiftOp:
+	case OperationType::CompareOp:
+	case OperationType::BinaryComp:
+		return true;
+	default:
+		return false;
+	}
 }
 
 Operation* BinaryOperation::getLeftInput() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "nautilus/tracing/Types.hpp"
+#include <compare>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -11,25 +12,17 @@ namespace nautilus::compiler::ir {
 
 class OperationIdentifier {
 public:
-	OperationIdentifier(uint32_t id);
+	constexpr OperationIdentifier(uint32_t id) : id(id) {
+	}
 
-	bool operator==(const OperationIdentifier& rhs) const;
+	constexpr auto operator<=>(const OperationIdentifier&) const = default;
+	constexpr bool operator==(const OperationIdentifier&) const = default;
 
-	bool operator!=(const OperationIdentifier& rhs) const;
+	[[nodiscard]] std::string toString() const;
 
-	friend std::hash<OperationIdentifier>;
-
-	std::string toString() const;
-
-	bool operator<(const OperationIdentifier& rhs) const;
-
-	bool operator>(const OperationIdentifier& rhs) const;
-
-	bool operator<=(const OperationIdentifier& rhs) const;
-
-	bool operator>=(const OperationIdentifier& rhs) const;
-
-	uint32_t getId() const;
+	[[nodiscard]] constexpr uint32_t getId() const {
+		return id;
+	}
 
 private:
 	uint32_t id;
@@ -71,7 +64,7 @@ public:
 		FunctionAddressOfOp,
 	};
 
-	explicit Operation(OperationType opType, const OperationIdentifier& identifier, Type type,
+	explicit Operation(OperationType opType, OperationIdentifier identifier, Type type,
 	                   const std::vector<Operation*>& inputs = {});
 
 	explicit Operation(OperationType opType, Type type, const std::vector<Operation*>& inputs = {});
@@ -93,7 +86,7 @@ public:
 
 	template <typename OP>
 	const OP* dynCast() const {
-		return dynamic_cast<const OP*>(this);
+		return OP::classof(this) ? static_cast<const OP*>(this) : nullptr;
 	}
 
 protected:
@@ -102,6 +95,36 @@ protected:
 	const Type stamp;
 	std::vector<Operation*> inputs;
 };
+
+/**
+ * @brief LLVM-style tag-based type tests. Every Operation subclass must expose
+ * `static bool classof(const Operation*)` returning true for the op types it
+ * represents. These helpers then avoid RTTI / dynamic_cast entirely.
+ */
+template <typename T>
+bool isa(const Operation* op) {
+	return op != nullptr && T::classof(op);
+}
+
+template <typename T>
+const T* dyn_cast(const Operation* op) {
+	return isa<T>(op) ? static_cast<const T*>(op) : nullptr;
+}
+
+template <typename T>
+T* dyn_cast(Operation* op) {
+	return isa<T>(op) ? static_cast<T*>(op) : nullptr;
+}
+
+template <typename T>
+const T* cast(const Operation* op) {
+	return static_cast<const T*>(op);
+}
+
+template <typename T>
+T* cast(Operation* op) {
+	return static_cast<T*>(op);
+}
 
 template <typename T>
 T* as(const Operation* op) {
@@ -115,8 +138,7 @@ T* as(const std::unique_ptr<Operation>& op) {
 
 class BinaryOperation : public Operation {
 public:
-	BinaryOperation(OperationType opType, const OperationIdentifier& identifier, Type type, Operation* left,
-	                Operation* right);
+	BinaryOperation(OperationType opType, OperationIdentifier identifier, Type type, Operation* left, Operation* right);
 
 	Operation* getLeftInput() const;
 
@@ -125,6 +147,8 @@ public:
 	void setLeftInput(Operation* newLeftInput);
 
 	void setRightInput(Operation* newRightInput);
+
+	static bool classof(const Operation* op);
 };
 
 } // namespace nautilus::compiler::ir
@@ -132,10 +156,8 @@ public:
 namespace std {
 template <>
 struct hash<nautilus::compiler::ir::OperationIdentifier> {
-	std::size_t operator()(const nautilus::compiler::ir::OperationIdentifier& k) const {
-		using std::hash;
-		using std::size_t;
-		return hash<uint32_t>()(k.id);
+	std::size_t operator()(nautilus::compiler::ir::OperationIdentifier k) const noexcept {
+		return std::hash<uint32_t> {}(k.getId());
 	}
 };
 } // namespace std

--- a/nautilus/src/nautilus/compiler/ir/operations/OperationProperties.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/OperationProperties.hpp
@@ -1,0 +1,99 @@
+
+#pragma once
+
+#include "nautilus/compiler/ir/operations/Operation.hpp"
+#include <array>
+#include <cstdint>
+
+namespace nautilus::compiler::ir {
+
+/**
+ * @brief Compile-time property table keyed by Operation::OperationType.
+ *
+ * Properties are packed into a single byte per op type so the table fits
+ * trivially in L1 and every query lowers to a constant-indexed array load
+ * followed by a mask. Use the helpers below instead of ad-hoc type chains.
+ */
+struct OpFlags {
+	static constexpr uint8_t None = 0;
+	static constexpr uint8_t Constant = 1u << 0;    // produces a compile-time constant value
+	static constexpr uint8_t Terminator = 1u << 1;  // ends a basic block (branch/if/return)
+	static constexpr uint8_t MayReadMem = 1u << 2;  // loads from memory
+	static constexpr uint8_t MayWriteMem = 1u << 3; // stores or calls that may mutate memory
+	static constexpr uint8_t Pure = 1u << 4;        // side-effect-free and deterministic
+};
+
+namespace detail {
+
+using OpType = Operation::OperationType;
+
+// Size the table by the largest enumerator we use. The enum is `uint8_t`, so
+// a 256-entry table is safe regardless of which value is highest.
+constexpr std::size_t kOpFlagTableSize = 256;
+
+constexpr std::array<uint8_t, kOpFlagTableSize> buildOpFlagTable() {
+	std::array<uint8_t, kOpFlagTableSize> t {};
+
+	auto set = [&](OpType op, uint8_t flags) {
+		t[static_cast<std::size_t>(op)] = flags;
+	};
+
+	// Constants: pure and marked Constant.
+	set(OpType::ConstIntOp, OpFlags::Constant | OpFlags::Pure);
+	set(OpType::ConstFloatOp, OpFlags::Constant | OpFlags::Pure);
+	set(OpType::ConstBooleanOp, OpFlags::Constant | OpFlags::Pure);
+	set(OpType::ConstPtrOp, OpFlags::Constant | OpFlags::Pure);
+
+	// Pure arithmetic / logical / bit / compare / cast / select.
+	for (auto op : {OpType::AddOp, OpType::SubOp, OpType::MulOp, OpType::DivOp, OpType::ModOp, OpType::AndOp,
+	                OpType::OrOp, OpType::NotOp, OpType::NegateOp, OpType::ShiftOp, OpType::CompareOp,
+	                OpType::BinaryComp, OpType::CastOp, OpType::SelectOp}) {
+		set(op, OpFlags::Pure);
+	}
+
+	// Terminators.
+	set(OpType::BranchOp, OpFlags::Terminator);
+	set(OpType::IfOp, OpFlags::Terminator);
+	set(OpType::ReturnOp, OpFlags::Terminator);
+
+	// Memory ops.
+	set(OpType::LoadOp, OpFlags::MayReadMem);
+	set(OpType::StoreOp, OpFlags::MayWriteMem);
+
+	// Calls may do anything.
+	set(OpType::ProxyCallOp, OpFlags::MayReadMem | OpFlags::MayWriteMem);
+	set(OpType::IndirectCallOp, OpFlags::MayReadMem | OpFlags::MayWriteMem);
+
+	// The rest (alloca, function-op, function-address-of, block args/invocations, yield) have no flags.
+	return t;
+}
+
+inline constexpr auto kOpFlagTable = buildOpFlagTable();
+
+constexpr uint8_t flagsFor(OpType op) {
+	return kOpFlagTable[static_cast<std::size_t>(op)];
+}
+
+} // namespace detail
+
+constexpr bool isConstantOp(Operation::OperationType op) {
+	return (detail::flagsFor(op) & OpFlags::Constant) != 0;
+}
+
+constexpr bool isTerminatorOp(Operation::OperationType op) {
+	return (detail::flagsFor(op) & OpFlags::Terminator) != 0;
+}
+
+constexpr bool isPureOp(Operation::OperationType op) {
+	return (detail::flagsFor(op) & OpFlags::Pure) != 0;
+}
+
+constexpr bool mayReadMemory(Operation::OperationType op) {
+	return (detail::flagsFor(op) & OpFlags::MayReadMem) != 0;
+}
+
+constexpr bool mayWriteMemory(Operation::OperationType op) {
+	return (detail::flagsFor(op) & OpFlags::MayWriteMem) != 0;
+}
+
+} // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.cpp
@@ -40,4 +40,8 @@ const FunctionAttributes& ProxyCallOperation::getFunctionAttributes() const {
 	return fnAttrs;
 }
 
+bool ProxyCallOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::ProxyCallOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.hpp
@@ -25,6 +25,8 @@ public:
 
 	[[nodiscard]] const FunctionAttributes& getFunctionAttributes() const;
 
+	static bool classof(const Operation* op);
+
 private:
 	const std::string mangedFunctionSymbol;
 	const std::string functionName;

--- a/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.cpp
@@ -23,4 +23,8 @@ bool ReturnOperation::hasReturnValue() const {
 	return stamp != Type::v;
 }
 
+bool ReturnOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::ReturnOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.hpp
@@ -17,5 +17,7 @@ public:
 	void setReturnValue(Operation* newReturnValue);
 
 	bool hasReturnValue() const;
+
+	static bool classof(const Operation* op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.cpp
@@ -31,4 +31,8 @@ void SelectOperation::setFalseValue(Operation* newFalseValue) {
 	inputs[2] = newFalseValue;
 }
 
+bool SelectOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::SelectOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.hpp
@@ -31,6 +31,8 @@ public:
 	void setCondition(Operation* newCondition);
 	void setTrueValue(Operation* newTrueValue);
 	void setFalseValue(Operation* newFalseValue);
+
+	static bool classof(const Operation* op);
 };
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.cpp
@@ -24,4 +24,8 @@ void StoreOperation::setAddress(Operation* newAddress) {
 	inputs[1] = newAddress;
 }
 
+bool StoreOperation::classof(const Operation* op) {
+	return op->getOperationType() == OperationType::StoreOp;
+}
+
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.hpp
@@ -17,5 +17,7 @@ public:
 	void setValue(Operation* newValue);
 
 	void setAddress(Operation* newAddress);
+
+	static bool classof(const Operation* op);
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp
+++ b/nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp
@@ -228,16 +228,17 @@ protected:
 		for (const auto& block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
 			if (writeBlocksOnly) {
 				auto& op = block->getOperations().back();
+				const auto fromId = std::to_string(block->getIdentifier().getId());
 				if (op->getOperationType() == Operation::OperationType::IfOp) {
 					auto ifOp = as<IfOperation>(op);
-					auto trueBlock = ifOp->getTrueBlockInvocation().getBlock()->getIdentifier();
-					writeEdge(block->getIdentifier(), trueBlock, "control", "true");
-					auto falseBlock = ifOp->getFalseBlockInvocation().getBlock()->getIdentifier();
-					writeEdge(block->getIdentifier(), falseBlock, "control", "false");
+					auto trueBlock = std::to_string(ifOp->getTrueBlockInvocation().getBlock()->getIdentifier().getId());
+					writeEdge(fromId, trueBlock, "control", "true");
+					auto falseBlock = std::to_string(ifOp->getFalseBlockInvocation().getBlock()->getIdentifier().getId());
+					writeEdge(fromId, falseBlock, "control", "false");
 				} else if (op->getOperationType() == Operation::OperationType::BranchOp) {
 					auto branchOp = as<BranchOperation>(op);
-					auto falseBlock = branchOp->getNextBlockInvocation().getBlock()->getIdentifier();
-					writeEdge(block->getIdentifier(), falseBlock, "control", "");
+					auto falseBlock = std::to_string(branchOp->getNextBlockInvocation().getBlock()->getIdentifier().getId());
+					writeEdge(fromId, falseBlock, "control", "");
 				}
 			} else {
 				for (const auto& op : block->getOperations()) {
@@ -268,7 +269,7 @@ protected:
 
 			// create control-flow edges
 			for (const auto& blocks : graph->getFunctionOperations()[0]->getBasicBlocks()) {
-				std::string from = "start_" + blocks->getIdentifier();
+				std::string from = "start_" + std::to_string(blocks->getIdentifier().getId());
 				for (const auto& op : blocks->getOperations()) {
 					if (isControlFlowOp(op.get())) {
 						const auto& to = nodeIdMap[op.get()];
@@ -278,13 +279,16 @@ protected:
 
 					if (op->getOperationType() == Operation::OperationType::IfOp) {
 						auto ifOp = as<IfOperation>(op);
-						std::string toTrue = "start_" + ifOp->getTrueBlockInvocation().getBlock()->getIdentifier();
+						std::string toTrue =
+						    "start_" + std::to_string(ifOp->getTrueBlockInvocation().getBlock()->getIdentifier().getId());
 						writeEdge(from, toTrue, "control", "true");
-						std::string toFalse = "start_" + ifOp->getFalseBlockInvocation().getBlock()->getIdentifier();
+						std::string toFalse =
+						    "start_" + std::to_string(ifOp->getFalseBlockInvocation().getBlock()->getIdentifier().getId());
 						writeEdge(from, toFalse, "control", "false");
 					} else if (op->getOperationType() == Operation::OperationType::BranchOp) {
 						auto branchOp = as<BranchOperation>(op);
-						std::string to = "start_" + branchOp->getNextBlockInvocation().getBlock()->getIdentifier();
+						std::string to =
+						    "start_" + std::to_string(branchOp->getNextBlockInvocation().getBlock()->getIdentifier().getId());
 						writeEdge(from, to, "control", "");
 					}
 				}
@@ -365,23 +369,24 @@ protected:
 	}
 
 	void writeNodesForBlock(const std::unique_ptr<BasicBlock>& block) {
-		writeNode("  ", "Start", "start_" + block->getIdentifier(), "control");
+		const auto blockIdStr = std::to_string(block->getIdentifier().getId());
+		writeNode("  ", "Start", "start_" + blockIdStr, "control");
 		for (const auto& op : block->getArguments()) {
 			std::string indent = "  ";
-			writeNodeForOp(indent, block->getIdentifier(), op.get());
+			writeNodeForOp(indent, blockIdStr, op.get());
 		}
 
 		for (const auto& op : block->getOperations()) {
 			std::string indent = "  ";
-			writeNodeForOp(indent, block->getIdentifier(), op.get());
+			writeNodeForOp(indent, blockIdStr, op.get());
 
 			if (op->getOperationType() == Operation::OperationType::IfOp) {
 				auto ifOp = as<IfOperation>(op);
-				writeNodeForOutputOp(indent, block->getIdentifier(), &ifOp->getTrueBlockInvocation());
-				writeNodeForOutputOp(indent, block->getIdentifier(), &ifOp->getFalseBlockInvocation());
+				writeNodeForOutputOp(indent, blockIdStr, &ifOp->getTrueBlockInvocation());
+				writeNodeForOutputOp(indent, blockIdStr, &ifOp->getFalseBlockInvocation());
 			} else if (op->getOperationType() == Operation::OperationType::BranchOp) {
 				auto branchOp = as<BranchOperation>(op);
-				writeNodeForOutputOp(indent, block->getIdentifier(), &branchOp->getNextBlockInvocation());
+				writeNodeForOutputOp(indent, blockIdStr, &branchOp->getNextBlockInvocation());
 			}
 		}
 	}
@@ -390,12 +395,13 @@ protected:
 		if (draw_blocks) {
 			// Assuming you have a way to divide nodes into blocks
 			for (const auto& block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
+				const auto blockIdStr = std::to_string(block->getIdentifier().getId());
 				if (!drawBlocksOnly) {
-					startSubgraph(block->getIdentifier());
+					startSubgraph(blockIdStr);
 					writeNodesForBlock(block);
 					endSubgraph();
 				} else {
-					writeNode("  ", "Block" + block->getIdentifier(), block->getIdentifier(), "control");
+					writeNode("  ", "Block" + blockIdStr, blockIdStr, "control");
 				}
 			}
 		} else {

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -66,9 +66,9 @@ TraceToIRConversionPhase::IRConversionContext::IRConversionContext(ExecutionTrac
 
 std::shared_ptr<IRGraph> TraceToIRConversionPhase::IRConversionContext::process() {
 	processBlock(trace->getBlocks().front());
-	auto functionOperation = std::make_unique<FunctionOperation>("execute", currentBasicBlocks, std::vector<Type> {},
-	                                                             std::vector<std::string> {}, returnType);
-	ir->addRootOperation(std::move(functionOperation));
+	auto functionOperation = std::make_unique<FunctionOperation>(
+	    "execute", std::move(currentBasicBlocks), std::vector<Type> {}, std::vector<std::string> {}, returnType);
+	ir->addFunctionOperation(std::move(functionOperation));
 	return ir;
 }
 
@@ -83,8 +83,8 @@ TraceToIRConversionPhase::IRConversionContext::processFunction(const std::string
 	processBlock(trace->getBlocks().front());
 
 	// Create and return the function operation
-	auto functionOperation = std::make_unique<FunctionOperation>(functionName, currentBasicBlocks, std::vector<Type> {},
-	                                                             std::vector<std::string> {}, returnType);
+	auto functionOperation = std::make_unique<FunctionOperation>(
+	    functionName, std::move(currentBasicBlocks), std::vector<Type> {}, std::vector<std::string> {}, returnType);
 	return functionOperation;
 }
 
@@ -98,7 +98,8 @@ BasicBlock* TraceToIRConversionPhase::IRConversionContext::processBlock(Block& b
 		blockFrame.setValue(argumentIdentifier, blockArgument.get());
 		blockArguments.emplace_back(std::move(blockArgument));
 	}
-	auto& irBasicBlock = currentBasicBlocks.emplace_back(std::make_unique<BasicBlock>(block.blockId, blockArguments));
+	auto& irBasicBlock =
+	    currentBasicBlocks.emplace_back(std::make_unique<BasicBlock>(block.blockId, std::move(blockArguments)));
 	auto irBasicBlockPtr = irBasicBlock.get();
 
 	blockMap[block.blockId] = irBasicBlockPtr;


### PR DESCRIPTION
Three small, independent IR-graph refactors:

1. `OperationIdentifier` is now a constexpr value type with a defaulted
   `operator<=>` / `operator==`. Six hand-written comparison operators,
   the `friend std::hash` dance, and the out-of-line constructor/getter
   are gone. Constructors that took it by `const&` now take it by value
   (it wraps one `uint32_t`).

2. `IRGraph::rootOperation` was a declared-but-never-used field, and
   `addRootOperation` was just an alias for `addFunctionOperation`. Both
   are removed; the single caller in TraceToIRConversionPhase now calls
   `addFunctionOperation` directly. `getFunctionOperation(name)` no
   longer scans the vector linearly: an `unordered_map<string_view,
   FunctionOperation*>` is maintained on insert, keyed by the stable
   name stored inside each FunctionOperation.

3. `FunctionOperation` and `BasicBlock` constructors used to take their
   owning vectors by non-const lvalue reference and move from them,
   which is an API smell (no temporaries, hides the move). They now
   take by value and move in the initializer list; call sites in
   TraceToIRConversionPhase pass `std::move(...)` explicitly.

All 141 tests pass.