### PR TITLE
Allocate trace blocks and operations from an arena

### DIFF
--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -15,6 +15,10 @@
 #include "nautilus/CompilableFunction.hpp"
 #endif
 
+namespace nautilus::common {
+class Arena;
+} // namespace nautilus::common
+
 namespace nautilus::engine {
 namespace details {
 
@@ -155,6 +159,15 @@ public:
 	 */
 	NautilusEngine(std::unique_ptr<compiler::JITCompiler> jit, const Options& options = Options());
 
+	~NautilusEngine();
+
+	// The const Options member makes assignment impossible; allow move
+	// construction so the engine can still be transferred.
+	NautilusEngine(const NautilusEngine&) = delete;
+	NautilusEngine& operator=(const NautilusEngine&) = delete;
+	NautilusEngine(NautilusEngine&&) noexcept;
+	NautilusEngine& operator=(NautilusEngine&&) noexcept = delete;
+
 	/// Register and compile a single function pointer. Defined after NautilusModule.
 	template <typename R, is_val... FunctionArguments>
 	auto registerFunction(R (*fnptr)(val<FunctionArguments>...)) const;
@@ -178,6 +191,18 @@ public:
 	}
 
 private:
+	/**
+	 * @brief Arena owned by the engine and reused across every compilation.
+	 *
+	 * The JIT compiler holds a non-owning reference to this arena and
+	 * softReset()s it at the start of each compile().  Keeping the arena
+	 * on the engine (rather than inside the compiler) matches the intent
+	 * that it is an engine-level resource that can be shared with other
+	 * engine-scoped infrastructure in the future.  Declared before
+	 * @ref jit_ so the compiler's reference remains valid throughout its
+	 * lifetime.
+	 */
+	std::unique_ptr<common::Arena> arena_;
 	std::unique_ptr<compiler::JITCompiler> jit_;
 	const Options options;
 };

--- a/nautilus/src/nautilus/common/Arena.hpp
+++ b/nautilus/src/nautilus/common/Arena.hpp
@@ -1,0 +1,260 @@
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace nautilus::common {
+
+/**
+ * @brief A bump-pointer arena ("area") allocator.
+ *
+ * The Arena hands out memory from large, pre-allocated chunks using a
+ * bump-pointer allocation scheme. Individual objects are never freed in
+ * isolation; instead, every object allocated via the arena is destroyed and
+ * every chunk released as part of destroying (or resetting) the Arena.
+ *
+ * This is a good fit for hot paths that produce a large number of short-lived,
+ * similarly-typed objects (e.g. Block / TraceOperation during trace
+ * construction) that are never freed until the owning structure is discarded.
+ * Compared to calling ::operator new per object, the arena:
+ *
+ *   - amortises allocator overhead across many small allocations,
+ *   - keeps logically related objects close together in memory, improving
+ *     cache locality during downstream passes,
+ *   - provides stable addresses for the lifetime of the arena: once an object
+ *     is created it never moves, so references to it are never invalidated.
+ *
+ * To keep tiny consumers from paying for a heap chunk allocation, the Arena
+ * carries a small inline buffer that is used first.  Only when the inline
+ * buffer is exhausted is a heap chunk allocated on demand.
+ *
+ * After @ref softReset the arena keeps its previously allocated heap chunks
+ * and walks back into them on subsequent overflows: the bump pointer first
+ * resumes in the inline buffer, then in chunk[0], then chunk[1], ... and
+ * only allocates a new chunk once the existing pool is exhausted.  This is
+ * what makes the arena cheap to reuse across many cycles.
+ *
+ * The arena is non-copyable and non-movable.  Callers that need ownership
+ * transfer should hold the Arena through a smart pointer.
+ */
+class Arena {
+public:
+	/// Size of the inline buffer embedded in every Arena instance.
+	static constexpr std::size_t INLINE_BUFFER_SIZE = 4 * 1024;
+
+	/// Size of the first heap chunk when the inline buffer is exhausted.
+	static constexpr std::size_t INITIAL_CHUNK_SIZE = 16 * 1024;
+
+	/// Maximum size an individual heap chunk is grown to.
+	static constexpr std::size_t MAX_CHUNK_SIZE = 256 * 1024;
+
+	Arena() noexcept {
+		current = inlineBuffer;
+		currentEnd = inlineBuffer + INLINE_BUFFER_SIZE;
+	}
+
+	~Arena() {
+		release();
+	}
+
+	// The arena is non-copyable and non-movable.  The inline buffer's address
+	// is part of the arena's identity, so moving would either leave pointers
+	// into the source's buffer dangling or require copying the buffer
+	// contents and fixing up pointers.  Neither is desirable.
+	Arena(const Arena&) = delete;
+	Arena& operator=(const Arena&) = delete;
+	Arena(Arena&&) = delete;
+	Arena& operator=(Arena&&) = delete;
+
+	/**
+	 * @brief Allocates @p size bytes with the requested @p align from the arena.
+	 */
+	void* allocate(std::size_t size, std::size_t align) {
+		auto cur = reinterpret_cast<std::uintptr_t>(current);
+		auto mask = static_cast<std::uintptr_t>(align) - 1;
+		auto aligned = (cur + mask) & ~mask;
+		if (aligned + size > reinterpret_cast<std::uintptr_t>(currentEnd)) {
+			growChunk(size, align);
+			cur = reinterpret_cast<std::uintptr_t>(current);
+			aligned = (cur + mask) & ~mask;
+		}
+		current = reinterpret_cast<std::byte*>(aligned + size);
+		return reinterpret_cast<void*>(aligned);
+	}
+
+	/**
+	 * @brief Constructs a T with the given arguments inside the arena and
+	 * registers its destructor (for non-trivially destructible types) so it is
+	 * invoked when the arena is destroyed or reset.
+	 */
+	template <typename T, typename... Args>
+	T* create(Args&&... args) {
+		void* mem = allocate(sizeof(T), alignof(T));
+		T* obj = ::new (mem) T(std::forward<Args>(args)...);
+		if constexpr (!std::is_trivially_destructible_v<T>) {
+			dtors.push_back({obj, &destroyThunk<T>});
+		}
+		return obj;
+	}
+
+	/**
+	 * @brief Constructs a T inside the arena without registering its
+	 * destructor.  The caller takes responsibility for explicitly destroying
+	 * the object before the Arena is reset or destroyed.
+	 *
+	 * This variant is meant for hot paths where the caller already knows the
+	 * full set of created objects and can destroy them in bulk without the
+	 * per-allocation overhead of the dtor bookkeeping.
+	 */
+	template <typename T, typename... Args>
+	T* createUnmanaged(Args&&... args) {
+		void* mem = allocate(sizeof(T), alignof(T));
+		return ::new (mem) T(std::forward<Args>(args)...);
+	}
+
+	/**
+	 * @brief Destroys all objects created through this arena and frees all
+	 * chunks.  After a reset the arena can be used to allocate again.
+	 */
+	void reset() {
+		release();
+		current = inlineBuffer;
+		currentEnd = inlineBuffer + INLINE_BUFFER_SIZE;
+		currentChunkIndex = INLINE_REGION_INDEX;
+		nextChunkSize = INITIAL_CHUNK_SIZE;
+	}
+
+	/**
+	 * @brief Resets the bump pointer and runs tracked destructors without
+	 * releasing the heap chunks.
+	 *
+	 * The arena is left ready to service new allocations and will reuse the
+	 * heap chunks it has already acquired before allocating any new ones.
+	 * After softReset, allocations resume from the inline buffer; on overflow
+	 * the bump pointer walks into chunk[0], chunk[1], ... in order, and only
+	 * once every existing chunk is exhausted does growChunk fall back to
+	 * std::malloc for a fresh chunk.  The caller is responsible for
+	 * destroying any objects produced via @ref createUnmanaged before
+	 * invoking this method.
+	 */
+	void softReset() noexcept {
+		// Run tracked destructors in reverse construction order.
+		for (auto it = dtors.rbegin(); it != dtors.rend(); ++it) {
+			it->dtor(it->obj);
+		}
+		dtors.clear();
+		current = inlineBuffer;
+		currentEnd = inlineBuffer + INLINE_BUFFER_SIZE;
+		currentChunkIndex = INLINE_REGION_INDEX;
+	}
+
+	/// Returns the total number of bytes currently held in heap chunks.
+	std::size_t capacity() const noexcept {
+		std::size_t total = 0;
+		for (const auto& chunk : chunks) {
+			total += chunk.size;
+		}
+		return total;
+	}
+
+	/// Returns the number of allocated objects whose destructors are tracked.
+	std::size_t trackedObjectCount() const noexcept {
+		return dtors.size();
+	}
+
+private:
+	struct Chunk {
+		std::byte* data;
+		std::size_t size;
+	};
+
+	struct DtorEntry {
+		void* obj;
+		void (*dtor)(void*);
+	};
+
+	/// Sentinel value for @ref currentChunkIndex meaning "we are bumping
+	/// inside the inline buffer, not in any heap chunk".
+	static constexpr std::size_t INLINE_REGION_INDEX = static_cast<std::size_t>(-1);
+
+	template <typename T>
+	static void destroyThunk(void* ptr) {
+		static_cast<T*>(ptr)->~T();
+	}
+
+	void growChunk(std::size_t size, std::size_t align) {
+		// Worst-case bytes the next region must accommodate (the requested
+		// size plus the alignment padding).
+		std::size_t needed = size + align;
+
+		// First try to walk into an already-allocated chunk that follows the
+		// current region.  Each existing chunk is treated as fresh because
+		// the bump pointer always restarts at chunk.data; this is what
+		// allows softReset to recycle memory across cycles without going
+		// through the system allocator.
+		std::size_t nextIdx = (currentChunkIndex == INLINE_REGION_INDEX) ? 0 : currentChunkIndex + 1;
+		while (nextIdx < chunks.size()) {
+			const auto& chunk = chunks[nextIdx];
+			if (chunk.size >= needed) {
+				currentChunkIndex = nextIdx;
+				current = chunk.data;
+				currentEnd = chunk.data + chunk.size;
+				return;
+			}
+			// Existing chunk is too small for this allocation; skip past it.
+			// It remains available for a later allocation that does fit
+			// within its size only if a future softReset rewinds the cursor
+			// back through it again.
+			++nextIdx;
+		}
+
+		// No existing chunk could service the allocation - allocate a new one.
+		std::size_t chunkSize = std::max(nextChunkSize, needed);
+		auto* mem = static_cast<std::byte*>(std::malloc(chunkSize));
+		if (mem == nullptr) {
+			throw std::bad_alloc();
+		}
+		chunks.push_back({mem, chunkSize});
+		currentChunkIndex = chunks.size() - 1;
+		current = mem;
+		currentEnd = mem + chunkSize;
+		// Grow subsequent chunks geometrically, capped at MAX_CHUNK_SIZE.
+		nextChunkSize = std::min(nextChunkSize * 2, MAX_CHUNK_SIZE);
+	}
+
+	void release() noexcept {
+		// Destroy tracked objects in reverse order of construction.
+		for (auto it = dtors.rbegin(); it != dtors.rend(); ++it) {
+			it->dtor(it->obj);
+		}
+		dtors.clear();
+		for (auto& chunk : chunks) {
+			std::free(chunk.data);
+		}
+		chunks.clear();
+		current = nullptr;
+		currentEnd = nullptr;
+		currentChunkIndex = INLINE_REGION_INDEX;
+	}
+
+	alignas(std::max_align_t) std::byte inlineBuffer[INLINE_BUFFER_SIZE];
+	std::byte* current;
+	std::byte* currentEnd;
+	/// Index into @ref chunks of the chunk we are currently bumping in, or
+	/// @ref INLINE_REGION_INDEX when the bump pointer is inside @ref
+	/// inlineBuffer.  Used by growChunk to walk into the next existing chunk
+	/// (instead of always allocating a fresh one) after a softReset.
+	std::size_t currentChunkIndex = INLINE_REGION_INDEX;
+	std::size_t nextChunkSize = INITIAL_CHUNK_SIZE;
+	std::vector<Chunk> chunks;
+	std::vector<DtorEntry> dtors;
+};
+
+} // namespace nautilus::common

--- a/nautilus/src/nautilus/compiler/Engine.cpp
+++ b/nautilus/src/nautilus/compiler/Engine.cpp
@@ -1,34 +1,40 @@
 #include "nautilus/Engine.hpp"
 #include "nautilus/JITCompiler.hpp"
+#include "nautilus/common/Arena.hpp"
 #include "nautilus/compiler/LegacyCompiler.hpp"
 #include "nautilus/compiler/TieredCompiler.hpp"
+
 namespace nautilus::engine {
 
 /**
- * @brief Creates the appropriate IJITCompiler implementation based on options.
+ * @brief Creates the appropriate JITCompiler implementation based on options.
  *
- * If tiered compilation options are set (engine.tier0.backend and engine.tier1.backend),
- * returns a TieredJITCompiler. Otherwise returns a standard JITCompiler.
+ * The engine-owned @p arena is injected into the compiler so every trace
+ * allocation across every compile() call shares a single pool of chunks.
  */
-inline std::unique_ptr<compiler::JITCompiler> createJITCompiler(const Options& options) {
+inline std::unique_ptr<compiler::JITCompiler> createJITCompiler(const Options& options, common::Arena& arena) {
 	// If the user explicitly selected a backend, use the legacy single-tier compiler
 	// so the requested backend is honoured directly.
 	auto explicitBackend = options.getOptionOrDefault<std::string>("engine.backend", "");
 	if (!explicitBackend.empty()) {
-		return std::make_unique<compiler::LegacyCompiler>(options);
+		return std::make_unique<compiler::LegacyCompiler>(options, arena);
 	}
 	std::string compilerStrategy = options.getOptionOrDefault("engine.compilationStrategy", std::string("tiered"));
 	if (compilerStrategy == "tiered") {
-		return std::make_unique<compiler::TieredJITCompiler>(options);
+		return std::make_unique<compiler::TieredJITCompiler>(options, arena);
 	}
-	return std::make_unique<compiler::LegacyCompiler>(options);
+	return std::make_unique<compiler::LegacyCompiler>(options, arena);
 }
 
-NautilusEngine::NautilusEngine(const Options& options) : jit_(createJITCompiler(options)), options(options) {
+NautilusEngine::NautilusEngine(const Options& options)
+    : arena_(std::make_unique<common::Arena>()), jit_(createJITCompiler(options, *arena_)), options(options) {
 }
 
 NautilusEngine::NautilusEngine(std::unique_ptr<compiler::JITCompiler> jit, const Options& options)
-    : jit_(std::move(jit)), options(options) {
+    : arena_(std::make_unique<common::Arena>()), jit_(std::move(jit)), options(options) {
 }
+
+NautilusEngine::~NautilusEngine() = default;
+NautilusEngine::NautilusEngine(NautilusEngine&&) noexcept = default;
 
 } // namespace nautilus::engine

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
@@ -26,11 +26,8 @@
 
 namespace nautilus::compiler {
 
-LegacyCompiler::LegacyCompiler() : options(), backends(CompilationBackendRegistry::getInstance()) {
-}
-
-LegacyCompiler::LegacyCompiler(engine::Options options)
-    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()) {
+LegacyCompiler::LegacyCompiler(engine::Options options, common::Arena& arena)
+    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()), arena_(&arena) {
 }
 
 LegacyCompiler::~LegacyCompiler() = default;
@@ -91,9 +88,13 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 
 	auto t0 = log::now();
 	auto traceMode = options.getOptionOrDefault(TRACE_MODE_OPTION, std::string(TRACE_MODE_LAZY));
+	// Recycle the chunks from the previous compile before this one starts.
+	// Any TraceModule from a previous compilation has already been
+	// destroyed by the time we get here, so no live pointers remain.
+	arena_->softReset();
 	std::shared_ptr<tracing::TraceModule> traceModule =
-	    (traceMode == TRACE_MODE_LAZY) ? tracing::LazyTraceContext::Trace(functions, options)
-	                                   : tracing::ExceptionBasedTraceContext::Trace(functions, options);
+	    (traceMode == TRACE_MODE_LAZY) ? tracing::LazyTraceContext::Trace(functions, options, *arena_)
+	                                   : tracing::ExceptionBasedTraceContext::Trace(functions, options, *arena_);
 	statsLogger.logTiming(t0, "Tracing completed");
 	dumpHandler.dump("after_tracing", "trace", [&]() { return traceModule->toString(); });
 

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nautilus/JITCompiler.hpp"
+#include "nautilus/common/Arena.hpp"
 #include <functional>
 #include <list>
 #include <memory>
@@ -12,11 +13,21 @@ namespace nautilus::compiler {
  *
  * Compiles functions using a single backend (selected via options).
  * This is the original Nautilus compilation strategy.
+ *
+ * The compiler never owns an Arena; callers must supply one that
+ * outlives the compiler.  The same Arena is reused across every
+ * compile() invocation: softReset() is called at the start of each
+ * compilation so chunk memory from the previous compile is recycled
+ * instead of being freed and reallocated.  This amortises allocation
+ * cost over many compilations and is the reason compile() is not
+ * thread-safe (callers that need concurrent compilation should hold
+ * one LegacyCompiler per thread, each with its own Arena).
  */
 class LegacyCompiler : public JITCompiler {
 public:
-	LegacyCompiler();
-	LegacyCompiler(engine::Options options);
+	/// Construct a compiler that uses the supplied Arena for every trace.
+	/// The arena must outlive the compiler.
+	LegacyCompiler(engine::Options options, common::Arena& arena);
 	~LegacyCompiler() override;
 
 	[[nodiscard]] std::unique_ptr<Executable> compile(wrapper_function function) const override;
@@ -45,5 +56,10 @@ public:
 private:
 	const engine::Options options;
 	const CompilationBackendRegistry* backends;
+
+	/// Non-owning pointer to the externally supplied Arena.  softReset()'d
+	/// at the start of each compile() invocation.  Marked mutable because
+	/// compile() is const but needs to recycle the arena between calls.
+	mutable common::Arena* arena_;
 };
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/TieredCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.cpp
@@ -26,7 +26,7 @@ static std::string createPromotionUnitID() {
 
 // --- TieredJITCompiler ---
 
-TieredJITCompiler::TieredJITCompiler(engine::Options options) : baseCompiler_(options) {
+TieredJITCompiler::TieredJITCompiler(engine::Options options, common::Arena& arena) : baseCompiler_(options, arena) {
 	auto tier0 = options.getOptionOrDefault<std::string>("engine.tier0.backend", "");
 	auto tier1 = options.getOptionOrDefault<std::string>("engine.tier1.backend", "");
 	if (!tier0.empty() && !tier1.empty()) {
@@ -35,8 +35,9 @@ TieredJITCompiler::TieredJITCompiler(engine::Options options) : baseCompiler_(op
 	}
 }
 
-TieredJITCompiler::TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config)
-    : baseCompiler_(options), config_(std::move(config)) {
+TieredJITCompiler::TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config,
+                                     common::Arena& arena)
+    : baseCompiler_(options, arena), config_(std::move(config)) {
 }
 
 TieredJITCompiler::~TieredJITCompiler() {
@@ -129,9 +130,10 @@ const engine::Options& TieredJITCompiler::getOptions() const {
 
 namespace nautilus::compiler {
 
-TieredJITCompiler::TieredJITCompiler(engine::Options) : baseCompiler_() {
+TieredJITCompiler::TieredJITCompiler(engine::Options, common::Arena& arena) : baseCompiler_(engine::Options(), arena) {
 }
-TieredJITCompiler::TieredJITCompiler(engine::Options, engine::TieredCompilationConfig) : baseCompiler_() {
+TieredJITCompiler::TieredJITCompiler(engine::Options, engine::TieredCompilationConfig, common::Arena& arena)
+    : baseCompiler_(engine::Options(), arena) {
 }
 TieredJITCompiler::~TieredJITCompiler() = default;
 std::unique_ptr<Executable> TieredJITCompiler::compile(wrapper_function) const {

--- a/nautilus/src/nautilus/compiler/TieredCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.hpp
@@ -51,8 +51,11 @@ namespace nautilus::compiler {
  */
 class TieredJITCompiler : public JITCompiler {
 public:
-	TieredJITCompiler(engine::Options options);
-	TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config);
+	/// Construct a tiered compiler that borrows the supplied Arena for
+	/// every tier-0 trace-and-compile cycle.  The arena must outlive the
+	/// compiler.
+	TieredJITCompiler(engine::Options options, common::Arena& arena);
+	TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config, common::Arena& arena);
 	~TieredJITCompiler() override;
 
 	[[nodiscard]] std::unique_ptr<Executable> compile(wrapper_function function) const override;

--- a/nautilus/src/nautilus/tracing/Block.cpp
+++ b/nautilus/src/nautilus/tracing/Block.cpp
@@ -7,11 +7,15 @@
 namespace nautilus::tracing {
 
 Block::Block(uint32_t blockId) : blockId(blockId), type(Type::Default) {
+	// Most blocks contain only a handful of operations; reserve a small
+	// initial capacity to avoid reallocating the operations pointer vector
+	// in the common case.
+	operations.reserve(4);
 }
 
-operation_identifier Block::addOperation(nautilus::tracing::TraceOperation&& operation) {
+operation_identifier Block::addOperation(TraceOperation* operation) {
 	uint32_t operationIndex = operations.size();
-	operations.emplace_back(std::move(operation));
+	operations.push_back(operation);
 	return {blockId, operationIndex};
 }
 

--- a/nautilus/src/nautilus/tracing/Block.hpp
+++ b/nautilus/src/nautilus/tracing/Block.hpp
@@ -14,7 +14,20 @@ struct operation_identifier {
 };
 
 /**
- * @brief Represents a basic block in a trace
+ * @brief Represents a basic block in a trace.
+ *
+ * Operations are stored as pointers that are owned by an Arena living in the
+ * enclosing ExecutionTrace.  Keeping operations in the arena (rather than by
+ * value inside a std::vector) delivers two benefits:
+ *
+ *   - pointer stability: addresses of operations are never invalidated when
+ *     the operations vector or the blocks vector grows,
+ *   - lower allocator pressure: TraceOperations (and their input vectors)
+ *     are allocated from pre-allocated arena chunks instead of going through
+ *     the general purpose allocator on every trace step.
+ *
+ * Moving operations between blocks is O(1) and never touches the heap: only
+ * the pointer moves, the TraceOperation object itself stays put in the arena.
  */
 class Block {
 public:
@@ -29,7 +42,10 @@ public:
 	 */
 	explicit Block(uint32_t blockId);
 
-	operation_identifier addOperation(TraceOperation&& operation);
+	/**
+	 * @brief Appends an (already arena-allocated) operation to this block.
+	 */
+	operation_identifier addOperation(TraceOperation* operation);
 
 	/**
 	 * @brief Adds a argument to the block
@@ -54,8 +70,11 @@ public:
 
 	/**
 	 * @brief Defines a list of operations this block contains.
+	 *
+	 * Pointers are non-owning; the referenced TraceOperations are owned by
+	 * the ExecutionTrace's Arena.
 	 */
-	std::vector<TraceOperation> operations;
+	std::vector<TraceOperation*> operations;
 
 	/**
 	 * @brief Indicates successors of this block.

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -82,10 +82,10 @@ TypedValueRef& ExceptionBasedTraceContext::traceConstant(Type type, const Consta
 	auto globalTabIter = state->executionTrace.globalTagMap.find(tag);
 	if (globalTabIter != state->executionTrace.globalTagMap.end()) {
 		auto& ref = globalTabIter->second;
-		auto& originalRef = state->executionTrace.getBlocks()[ref.blockIndex].operations[ref.operationIndex];
+		auto* originalRef = state->executionTrace.getBlocks()[ref.blockIndex]->operations[ref.operationIndex];
 		auto resultRef = state->executionTrace.addOperationWithResult(tag, op, type, {constValue});
-		state->executionTrace.addAssignmentOperation(tag, originalRef.resultRef, resultRef, resultRef.type);
-		return originalRef.resultRef;
+		state->executionTrace.addAssignmentOperation(tag, originalRef->resultRef, resultRef, resultRef.type);
+		return originalRef->resultRef;
 	} else {
 		return state->executionTrace.addOperationWithResult(tag, op, type, {constValue});
 	}
@@ -279,18 +279,19 @@ bool ExceptionBasedTraceContext::traceBool(const TypedValueRef& value, const dou
 }
 
 std::unique_ptr<ExecutionTrace> ExceptionBasedTraceContext::trace(std::function<void()>& traceFunction,
-                                                                  const engine::Options& options) {
+                                                                  const engine::Options& options, Arena& arena) {
 	log::debug("Initialize Tracing");
 	auto rootAddress = __builtin_return_address(0);
 	auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress);
 
-	// Allocate ExecutionTrace and SymbolicExecutionContext on the stack
-	// This is the key optimization: no heap allocations for these large objects
-	ExecutionTrace executionTrace;
+	// The ExecutionTrace borrows the caller-provided arena for all Block
+	// and TraceOperation allocations.  The arena must outlive the returned
+	// trace.
+	auto executionTrace = std::make_unique<ExecutionTrace>(arena);
 	SymbolicExecutionContext symbolicExecutionContext;
 
-	// Initialize ExceptionBasedTraceContext with references to our stack objects
-	auto tc = initialize(tr, executionTrace, symbolicExecutionContext, options);
+	// Initialize ExceptionBasedTraceContext with references to our objects
+	auto tc = initialize(tr, *executionTrace, symbolicExecutionContext, options);
 	auto traceIteration = 0;
 
 	// Symbolic execution loop: explore all execution paths
@@ -298,11 +299,11 @@ std::unique_ptr<ExecutionTrace> ExceptionBasedTraceContext::trace(std::function<
 		try {
 			traceIteration = traceIteration + 1;
 			log::trace("Trace Iteration {}", traceIteration);
-			log::trace("{}", executionTrace);
+			log::trace("{}", *executionTrace);
 
 			// Prepare for next iteration
 			symbolicExecutionContext.next();
-			executionTrace.resetExecution();
+			executionTrace->resetExecution();
 			tc->resume(); // Reset persistent state (staticVars, aliveVars)
 
 			// Execute the traced function
@@ -320,20 +321,18 @@ std::unique_ptr<ExecutionTrace> ExceptionBasedTraceContext::trace(std::function<
 	tc->state.reset();
 
 	log::debug("Tracing Terminated with {} iterations", traceIteration);
-	log::trace("Final trace: {}", executionTrace);
+	log::trace("Final trace: {}", *executionTrace);
 
-	// Move stack-allocated executionTrace into a unique_ptr for return
-	// The caller gets ownership of the trace
-	return std::make_unique<ExecutionTrace>(std::move(executionTrace));
+	return executionTrace;
 }
 
 std::unique_ptr<TraceModule> ExceptionBasedTraceContext::Trace(std::list<compiler::CompilableFunction>& functions,
-                                                               const engine::Options& options) {
-	return traceContext.startTrace(functions, options);
+                                                               const engine::Options& options, Arena& arena) {
+	return traceContext.startTrace(functions, options, arena);
 }
 
 std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<compiler::CompilableFunction>& functions,
-                                                                    const engine::Options& options) {
+                                                                    const engine::Options& options, Arena& arena) {
 	log::debug("Initialize Tracing");
 	auto traceModule = std::make_unique<TraceModule>();
 	functionsToTrace = functions;
@@ -348,7 +347,7 @@ std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<co
 			continue;
 		}
 
-		auto& executionTrace = traceModule->addNewFunction(currentFunction.getName());
+		auto& executionTrace = traceModule->addNewFunction(currentFunction.getName(), arena);
 		auto wrapperFunc = currentFunction.getFunction();
 
 		auto rootAddress = __builtin_return_address(0);

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
@@ -200,12 +200,15 @@ public:
 	 * @brief Main tracing entry point - allocates all objects on stack and executes symbolic tracing.
 	 * @param functionsToTrace List of functions to trace
 	 * @param options Engine options for configuration
+	 * @param arena Arena used to allocate Blocks/TraceOperations for every
+	 *              ExecutionTrace in the returned TraceModule; must outlive
+	 *              the returned module.
 	 * @return unique_ptr to TraceModule containing all function traces
 	 */
 	std::unique_ptr<TraceModule> startTrace(std::list<compiler::CompilableFunction>& functionsToTrace,
-	                                        const engine::Options& options);
+	                                        const engine::Options& options, Arena& arena);
 	static std::unique_ptr<TraceModule> Trace(std::list<compiler::CompilableFunction>& functionsToTrace,
-	                                          const engine::Options& options);
+	                                          const engine::Options& options, Arena& arena);
 
 	TypedValueRef& traceCopy(const TypedValueRef& ref) override;
 
@@ -268,13 +271,16 @@ public:
 	                                              const engine::Options& options);
 
 	/**
-	 * @brief Main tracing entry point - allocates all objects on stack and executes symbolic tracing.
-	 * @param traceFunction The function to trace
-	 * @param options Engine options for configuration
-	 * @return unique_ptr to ExecutionTrace containing the complete trace
+	 * @brief Main tracing entry point - executes symbolic tracing of the
+	 * supplied function.
+	 * @param traceFunction The function to trace.
+	 * @param options Engine options for configuration.
+	 * @param arena Arena used to allocate the trace's Blocks and
+	 *              TraceOperations; must outlive the returned trace.
+	 * @return unique_ptr to ExecutionTrace containing the complete trace.
 	 */
-	static std::unique_ptr<ExecutionTrace> trace(std::function<void()>& traceFunction,
-	                                             const engine::Options& options = engine::Options());
+	static std::unique_ptr<ExecutionTrace> trace(std::function<void()>& traceFunction, const engine::Options& options,
+	                                             Arena& arena);
 
 	/// Low-level entry point used by the internal tracing loop.
 	TypedValueRef& traceOperation(Op op, Type resultType, std::vector<InputVariant> inputRef);

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -9,8 +9,8 @@
 
 namespace nautilus::tracing {
 
-ExecutionTrace& TraceModule::addNewFunction(std::string_view functionName) {
-	auto trace = std::make_unique<ExecutionTrace>();
+ExecutionTrace& TraceModule::addNewFunction(std::string_view functionName, Arena& arena) {
+	auto trace = std::make_unique<ExecutionTrace>(arena);
 	auto& traceRef = *trace;
 	functions[std::string(functionName)] = std::move(trace);
 	return traceRef;
@@ -55,15 +55,28 @@ std::vector<std::string> TraceModule::getFunctionNames() const {
 	return names;
 }
 
-ExecutionTrace::ExecutionTrace() : currentBlockIndex(0), currentOperationIndex(0), blocks() {
+ExecutionTrace::ExecutionTrace(Arena& arena) : arena(&arena), currentBlockIndex(0), currentOperationIndex(0), blocks() {
+	// A typical short trace has only a handful of blocks; reserving a small
+	// initial capacity eliminates the first few reallocations of the pointer
+	// vector in the tracing hot path.
+	blocks.reserve(8);
 	createBlock();
+}
+
+ExecutionTrace::~ExecutionTrace() {
+	// Blocks and TraceOperations are arena-allocated via Arena::create
+	// (which registers their destructors with the arena).  The arena runs
+	// those destructors when it is softReset() or destroyed, so there is
+	// nothing to do here.  Doing it explicitly would double-destruct any
+	// operations that the SSA phase removed from a block (e.g. ASSIGN ops
+	// erased from block.operations whose objects still live in the arena).
 }
 
 Block& ExecutionTrace::getBlock(uint32_t blockIndex) {
 	if (blockIndex >= blocks.size()) {
 		throw RuntimeException("Block index out of bounds: " + std::to_string(blockIndex));
 	}
-	return blocks[blockIndex];
+	return *blocks[blockIndex];
 }
 
 uint32_t ExecutionTrace::getCurrentBlockIndex() const {
@@ -74,7 +87,7 @@ Block& ExecutionTrace::getCurrentBlock() {
 	if (currentBlockIndex >= blocks.size()) {
 		throw RuntimeException("Current block index out of bounds: " + std::to_string(currentBlockIndex));
 	}
-	return blocks[currentBlockIndex];
+	return *blocks[currentBlockIndex];
 }
 
 void ExecutionTrace::setCurrentBlock(uint32_t index) {
@@ -85,8 +98,12 @@ void ExecutionTrace::setCurrentBlock(uint32_t index) {
 	currentBlockIndex = index;
 }
 
-std::vector<Block>& ExecutionTrace::getBlocks() {
+std::vector<Block*>& ExecutionTrace::getBlocks() {
 	return blocks;
+}
+
+Arena& ExecutionTrace::getArena() {
+	return *arena;
 }
 
 bool ExecutionTrace::checkTag(Snapshot& snapshot) {
@@ -113,13 +130,17 @@ void ExecutionTrace::addReturn(Snapshot& snapshot, Type resultType, const TypedV
 	if (blocks.empty()) {
 		createBlock();
 	}
-	auto& operations = blocks[currentBlockIndex].operations;
+	auto& operations = blocks[currentBlockIndex]->operations;
 	auto op = Op::RETURN;
+	TraceOperation* newOp;
 	if (ref.type == Type::v) {
-		operations.emplace_back(snapshot, op, resultType, TypedValueRef(0, Type::v), std::vector<InputVariant> {});
+		newOp = arena->create<TraceOperation>(snapshot, op, resultType, TypedValueRef(0, Type::v),
+		                                      std::vector<InputVariant> {});
 	} else {
-		operations.emplace_back(snapshot, op, resultType, TypedValueRef(0, Type::v), std::vector<InputVariant> {ref});
+		newOp = arena->create<TraceOperation>(snapshot, op, resultType, TypedValueRef(0, Type::v),
+		                                      std::vector<InputVariant> {ref});
 	}
+	operations.push_back(newOp);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
 
@@ -131,20 +152,24 @@ TypedValueRef& ExecutionTrace::addAssignmentOperation(Snapshot& snapshot, const 
 	if (blocks.empty()) {
 		createBlock();
 	}
-	auto& operations = blocks[currentBlockIndex].operations;
+	auto& operations = blocks[currentBlockIndex]->operations;
 	auto op = ASSIGN;
-	auto& operation = operations.emplace_back(snapshot, op, resultType, targetRef, std::vector<InputVariant> {srcRef});
+	auto* operation =
+	    arena->create<TraceOperation>(snapshot, op, resultType, targetRef, std::vector<InputVariant> {srcRef});
+	operations.push_back(operation);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
-	return operation.resultRef;
+	return operation->resultRef;
 }
 
 void ExecutionTrace::addOperation(Snapshot& snapshot, Op& operation, std::vector<InputVariant> inputs) {
 	if (blocks.empty()) {
 		createBlock();
 	}
-	auto& operations = blocks[currentBlockIndex].operations;
-	operations.emplace_back(snapshot, operation, Type::v, TypedValueRef(0, Type::v), std::move(inputs));
+	auto& operations = blocks[currentBlockIndex]->operations;
+	auto* newOp =
+	    arena->create<TraceOperation>(snapshot, operation, Type::v, TypedValueRef(0, Type::v), std::move(inputs));
+	operations.push_back(newOp);
 }
 
 TypedValueRef& ExecutionTrace::addOperationWithResult(Snapshot& snapshot, Op& operation, Type& resultType,
@@ -153,13 +178,14 @@ TypedValueRef& ExecutionTrace::addOperationWithResult(Snapshot& snapshot, Op& op
 		createBlock();
 	}
 
-	auto& operations = blocks[currentBlockIndex].operations;
-	auto& to = operations.emplace_back(snapshot, operation, resultType, TypedValueRef(getNextValueRef(), resultType),
-	                                   std::move(inputs));
+	auto& operations = blocks[currentBlockIndex]->operations;
+	auto* to = arena->create<TraceOperation>(snapshot, operation, resultType,
+	                                         TypedValueRef(getNextValueRef(), resultType), std::move(inputs));
+	operations.push_back(to);
 
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
-	return to.resultRef;
+	return to->resultRef;
 }
 
 // Adds a comparison operation to the execution trace
@@ -174,10 +200,11 @@ void ExecutionTrace::addCmpOperation(Snapshot& snapshot, const TypedValueRef& co
 	getBlock(trueBlock).predecessors.emplace_back(getCurrentBlockIndex());
 	auto falseBlock = createBlock();
 	getBlock(falseBlock).predecessors.emplace_back(getCurrentBlockIndex());
-	auto& operations = blocks[currentBlockIndex].operations;
-	operations.emplace_back(
+	auto& operations = blocks[currentBlockIndex]->operations;
+	auto* cmpOp = arena->create<TraceOperation>(
 	    snapshot, CMP, Type::v, TypedValueRef(getNextValueRef(), Type::v),
 	    std::vector<InputVariant> {condition, BlockRef(trueBlock), BlockRef(falseBlock), probability});
+	operations.push_back(cmpOp);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
 }
@@ -188,9 +215,9 @@ void ExecutionTrace::nextOperation() {
 	if (currentOperationIndex >= block.operations.size()) {
 		throw RuntimeException("Operation index out of bounds: " + std::to_string(currentOperationIndex));
 	}
-	auto& currentOp = block.operations[currentOperationIndex];
-	if (currentOp.op == JMP) {
-		auto& nextBlock = std::get<BlockRef>(currentOp.input[0]);
+	auto* currentOp = block.operations[currentOperationIndex];
+	if (currentOp->op == JMP) {
+		auto& nextBlock = std::get<BlockRef>(currentOp->input[0]);
 		setCurrentBlock(nextBlock.block);
 	}
 }
@@ -199,20 +226,22 @@ TraceOperation& ExecutionTrace::getCurrentOperation() {
 	if (currentOperationIndex >= getCurrentBlock().operations.size()) {
 		throw RuntimeException("Current operation index out of bounds: " + std::to_string(currentOperationIndex));
 	}
-	while (getCurrentBlock().operations[currentOperationIndex].op == JMP) {
-		auto& nextBlock = std::get<BlockRef>(getCurrentBlock().operations[currentOperationIndex].input[0]);
+	while (getCurrentBlock().operations[currentOperationIndex]->op == JMP) {
+		auto& nextBlock = std::get<BlockRef>(getCurrentBlock().operations[currentOperationIndex]->input[0]);
 		setCurrentBlock(nextBlock.block);
 		if (currentOperationIndex >= getCurrentBlock().operations.size()) {
 			throw RuntimeException("Current operation index out of bounds after JMP: " +
 			                       std::to_string(currentOperationIndex));
 		}
 	}
-	return getCurrentBlock().operations[currentOperationIndex];
+	return *getCurrentBlock().operations[currentOperationIndex];
 }
 
 uint32_t ExecutionTrace::createBlock() {
-	auto& block = blocks.emplace_back(blocks.size());
-	return block.blockId;
+	auto blockId = static_cast<uint32_t>(blocks.size());
+	auto* block = arena->create<Block>(blockId);
+	blocks.push_back(block);
+	return block->blockId;
 }
 
 Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
@@ -224,20 +253,20 @@ Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
 	auto mergedBlockId = createBlock();
 	// perform a control flow merge and merge the current block with operations in
 	// some other block.
-	auto& referenceBlock = blocks[oi.blockIndex];
-	auto& currentBlock = blocks[currentBlockIndex];
+	auto& referenceBlock = *blocks[oi.blockIndex];
+	auto& currentBlock = *blocks[currentBlockIndex];
 
 	auto& mergeBlock = getBlock(mergedBlockId);
 	mergeBlock.type = Block::Type::ControlFlowMerge;
 
-	// 1. move operation to new block
-	// move everything from the reference block between opId and end to merge block
+	// 1. move operation pointers to new block
+	// Pointers are stable (arena-allocated), so we only move the entries in
+	// the operations vector; the TraceOperation objects themselves stay put.
 	for (uint32_t opIndex = oi.operationIndex; opIndex < referenceBlock.operations.size(); opIndex++) {
-		auto& sourceOperation = referenceBlock.operations[opIndex];
-		// Save values needed after move
-		auto opType = sourceOperation.op;
-		auto opTag = sourceOperation.tag;
-		auto operationReference = mergeBlock.addOperation(std::move(sourceOperation));
+		auto* sourceOperation = referenceBlock.operations[opIndex];
+		auto opType = sourceOperation->op;
+		auto opTag = sourceOperation->tag;
+		auto operationReference = mergeBlock.addOperation(sourceOperation);
 		// update in global and local tag map
 
 		if (opType == RETURN) {
@@ -258,19 +287,19 @@ Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
 
 	// add jump from referenced block to merge block
 	auto mergeBlockRef = BlockRef(mergedBlockId);
-	referenceBlock.addOperation({Op::JMP, {mergeBlockRef}});
+	referenceBlock.addOperation(arena->create<TraceOperation>(Op::JMP, std::vector<InputVariant> {mergeBlockRef}));
 
 	// add jump from current block to merge block
-	currentBlock.addOperation({Op::JMP, {mergeBlockRef}});
+	currentBlock.addOperation(arena->create<TraceOperation>(Op::JMP, std::vector<InputVariant> {mergeBlockRef}));
 
 	mergeBlock.predecessors.emplace_back(oi.blockIndex);
 	mergeBlock.predecessors.emplace_back(currentBlockIndex);
 	setCurrentBlock(mergedBlockId);
 
 	// update predecessors of merge merge block
-	auto& lastMergeOperation = mergeBlock.operations[mergeBlock.operations.size() - 1];
-	if (lastMergeOperation.op == Op::CMP || lastMergeOperation.op == Op::JMP) {
-		for (auto& input : lastMergeOperation.input) {
+	auto* lastMergeOperation = mergeBlock.operations[mergeBlock.operations.size() - 1];
+	if (lastMergeOperation->op == Op::CMP || lastMergeOperation->op == Op::JMP) {
+		for (auto& input : lastMergeOperation->input) {
 			if (auto blockRef = std::get_if<BlockRef>(&input)) {
 				auto& blockPredecessor = getBlock(blockRef->block).predecessors;
 				std::replace(blockPredecessor.begin(), blockPredecessor.end(), oi.blockIndex, mergedBlockId);
@@ -284,7 +313,7 @@ Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
 TypedValueRef& ExecutionTrace::setArgument(Type type, size_t index) {
 	++lastValueRef;
 	ValueRef argRef = index + 1;
-	auto& arguments = blocks[0].arguments;
+	auto& arguments = blocks[0]->arguments;
 	if (arguments.size() < argRef) {
 		arguments.resize(argRef);
 	}
@@ -313,7 +342,7 @@ void ExecutionTrace::resetExecution() {
 }
 
 const std::vector<TypedValueRef>& ExecutionTrace::getArguments() {
-	return blocks[0].arguments;
+	return blocks[0]->arguments;
 }
 
 void ExecutionTrace::addTag(Snapshot& snapshot, operation_identifier& identifier) {
@@ -347,7 +376,7 @@ auto formatter<nautilus::tracing::ExecutionTrace>::format(const nautilus::tracin
                                                           fmt::format_context& ctx) -> format_context::iterator {
 	auto out = ctx.out();
 	for (size_t i = 0; i < trace.blocks.size(); i++) {
-		fmt::format_to(out, "B{}{}", i, trace.blocks[i]);
+		fmt::format_to(out, "B{}{}", i, *trace.blocks[i]);
 	}
 	return out;
 }
@@ -367,8 +396,8 @@ auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block&
 		fmt::format_to(out, " ControlFlowMerge");
 	}
 	fmt::format_to(out, "\n");
-	for (const auto& operation : block.operations) {
-		fmt::format_to(out, "{}\n", operation);
+	for (const auto* operation : block.operations) {
+		fmt::format_to(out, "{}\n", *operation);
 	}
 	return out;
 }

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
@@ -3,12 +3,15 @@
 
 #include "Block.hpp"
 #include "TraceOperation.hpp"
+#include "nautilus/common/Arena.hpp"
 #include "tag/TagRecorder.hpp"
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
 namespace nautilus::tracing {
+
+using Arena = common::Arena;
 
 class ExecutionTrace;
 
@@ -43,14 +46,16 @@ public:
 	/**
 	 * @brief Creates and adds a new function trace to the module.
 	 *
-	 * Creates a new ExecutionTrace for the given function name and stores it in the module.
+	 * Creates a new ExecutionTrace for the given function name that
+	 * allocates its Blocks and TraceOperations from the supplied Arena.
 	 * If a function with the same name already exists, it will be replaced.
 	 *
-	 * @param functionName Name of the function to trace (e.g., "execute", "helper_function")
-	 * @return Reference to the newly created ExecutionTrace
-	 * @note The returned reference remains valid until the TraceModule is destroyed or moved
+	 * @param functionName Name of the function to trace.
+	 * @param arena Arena backing the trace's allocations; must outlive
+	 *              the returned trace and the enclosing TraceModule.
+	 * @return Reference to the newly created ExecutionTrace.
 	 */
-	ExecutionTrace& addNewFunction(std::string_view functionName);
+	ExecutionTrace& addNewFunction(std::string_view functionName, Arena& arena);
 
 	/**
 	 * @brief Retrieves the execution trace for a specific function.
@@ -116,24 +121,45 @@ private:
 };
 
 /**
- * @brief The execution trace captures the trace of a program
+ * @brief The execution trace captures the trace of a program.
+ *
+ * An ExecutionTrace allocates all of its Blocks and TraceOperations from an
+ * externally provided Arena.  Callers (the trace contexts, the engine, etc.)
+ * are responsible for the Arena's lifetime and may reuse a single Arena
+ * across multiple trace/compile cycles to amortise allocation costs.
  */
 class ExecutionTrace {
 public:
 	/**
-	 * @brief Constructs a new execution trace
+	 * @brief Constructs a new execution trace that allocates its Blocks and
+	 * TraceOperations from the supplied Arena.
+	 *
+	 * The Arena must outlive the ExecutionTrace.  Long-lived components
+	 * (e.g. a JIT compiler or Engine) can keep a single Arena alive across
+	 * many trace/compile cycles and call Arena::softReset() between them
+	 * to reuse the memory.
+	 *
+	 * @param arena Non-owning reference to the Arena to allocate from.
 	 */
-	ExecutionTrace();
+	explicit ExecutionTrace(Arena& arena);
 
-	~ExecutionTrace() = default;
+	/**
+	 * Destroys the trace, including explicit destruction of all
+	 * arena-allocated Blocks and TraceOperations.  The Arena itself is left
+	 * untouched so the caller can softReset() and reuse it for the next
+	 * trace.
+	 */
+	~ExecutionTrace();
 
-	// Delete copy operations (ExecutionTrace is move-only)
+	// ExecutionTrace is neither copyable nor movable: Block and TraceOperation
+	// instances hold pointers into the Arena, and moving them would leave
+	// those pointers dangling.  Callers that need ownership transfer should
+	// heap-allocate the trace via std::unique_ptr<ExecutionTrace>, which
+	// moves the pointer rather than the object.
 	ExecutionTrace(const ExecutionTrace&) = delete;
 	ExecutionTrace& operator=(const ExecutionTrace&) = delete;
-
-	// Default move operations
-	ExecutionTrace(ExecutionTrace&&) = default;
-	ExecutionTrace& operator=(ExecutionTrace&&) = default;
+	ExecutionTrace(ExecutionTrace&&) = delete;
+	ExecutionTrace& operator=(ExecutionTrace&&) = delete;
 
 	/**
 	 * @brief Adds an operation with a result to the trace
@@ -216,10 +242,22 @@ public:
 	Block& getBlock(uint32_t blockIndex);
 
 	/**
-	 * @brief Returns a reference to all blocks
-	 * @return std::vector<Block>&
+	 * @brief Returns a reference to all blocks.
+	 *
+	 * Blocks are owned by the trace's Arena; the vector stores non-owning
+	 * pointers whose target addresses are stable for the lifetime of the
+	 * trace.
+	 * @return std::vector<Block*>&
 	 */
-	std::vector<Block>& getBlocks();
+	std::vector<Block*>& getBlocks();
+
+	/**
+	 * @brief Returns a reference to the underlying arena used to allocate
+	 * blocks and operations.  Phases that need to mint new TraceOperation /
+	 * Block instances (e.g. during SSA construction) should use this arena
+	 * instead of allocating on the heap directly.
+	 */
+	Arena& getArena();
 
 	/**
 	 * @brief Returns the index to the current block.
@@ -288,9 +326,16 @@ private:
 	void addTag(Snapshot& snapshot, operation_identifier& identifier);
 
 public:
+	/**
+	 * @brief Non-owning pointer to the arena supplied at construction time
+	 * that backs all Block and TraceOperation allocations for this trace.
+	 * The pointed-to arena must outlive the ExecutionTrace.
+	 */
+	Arena* arena;
 	uint32_t currentBlockIndex;
 	ValueRef currentOperationIndex;
-	std::vector<Block> blocks;
+	/// Non-owning pointers to arena-allocated Block instances.
+	std::vector<Block*> blocks;
 	std::vector<operation_identifier> returnRefs;
 	ValueRef lastValueRef = 0;
 	std::unordered_map<Snapshot, operation_identifier> globalTagMap;

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -69,10 +69,10 @@ TypedValueRef& LazyTraceContext::traceConstant(Type type, const ConstantLiteral&
 	auto globalTabIter = state->executionTrace.globalTagMap.find(tag);
 	if (globalTabIter != state->executionTrace.globalTagMap.end()) {
 		auto& ref = globalTabIter->second;
-		auto& originalRef = state->executionTrace.getBlocks()[ref.blockIndex].operations[ref.operationIndex];
+		auto* originalRef = state->executionTrace.getBlocks()[ref.blockIndex]->operations[ref.operationIndex];
 		auto resultRef = state->executionTrace.addOperationWithResult(tag, op, type, {constValue});
-		state->executionTrace.addAssignmentOperation(tag, originalRef.resultRef, resultRef, resultRef.type);
-		return originalRef.resultRef;
+		state->executionTrace.addAssignmentOperation(tag, originalRef->resultRef, resultRef, resultRef.type);
+		return originalRef->resultRef;
 	} else {
 		return state->executionTrace.addOperationWithResult(tag, op, type, {constValue});
 	}
@@ -297,17 +297,18 @@ bool LazyTraceContext::traceBool(const TypedValueRef& value, const double probab
 }
 
 std::unique_ptr<ExecutionTrace> LazyTraceContext::trace(std::function<void()>& traceFunction,
-                                                        const engine::Options& options) {
+                                                        const engine::Options& options, Arena& arena) {
 	log::debug("Initialize Completing Tracing");
 	auto rootAddress = __builtin_return_address(0);
 	auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress);
 
-	// Allocate ExecutionTrace and SymbolicExecutionContext on the stack
-	ExecutionTrace executionTrace;
+	// The ExecutionTrace borrows the caller-provided arena for all
+	// allocations; the arena must outlive the returned trace.
+	auto executionTrace = std::make_unique<ExecutionTrace>(arena);
 	SymbolicExecutionContext symbolicExecutionContext;
 
-	// Initialize LazyTraceContext with references to our stack objects
-	auto tc = initialize(tr, executionTrace, symbolicExecutionContext, options);
+	// Initialize LazyTraceContext with references to our objects
+	auto tc = initialize(tr, *executionTrace, symbolicExecutionContext, options);
 	auto traceIteration = 0;
 
 	// Symbolic execution loop: explore all execution paths
@@ -315,11 +316,11 @@ std::unique_ptr<ExecutionTrace> LazyTraceContext::trace(std::function<void()>& t
 	while (symbolicExecutionContext.shouldContinue()) {
 		traceIteration = traceIteration + 1;
 		log::trace("Completing Trace Iteration {}", traceIteration);
-		log::trace("{}", executionTrace);
+		log::trace("{}", *executionTrace);
 
 		// Prepare for next iteration
 		symbolicExecutionContext.next();
-		executionTrace.resetExecution();
+		executionTrace->resetExecution();
 		tc->resume(); // Reset persistent state (staticVars, aliveVars, paused_)
 
 		// Execute the traced function - it always returns normally
@@ -335,18 +336,18 @@ std::unique_ptr<ExecutionTrace> LazyTraceContext::trace(std::function<void()>& t
 	tc->state.reset();
 
 	log::debug("Completing Tracing Terminated with {} iterations", traceIteration);
-	log::trace("Final trace: {}", executionTrace);
+	log::trace("Final trace: {}", *executionTrace);
 
-	return std::make_unique<ExecutionTrace>(std::move(executionTrace));
+	return executionTrace;
 }
 
 std::unique_ptr<TraceModule> LazyTraceContext::Trace(std::list<compiler::CompilableFunction>& functions,
-                                                     const engine::Options& options) {
-	return completingTraceContext.startTrace(functions, options);
+                                                     const engine::Options& options, Arena& arena) {
+	return completingTraceContext.startTrace(functions, options, arena);
 }
 
 std::unique_ptr<TraceModule> LazyTraceContext::startTrace(std::list<compiler::CompilableFunction>& functions,
-                                                          const engine::Options& options) {
+                                                          const engine::Options& options, Arena& arena) {
 	log::debug("Initialize Lazy Tracing");
 	auto traceModule = std::make_unique<TraceModule>();
 	functionsToTrace = functions;
@@ -361,7 +362,7 @@ std::unique_ptr<TraceModule> LazyTraceContext::startTrace(std::list<compiler::Co
 			continue;
 		}
 
-		auto& executionTrace = traceModule->addNewFunction(currentFunction.getName());
+		auto& executionTrace = traceModule->addNewFunction(currentFunction.getName(), arena);
 		auto wrapperFunc = currentFunction.getFunction();
 
 		auto rootAddress = __builtin_return_address(0);

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.hpp
@@ -80,27 +80,30 @@ public:
 	                                    const engine::Options& options);
 
 	/**
-	 * @brief Main tracing entry point - allocates all objects on stack and executes symbolic tracing.
-	 * Unlike ExceptionBasedTraceContext::trace(), this method never uses try/catch - the traced function always
-	 * returns normally.
-	 * @param traceFunction The function to trace
-	 * @param options Engine options for configuration
-	 * @return unique_ptr to ExecutionTrace containing the complete trace
+	 * @brief Main tracing entry point.  Unlike ExceptionBasedTraceContext::trace(),
+	 * this method never uses try/catch - the traced function always returns normally.
+	 * @param traceFunction The function to trace.
+	 * @param options Engine options for configuration.
+	 * @param arena Arena used to allocate the trace's Blocks and TraceOperations;
+	 *              must outlive the returned trace.
+	 * @return unique_ptr to ExecutionTrace containing the complete trace.
 	 */
-	static std::unique_ptr<ExecutionTrace> trace(std::function<void()>& traceFunction,
-	                                             const engine::Options& options = engine::Options());
+	static std::unique_ptr<ExecutionTrace> trace(std::function<void()>& traceFunction, const engine::Options& options,
+	                                             Arena& arena);
 
 	/**
 	 * @brief Multi-function tracing entry point. Traces all functions in the work-list,
 	 * including nested Nautilus functions discovered during tracing.
-	 * @param functions Initial list of functions to trace
-	 * @param options Engine options for configuration
-	 * @return unique_ptr to TraceModule containing all function traces
+	 * @param functions Initial list of functions to trace.
+	 * @param options Engine options for configuration.
+	 * @param arena Arena backing all traces in the returned module; must
+	 *              outlive the returned module.
+	 * @return unique_ptr to TraceModule containing all function traces.
 	 */
 	std::unique_ptr<TraceModule> startTrace(std::list<compiler::CompilableFunction>& functions,
-	                                        const engine::Options& options);
+	                                        const engine::Options& options, Arena& arena);
 	static std::unique_ptr<TraceModule> Trace(std::list<compiler::CompilableFunction>& functions,
-	                                          const engine::Options& options);
+	                                          const engine::Options& options, Arena& arena);
 
 	LazyTraceContext() = default;
 

--- a/nautilus/src/nautilus/tracing/phases/SSACreationPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/SSACreationPhase.cpp
@@ -52,24 +52,28 @@ Block& SSACreationPhase::SSACreationPhaseContext::getReturnBlock() {
 		return trace->getBlock(firstReturnOp.blockIndex);
 	}
 
-	auto defaultReturnOp = trace->getBlock(returns.front().blockIndex).operations[firstReturnOp.operationIndex];
+	auto* defaultReturnOp = trace->getBlock(returns.front().blockIndex).operations[firstReturnOp.operationIndex];
 
 	// add return block
 	auto& returnBlock = trace->getBlock(trace->createBlock());
-	returnBlock.operations.emplace_back(defaultReturnOp);
+	// Allocate a copy of the default return op in the arena so that both
+	// the return block and any subsequent in-place modifications of the
+	// original operation stay independent.
+	returnBlock.operations.push_back(trace->getArena().create<TraceOperation>(*defaultReturnOp));
 	for (auto returnOp : returns) {
 		auto& returnOpBlock = trace->getBlock(returnOp.blockIndex);
-		auto returnValue = returnOpBlock.operations[returnOp.operationIndex];
+		auto* returnValue = returnOpBlock.operations[returnOp.operationIndex];
 		// check if we have return values
-		if (returnValue.input.empty()) {
+		if (returnValue->input.empty()) {
 			returnOpBlock.operations.erase(returnOpBlock.operations.cbegin() + returnOp.operationIndex);
 		} else {
 			auto snap = Snapshot();
-			returnOpBlock.operations[returnOp.operationIndex] =
-			    TraceOperation(snap, ASSIGN, defaultReturnOp.resultType,
-			                   std::get<TypedValueRef>(defaultReturnOp.input[0]), {returnValue.input[0]});
+			returnOpBlock.operations[returnOp.operationIndex] = trace->getArena().create<TraceOperation>(
+			    snap, ASSIGN, defaultReturnOp->resultType, std::get<TypedValueRef>(defaultReturnOp->input[0]),
+			    std::vector<InputVariant> {returnValue->input[0]});
 		}
-		returnOpBlock.addOperation({Op::JMP, std::vector<InputVariant> {BlockRef(returnBlock.blockId)}});
+		returnOpBlock.addOperation(trace->getArena().create<TraceOperation>(
+		    Op::JMP, std::vector<InputVariant> {BlockRef(returnBlock.blockId)}));
 		returnBlock.predecessors.emplace_back(returnOp.blockIndex);
 	}
 
@@ -82,22 +86,25 @@ void SSACreationPhase::SSACreationPhaseContext::hoistAllocaOperations() {
 	// order.  Instead of erasing the original operation (which would invalidate
 	// every operationIndex stored in returnRefs and elsewhere), we replace it
 	// with an ALLOCA_TOMBSTONE that later phases simply skip.
-	std::vector<TraceOperation> allocaOps;
+	//
+	// Because operations live in the trace's arena, we allocate independent
+	// copies there so that tombstoning the originals does not affect the
+	// hoisted copies we prepend to the initial block.
+	std::vector<TraceOperation*> allocaOps;
 	auto& blocks = trace->getBlocks();
-	for (auto& block : blocks) {
-		for (auto& op : block.operations) {
-			if (op.op == Op::ALLOCA) {
-				allocaOps.push_back(op);
-				op.op = Op::ALLOCA_TOMBSTONE;
+	for (auto* block : blocks) {
+		for (auto* op : block->operations) {
+			if (op->op == Op::ALLOCA) {
+				allocaOps.push_back(trace->getArena().create<TraceOperation>(*op));
+				op->op = Op::ALLOCA_TOMBSTONE;
 			}
 		}
 	}
 
 	// Prepend the collected ALLOCA operations to the head of the initial block.
 	if (!allocaOps.empty()) {
-		auto& initialBlock = blocks.front();
-		initialBlock.operations.insert(initialBlock.operations.begin(), std::make_move_iterator(allocaOps.begin()),
-		                               std::make_move_iterator(allocaOps.end()));
+		auto* initialBlock = blocks.front();
+		initialBlock->operations.insert(initialBlock->operations.begin(), allocaOps.begin(), allocaOps.end());
 	}
 }
 
@@ -118,12 +125,12 @@ std::shared_ptr<ExecutionTrace> SSACreationPhase::SSACreationPhaseContext::proce
 	removeAssignOperations();
 
 	// check arguments
-	if (rootBlockNumberOfArguments != trace->getBlocks().front().arguments.size()) {
+	if (rootBlockNumberOfArguments != trace->getBlocks().front()->arguments.size()) {
 		throw RuntimeException(fmt::format("Wrong number of arguments in trace: expected {}, got {}\n",
-		                                   rootBlockNumberOfArguments, trace->getBlocks().front().arguments.size()));
+		                                   rootBlockNumberOfArguments, trace->getBlocks().front()->arguments.size()));
 	}
 	// sort arguments
-	std::sort(trace->getBlocks().front().arguments.begin(), trace->getBlocks().front().arguments.end());
+	std::sort(trace->getBlocks().front()->arguments.begin(), trace->getBlocks().front()->arguments.end());
 
 	return std::move(trace);
 }
@@ -133,11 +140,11 @@ bool SSACreationPhase::SSACreationPhaseContext::isLocalValueRef(Block& block, Ty
 	// A value ref is defined in the local scope, if it is the result of an
 	// operation before the operationIndex
 	for (uint32_t i = 0; i < operationIndex; i++) {
-		auto& resOperation = block.operations[i];
-		if (resOperation.op == Op::ALLOCA_TOMBSTONE) {
+		auto* resOperation = block.operations[i];
+		if (resOperation->op == Op::ALLOCA_TOMBSTONE) {
 			continue;
 		}
-		if (resOperation.resultRef == ref) {
+		if (resOperation->resultRef == ref) {
 			return true;
 		}
 	}
@@ -166,7 +173,7 @@ void SSACreationPhase::SSACreationPhaseContext::processBlock(Block& startBlock) 
 
 		// Process the inputs of all operations in the current block
 		for (int64_t i = block.operations.size() - 1; i >= 0; i--) {
-			auto& operation = block.operations[i];
+			auto& operation = *block.operations[i];
 			// process input for each variable
 			for (auto& input : operation.input) {
 				if (auto* valueRef = std::get_if<TypedValueRef>(&input)) {
@@ -218,11 +225,11 @@ const std::unordered_set<ValueRef>& SSACreationPhase::SSACreationPhaseContext::g
 		return it->second;
 	}
 	auto& defined = blockDefinitions[blockId];
-	for (auto& op : trace->getBlock(blockId).operations) {
-		if (op.op == Op::ALLOCA_TOMBSTONE) {
+	for (auto* op : trace->getBlock(blockId).operations) {
+		if (op->op == Op::ALLOCA_TOMBSTONE) {
 			continue;
 		}
-		defined.insert(op.resultRef.ref);
+		defined.insert(op->resultRef.ref);
 	}
 	return defined;
 }
@@ -243,7 +250,7 @@ void SSACreationPhase::SSACreationPhaseContext::propagateValue(Block& block, Typ
 
 		for (auto& predecessor : curBlock.predecessors) {
 			auto& predBlock = trace->getBlock(predecessor);
-			auto& lastOperation = predBlock.operations.back();
+			auto& lastOperation = *predBlock.operations.back();
 			if (lastOperation.op == Op::JMP || lastOperation.op == Op::CMP) {
 				for (auto& input : lastOperation.input) {
 					if (auto blockRef = std::get_if<BlockRef>(&input)) {
@@ -294,9 +301,11 @@ void SSACreationPhase::SSACreationPhaseContext::processBlockRef(Block& block, Bl
 
 void SSACreationPhase::SSACreationPhaseContext::removeAssignOperations() {
 	// Iterate over all block and eliminate the ASSIGN operation.
-	for (Block& block : trace->getBlocks()) {
+	for (Block* blockPtr : trace->getBlocks()) {
+		Block& block = *blockPtr;
 		std::unordered_map<ValueRef, ValueRef> assignmentMap;
-		for (auto& operation : block.operations) {
+		for (auto* operationPtr : block.operations) {
+			auto& operation = *operationPtr;
 			if (operation.op == Op::ASSIGN) {
 				auto& valueRef = get<TypedValueRef>(operation.input[0]);
 				auto foundAssignment = assignmentMap.find(valueRef.ref);
@@ -342,12 +351,13 @@ void SSACreationPhase::SSACreationPhaseContext::removeAssignOperations() {
 			}
 		}
 		std::erase_if(block.operations,
-		              [&](const auto& item) { return item.op == Op::ASSIGN || item.op == Op::ALLOCA_TOMBSTONE; });
+		              [&](const auto* item) { return item->op == Op::ASSIGN || item->op == Op::ALLOCA_TOMBSTONE; });
 	}
 }
 
 void SSACreationPhase::SSACreationPhaseContext::makeBlockArgumentsUnique() {
-	for (Block& block : trace->getBlocks()) {
+	for (Block* blockPtr : trace->getBlocks()) {
+		Block& block = *blockPtr;
 		std::unordered_map<ValueRef, ValueRef> blockArgumentMap;
 
 		// iterate over all arguments of this block and create new ValRefs if the
@@ -366,7 +376,7 @@ void SSACreationPhase::SSACreationPhaseContext::makeBlockArgumentsUnique() {
 
 		// set the new ValRefs to all depending on operations.
 		for (uint64_t i = 0; i < block.operations.size(); i++) {
-			auto& operation = block.operations[i];
+			auto& operation = *block.operations[i];
 			for (auto& input : operation.input) {
 				if (auto* valueRef = std::get_if<TypedValueRef>(&input)) {
 					auto foundAssignment = blockArgumentMap.find(valueRef->ref);
@@ -392,7 +402,7 @@ void SSACreationPhase::SSACreationPhaseContext::makeBlockArgumentsUnique() {
 		}
 
 		std::erase_if(block.operations,
-		              [&](const auto& item) { return item.op == Op::ASSIGN || item.op == Op::ALLOCA_TOMBSTONE; });
+		              [&](const auto* item) { return item->op == Op::ASSIGN || item->op == Op::ALLOCA_TOMBSTONE; });
 	}
 }
 

--- a/nautilus/src/nautilus/tracing/phases/SSAVerifier.cpp
+++ b/nautilus/src/nautilus/tracing/phases/SSAVerifier.cpp
@@ -14,10 +14,11 @@ SSAVerificationResult VerifySSA(const ExecutionTrace& trace) {
 	// Build a map from blockId to index for quick lookup
 	std::unordered_map<uint16_t, size_t> blockIdToIndex;
 	for (size_t i = 0; i < trace.blocks.size(); i++) {
-		blockIdToIndex[trace.blocks[i].blockId] = i;
+		blockIdToIndex[trace.blocks[i]->blockId] = i;
 	}
 
-	for (const auto& block : trace.blocks) {
+	for (const auto* blockPtr : trace.blocks) {
+		const auto& block = *blockPtr;
 		// Collect the set of value refs defined in this block:
 		// block arguments + operation results (in order)
 		std::unordered_set<uint16_t> definedRefs;
@@ -30,7 +31,7 @@ SSAVerificationResult VerifySSA(const ExecutionTrace& trace) {
 		}
 
 		for (size_t opIdx = 0; opIdx < block.operations.size(); opIdx++) {
-			const auto& operation = block.operations[opIdx];
+			const auto& operation = *block.operations[opIdx];
 
 			// Check 1: No ASSIGN operations should remain
 			if (operation.op == Op::ASSIGN) {
@@ -61,7 +62,7 @@ SSAVerificationResult VerifySSA(const ExecutionTrace& trace) {
 					                                    opIdx, blockRef.block));
 					return;
 				}
-				const auto& targetBlock = trace.blocks[it->second];
+				const auto& targetBlock = *trace.blocks[it->second];
 				if (blockRef.arguments.size() != targetBlock.arguments.size()) {
 					result.valid = false;
 					result.errors.push_back(
@@ -103,7 +104,7 @@ SSAVerificationResult VerifySSA(const ExecutionTrace& trace) {
 
 		// Check 4: Every non-empty block must end with a terminator
 		if (!block.operations.empty()) {
-			auto lastOp = block.operations.back().op;
+			auto lastOp = block.operations.back()->op;
 			if (lastOp != Op::JMP && lastOp != Op::CMP && lastOp != Op::RETURN) {
 				result.valid = false;
 				result.errors.push_back(

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -65,7 +65,7 @@ TraceToIRConversionPhase::IRConversionContext::IRConversionContext(ExecutionTrac
 }
 
 std::shared_ptr<IRGraph> TraceToIRConversionPhase::IRConversionContext::process() {
-	processBlock(trace->getBlocks().front());
+	processBlock(*trace->getBlocks().front());
 	auto functionOperation = std::make_unique<FunctionOperation>(
 	    "execute", std::move(currentBasicBlocks), std::vector<Type> {}, std::vector<std::string> {}, returnType);
 	ir->addFunctionOperation(std::move(functionOperation));
@@ -80,7 +80,7 @@ TraceToIRConversionPhase::IRConversionContext::processFunction(const std::string
 	returnType = Type::v;
 
 	// Process all blocks starting from the first block
-	processBlock(trace->getBlocks().front());
+	processBlock(*trace->getBlocks().front());
 
 	// Create and return the function operation
 	auto functionOperation = std::make_unique<FunctionOperation>(
@@ -103,8 +103,8 @@ BasicBlock* TraceToIRConversionPhase::IRConversionContext::processBlock(Block& b
 	auto irBasicBlockPtr = irBasicBlock.get();
 
 	blockMap[block.blockId] = irBasicBlockPtr;
-	for (auto& operation : block.operations) {
-		processOperation(blockFrame, block, irBasicBlockPtr, operation);
+	for (auto* operation : block.operations) {
+		processOperation(blockFrame, block, irBasicBlockPtr, *operation);
 	}
 	return irBasicBlockPtr;
 }

--- a/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
+++ b/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
@@ -1,4 +1,5 @@
 #include "nautilus/Engine.hpp"
+#include "nautilus/common/Arena.hpp"
 #include "nautilus/compiler/TieredCompiler.hpp"
 #include "nautilus/config.hpp"
 #include <catch2/catch_all.hpp>
@@ -41,7 +42,9 @@ TEST_CASE("Tiered Compilation Latency Benchmark") {
 				    TieredCompilationConfig config;
 				    config.tier0.backend = "bc";
 				    config.tier1.backend = "mlir";
-				    auto engine = NautilusEngine(std::make_unique<compiler::TieredJITCompiler>(Options(), config));
+				    common::Arena arena;
+				    auto engine =
+				        NautilusEngine(std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena));
 				    auto module = engine.createModule();
 				    registerFn(module);
 				    return module.compile();
@@ -121,7 +124,8 @@ TEST_CASE("Tiered End-to-End Benchmark") {
 			TieredCompilationConfig config;
 			config.tier0.backend = "bc";
 			config.tier1.backend = "mlir";
-			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config);
+			common::Arena arena;
+			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
 			auto* jit = tieredJit.get();
 			auto engine = NautilusEngine(std::move(tieredJit));
 			auto module = engine.createModule();

--- a/nautilus/test/benchmark/TracingBenchmark.cpp
+++ b/nautilus/test/benchmark/TracingBenchmark.cpp
@@ -24,7 +24,8 @@
 
 namespace nautilus::engine {
 
-using TraceFn = std::unique_ptr<tracing::ExecutionTrace> (*)(std::function<void()>&, const engine::Options&);
+using TraceFn = std::unique_ptr<tracing::ExecutionTrace> (*)(std::function<void()>&, const engine::Options&,
+                                                             common::Arena&);
 
 static auto tests = std::vector<std::tuple<std::string, std::function<void()>>> {
     {"add", details::createFunctionWrapper(int8AddExpression)},
@@ -54,9 +55,40 @@ TEST_CASE("Tracing Benchmark") {
 		for (auto& [ctxName, traceFn] : traceContexts) {
 			auto benchName = ctxName + "_" + name;
 			auto fn = traceFn;
+			// A fresh arena per iteration matches the previous behaviour where
+			// each trace managed its own arena.  Engine/JIT consumers that
+			// want to amortise allocation across many compiles can hoist the
+			// arena out of the measured block and softReset() between uses.
 			Catch::Benchmark::Benchmark(std::string(benchName))
 			    .operator=([&func, fn](Catch::Benchmark::Chronometer meter) {
-				    meter.measure([&func, fn] { return fn(func, engine::Options()); });
+				    meter.measure([&func, fn] {
+					    common::Arena arena;
+					    return fn(func, engine::Options(), arena);
+				    });
+			    });
+		}
+	}
+}
+
+TEST_CASE("Tracing Benchmark (reused arena)") {
+	// Reuses a single arena across all 100 iterations per sample by softResetting
+	// between calls.  This matches the intended Engine/JIT integration where a
+	// long-lived arena serves many compilations.
+	for (auto& [name, func] : tests) {
+		for (auto& [ctxName, traceFn] : traceContexts) {
+			auto benchName = ctxName + "_reused_" + name;
+			auto fn = traceFn;
+			Catch::Benchmark::Benchmark(std::string(benchName))
+			    .operator=([&func, fn](Catch::Benchmark::Chronometer meter) {
+				    common::Arena arena;
+				    meter.measure([&func, fn, &arena] {
+					    auto trace = fn(func, engine::Options(), arena);
+					    // Drop the trace here so its destructors run; then
+					    // softReset recycles the arena for the next sample.
+					    trace.reset();
+					    arena.softReset();
+					    return 0;
+				    });
 			    });
 		}
 	}
@@ -75,7 +107,9 @@ TEST_CASE("SSA Creation Benchmark") {
 		}
 
 		Catch::Benchmark::Benchmark("ssa_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
-			std::shared_ptr<tracing::ExecutionTrace> trace = tracing::ExceptionBasedTraceContext::trace(func);
+			common::Arena arena;
+			std::shared_ptr<tracing::ExecutionTrace> trace =
+			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), arena);
 			meter.measure([&] {
 				auto ssaCreationPhase = tracing::SSACreationPhase();
 				return ssaCreationPhase.apply(trace);
@@ -91,7 +125,9 @@ TEST_CASE("IR Creation Benchmark") {
 		auto name = std::get<0>(test);
 
 		Catch::Benchmark::Benchmark("ir_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
-			std::shared_ptr<tracing::ExecutionTrace> trace = tracing::ExceptionBasedTraceContext::trace(func);
+			common::Arena arena;
+			std::shared_ptr<tracing::ExecutionTrace> trace =
+			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), arena);
 			auto ssaCreationPhase = tracing::SSACreationPhase();
 			auto afterSSAModule = ssaCreationPhase.apply(std::move(trace));
 
@@ -127,7 +163,9 @@ TEST_CASE("Backend Compilation Benchmark") {
 
 			Catch::Benchmark::Benchmark("comp_" + backend + "_" + name)
 			    .operator=([&func, &registry, backend](Catch::Benchmark::Chronometer meter) {
-				    std::shared_ptr<tracing::ExecutionTrace> trace = tracing::ExceptionBasedTraceContext::trace(func);
+				    common::Arena arena;
+				    std::shared_ptr<tracing::ExecutionTrace> trace =
+				        tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), arena);
 				    auto ssaCreationPhase = tracing::SSACreationPhase();
 				    auto afterSSAModule = ssaCreationPhase.apply(std::move(trace));
 

--- a/nautilus/test/execution-tests/TieredCompilationTest.cpp
+++ b/nautilus/test/execution-tests/TieredCompilationTest.cpp
@@ -1,5 +1,6 @@
 #include "catch2/catch_test_macros.hpp"
 #include "nautilus/Engine.hpp"
+#include "nautilus/common/Arena.hpp"
 #include "nautilus/compiler/TieredCompiler.hpp"
 #include "nautilus/config.hpp"
 #include <catch2/catch_all.hpp>
@@ -42,7 +43,8 @@ TEST_CASE("Tiered Compilation - Tier 0 Executes Correctly") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config);
+	common::Arena arena;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -79,7 +81,8 @@ TEST_CASE("Tiered Compilation - Background Promotion Completes") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config);
+	common::Arena arena;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -111,7 +114,8 @@ TEST_CASE("Tiered Compilation - Results Correct After Promotion") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config);
+	common::Arena arena;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -159,7 +163,8 @@ TEST_CASE("Tiered Compilation - Custom Backend Per Tier") {
 			config.tier0.backend = t0;
 			config.tier1.backend = t1;
 
-			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config);
+			common::Arena arena;
+			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
 			auto* jit = tieredJit.get();
 			auto engine = NautilusEngine(std::move(tieredJit));
 			auto module = engine.createModule();
@@ -216,7 +221,8 @@ TEST_CASE("Tiered Compilation - Multiple Functions In Module") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config);
+	common::Arena arena;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();

--- a/nautilus/test/execution-tests/TracingTest.cpp
+++ b/nautilus/test/execution-tests/TracingTest.cpp
@@ -80,7 +80,7 @@ bool checkTestFile(std::string actual, const std::string category, const std::st
 }
 
 using TraceFn = std::unique_ptr<tracing::TraceModule> (*)(std::list<compiler::CompilableFunction>&,
-                                                          const engine::Options&);
+                                                          const engine::Options&, common::Arena&);
 
 static auto traceContexts = std::vector<std::tuple<std::string, TraceFn>> {
     {"ExceptionBasedTraceContext", tracing::ExceptionBasedTraceContext::Trace},
@@ -100,7 +100,8 @@ void runTraceTests(const std::string& category, std::vector<std::tuple<std::stri
 
 					// Trace all functions (initially just "execute", but may include nested functions)
 
-					auto executionTrace = traceFn(functionsToTrace, engine::Options());
+					common::Arena arena;
+					auto executionTrace = traceFn(functionsToTrace, engine::Options(), arena);
 					DYNAMIC_SECTION("tracing") {
 						REQUIRE(checkTestFile(executionTrace.get()->toString(), category, "tracing", name));
 					}


### PR DESCRIPTION
Introduce a bump-pointer Arena allocator owned by each ExecutionTrace
and use it to allocate Block and TraceOperation objects.  The blocks
vector and per-block operations vectors now store stable, arena-owned
pointers, so trace construction avoids per-object heap allocations and
addresses stay valid across container growth.  Tracing phases (SSA
creation, verifier, IR conversion) and the exception / lazy trace
contexts are updated to dereference through the pointer vectors.