### PR TITLE
Introduce shared CRTP OperationDispatcher for backend lowering

### DIFF
--- a/nautilus/include/nautilus/val_ptr.hpp
+++ b/nautilus/include/nautilus/val_ptr.hpp
@@ -90,13 +90,13 @@ public:
 #define BINARY_AND_ASSIGN_OPERATOR(OP)                                                                                 \
 	template <class T>                                                                                                 \
 	    requires std::is_convertible_v<T, baseType>                                                                    \
-	void operator OP## = (T other) noexcept {                                                                          \
+	void operator OP##=(T other) noexcept {                                                                            \
 		val<baseType> value {other};                                                                                   \
 		*this OP## = value;                                                                                            \
 	}                                                                                                                  \
 	template <class T>                                                                                                 \
 	    requires std::is_convertible_v<T, baseType>                                                                    \
-	void operator OP## = (val<T> other) noexcept {                                                                     \
+	void operator OP##=(val<T> other) noexcept {                                                                       \
 		val<baseType> value {other};                                                                                   \
 		*this = *this OP value;                                                                                        \
 	}                                                                                                                  \
@@ -246,7 +246,7 @@ protected:
 };
 
 template <typename T, typename F>
-std::size_t field_offset(F T::* pm) {
+std::size_t field_offset(F T::*pm) {
 	alignas(T) std::byte storage[sizeof(T)] {};
 	T* obj = std::launder(reinterpret_cast<T*>(storage));                       // ← reinterpret_cast: not constexpr
 	return reinterpret_cast<char*>(&(obj->*pm)) - reinterpret_cast<char*>(obj); // ← same
@@ -261,7 +261,7 @@ public:
 
 	template <typename F, typename T = ValType>
 	    requires std::is_class_v<T>
-	auto get(F T::* pm) {
+	auto get(F T::*pm) {
 		auto offset = field_offset(pm);
 		val<uint8_t*> bytePtr = static_cast<val<uint8_t*>>(*this);
 		val<uint8_t*> fieldBytePtr = bytePtr + offset;
@@ -275,14 +275,14 @@ public:
 
 	template <typename F, typename T = ValType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, val<F> value) {
+	void set(F T::*pm, val<F> value) {
 		val<F&> valueRef = get(pm);
 		valueRef = value;
 	}
 
 	template <typename F, typename T = ValType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, F value) {
+	void set(F T::*pm, F value) {
 		val<F&> valueRef = get(pm);
 		valueRef = value;
 	}

--- a/nautilus/include/nautilus/val_std.hpp
+++ b/nautilus/include/nautilus/val_std.hpp
@@ -252,7 +252,7 @@ public:
 	 */
 	template <typename F, typename T = ValueType>
 	    requires std::is_class_v<T>
-	auto get(F T::* pm) {
+	auto get(F T::*pm) {
 		return value_ptr.get(pm);
 	}
 
@@ -264,7 +264,7 @@ public:
 	 */
 	template <typename F, typename T = ValueType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, val<F> value) {
+	void set(F T::*pm, val<F> value) {
 		return value_ptr.set(pm, value);
 	}
 
@@ -279,7 +279,7 @@ public:
 	 */
 	template <typename F, typename T = ValueType>
 	    requires std::is_class_v<T>
-	void set(F T::* pm, F value) {
+	void set(F T::*pm, F value) {
 		return value_ptr.set(pm, value);
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -220,7 +220,7 @@ void AsmJitLoweringProvider::LoweringContext::processBlock(const ir::BasicBlock*
 	cc.bind(getOrCreateLabel(id));
 
 	for (auto& op : block->getOperations()) {
-		processOperation(op, frame);
+		dispatch(op, frame);
 	}
 }
 
@@ -256,118 +256,21 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 	}
 }
 
-// ── Main dispatch ─────────────────────────────────────────────────────────────
-
-void AsmJitLoweringProvider::LoweringContext::processOperation(const std::unique_ptr<ir::Operation>& op,
-                                                               RegisterFrame& frame) {
-	using OT = ir::Operation::OperationType;
-	switch (op->getOperationType()) {
-	case OT::ConstBooleanOp:
-		processConstBool(as<ir::ConstBooleanOperation>(op), frame);
-		return;
-	case OT::ConstIntOp:
-		processConstInt(as<ir::ConstIntOperation>(op), frame);
-		return;
-	case OT::ConstFloatOp:
-		processConstFloat(as<ir::ConstFloatOperation>(op), frame);
-		return;
-	case OT::ConstPtrOp:
-		processConstPtr(as<ir::ConstPtrOperation>(op), frame);
-		return;
-	case OT::AddOp:
-		processAdd(as<ir::AddOperation>(op), frame);
-		return;
-	case OT::SubOp:
-		processSub(as<ir::SubOperation>(op), frame);
-		return;
-	case OT::MulOp:
-		processMul(as<ir::MulOperation>(op), frame);
-		return;
-	case OT::DivOp:
-		processDiv(as<ir::DivOperation>(op), frame);
-		return;
-	case OT::ModOp:
-		processMod(as<ir::ModOperation>(op), frame);
-		return;
-	case OT::CompareOp:
-		processCompare(as<ir::CompareOperation>(op), frame);
-		return;
-	case OT::AndOp:
-		processAnd(as<ir::AndOperation>(op), frame);
-		return;
-	case OT::OrOp:
-		processOr(as<ir::OrOperation>(op), frame);
-		return;
-	case OT::NotOp:
-		processNot(as<ir::NotOperation>(op), frame);
-		return;
-	case OT::NegateOp:
-		processNegate(as<ir::NegateOperation>(op), frame);
-		return;
-	case OT::ShiftOp:
-		processShift(as<ir::ShiftOperation>(op), frame);
-		return;
-	case OT::BinaryComp:
-		processBinaryComp(as<ir::BinaryCompOperation>(op), frame);
-		return;
-	case OT::IfOp:
-		processIf(as<ir::IfOperation>(op), frame);
-		return;
-	case OT::BranchOp:
-		processBranch(as<ir::BranchOperation>(op), frame);
-		return;
-	case OT::ReturnOp:
-		processReturn(as<ir::ReturnOperation>(op), frame);
-		return;
-	case OT::SelectOp:
-		processSelect(as<ir::SelectOperation>(op), frame);
-		return;
-	case OT::LoadOp:
-		processLoad(as<ir::LoadOperation>(op), frame);
-		return;
-	case OT::StoreOp:
-		processStore(as<ir::StoreOperation>(op), frame);
-		return;
-	case OT::AllocaOp:
-		processAlloca(as<ir::AllocaOperation>(op), frame);
-		return;
-	case OT::ProxyCallOp:
-		processProxyCall(as<ir::ProxyCallOperation>(op), frame);
-		return;
-	case OT::IndirectCallOp:
-		processIndirectCall(as<ir::IndirectCallOperation>(op), frame);
-		return;
-	case OT::FunctionAddressOfOp:
-		processFunctionAddressOf(as<ir::FunctionAddressOfOperation>(op), frame);
-		return;
-	case OT::CastOp:
-		processCast(as<ir::CastOperation>(op), frame);
-		return;
-	case OT::BasicBlockArgument:
-	case OT::BlockInvocation:
-	case OT::FunctionOp:
-	case OT::MLIR_YIELD:
-		return;
-	default:
-		throw NotImplementedException("AsmJit/A64: operation not implemented");
-	}
-}
-
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processConstBool(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::b);
 	cc.mov(toGp(reg), static_cast<int64_t>(op->getValue() ? 1 : 0));
 	frame.setValue(op->getIdentifier(), reg);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(op->getStamp());
 	cc.mov(toGp(reg), op->getValue());
 	frame.setValue(op->getIdentifier(), reg);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(op->getStamp());
 	auto vecReg = toVec(reg);
 	if (op->getStamp() == Type::f32) {
@@ -388,7 +291,7 @@ void AsmJitLoweringProvider::LoweringContext::processConstFloat(ir::ConstFloatOp
 	frame.setValue(op->getIdentifier(), reg);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::ptr);
 	cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getValue()));
 	frame.setValue(op->getIdentifier(), reg);
@@ -396,7 +299,7 @@ void AsmJitLoweringProvider::LoweringContext::processConstPtr(ir::ConstPtrOperat
 
 // ── Arithmetic ────────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processAdd(ir::AddOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -408,7 +311,7 @@ void AsmJitLoweringProvider::LoweringContext::processAdd(ir::AddOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processSub(ir::SubOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -420,7 +323,7 @@ void AsmJitLoweringProvider::LoweringContext::processSub(ir::SubOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processMul(ir::MulOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -432,7 +335,7 @@ void AsmJitLoweringProvider::LoweringContext::processMul(ir::MulOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processDiv(ir::DivOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -446,7 +349,7 @@ void AsmJitLoweringProvider::LoweringContext::processDiv(ir::DivOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processMod(ir::ModOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -464,7 +367,7 @@ void AsmJitLoweringProvider::LoweringContext::processMod(ir::ModOperation* op, R
 
 // ── Logical / compare ─────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processCompare(ir::CompareOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(Type::b);
@@ -558,7 +461,7 @@ void AsmJitLoweringProvider::LoweringContext::processCompare(ir::CompareOperatio
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processAnd(ir::AndOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -566,7 +469,7 @@ void AsmJitLoweringProvider::LoweringContext::processAnd(ir::AndOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processOr(ir::OrOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -574,14 +477,14 @@ void AsmJitLoweringProvider::LoweringContext::processOr(ir::OrOperation* op, Reg
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processNot(ir::NotOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, RegisterFrame& frame) {
 	auto input = toGp(frame.getValue(op->getInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 	cc.eor(toGp(result), input, Imm(1));
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processNegate(ir::NegateOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	cc.mvn(toGp(result), toGp(src));
@@ -590,7 +493,7 @@ void AsmJitLoweringProvider::LoweringContext::processNegate(ir::NegateOperation*
 
 // ── Binary bit operations ─────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processShift(ir::ShiftOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -604,7 +507,7 @@ void AsmJitLoweringProvider::LoweringContext::processShift(ir::ShiftOperation* o
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -624,7 +527,7 @@ void AsmJitLoweringProvider::LoweringContext::processBinaryComp(ir::BinaryCompOp
 
 // ── Control flow ──────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processIf(ir::IfOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitIf(ir::IfOperation* op, RegisterFrame& frame) {
 	auto condGp = toGp(frame.getValue(op->getValue()->getIdentifier()));
 	auto trueLabel = getOrCreateLabel(op->getTrueBlockInvocation().getBlock()->getIdentifier());
 	auto falseLabel = getOrCreateLabel(op->getFalseBlockInvocation().getBlock()->getIdentifier());
@@ -646,14 +549,14 @@ void AsmJitLoweringProvider::LoweringContext::processIf(ir::IfOperation* op, Reg
 	processBlock(op->getFalseBlockInvocation().getBlock(), frame);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processBranch(ir::BranchOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* op, RegisterFrame& frame) {
 	const auto& bi = op->getNextBlockInvocation();
 	processBlockInvocation(bi, frame);
 	cc.b(getOrCreateLabel(bi.getBlock()->getIdentifier()));
 	processBlock(bi.getBlock(), frame);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processReturn(ir::ReturnOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* op, RegisterFrame& frame) {
 	if (op->hasReturnValue()) {
 		auto retReg = frame.getValue(op->getReturnValue()->getIdentifier());
 		if (std::holds_alternative<Vec>(retReg)) {
@@ -687,7 +590,7 @@ void AsmJitLoweringProvider::LoweringContext::processReturn(ir::ReturnOperation*
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processSelect(ir::SelectOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* op, RegisterFrame& frame) {
 	auto condGp = toGp(frame.getValue(op->getCondition()->getIdentifier()));
 	auto trueVal = frame.getValue(op->getTrueValue()->getIdentifier());
 	auto falseVal = frame.getValue(op->getFalseValue()->getIdentifier());
@@ -709,7 +612,7 @@ void AsmJitLoweringProvider::LoweringContext::processSelect(ir::SelectOperation*
 
 // ── Memory ────────────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processLoad(ir::LoadOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* op, RegisterFrame& frame) {
 	auto addrGp = toGp(frame.getValue(op->getAddress()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 
@@ -752,7 +655,7 @@ void AsmJitLoweringProvider::LoweringContext::processLoad(ir::LoadOperation* op,
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processStore(ir::StoreOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* op, RegisterFrame& frame) {
 	auto addrGp = toGp(frame.getValue(op->getAddress()->getIdentifier()));
 	auto valReg = frame.getValue(op->getValue()->getIdentifier());
 
@@ -782,7 +685,7 @@ void AsmJitLoweringProvider::LoweringContext::processStore(ir::StoreOperation* o
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processAlloca(ir::AllocaOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* op, RegisterFrame& frame) {
 	auto stackMem = cc.newStack(static_cast<uint32_t>(op->getSize()), 8 /*align*/);
 	auto ptrReg = cc.newIntPtr();
 	cc.loadAddressOf(ptrReg, stackMem);
@@ -791,7 +694,7 @@ void AsmJitLoweringProvider::LoweringContext::processAlloca(ir::AllocaOperation*
 
 // ── External function calls ───────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame) {
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));
 	for (auto* arg : op->getInputArguments()) {
@@ -832,7 +735,7 @@ void AsmJitLoweringProvider::LoweringContext::processProxyCall(ir::ProxyCallOper
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame) {
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));
 	for (auto* arg : op->getInputArguments()) {
@@ -863,8 +766,8 @@ void AsmJitLoweringProvider::LoweringContext::processIndirectCall(ir::IndirectCa
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processFunctionAddressOf(ir::FunctionAddressOfOperation* op,
-                                                                       RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::FunctionAddressOfOperation* op,
+                                                                     RegisterFrame& frame) {
 	auto reg = allocReg(Type::ptr);
 	auto it = funcNodes_.find(op->getFunctionName());
 	if (it != funcNodes_.end()) {
@@ -877,7 +780,7 @@ void AsmJitLoweringProvider::LoweringContext::processFunctionAddressOf(ir::Funct
 
 // ── Type conversion ───────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processCast(ir::CastOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, RegisterFrame& frame) {
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	const Type srcType = op->getInput()->getStamp();
 	const Type dstType = op->getStamp();

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
@@ -3,36 +3,9 @@
 
 #include "nautilus/compiler/Frame.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
+#include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp"
-#include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
-#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
-#include "nautilus/compiler/ir/operations/CastOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstPtrOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/operations/IfOperation.hpp"
-#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/LoadOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
-#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
-#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
-#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include <asmjit/a64.h>
 #include <unordered_map>
 #include <unordered_set>
@@ -65,7 +38,7 @@ private:
 	using AsmReg = std::variant<::asmjit::a64::Gp, ::asmjit::a64::Vec>;
 	using RegisterFrame = Frame<ir::OperationIdentifier, AsmReg>;
 
-	class LoweringContext {
+	class LoweringContext : public ir::OperationDispatcher<LoweringContext> {
 	public:
 		LoweringContext(std::shared_ptr<ir::IRGraph> ir, ::asmjit::CodeHolder& code);
 
@@ -78,6 +51,9 @@ private:
 		}
 
 	private:
+		// Allow the CRTP dispatcher to call our private visitXxx hooks.
+		friend class ir::OperationDispatcher<LoweringContext>;
+
 		::asmjit::a64::Compiler cc;
 		std::shared_ptr<ir::IRGraph> ir;
 		/// Maps Nautilus function name → AsmJit FuncNode (stable label for forward calls).
@@ -99,39 +75,39 @@ private:
 
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);
 		void processBlockInvocation(const ir::BasicBlockInvocation& bi, RegisterFrame& frame);
-		void processOperation(const std::unique_ptr<ir::Operation>& op, RegisterFrame& frame);
 
-		void processConstBool(ir::ConstBooleanOperation* op, RegisterFrame& frame);
-		void processConstInt(ir::ConstIntOperation* op, RegisterFrame& frame);
-		void processConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame);
-		void processConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame);
+		// Per-operation hooks invoked by OperationDispatcher::dispatch.
+		void visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame);
+		void visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame);
+		void visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame);
+		void visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame);
 
-		void processAdd(ir::AddOperation* op, RegisterFrame& frame);
-		void processSub(ir::SubOperation* op, RegisterFrame& frame);
-		void processMul(ir::MulOperation* op, RegisterFrame& frame);
-		void processDiv(ir::DivOperation* op, RegisterFrame& frame);
-		void processMod(ir::ModOperation* op, RegisterFrame& frame);
+		void visitAdd(ir::AddOperation* op, RegisterFrame& frame);
+		void visitSub(ir::SubOperation* op, RegisterFrame& frame);
+		void visitMul(ir::MulOperation* op, RegisterFrame& frame);
+		void visitDiv(ir::DivOperation* op, RegisterFrame& frame);
+		void visitMod(ir::ModOperation* op, RegisterFrame& frame);
 
-		void processCompare(ir::CompareOperation* op, RegisterFrame& frame);
-		void processAnd(ir::AndOperation* op, RegisterFrame& frame);
-		void processOr(ir::OrOperation* op, RegisterFrame& frame);
-		void processNot(ir::NotOperation* op, RegisterFrame& frame);
-		void processNegate(ir::NegateOperation* op, RegisterFrame& frame);
-		void processShift(ir::ShiftOperation* op, RegisterFrame& frame);
-		void processBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame);
+		void visitCompare(ir::CompareOperation* op, RegisterFrame& frame);
+		void visitAnd(ir::AndOperation* op, RegisterFrame& frame);
+		void visitOr(ir::OrOperation* op, RegisterFrame& frame);
+		void visitNot(ir::NotOperation* op, RegisterFrame& frame);
+		void visitNegate(ir::NegateOperation* op, RegisterFrame& frame);
+		void visitShift(ir::ShiftOperation* op, RegisterFrame& frame);
+		void visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame);
 
-		void processIf(ir::IfOperation* op, RegisterFrame& frame);
-		void processBranch(ir::BranchOperation* op, RegisterFrame& frame);
-		void processReturn(ir::ReturnOperation* op, RegisterFrame& frame);
-		void processSelect(ir::SelectOperation* op, RegisterFrame& frame);
+		void visitIf(ir::IfOperation* op, RegisterFrame& frame);
+		void visitBranch(ir::BranchOperation* op, RegisterFrame& frame);
+		void visitReturn(ir::ReturnOperation* op, RegisterFrame& frame);
+		void visitSelect(ir::SelectOperation* op, RegisterFrame& frame);
 
-		void processLoad(ir::LoadOperation* op, RegisterFrame& frame);
-		void processStore(ir::StoreOperation* op, RegisterFrame& frame);
-		void processAlloca(ir::AllocaOperation* op, RegisterFrame& frame);
-		void processProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame);
-		void processIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame);
-		void processFunctionAddressOf(ir::FunctionAddressOfOperation* op, RegisterFrame& frame);
-		void processCast(ir::CastOperation* op, RegisterFrame& frame);
+		void visitLoad(ir::LoadOperation* op, RegisterFrame& frame);
+		void visitStore(ir::StoreOperation* op, RegisterFrame& frame);
+		void visitAlloca(ir::AllocaOperation* op, RegisterFrame& frame);
+		void visitProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame);
+		void visitIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame);
+		void visitFunctionAddressOf(ir::FunctionAddressOfOperation* op, RegisterFrame& frame);
+		void visitCast(ir::CastOperation* op, RegisterFrame& frame);
 	};
 };
 

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -235,7 +235,7 @@ void AsmJitLoweringProvider::LoweringContext::processBlock(const ir::BasicBlock*
 	cc.bind(getOrCreateLabel(id));
 
 	for (auto& op : block->getOperations()) {
-		processOperation(op, frame);
+		dispatch(op, frame);
 	}
 }
 
@@ -279,119 +279,21 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 	}
 }
 
-// ── Main dispatch ─────────────────────────────────────────────────────────────
-
-void AsmJitLoweringProvider::LoweringContext::processOperation(const std::unique_ptr<ir::Operation>& op,
-                                                               RegisterFrame& frame) {
-	using OT = ir::Operation::OperationType;
-	switch (op->getOperationType()) {
-	case OT::ConstBooleanOp:
-		processConstBool(as<ir::ConstBooleanOperation>(op), frame);
-		return;
-	case OT::ConstIntOp:
-		processConstInt(as<ir::ConstIntOperation>(op), frame);
-		return;
-	case OT::ConstFloatOp:
-		processConstFloat(as<ir::ConstFloatOperation>(op), frame);
-		return;
-	case OT::ConstPtrOp:
-		processConstPtr(as<ir::ConstPtrOperation>(op), frame);
-		return;
-	case OT::AddOp:
-		processAdd(as<ir::AddOperation>(op), frame);
-		return;
-	case OT::SubOp:
-		processSub(as<ir::SubOperation>(op), frame);
-		return;
-	case OT::MulOp:
-		processMul(as<ir::MulOperation>(op), frame);
-		return;
-	case OT::DivOp:
-		processDiv(as<ir::DivOperation>(op), frame);
-		return;
-	case OT::ModOp:
-		processMod(as<ir::ModOperation>(op), frame);
-		return;
-	case OT::CompareOp:
-		processCompare(as<ir::CompareOperation>(op), frame);
-		return;
-	case OT::AndOp:
-		processAnd(as<ir::AndOperation>(op), frame);
-		return;
-	case OT::OrOp:
-		processOr(as<ir::OrOperation>(op), frame);
-		return;
-	case OT::NotOp:
-		processNot(as<ir::NotOperation>(op), frame);
-		return;
-	case OT::NegateOp:
-		processNegate(as<ir::NegateOperation>(op), frame);
-		return;
-	case OT::ShiftOp:
-		processShift(as<ir::ShiftOperation>(op), frame);
-		return;
-	case OT::BinaryComp:
-		processBinaryComp(as<ir::BinaryCompOperation>(op), frame);
-		return;
-	case OT::IfOp:
-		processIf(as<ir::IfOperation>(op), frame);
-		return;
-	case OT::BranchOp:
-		processBranch(as<ir::BranchOperation>(op), frame);
-		return;
-	case OT::ReturnOp:
-		processReturn(as<ir::ReturnOperation>(op), frame);
-		return;
-	case OT::SelectOp:
-		processSelect(as<ir::SelectOperation>(op), frame);
-		return;
-	case OT::LoadOp:
-		processLoad(as<ir::LoadOperation>(op), frame);
-		return;
-	case OT::StoreOp:
-		processStore(as<ir::StoreOperation>(op), frame);
-		return;
-	case OT::AllocaOp:
-		processAlloca(as<ir::AllocaOperation>(op), frame);
-		return;
-	case OT::ProxyCallOp:
-		processProxyCall(as<ir::ProxyCallOperation>(op), frame);
-		return;
-	case OT::IndirectCallOp:
-		processIndirectCall(as<ir::IndirectCallOperation>(op), frame);
-		return;
-	case OT::FunctionAddressOfOp:
-		processFunctionAddressOf(as<ir::FunctionAddressOfOperation>(op), frame);
-		return;
-	case OT::CastOp:
-		processCast(as<ir::CastOperation>(op), frame);
-		return;
-	// Structural ops handled at a higher level – nothing to emit.
-	case OT::BasicBlockArgument:
-	case OT::BlockInvocation:
-	case OT::FunctionOp:
-	case OT::MLIR_YIELD:
-		return;
-	default:
-		throw NotImplementedException("AsmJit: operation not implemented");
-	}
-}
-
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processConstBool(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::b);
 	cc.mov(toGp(reg), static_cast<int64_t>(op->getValue() ? 1 : 0));
 	frame.setValue(op->getIdentifier(), reg);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(op->getStamp());
 	cc.mov(toGp(reg), op->getValue());
 	frame.setValue(op->getIdentifier(), reg);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(op->getStamp());
 	auto xmmReg = toXmm(reg);
 	if (op->getStamp() == Type::f32) {
@@ -412,7 +314,7 @@ void AsmJitLoweringProvider::LoweringContext::processConstFloat(ir::ConstFloatOp
 	frame.setValue(op->getIdentifier(), reg);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::ptr);
 	cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getValue()));
 	frame.setValue(op->getIdentifier(), reg);
@@ -420,7 +322,7 @@ void AsmJitLoweringProvider::LoweringContext::processConstPtr(ir::ConstPtrOperat
 
 // ── Arithmetic ────────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processAdd(ir::AddOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -439,7 +341,7 @@ void AsmJitLoweringProvider::LoweringContext::processAdd(ir::AddOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processSub(ir::SubOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -458,7 +360,7 @@ void AsmJitLoweringProvider::LoweringContext::processSub(ir::SubOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processMul(ir::MulOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -477,7 +379,7 @@ void AsmJitLoweringProvider::LoweringContext::processMul(ir::MulOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processDiv(ir::DivOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -506,7 +408,7 @@ void AsmJitLoweringProvider::LoweringContext::processDiv(ir::DivOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processMod(ir::ModOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -526,7 +428,7 @@ void AsmJitLoweringProvider::LoweringContext::processMod(ir::ModOperation* op, R
 
 // ── Logical / compare ─────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processCompare(ir::CompareOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation* op, RegisterFrame& frame) {
 	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
 	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(Type::b);
@@ -619,7 +521,7 @@ void AsmJitLoweringProvider::LoweringContext::processCompare(ir::CompareOperatio
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processAnd(ir::AndOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -628,7 +530,7 @@ void AsmJitLoweringProvider::LoweringContext::processAnd(ir::AndOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processOr(ir::OrOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -637,7 +539,7 @@ void AsmJitLoweringProvider::LoweringContext::processOr(ir::OrOperation* op, Reg
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processNot(ir::NotOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, RegisterFrame& frame) {
 	// NotOperation is logical NOT on a boolean: result = input XOR 1.
 	auto input = toGp(frame.getValue(op->getInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -646,7 +548,7 @@ void AsmJitLoweringProvider::LoweringContext::processNot(ir::NotOperation* op, R
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processNegate(ir::NegateOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
 	// NegateOperation is bitwise NOT (~x): result = input XOR all-ones.
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
@@ -657,7 +559,7 @@ void AsmJitLoweringProvider::LoweringContext::processNegate(ir::NegateOperation*
 
 // ── Binary bit operations ─────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processShift(ir::ShiftOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -674,7 +576,7 @@ void AsmJitLoweringProvider::LoweringContext::processShift(ir::ShiftOperation* o
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
@@ -695,7 +597,7 @@ void AsmJitLoweringProvider::LoweringContext::processBinaryComp(ir::BinaryCompOp
 
 // ── Control flow ──────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processIf(ir::IfOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitIf(ir::IfOperation* op, RegisterFrame& frame) {
 	auto condGp = toGp(frame.getValue(op->getValue()->getIdentifier()));
 	auto trueLabel = getOrCreateLabel(op->getTrueBlockInvocation().getBlock()->getIdentifier());
 	auto falseLabel = getOrCreateLabel(op->getFalseBlockInvocation().getBlock()->getIdentifier());
@@ -718,14 +620,14 @@ void AsmJitLoweringProvider::LoweringContext::processIf(ir::IfOperation* op, Reg
 	processBlock(op->getFalseBlockInvocation().getBlock(), frame);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processBranch(ir::BranchOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* op, RegisterFrame& frame) {
 	const auto& bi = op->getNextBlockInvocation();
 	processBlockInvocation(bi, frame);
 	cc.jmp(getOrCreateLabel(bi.getBlock()->getIdentifier()));
 	processBlock(bi.getBlock(), frame);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processReturn(ir::ReturnOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* op, RegisterFrame& frame) {
 	if (op->hasReturnValue()) {
 		auto retReg = frame.getValue(op->getReturnValue()->getIdentifier());
 		if (std::holds_alternative<Xmm>(retReg))
@@ -737,7 +639,7 @@ void AsmJitLoweringProvider::LoweringContext::processReturn(ir::ReturnOperation*
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processSelect(ir::SelectOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* op, RegisterFrame& frame) {
 	auto condGp = toGp(frame.getValue(op->getCondition()->getIdentifier()));
 	auto trueVal = frame.getValue(op->getTrueValue()->getIdentifier());
 	auto falseVal = frame.getValue(op->getFalseValue()->getIdentifier());
@@ -759,7 +661,7 @@ void AsmJitLoweringProvider::LoweringContext::processSelect(ir::SelectOperation*
 
 // ── Memory ────────────────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processLoad(ir::LoadOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* op, RegisterFrame& frame) {
 	auto addrGp = toGp(frame.getValue(op->getAddress()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 
@@ -802,7 +704,7 @@ void AsmJitLoweringProvider::LoweringContext::processLoad(ir::LoadOperation* op,
 	frame.setValue(op->getIdentifier(), result);
 }
 
-void AsmJitLoweringProvider::LoweringContext::processStore(ir::StoreOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* op, RegisterFrame& frame) {
 	auto addrGp = toGp(frame.getValue(op->getAddress()->getIdentifier()));
 	auto valReg = frame.getValue(op->getValue()->getIdentifier());
 
@@ -836,7 +738,7 @@ void AsmJitLoweringProvider::LoweringContext::processStore(ir::StoreOperation* o
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processAlloca(ir::AllocaOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* op, RegisterFrame& frame) {
 	// Allocate aligned stack space and capture its address in a GP register.
 	auto stackMem = cc.newStack(static_cast<uint32_t>(op->getSize()), 8 /*align*/);
 	auto ptrReg = cc.newIntPtr();
@@ -846,7 +748,7 @@ void AsmJitLoweringProvider::LoweringContext::processAlloca(ir::AllocaOperation*
 
 // ── External function calls ───────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame) {
 	// Build the callee's signature dynamically from the IR's type information.
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));
@@ -882,7 +784,7 @@ void AsmJitLoweringProvider::LoweringContext::processProxyCall(ir::ProxyCallOper
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame) {
 	// Build callee signature from IR type information.
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));
@@ -915,8 +817,8 @@ void AsmJitLoweringProvider::LoweringContext::processIndirectCall(ir::IndirectCa
 	}
 }
 
-void AsmJitLoweringProvider::LoweringContext::processFunctionAddressOf(ir::FunctionAddressOfOperation* op,
-                                                                       RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::FunctionAddressOfOperation* op,
+                                                                     RegisterFrame& frame) {
 	auto reg = allocReg(Type::ptr);
 	auto it = funcNodes_.find(op->getFunctionName());
 	if (it != funcNodes_.end()) {
@@ -931,7 +833,7 @@ void AsmJitLoweringProvider::LoweringContext::processFunctionAddressOf(ir::Funct
 
 // ── Type conversion ───────────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processCast(ir::CastOperation* op, RegisterFrame& frame) {
+void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, RegisterFrame& frame) {
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	const Type srcType = op->getInput()->getStamp();
 	const Type dstType = op->getStamp();

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -3,36 +3,9 @@
 
 #include "nautilus/compiler/Frame.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
+#include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp"
-#include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
-#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
-#include "nautilus/compiler/ir/operations/CastOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstPtrOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/operations/IfOperation.hpp"
-#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/LoadOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
-#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
-#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
-#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include <asmjit/x86.h>
 #include <unordered_map>
 #include <unordered_set>
@@ -65,7 +38,7 @@ private:
 	using AsmReg = std::variant<::asmjit::x86::Gp, ::asmjit::x86::Xmm>;
 	using RegisterFrame = Frame<ir::OperationIdentifier, AsmReg>;
 
-	class LoweringContext {
+	class LoweringContext : public ir::OperationDispatcher<LoweringContext> {
 	public:
 		LoweringContext(std::shared_ptr<ir::IRGraph> ir, ::asmjit::CodeHolder& code);
 
@@ -78,6 +51,9 @@ private:
 		}
 
 	private:
+		// Allow the CRTP dispatcher to call our private visitXxx hooks.
+		friend class ir::OperationDispatcher<LoweringContext>;
+
 		::asmjit::x86::Compiler cc;
 		std::shared_ptr<ir::IRGraph> ir;
 		/// Maps Nautilus function name → AsmJit FuncNode (stable label for forward calls).
@@ -99,39 +75,39 @@ private:
 
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);
 		void processBlockInvocation(const ir::BasicBlockInvocation& bi, RegisterFrame& frame);
-		void processOperation(const std::unique_ptr<ir::Operation>& op, RegisterFrame& frame);
 
-		void processConstBool(ir::ConstBooleanOperation* op, RegisterFrame& frame);
-		void processConstInt(ir::ConstIntOperation* op, RegisterFrame& frame);
-		void processConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame);
-		void processConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame);
+		// Per-operation hooks invoked by OperationDispatcher::dispatch.
+		void visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame);
+		void visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame);
+		void visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame);
+		void visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame);
 
-		void processAdd(ir::AddOperation* op, RegisterFrame& frame);
-		void processSub(ir::SubOperation* op, RegisterFrame& frame);
-		void processMul(ir::MulOperation* op, RegisterFrame& frame);
-		void processDiv(ir::DivOperation* op, RegisterFrame& frame);
-		void processMod(ir::ModOperation* op, RegisterFrame& frame);
+		void visitAdd(ir::AddOperation* op, RegisterFrame& frame);
+		void visitSub(ir::SubOperation* op, RegisterFrame& frame);
+		void visitMul(ir::MulOperation* op, RegisterFrame& frame);
+		void visitDiv(ir::DivOperation* op, RegisterFrame& frame);
+		void visitMod(ir::ModOperation* op, RegisterFrame& frame);
 
-		void processCompare(ir::CompareOperation* op, RegisterFrame& frame);
-		void processAnd(ir::AndOperation* op, RegisterFrame& frame);
-		void processOr(ir::OrOperation* op, RegisterFrame& frame);
-		void processNot(ir::NotOperation* op, RegisterFrame& frame);
-		void processNegate(ir::NegateOperation* op, RegisterFrame& frame);
-		void processShift(ir::ShiftOperation* op, RegisterFrame& frame);
-		void processBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame);
+		void visitCompare(ir::CompareOperation* op, RegisterFrame& frame);
+		void visitAnd(ir::AndOperation* op, RegisterFrame& frame);
+		void visitOr(ir::OrOperation* op, RegisterFrame& frame);
+		void visitNot(ir::NotOperation* op, RegisterFrame& frame);
+		void visitNegate(ir::NegateOperation* op, RegisterFrame& frame);
+		void visitShift(ir::ShiftOperation* op, RegisterFrame& frame);
+		void visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame);
 
-		void processIf(ir::IfOperation* op, RegisterFrame& frame);
-		void processBranch(ir::BranchOperation* op, RegisterFrame& frame);
-		void processReturn(ir::ReturnOperation* op, RegisterFrame& frame);
-		void processSelect(ir::SelectOperation* op, RegisterFrame& frame);
+		void visitIf(ir::IfOperation* op, RegisterFrame& frame);
+		void visitBranch(ir::BranchOperation* op, RegisterFrame& frame);
+		void visitReturn(ir::ReturnOperation* op, RegisterFrame& frame);
+		void visitSelect(ir::SelectOperation* op, RegisterFrame& frame);
 
-		void processLoad(ir::LoadOperation* op, RegisterFrame& frame);
-		void processStore(ir::StoreOperation* op, RegisterFrame& frame);
-		void processAlloca(ir::AllocaOperation* op, RegisterFrame& frame);
-		void processProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame);
-		void processIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame);
-		void processFunctionAddressOf(ir::FunctionAddressOfOperation* op, RegisterFrame& frame);
-		void processCast(ir::CastOperation* op, RegisterFrame& frame);
+		void visitLoad(ir::LoadOperation* op, RegisterFrame& frame);
+		void visitStore(ir::StoreOperation* op, RegisterFrame& frame);
+		void visitAlloca(ir::AllocaOperation* op, RegisterFrame& frame);
+		void visitProxyCall(ir::ProxyCallOperation* op, RegisterFrame& frame);
+		void visitIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame);
+		void visitFunctionAddressOf(ir::FunctionAddressOfOperation* op, RegisterFrame& frame);
+		void visitCast(ir::CastOperation* op, RegisterFrame& frame);
 	};
 };
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -117,7 +117,7 @@ short BCLoweringProvider::LoweringContext::process(const ir::BasicBlock* block, 
 		// create bytecode block;
 		program.blocks.emplace_back();
 		for (auto& opt : block->getOperations()) {
-			this->process(opt, blockIndex, frame);
+			this->dispatch(opt, blockIndex, frame);
 		}
 		return blockIndex;
 	} else {
@@ -125,7 +125,7 @@ short BCLoweringProvider::LoweringContext::process(const ir::BasicBlock* block, 
 	}
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::AndOperation* addOpt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* addOpt, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(addOpt->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(addOpt->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(addOpt, frame);
@@ -135,7 +135,7 @@ void BCLoweringProvider::LoweringContext::process(ir::AndOperation* addOpt, shor
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::OrOperation* addOpt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitOr(ir::OrOperation* addOpt, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(addOpt->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(addOpt->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(addOpt, frame);
@@ -145,7 +145,7 @@ void BCLoweringProvider::LoweringContext::process(ir::OrOperation* addOpt, short
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::AddOperation* addOpt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* addOpt, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(addOpt->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(addOpt->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(addOpt, frame);
@@ -194,7 +194,7 @@ void BCLoweringProvider::LoweringContext::process(ir::AddOperation* addOpt, shor
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::SubOperation* subOpt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitSub(ir::SubOperation* subOpt, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(subOpt->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(subOpt->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(subOpt, frame);
@@ -242,7 +242,7 @@ void BCLoweringProvider::LoweringContext::process(ir::SubOperation* subOpt, shor
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::MulOperation* mulOpt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitMul(ir::MulOperation* mulOpt, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(mulOpt->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(mulOpt->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(mulOpt, frame);
@@ -291,7 +291,7 @@ void BCLoweringProvider::LoweringContext::process(ir::MulOperation* mulOpt, shor
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::DivOperation* divOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* divOp, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(divOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(divOp->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(divOp, frame);
@@ -339,7 +339,7 @@ void BCLoweringProvider::LoweringContext::process(ir::DivOperation* divOp, short
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::ModOperation* divOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitMod(ir::ModOperation* divOp, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(divOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(divOp->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(divOp, frame);
@@ -378,7 +378,7 @@ void BCLoweringProvider::LoweringContext::process(ir::ModOperation* divOp, short
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::CompareOperation* cmpOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation* cmpOp, short block, RegisterFrame& frame) {
 	auto leftInput = frame.getValue(cmpOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(cmpOp->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(cmpOp, frame);
@@ -685,7 +685,7 @@ void BCLoweringProvider::LoweringContext::process(ir::CompareOperation* cmpOp, s
 	}
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::LoadOperation* loadOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* loadOp, short block, RegisterFrame& frame) {
 	auto address = frame.getValue(loadOp->getAddress()->getIdentifier());
 	auto resultReg = getResultRegister(loadOp, frame);
 	frame.setValue(loadOp->getIdentifier(), resultReg);
@@ -737,7 +737,7 @@ void BCLoweringProvider::LoweringContext::process(ir::LoadOperation* loadOp, sho
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::StoreOperation* storeOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* storeOp, short block, RegisterFrame& frame) {
 	auto addressReg = frame.getValue(storeOp->getAddress()->getIdentifier());
 	auto valueReg = frame.getValue(storeOp->getValue()->getIdentifier());
 	auto type = storeOp->getValue()->getStamp();
@@ -787,8 +787,8 @@ void BCLoweringProvider::LoweringContext::process(ir::StoreOperation* storeOp, s
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::BinaryCompOperation* binaryCompOperation, short block,
-                                                  RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* binaryCompOperation, short block,
+                                                          RegisterFrame& frame) {
 	auto leftReg = frame.getValue(binaryCompOperation->getLeftInput()->getIdentifier());
 	auto rightReg = frame.getValue(binaryCompOperation->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(binaryCompOperation, frame);
@@ -910,8 +910,8 @@ void BCLoweringProvider::LoweringContext::process(ir::BinaryCompOperation* binar
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::ShiftOperation* shiftOperation, short block,
-                                                  RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* shiftOperation, short block,
+                                                     RegisterFrame& frame) {
 	auto leftReg = frame.getValue(shiftOperation->getLeftInput()->getIdentifier());
 	auto rightReg = frame.getValue(shiftOperation->getRightInput()->getIdentifier());
 	auto resultReg = getResultRegister(shiftOperation, frame);
@@ -1041,7 +1041,7 @@ void BCLoweringProvider::LoweringContext::process(const ir::BasicBlockInvocation
 	}
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::IfOperation* ifOpt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitIf(ir::IfOperation* ifOpt, short block, RegisterFrame& frame) {
 	auto conditionalReg = frame.getValue(ifOpt->getValue()->getIdentifier());
 	process(ifOpt->getTrueBlockInvocation(), block, frame);
 	process(ifOpt->getFalseBlockInvocation(), block, frame);
@@ -1050,209 +1050,88 @@ void BCLoweringProvider::LoweringContext::process(ir::IfOperation* ifOpt, short 
 	program.blocks[block].terminatorOp = ConditionalJumpOp {conditionalReg, trueBlockIndex, falseBlockIndex};
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::BranchOperation* branchOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* branchOp, short block,
+                                                      RegisterFrame& frame) {
 	process(branchOp->getNextBlockInvocation(), block, frame);
 	auto blockIndex = process(branchOp->getNextBlockInvocation().getBlock(), frame);
 	program.blocks[block].terminatorOp = BranchOp {blockIndex};
 }
 
-void BCLoweringProvider::LoweringContext::process(const std::unique_ptr<ir::Operation>& opt, short block,
-                                                  RegisterFrame& frame) {
-	switch (opt->getOperationType()) {
-	case ir::Operation::OperationType::ConstPtrOp: {
-		auto constPtr = as<ir::ConstPtrOperation>(opt);
-		auto defaultRegister = registerProvider.allocRegister();
-		allocateRegister(defaultRegister);
-		defaultRegisterFile[defaultRegister] = (int64_t) constPtr->getValue();
+// Constant-operation hooks: emit a REG_MOV from a preloaded default register.
+void BCLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* constPtr, short block,
+                                                        RegisterFrame& frame) {
+	auto defaultRegister = registerProvider.allocRegister();
+	allocateRegister(defaultRegister);
+	defaultRegisterFile[defaultRegister] = (int64_t) constPtr->getValue();
 
-		auto targetRegister = registerProvider.allocRegister();
-		frame.setValue(constPtr->getIdentifier(), targetRegister);
-		OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
-		program.blocks[block].code.emplace_back(oc);
-		return;
-	}
-	case ir::Operation::OperationType::ConstBooleanOp: {
-		auto constInt = as<ir::ConstBooleanOperation>(opt);
-		auto defaultRegister = registerProvider.allocRegister();
-		allocateRegister(defaultRegister);
-		defaultRegisterFile[defaultRegister] = constInt->getValue();
+	auto targetRegister = registerProvider.allocRegister();
+	frame.setValue(constPtr->getIdentifier(), targetRegister);
+	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
+	program.blocks[block].code.emplace_back(oc);
+}
 
-		auto targetRegister = registerProvider.allocRegister();
-		frame.setValue(constInt->getIdentifier(), targetRegister);
-		OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
-		program.blocks[block].code.emplace_back(oc);
-		return;
-	}
-	case ir::Operation::OperationType::ConstIntOp: {
-		auto constInt = as<ir::ConstIntOperation>(opt);
-		auto defaultRegister = registerProvider.allocRegister();
-		allocateRegister(defaultRegister);
-		defaultRegisterFile[defaultRegister] = constInt->getValue();
-		auto targetRegister = registerProvider.allocRegister();
-		frame.setValue(constInt->getIdentifier(), targetRegister);
-		OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
-		program.blocks[block].code.emplace_back(oc);
-		return;
-	}
-	case ir::Operation::OperationType::ConstFloatOp: {
-		auto constInt = as<ir::ConstFloatOperation>(opt);
-		auto defaultRegister = registerProvider.allocRegister();
-		allocateRegister(defaultRegister);
-		if (constInt->getStamp() == Type::f32) {
-			auto floatValue = (float) constInt->getValue();
-			auto floatReg = reinterpret_cast<float*>(&defaultRegisterFile[defaultRegister]);
-			*floatReg = floatValue;
-		} else {
-			auto floatValue = (double) constInt->getValue();
-			auto floatReg = reinterpret_cast<double*>(&defaultRegisterFile[defaultRegister]);
-			*floatReg = floatValue;
-		}
+void BCLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* constInt, short block,
+                                                            RegisterFrame& frame) {
+	auto defaultRegister = registerProvider.allocRegister();
+	allocateRegister(defaultRegister);
+	defaultRegisterFile[defaultRegister] = constInt->getValue();
 
-		auto targetRegister = registerProvider.allocRegister();
-		frame.setValue(constInt->getIdentifier(), targetRegister);
-		OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
-		program.blocks[block].code.emplace_back(oc);
-		return;
-	}
-	case ir::Operation::OperationType::AddOp: {
-		auto addOpt = as<ir::AddOperation>(opt);
-		process(addOpt, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::MulOp: {
-		auto mulOpt = as<ir::MulOperation>(opt);
-		process(mulOpt, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::SubOp: {
-		auto subOpt = as<ir::SubOperation>(opt);
-		process(subOpt, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::DivOp: {
-		auto divOpt = as<ir::DivOperation>(opt);
-		process(divOpt, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ReturnOp: {
-		auto returnOpt = as<ir::ReturnOperation>(opt);
-		if (returnOpt->hasReturnValue()) {
-			auto returnFOp = frame.getValue(returnOpt->getReturnValue()->getIdentifier());
-			program.blocks[block].terminatorOp = ReturnOp {returnFOp};
-			program.returnType = returnOpt->getReturnValue()->getStamp();
-			return;
-		} else {
-			program.blocks[block].terminatorOp = ReturnOp {-1};
-			return;
-		}
-	}
-	case ir::Operation::OperationType::CompareOp: {
-		auto compOpt = as<ir::CompareOperation>(opt);
-		process(compOpt, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::IfOp: {
-		auto ifOpt = as<ir::IfOperation>(opt);
-		process(ifOpt, block, frame);
-		return;
+	auto targetRegister = registerProvider.allocRegister();
+	frame.setValue(constInt->getIdentifier(), targetRegister);
+	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
+	program.blocks[block].code.emplace_back(oc);
+}
+
+void BCLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* constInt, short block,
+                                                        RegisterFrame& frame) {
+	auto defaultRegister = registerProvider.allocRegister();
+	allocateRegister(defaultRegister);
+	defaultRegisterFile[defaultRegister] = constInt->getValue();
+	auto targetRegister = registerProvider.allocRegister();
+	frame.setValue(constInt->getIdentifier(), targetRegister);
+	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
+	program.blocks[block].code.emplace_back(oc);
+}
+
+void BCLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* constInt, short block,
+                                                          RegisterFrame& frame) {
+	auto defaultRegister = registerProvider.allocRegister();
+	allocateRegister(defaultRegister);
+	if (constInt->getStamp() == Type::f32) {
+		auto floatValue = (float) constInt->getValue();
+		auto floatReg = reinterpret_cast<float*>(&defaultRegisterFile[defaultRegister]);
+		*floatReg = floatValue;
+	} else {
+		auto floatValue = (double) constInt->getValue();
+		auto floatReg = reinterpret_cast<double*>(&defaultRegisterFile[defaultRegister]);
+		*floatReg = floatValue;
 	}
 
-	case ir::Operation::OperationType::BranchOp: {
-		auto branchOp = as<ir::BranchOperation>(opt);
-		process(branchOp, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::LoadOp: {
-		auto load = as<ir::LoadOperation>(opt);
-		process(load, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::StoreOp: {
-		auto store = as<ir::StoreOperation>(opt);
-		process(store, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ProxyCallOp: {
-		auto call = as<ir::ProxyCallOperation>(opt);
-		process(call, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::IndirectCallOp: {
-		auto call = as<ir::IndirectCallOperation>(opt);
-		process(call, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::OrOp: {
-		auto call = as<ir::OrOperation>(opt);
-		process(call, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::AndOp: {
-		auto call = as<ir::AndOperation>(opt);
-		process(call, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::NegateOp: {
-		auto call = as<ir::NegateOperation>(opt);
-		process(call, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::NotOp: {
-		auto call = as<ir::NotOperation>(opt);
-		process(call, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::CastOp: {
-		auto cast = as<ir::CastOperation>(opt);
-		process(cast, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ModOp: {
-		auto cast = as<ir::ModOperation>(opt);
-		process(cast, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::BinaryComp: {
-		auto cast = as<ir::BinaryCompOperation>(opt);
-		process(cast, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ShiftOp: {
-		auto cast = as<ir::ShiftOperation>(opt);
-		process(cast, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::SelectOp: {
-		auto select = as<ir::SelectOperation>(opt);
-		process(select, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::AllocaOp: {
-		auto alloca = as<ir::AllocaOperation>(opt);
-		process(alloca, block, frame);
-		return;
-	}
-	case ir::Operation::OperationType::FunctionAddressOfOp: {
-		auto funcAddr = as<ir::FunctionAddressOfOperation>(opt);
-		process(funcAddr, block, frame);
-		return;
-	}
-	default: {
+	auto targetRegister = registerProvider.allocRegister();
+	frame.setValue(constInt->getIdentifier(), targetRegister);
+	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
+	program.blocks[block].code.emplace_back(oc);
+}
 
-		throw NotImplementedException("This type is not supported.");
-		// NES_THROW_RUNTIME_ERROR("Operation " << opt->toString() << " not
-		// handled");
-		return;
-	}
+void BCLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* returnOpt, short block,
+                                                      RegisterFrame& frame) {
+	if (returnOpt->hasReturnValue()) {
+		auto returnFOp = frame.getValue(returnOpt->getReturnValue()->getIdentifier());
+		program.blocks[block].terminatorOp = ReturnOp {returnFOp};
+		program.returnType = returnOpt->getReturnValue()->getStamp();
+	} else {
+		program.blocks[block].terminatorOp = ReturnOp {-1};
 	}
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::ProxyCallOperation* opt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperation* opt, short block,
+                                                         RegisterFrame& frame) {
 	// create a dynamic call using dyncall.h
 	processDynamicCall(opt, block, frame);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::IndirectCallOperation* opt, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOperation* opt, short block,
+                                                            RegisterFrame& frame) {
 	auto& code = program.blocks[block].code;
 	auto arguments = opt->getInputArguments();
 
@@ -1492,8 +1371,8 @@ void BCLoweringProvider::LoweringContext::processDynamicCall(ir::ProxyCallOperat
 	}
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::NotOperation* negateOperation, short block,
-                                                  RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitNot(ir::NotOperation* negateOperation, short block,
+                                                   RegisterFrame& frame) {
 	auto input = frame.getValue(negateOperation->getInput()->getIdentifier());
 	auto resultReg = getResultRegister(negateOperation, frame);
 	frame.setValue(negateOperation->getIdentifier(), resultReg);
@@ -1502,8 +1381,8 @@ void BCLoweringProvider::LoweringContext::process(ir::NotOperation* negateOperat
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::NegateOperation* negateOperation, short block,
-                                                  RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* negateOperation, short block,
+                                                      RegisterFrame& frame) {
 	auto input = frame.getValue(negateOperation->getInput()->getIdentifier());
 	auto resultReg = getResultRegister(negateOperation, frame);
 	frame.setValue(negateOperation->getIdentifier(), resultReg);
@@ -1512,7 +1391,7 @@ void BCLoweringProvider::LoweringContext::process(ir::NegateOperation* negateOpe
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::CastOperation* castOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitCast(ir::CastOperation* castOp, short block, RegisterFrame& frame) {
 	auto input = frame.getValue(castOp->getInput()->getIdentifier());
 	auto resultReg = getResultRegister(castOp, frame);
 	frame.setValue(castOp->getIdentifier(), resultReg);
@@ -2052,7 +1931,8 @@ void BCLoweringProvider::LoweringContext::useValue(const ir::OperationIdentifier
 	}
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::SelectOperation* selectOp, short block, RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* selectOp, short block,
+                                                      RegisterFrame& frame) {
 	auto conditionReg = frame.getValue(selectOp->getCondition()->getIdentifier());
 	auto trueValueReg = frame.getValue(selectOp->getTrueValue()->getIdentifier());
 	auto falseValueReg = frame.getValue(selectOp->getFalseValue()->getIdentifier());
@@ -2108,8 +1988,8 @@ void BCLoweringProvider::LoweringContext::process(ir::SelectOperation* selectOp,
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::AllocaOperation* allocaOp, short /*block*/,
-                                                  RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* allocaOp, short /*block*/,
+                                                      RegisterFrame& frame) {
 	auto resultRegister = registerProvider.allocRegister();
 	allocateRegister(resultRegister);
 	auto bufferIndex = program.allocaBuffers.size();
@@ -2119,8 +1999,8 @@ void BCLoweringProvider::LoweringContext::process(ir::AllocaOperation* allocaOp,
 	frame.setValue(allocaOp->getIdentifier(), resultRegister);
 }
 
-void BCLoweringProvider::LoweringContext::process(ir::FunctionAddressOfOperation* funcAddrOp, short block,
-                                                  RegisterFrame& frame) {
+void BCLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::FunctionAddressOfOperation* funcAddrOp,
+                                                                 short block, RegisterFrame& frame) {
 	// Store the function pointer constant into a register, same pattern as ConstPtrOperation.
 	auto defaultRegister = registerProvider.allocRegister();
 	allocateRegister(defaultRegister);

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
@@ -3,36 +3,8 @@
 #include "nautilus/compiler/Frame.hpp"
 #include "nautilus/compiler/backends/bc/ByteCode.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
+#include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
-#include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
-#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
-#include "nautilus/compiler/ir/operations/CastOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstPtrOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/operations/IfOperation.hpp"
-#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/LoadOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
-#include "nautilus/compiler/ir/operations/Operation.hpp"
-#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
-#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
-#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include <unordered_map>
 #include <unordered_set>
 
@@ -77,7 +49,7 @@ private:
 		std::vector<short> freeList;
 	};
 
-	class LoweringContext {
+	class LoweringContext : public ir::OperationDispatcher<LoweringContext> {
 	public:
 		LoweringContext(std::shared_ptr<ir::IRGraph> ir, std::string targetFunctionName = "execute");
 		LoweringContext(std::shared_ptr<ir::IRGraph> ir,
@@ -89,9 +61,10 @@ private:
 
 		short process(const ir::BasicBlock*, RegisterFrame& frame);
 
-		void process(const std::unique_ptr<ir::Operation>& operation, short block, RegisterFrame& frame);
-
 	private:
+		// Allow the CRTP dispatcher to call our private visitXxx hooks.
+		friend class ir::OperationDispatcher<LoweringContext>;
+
 		Code program;
 		RegisterFile defaultRegisterFile;
 		std::shared_ptr<ir::IRGraph> ir;
@@ -102,45 +75,36 @@ private:
 		std::unordered_map<ir::OperationIdentifier, int> usageCounts;
 		std::unordered_set<ir::OperationIdentifier> functionArgs;
 
-		void process(ir::AddOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::MulOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::DivOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::ModOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::SubOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::IfOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::CompareOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::BranchOperation* opt, short block, RegisterFrame& frame);
-
 		void process(const ir::BasicBlockInvocation& opt, short block, RegisterFrame& frame);
 
-		void process(ir::LoadOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::StoreOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::ProxyCallOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::IndirectCallOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::OrOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::AndOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::NegateOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::NotOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::AllocaOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::CastOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::SelectOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::BinaryCompOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::ShiftOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::FunctionAddressOfOperation* opt, short block, RegisterFrame& frame);
+		// Per-operation hooks invoked by OperationDispatcher::dispatch.
+		void visitAdd(ir::AddOperation* opt, short block, RegisterFrame& frame);
+		void visitMul(ir::MulOperation* opt, short block, RegisterFrame& frame);
+		void visitDiv(ir::DivOperation* opt, short block, RegisterFrame& frame);
+		void visitMod(ir::ModOperation* opt, short block, RegisterFrame& frame);
+		void visitSub(ir::SubOperation* opt, short block, RegisterFrame& frame);
+		void visitIf(ir::IfOperation* opt, short block, RegisterFrame& frame);
+		void visitCompare(ir::CompareOperation* opt, short block, RegisterFrame& frame);
+		void visitBranch(ir::BranchOperation* opt, short block, RegisterFrame& frame);
+		void visitLoad(ir::LoadOperation* opt, short block, RegisterFrame& frame);
+		void visitStore(ir::StoreOperation* opt, short block, RegisterFrame& frame);
+		void visitProxyCall(ir::ProxyCallOperation* opt, short block, RegisterFrame& frame);
+		void visitIndirectCall(ir::IndirectCallOperation* opt, short block, RegisterFrame& frame);
+		void visitOr(ir::OrOperation* opt, short block, RegisterFrame& frame);
+		void visitAnd(ir::AndOperation* opt, short block, RegisterFrame& frame);
+		void visitNegate(ir::NegateOperation* opt, short block, RegisterFrame& frame);
+		void visitNot(ir::NotOperation* opt, short block, RegisterFrame& frame);
+		void visitAlloca(ir::AllocaOperation* opt, short block, RegisterFrame& frame);
+		void visitCast(ir::CastOperation* opt, short block, RegisterFrame& frame);
+		void visitSelect(ir::SelectOperation* opt, short block, RegisterFrame& frame);
+		void visitBinaryComp(ir::BinaryCompOperation* opt, short block, RegisterFrame& frame);
+		void visitShift(ir::ShiftOperation* opt, short block, RegisterFrame& frame);
+		void visitFunctionAddressOf(ir::FunctionAddressOfOperation* opt, short block, RegisterFrame& frame);
+		void visitReturn(ir::ReturnOperation* opt, short block, RegisterFrame& frame);
+		void visitConstInt(ir::ConstIntOperation* opt, short block, RegisterFrame& frame);
+		void visitConstFloat(ir::ConstFloatOperation* opt, short block, RegisterFrame& frame);
+		void visitConstBoolean(ir::ConstBooleanOperation* opt, short block, RegisterFrame& frame);
+		void visitConstPtr(ir::ConstPtrOperation* opt, short block, RegisterFrame& frame);
 
 		void processDynamicCall(ir::ProxyCallOperation* opt, short block, RegisterFrame& frame);
 

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -161,7 +161,7 @@ std::string CPPLoweringProvider::LoweringContext::process(const ir::BasicBlock* 
 		currentBlock << blockName << ":\n";
 		activeBlocks.emplace(block->getIdentifier(), blockName);
 		for (auto& opt : block->getOperations()) {
-			this->process(opt, blockIndex, frame);
+			this->dispatch(opt, blockIndex, frame);
 		}
 		return blockName;
 	} else {
@@ -169,8 +169,8 @@ std::string CPPLoweringProvider::LoweringContext::process(const ir::BasicBlock* 
 	}
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::CompareOperation* cmpOp, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation* cmpOp, short blockIndex,
+                                                        RegisterFrame& frame) {
 	auto leftInput = frame.getValue(cmpOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(cmpOp->getRightInput()->getIdentifier());
 	auto resultVar = getVariable(cmpOp->getIdentifier());
@@ -208,7 +208,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::CompareOperation* cmpOp, 
 	blocks[blockIndex] << resultVar << " = " << leftInput << comperator << rightInput << ";\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::LoadOperation* loadOp, short blockIndex, RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* loadOp, short blockIndex,
+                                                     RegisterFrame& frame) {
 	auto address = frame.getValue(loadOp->getAddress()->getIdentifier());
 	auto resultVar = getVariable(loadOp->getIdentifier());
 	if (!frame.contains(loadOp->getIdentifier())) {
@@ -219,8 +220,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::LoadOperation* loadOp, sh
 	blocks[blockIndex] << resultVar << " = *reinterpret_cast<" << type << "*>(" << address << ");\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::StoreOperation* storeOp, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* storeOp, short blockIndex,
+                                                      RegisterFrame& frame) {
 	auto address = frame.getValue(storeOp->getAddress()->getIdentifier());
 	auto value = frame.getValue(storeOp->getValue()->getIdentifier());
 	auto type = getType(storeOp->getValue()->getStamp());
@@ -252,7 +253,7 @@ void CPPLoweringProvider::LoweringContext::process(const ir::BasicBlockInvocatio
 	blocks[blockIndex] << "}\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::IfOperation* ifOpt, short blockIndex, RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitIf(ir::IfOperation* ifOpt, short blockIndex, RegisterFrame& frame) {
 	auto conditionalReg = frame.getValue(ifOpt->getValue()->getIdentifier());
 	auto trueBlock = process(ifOpt->getTrueBlockInvocation().getBlock(), frame);
 	auto falseBlock = process(ifOpt->getFalseBlockInvocation().getBlock(), frame);
@@ -264,171 +265,102 @@ void CPPLoweringProvider::LoweringContext::process(ir::IfOperation* ifOpt, short
 	blocks[blockIndex] << "goto " << falseBlock << ";}\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::BranchOperation* branchOp, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* branchOp, short blockIndex,
+                                                       RegisterFrame& frame) {
 	process(branchOp->getNextBlockInvocation(), blockIndex, frame);
 	auto nextBlock = process(branchOp->getNextBlockInvocation().getBlock(), frame);
 	blocks[blockIndex] << "goto " << nextBlock << ";\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(const std::unique_ptr<ir::Operation>& opt, short blockIndex,
-                                                   RegisterFrame& frame) {
-	switch (opt->getOperationType()) {
-	case ir::Operation::OperationType::ConstBooleanOp: {
-		processConst<ir::ConstBooleanOperation>(opt, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ConstIntOp: {
-		processConst<ir::ConstIntOperation>(opt, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ConstFloatOp: {
-		processConst<ir::ConstFloatOperation>(opt, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ConstPtrOp: {
-		processConst<ir::ConstPtrOperation>(opt, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::AddOp: {
-		processBinary<ir::AddOperation>(opt, "+", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::MulOp: {
-		processBinary<ir::MulOperation>(opt, "*", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::SubOp: {
-		processBinary<ir::SubOperation>(opt, "-", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::DivOp: {
-		processBinary<ir::DivOperation>(opt, "/", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ModOp: {
-		processBinary<ir::ModOperation>(opt, "%", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ShiftOp: {
-		auto op = static_cast<ir::ShiftOperation*>(opt.get());
-		if (op->getType() == ir::ShiftOperation::LS) {
-			processBinary<ir::ShiftOperation>(opt, "<<", blockIndex, frame);
-		} else {
-			processBinary<ir::ShiftOperation>(opt, ">>", blockIndex, frame);
-		}
-		return;
-	}
-	case ir::Operation::OperationType::BinaryComp: {
-		auto op = static_cast<ir::BinaryCompOperation*>(opt.get());
-		switch (op->getType()) {
-		case ir::BinaryCompOperation::BAND:
-			processBinary<ir::BinaryCompOperation>(opt, "&", blockIndex, frame);
-			break;
-		case ir::BinaryCompOperation::BOR:
-			processBinary<ir::BinaryCompOperation>(opt, "|", blockIndex, frame);
-			break;
-		case ir::BinaryCompOperation::XOR:
-			processBinary<ir::BinaryCompOperation>(opt, "^", blockIndex, frame);
-			break;
-		}
-		return;
-	}
-	case ir::Operation::OperationType::ReturnOp: {
-		auto returnOpt = static_cast<ir::ReturnOperation*>(opt.get());
-		if (returnOpt->hasReturnValue()) {
-			auto returnFOp = frame.getValue(returnOpt->getReturnValue()->getIdentifier());
-			blocks[blockIndex] << "return " << returnFOp << ";\n";
+// Thin wrappers that turn a typed op into the matching C operator and delegate
+// to processBinary / processConst. All other per-op handlers keep their dedicated
+// definitions below (renamed from `process` to `visitXxx`).
+void CPPLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::AddOperation>(op, "+", blockIndex, frame);
+}
 
-			this->returnType = getType(returnOpt->getStamp());
-		} else {
-			blocks[blockIndex] << "return;\n";
-			this->returnType = "void";
-		}
-		return;
-	}
-	case ir::Operation::OperationType::CompareOp: {
-		auto compOpt = as<ir::CompareOperation>(opt);
-		process(compOpt, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::IfOp: {
-		auto ifOpt = as<ir::IfOperation>(opt);
-		process(ifOpt, blockIndex, frame);
-		return;
-	}
+void CPPLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::SubOperation>(op, "-", blockIndex, frame);
+}
 
-	case ir::Operation::OperationType::BranchOp: {
-		auto branchOp = as<ir::BranchOperation>(opt);
-		process(branchOp, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::LoadOp: {
-		auto load = as<ir::LoadOperation>(opt);
-		process(load, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::StoreOp: {
-		auto store = as<ir::StoreOperation>(opt);
-		process(store, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::ProxyCallOp: {
-		auto call = as<ir::ProxyCallOperation>(opt);
-		process(call, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::IndirectCallOp: {
-		auto call = as<ir::IndirectCallOperation>(opt);
-		process(call, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::OrOp: {
-		processBinary<ir::OrOperation>(opt, "||", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::AndOp: {
-		processBinary<ir::AndOperation>(opt, "&&", blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::NegateOp: {
-		auto call = as<ir::NegateOperation>(opt);
-		process(call, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::NotOp: {
-		auto call = as<ir::NotOperation>(opt);
-		process(call, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::CastOp: {
-		auto cast = as<ir::CastOperation>(opt);
-		process(cast, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::SelectOp: {
-		auto select = as<ir::SelectOperation>(opt);
-		process(select, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::AllocaOp: {
-		auto alloca = as<ir::AllocaOperation>(opt);
-		process(alloca, blockIndex, frame);
-		return;
-	}
-	case ir::Operation::OperationType::FunctionAddressOfOp: {
-		auto funcAddr = as<ir::FunctionAddressOfOperation>(opt);
-		process(funcAddr, blockIndex, frame);
-		return;
-	}
-	default: {
-		throw NotImplementedException("Operation is not implemented");
-	}
+void CPPLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::MulOperation>(op, "*", blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::DivOperation>(op, "/", blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::ModOperation>(op, "%", blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::OrOperation>(op, "||", blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, short blockIndex, RegisterFrame& frame) {
+	processBinary<ir::AndOperation>(op, "&&", blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op, short blockIndex, RegisterFrame& frame) {
+	if (op->getType() == ir::ShiftOperation::LS) {
+		processBinary<ir::ShiftOperation>(op, "<<", blockIndex, frame);
+	} else {
+		processBinary<ir::ShiftOperation>(op, ">>", blockIndex, frame);
 	}
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::ProxyCallOperation* opt, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, short blockIndex,
+                                                           RegisterFrame& frame) {
+	switch (op->getType()) {
+	case ir::BinaryCompOperation::BAND:
+		processBinary<ir::BinaryCompOperation>(op, "&", blockIndex, frame);
+		break;
+	case ir::BinaryCompOperation::BOR:
+		processBinary<ir::BinaryCompOperation>(op, "|", blockIndex, frame);
+		break;
+	case ir::BinaryCompOperation::XOR:
+		processBinary<ir::BinaryCompOperation>(op, "^", blockIndex, frame);
+		break;
+	}
+}
+
+void CPPLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, short blockIndex,
+                                                         RegisterFrame& frame) {
+	processConst<ir::ConstIntOperation>(op, blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* op, short blockIndex,
+                                                           RegisterFrame& frame) {
+	processConst<ir::ConstFloatOperation>(op, blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* op, short blockIndex,
+                                                             RegisterFrame& frame) {
+	processConst<ir::ConstBooleanOperation>(op, blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, short blockIndex,
+                                                         RegisterFrame& frame) {
+	processConst<ir::ConstPtrOperation>(op, blockIndex, frame);
+}
+
+void CPPLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* returnOpt, short blockIndex,
+                                                       RegisterFrame& frame) {
+	if (returnOpt->hasReturnValue()) {
+		auto returnFOp = frame.getValue(returnOpt->getReturnValue()->getIdentifier());
+		blocks[blockIndex] << "return " << returnFOp << ";\n";
+
+		this->returnType = getType(returnOpt->getStamp());
+	} else {
+		blocks[blockIndex] << "return;\n";
+		this->returnType = "void";
+	}
+}
+
+void CPPLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperation* opt, short blockIndex,
+                                                          RegisterFrame& frame) {
 
 	auto returnType = getType(opt->getStamp());
 	std::stringstream argTypes;
@@ -468,8 +400,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::ProxyCallOperation* opt, 
 	}
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::IndirectCallOperation* opt, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOperation* opt, short blockIndex,
+                                                             RegisterFrame& frame) {
 	auto returnType = getType(opt->getStamp());
 	std::stringstream argTypes;
 	std::stringstream args;
@@ -498,8 +430,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::IndirectCallOperation* op
 	}
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::NegateOperation* negateOperation, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* negateOperation, short blockIndex,
+                                                       RegisterFrame& frame) {
 	auto input = frame.getValue(negateOperation->getInput()->getIdentifier());
 	auto resultVar = getVariable(negateOperation->getIdentifier());
 	if (!frame.contains(negateOperation->getIdentifier())) {
@@ -509,8 +441,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::NegateOperation* negateOp
 	blocks[blockIndex] << resultVar << "= ~" << input << ";\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::NotOperation* notOperation, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitNot(ir::NotOperation* notOperation, short blockIndex,
+                                                    RegisterFrame& frame) {
 	auto input = frame.getValue(notOperation->getInput()->getIdentifier());
 	auto resultVar = getVariable(notOperation->getIdentifier());
 	if (!frame.contains(notOperation->getIdentifier())) {
@@ -520,7 +452,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::NotOperation* notOperatio
 	blocks[blockIndex] << resultVar << "= !" << input << ";\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::CastOperation* castOp, short blockIndex, RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitCast(ir::CastOperation* castOp, short blockIndex,
+                                                     RegisterFrame& frame) {
 	auto input = frame.getValue(castOp->getInput()->getIdentifier());
 	auto var = getVariable(castOp->getIdentifier());
 	auto inputStamp = castOp->getInput()->getStamp();
@@ -539,8 +472,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::CastOperation* castOp, sh
 	}
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::SelectOperation* selectOp, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* selectOp, short blockIndex,
+                                                       RegisterFrame& frame) {
 	auto condition = frame.getValue(selectOp->getCondition()->getIdentifier());
 	auto trueValue = frame.getValue(selectOp->getTrueValue()->getIdentifier());
 	auto falseValue = frame.getValue(selectOp->getFalseValue()->getIdentifier());
@@ -552,8 +485,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::SelectOperation* selectOp
 	blocks[blockIndex] << resultVar << " = " << condition << " ? " << trueValue << " : " << falseValue << ";\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::AllocaOperation* allocaOp, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* allocaOp, short blockIndex,
+                                                       RegisterFrame& frame) {
 	auto resultVar = getVariable(allocaOp->getIdentifier());
 	auto bufVar = "alloca_buf_" + allocaOp->getIdentifier().toString();
 	if (!frame.contains(allocaOp->getIdentifier())) {
@@ -564,8 +497,8 @@ void CPPLoweringProvider::LoweringContext::process(ir::AllocaOperation* allocaOp
 	blocks[blockIndex] << resultVar << " = " << bufVar << ";\n";
 }
 
-void CPPLoweringProvider::LoweringContext::process(ir::FunctionAddressOfOperation* funcAddrOp, short blockIndex,
-                                                   RegisterFrame& frame) {
+void CPPLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::FunctionAddressOfOperation* funcAddrOp,
+                                                                  short blockIndex, RegisterFrame& frame) {
 	auto resultVar = getVariable(funcAddrOp->getIdentifier());
 	if (!frame.contains(funcAddrOp->getIdentifier())) {
 		blockArguments << "uint8_t* " << resultVar << ";\n";

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
@@ -2,35 +2,8 @@
 
 #include "nautilus/compiler/Frame.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
+#include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
-#include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
-#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
-#include "nautilus/compiler/ir/operations/CastOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/operations/IfOperation.hpp"
-#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/LoadOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
-#include "nautilus/compiler/ir/operations/Operation.hpp"
-#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
-#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
-#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include <sstream>
 #include <unordered_set>
 #include <vector>
@@ -50,13 +23,16 @@ private:
 	using RegisterFrame = Frame<ir::OperationIdentifier, std::string>;
 	using Code = std::stringstream;
 
-	class LoweringContext {
+	class LoweringContext : public ir::OperationDispatcher<LoweringContext> {
 	public:
 		explicit LoweringContext(std::shared_ptr<ir::IRGraph> ir);
 
 		Code process();
 
 	private:
+		// Allow the CRTP dispatcher to call our private visitXxx hooks.
+		friend class ir::OperationDispatcher<LoweringContext>;
+
 		Code blockArguments;
 		Code functions;
 		std::vector<Code> blocks;
@@ -69,39 +45,41 @@ private:
 
 		void process(const ir::BasicBlockInvocation& opt, short block, RegisterFrame& frame);
 
-		void process(const std::unique_ptr<ir::Operation>& operation, short block, RegisterFrame& frame);
-
-		void process(ir::IfOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::CompareOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::BranchOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::LoadOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::StoreOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::ProxyCallOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::IndirectCallOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::NegateOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::NotOperation* opt, short block, RegisterFrame& frame);
-
-		void process(ir::AllocaOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::CastOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::SelectOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::BinaryCompOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::ShiftOperation* opt, short block, RegisterFrame& frame);
-		void process(ir::FunctionAddressOfOperation* opt, short block, RegisterFrame& frame);
+		// Per-operation hooks invoked by OperationDispatcher::dispatch.
+		void visitAdd(ir::AddOperation* opt, short block, RegisterFrame& frame);
+		void visitSub(ir::SubOperation* opt, short block, RegisterFrame& frame);
+		void visitMul(ir::MulOperation* opt, short block, RegisterFrame& frame);
+		void visitDiv(ir::DivOperation* opt, short block, RegisterFrame& frame);
+		void visitMod(ir::ModOperation* opt, short block, RegisterFrame& frame);
+		void visitAnd(ir::AndOperation* opt, short block, RegisterFrame& frame);
+		void visitOr(ir::OrOperation* opt, short block, RegisterFrame& frame);
+		void visitShift(ir::ShiftOperation* opt, short block, RegisterFrame& frame);
+		void visitBinaryComp(ir::BinaryCompOperation* opt, short block, RegisterFrame& frame);
+		void visitConstInt(ir::ConstIntOperation* opt, short block, RegisterFrame& frame);
+		void visitConstFloat(ir::ConstFloatOperation* opt, short block, RegisterFrame& frame);
+		void visitConstBoolean(ir::ConstBooleanOperation* opt, short block, RegisterFrame& frame);
+		void visitConstPtr(ir::ConstPtrOperation* opt, short block, RegisterFrame& frame);
+		void visitReturn(ir::ReturnOperation* opt, short block, RegisterFrame& frame);
+		void visitIf(ir::IfOperation* opt, short block, RegisterFrame& frame);
+		void visitCompare(ir::CompareOperation* opt, short block, RegisterFrame& frame);
+		void visitBranch(ir::BranchOperation* opt, short block, RegisterFrame& frame);
+		void visitLoad(ir::LoadOperation* opt, short block, RegisterFrame& frame);
+		void visitStore(ir::StoreOperation* opt, short block, RegisterFrame& frame);
+		void visitProxyCall(ir::ProxyCallOperation* opt, short block, RegisterFrame& frame);
+		void visitIndirectCall(ir::IndirectCallOperation* opt, short block, RegisterFrame& frame);
+		void visitNegate(ir::NegateOperation* opt, short block, RegisterFrame& frame);
+		void visitNot(ir::NotOperation* opt, short block, RegisterFrame& frame);
+		void visitAlloca(ir::AllocaOperation* opt, short block, RegisterFrame& frame);
+		void visitCast(ir::CastOperation* opt, short block, RegisterFrame& frame);
+		void visitSelect(ir::SelectOperation* opt, short block, RegisterFrame& frame);
+		void visitFunctionAddressOf(ir::FunctionAddressOfOperation* opt, short block, RegisterFrame& frame);
 
 		static std::string getVariable(const ir::OperationIdentifier& id);
 
 		static std::string getType(const Type& stamp);
 
 		template <class Type>
-		void processConst(const std::unique_ptr<ir::Operation>& opt, short blockIndex, RegisterFrame& frame) {
-			auto constValue = static_cast<Type*>(opt.get());
+		void processConst(Type* constValue, short blockIndex, RegisterFrame& frame) {
 			auto var = getVariable(constValue->getIdentifier());
 			if (!frame.contains(constValue->getIdentifier())) {
 				blockArguments << getType(constValue->getStamp()) << " " << var << ";\n";
@@ -119,9 +97,7 @@ private:
 		}
 
 		template <class Type>
-		void processBinary(const std::unique_ptr<ir::Operation>& o, const std::string& operation, short blockIndex,
-		                   RegisterFrame& frame) {
-			auto op = static_cast<Type*>(o.get());
+		void processBinary(Type* op, const std::string& operation, short blockIndex, RegisterFrame& frame) {
 			auto leftInput = frame.getValue(op->getLeftInput()->getIdentifier());
 			auto rightInput = frame.getValue(op->getRightInput()->getIdentifier());
 			auto resultVar = getVariable(op->getIdentifier());

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -364,102 +364,11 @@ mlir::OwningOpRef<mlir::ModuleOp> MLIRLoweringProvider::generateModuleFromIR(std
 
 void MLIRLoweringProvider::generateMLIR(const ir::BasicBlock* basicBlock, ValueFrame& frame) {
 	for (const auto& operation : basicBlock->getOperations()) {
-		generateMLIR(operation, frame);
+		dispatch(operation, frame);
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(const std::unique_ptr<ir::Operation>& operation, ValueFrame& frame) {
-	switch (operation->getOperationType()) {
-	case ir::Operation::OperationType::FunctionOp:
-		break;
-	case ir::Operation::OperationType::ConstIntOp:
-		generateMLIR(as<ir::ConstIntOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ConstFloatOp:
-		generateMLIR(as<ir::ConstFloatOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ConstPtrOp:
-		generateMLIR(as<ir::ConstPtrOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::AddOp:
-		generateMLIR(as<ir::AddOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::SubOp:
-		generateMLIR(as<ir::SubOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::MulOp:
-		generateMLIR(as<ir::MulOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::DivOp:
-		generateMLIR(as<ir::DivOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ModOp:
-		generateMLIR(as<ir::ModOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::LoadOp:
-		generateMLIR(as<ir::LoadOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::StoreOp:
-		generateMLIR(as<ir::StoreOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::BranchOp:
-		generateMLIR(as<ir::BranchOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::IfOp:
-		generateMLIR(as<ir::IfOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::CompareOp:
-		generateMLIR(as<ir::CompareOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ProxyCallOp:
-		generateMLIR(as<ir::ProxyCallOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::IndirectCallOp:
-		generateMLIR(as<ir::IndirectCallOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ReturnOp:
-		generateMLIR(as<ir::ReturnOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::OrOp:
-		generateMLIR(as<ir::OrOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::AndOp:
-		generateMLIR(as<ir::AndOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::NegateOp:
-		generateMLIR(as<ir::NegateOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::NotOp:
-		generateMLIR(as<ir::NotOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::CastOp:
-		generateMLIR(as<ir::CastOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ConstBooleanOp:
-		generateMLIR(as<ir::ConstBooleanOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::BinaryComp:
-		generateMLIR(as<ir::BinaryCompOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::ShiftOp:
-		generateMLIR(as<ir::ShiftOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::AllocaOp:
-		generateMLIR(as<ir::AllocaOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::SelectOp:
-		generateMLIR(as<ir::SelectOperation>(operation), frame);
-		break;
-	case ir::Operation::OperationType::FunctionAddressOfOp:
-		generateMLIR(as<ir::FunctionAddressOfOperation>(operation), frame);
-		break;
-	default: {
-		throw NotImplementedException("");
-	}
-	}
-}
-
-void MLIRLoweringProvider::generateMLIR(ir::NegateOperation* negateOperation, ValueFrame& frame) {
+void MLIRLoweringProvider::visitNegate(ir::NegateOperation* negateOperation, ValueFrame& frame) {
 	auto input = frame.getValue(negateOperation->getInput()->getIdentifier());
 	auto constInt = builder->create<mlir::arith::ConstantOp>(getNameLoc("location"), input.getType(),
 	                                                         builder->getIntegerAttr(input.getType(), ~0));
@@ -467,14 +376,14 @@ void MLIRLoweringProvider::generateMLIR(ir::NegateOperation* negateOperation, Va
 	frame.setValue(negateOperation->getIdentifier(), negate);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::NotOperation* notOperation, ValueFrame& frame) {
+void MLIRLoweringProvider::visitNot(ir::NotOperation* notOperation, ValueFrame& frame) {
 	auto input = frame.getValue(notOperation->getInput()->getIdentifier());
 	auto constInt = getConstBool("loc", true);
 	auto negate = builder->create<mlir::arith::XOrIOp>(getNameLoc("comparison"), input, constInt);
 	frame.setValue(notOperation->getIdentifier(), negate);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::SelectOperation* selectOperation, ValueFrame& frame) {
+void MLIRLoweringProvider::visitSelect(ir::SelectOperation* selectOperation, ValueFrame& frame) {
 	auto condition = frame.getValue(selectOperation->getCondition()->getIdentifier());
 	auto trueValue = frame.getValue(selectOperation->getTrueValue()->getIdentifier());
 	auto falseValue = frame.getValue(selectOperation->getFalseValue()->getIdentifier());
@@ -483,14 +392,14 @@ void MLIRLoweringProvider::generateMLIR(ir::SelectOperation* selectOperation, Va
 	frame.setValue(selectOperation->getIdentifier(), mlirSelectOp);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::OrOperation* orOperation, ValueFrame& frame) {
+void MLIRLoweringProvider::visitOr(ir::OrOperation* orOperation, ValueFrame& frame) {
 	auto leftInput = frame.getValue(orOperation->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(orOperation->getRightInput()->getIdentifier());
 	auto mlirOrOp = builder->create<mlir::LLVM::OrOp>(getNameLoc("binOpResult"), leftInput, rightInput);
 	frame.setValue(orOperation->getIdentifier(), mlirOrOp);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::AndOperation* andOperation, ValueFrame& frame) {
+void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& frame) {
 	auto leftInput = frame.getValue(andOperation->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(andOperation->getRightInput()->getIdentifier());
 	auto mlirAndOp = builder->create<mlir::LLVM::AndOp>(getNameLoc("binOpResult"), leftInput, rightInput);
@@ -561,19 +470,19 @@ void MLIRLoweringProvider::generateFunction(mlir::func::FuncOp& mlirFunction, co
 	// Don't add the function again - it's already been added in generateFunctionDefinitions
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::LoadOperation* loadOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitLoad(ir::LoadOperation* loadOp, ValueFrame& frame) {
 	auto address = frame.getValue(loadOp->getAddress()->getIdentifier());
 	auto mlirLoadOp =
 	    builder->create<mlir::LLVM::LoadOp>(getNameLoc("loadedValue"), getMLIRType(loadOp->getStamp()), address);
 	frame.setValue(loadOp->getIdentifier(), mlirLoadOp);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ConstIntOperation* constIntOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitConstInt(ir::ConstIntOperation* constIntOp, ValueFrame& frame) {
 	frame.setValue(constIntOp->getIdentifier(),
 	               getConstInt("ConstantOp", constIntOp->getStamp(), constIntOp->getValue()));
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ConstPtrOperation* constPtr, ValueFrame& frame) {
+void MLIRLoweringProvider::visitConstPtr(ir::ConstPtrOperation* constPtr, ValueFrame& frame) {
 	auto val = (int64_t) constPtr->getValue();
 	auto constInt = builder->create<mlir::arith::ConstantOp>(getNameLoc("location"), builder->getI64Type(),
 	                                                         builder->getIntegerAttr(builder->getI64Type(), val));
@@ -583,7 +492,7 @@ void MLIRLoweringProvider::generateMLIR(ir::ConstPtrOperation* constPtr, ValueFr
 	frame.setValue(constPtr->getIdentifier(), elementAddress);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ConstFloatOperation* constFloatOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitConstFloat(ir::ConstFloatOperation* constFloatOp, ValueFrame& frame) {
 	if (isFloat(constFloatOp->getStamp())) {
 		auto floatType = (constFloatOp->getStamp() == Type::f32) ? builder->getF32Type() : builder->getF64Type();
 		frame.setValue(constFloatOp->getIdentifier(), builder->create<mlir::LLVM::ConstantOp>(
@@ -595,7 +504,7 @@ void MLIRLoweringProvider::generateMLIR(ir::ConstFloatOperation* constFloatOp, V
 //==---------------------------==//
 //==-- ARITHMETIC OPERATIONS --==//
 //==---------------------------==//
-void MLIRLoweringProvider::generateMLIR(ir::AddOperation* addOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitAdd(ir::AddOperation* addOp, ValueFrame& frame) {
 	auto leftInput = frame.getValue(addOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(addOp->getRightInput()->getIdentifier());
 	if (addOp->getLeftInput()->getStamp() == Type::ptr) {
@@ -621,7 +530,7 @@ void MLIRLoweringProvider::generateMLIR(ir::AddOperation* addOp, ValueFrame& fra
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::SubOperation* subIntOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitSub(ir::SubOperation* subIntOp, ValueFrame& frame) {
 	auto leftInput = frame.getValue(subIntOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(subIntOp->getRightInput()->getIdentifier());
 	if (subIntOp->getLeftInput()->getStamp() == Type::ptr) {
@@ -641,7 +550,7 @@ void MLIRLoweringProvider::generateMLIR(ir::SubOperation* subIntOp, ValueFrame& 
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::MulOperation* mulOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitMul(ir::MulOperation* mulOp, ValueFrame& frame) {
 	auto leftInput = frame.getValue(mulOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(mulOp->getRightInput()->getIdentifier());
 	auto resultType = leftInput.getType();
@@ -656,7 +565,7 @@ void MLIRLoweringProvider::generateMLIR(ir::MulOperation* mulOp, ValueFrame& fra
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::DivOperation* divIntOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitDiv(ir::DivOperation* divIntOp, ValueFrame& frame) {
 	auto leftInput = frame.getValue(divIntOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(divIntOp->getRightInput()->getIdentifier());
 	auto resultType = leftInput.getType();
@@ -677,7 +586,7 @@ void MLIRLoweringProvider::generateMLIR(ir::DivOperation* divIntOp, ValueFrame& 
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ModOperation* modIntOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitMod(ir::ModOperation* modIntOp, ValueFrame& frame) {
 	auto leftInput = frame.getValue(modIntOp->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(modIntOp->getRightInput()->getIdentifier());
 	auto resultType = leftInput.getType();
@@ -698,13 +607,13 @@ void MLIRLoweringProvider::generateMLIR(ir::ModOperation* modIntOp, ValueFrame& 
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::StoreOperation* storeOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitStore(ir::StoreOperation* storeOp, ValueFrame& frame) {
 	auto value = frame.getValue(storeOp->getValue()->getIdentifier());
 	auto address = frame.getValue(storeOp->getAddress()->getIdentifier());
 	builder->create<mlir::LLVM::StoreOp>(getNameLoc("outputStore"), value, address);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ReturnOperation* returnOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitReturn(ir::ReturnOperation* returnOp, ValueFrame& frame) {
 	// Insert return into function block.
 	// Use func::ReturnOp for func::FuncOp functions (not LLVM::ReturnOp)
 	if (!returnOp->hasReturnValue()) {
@@ -715,7 +624,7 @@ void MLIRLoweringProvider::generateMLIR(ir::ReturnOperation* returnOp, ValueFram
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ProxyCallOperation* proxyCallOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitProxyCall(ir::ProxyCallOperation* proxyCallOp, ValueFrame& frame) {
 	// First check if this is handled by an intrinsic
 	if (auto intrinsic = intrinsicManager.getIntrinsic(proxyCallOp->getFunctionPtr())) {
 		const auto& intrinsicFunction = *intrinsic;
@@ -769,7 +678,7 @@ void MLIRLoweringProvider::generateMLIR(ir::ProxyCallOperation* proxyCallOp, Val
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::IndirectCallOperation* indirectCallOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitIndirectCall(ir::IndirectCallOperation* indirectCallOp, ValueFrame& frame) {
 	auto calleePtr = frame.getValue(indirectCallOp->getFunctionPtrOperand()->getIdentifier());
 	// For indirect calls in the MLIR LLVM dialect, the callee pointer is the first element of the operands.
 	std::vector<mlir::Value> allOperands;
@@ -789,7 +698,7 @@ void MLIRLoweringProvider::generateMLIR(ir::IndirectCallOperation* indirectCallO
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::FunctionAddressOfOperation* funcAddrOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitFunctionAddressOf(ir::FunctionAddressOfOperation* funcAddrOp, ValueFrame& frame) {
 	auto functionName = funcAddrOp->getFunctionName();
 	auto ptrType = mlir::LLVM::LLVMPointerType::get(builder->getContext());
 
@@ -829,7 +738,7 @@ void MLIRLoweringProvider::generateMLIR(ir::FunctionAddressOfOperation* funcAddr
 	frame.setValue(funcAddrOp->getIdentifier(), castOp.getResult(0));
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::CompareOperation* compareOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitCompare(ir::CompareOperation* compareOp, ValueFrame& frame) {
 	auto leftStamp = compareOp->getLeftInput()->getStamp();
 	auto rightStamp = compareOp->getRightInput()->getStamp();
 
@@ -869,7 +778,7 @@ void MLIRLoweringProvider::generateMLIR(ir::CompareOperation* compareOp, ValueFr
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::IfOperation* ifOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitIf(ir::IfOperation* ifOp, ValueFrame& frame) {
 	auto parentBlockInsertionPoint = builder->saveInsertionPoint();
 
 	// create true block and set block arguments
@@ -904,7 +813,7 @@ void MLIRLoweringProvider::generateMLIR(ir::IfOperation* ifOp, ValueFrame& frame
 	}
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::BranchOperation* branchOp, ValueFrame& frame) {
+void MLIRLoweringProvider::visitBranch(ir::BranchOperation* branchOp, ValueFrame& frame) {
 	std::vector<mlir::Value> mlirTargetBlockArguments;
 	for (auto targetBlockArgument : branchOp->getNextBlockInvocation().getArguments()) {
 		mlirTargetBlockArguments.push_back(frame.getValue(targetBlockArgument->getIdentifier()));
@@ -962,7 +871,7 @@ MLIRLoweringProvider::createFrameFromParentBlock(MLIRLoweringProvider::ValueFram
 	return childFrame;
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::CastOperation* castOperation, MLIRLoweringProvider::ValueFrame& frame) {
+void MLIRLoweringProvider::visitCast(ir::CastOperation* castOperation, MLIRLoweringProvider::ValueFrame& frame) {
 	auto inputStamp = castOperation->getInput()->getStamp();
 	auto outputStamp = castOperation->getStamp();
 	auto mlirInput = frame.getValue(castOperation->getInput()->getIdentifier());
@@ -1083,8 +992,8 @@ void MLIRLoweringProvider::generateMLIR(ir::CastOperation* castOperation, MLIRLo
 	    fmt::format("Cast from {} to {} is not supported.", toString(inputStamp), toString(outputStamp)));
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::BinaryCompOperation* binaryCompOperation,
-                                        nautilus::compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) {
+void MLIRLoweringProvider::visitBinaryComp(ir::BinaryCompOperation* binaryCompOperation,
+                                           nautilus::compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) {
 	auto leftInput = frame.getValue(binaryCompOperation->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(binaryCompOperation->getRightInput()->getIdentifier());
 	mlir::Value op;
@@ -1102,8 +1011,8 @@ void MLIRLoweringProvider::generateMLIR(ir::BinaryCompOperation* binaryCompOpera
 	frame.setValue(binaryCompOperation->getIdentifier(), op);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ShiftOperation* shiftOperation,
-                                        nautilus::compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) {
+void MLIRLoweringProvider::visitShift(ir::ShiftOperation* shiftOperation,
+                                      nautilus::compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) {
 	auto leftInput = frame.getValue(shiftOperation->getLeftInput()->getIdentifier());
 	auto rightInput = frame.getValue(shiftOperation->getRightInput()->getIdentifier());
 	mlir::Value op;
@@ -1118,7 +1027,7 @@ void MLIRLoweringProvider::generateMLIR(ir::ShiftOperation* shiftOperation,
 	frame.setValue(shiftOperation->getIdentifier(), op);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::AllocaOperation* allocaOperation, ValueFrame& frame) {
+void MLIRLoweringProvider::visitAlloca(ir::AllocaOperation* allocaOperation, ValueFrame& frame) {
 	auto i8Type = builder->getI8Type();
 	auto ptrTy = LLVM::LLVMPointerType::get(context);
 	auto i64Ty = IntegerType::get(context, 64);
@@ -1129,8 +1038,8 @@ void MLIRLoweringProvider::generateMLIR(ir::AllocaOperation* allocaOperation, Va
 	frame.setValue(allocaOperation->getIdentifier(), alloca);
 }
 
-void MLIRLoweringProvider::generateMLIR(ir::ConstBooleanOperation* constBooleanOp,
-                                        MLIRLoweringProvider::ValueFrame& frame) {
+void MLIRLoweringProvider::visitConstBoolean(ir::ConstBooleanOperation* constBooleanOp,
+                                             MLIRLoweringProvider::ValueFrame& frame) {
 	auto constOp = builder->create<mlir::arith::ConstantOp>(
 	    getNameLoc("location"), builder->getI1Type(),
 	    builder->getIntegerAttr(builder->getI1Type(), constBooleanOp->getValue()));

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -4,36 +4,8 @@
 #include "nautilus/compiler/Frame.hpp"
 #include "nautilus/compiler/backends/mlir/ProxyFunctions.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
+#include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
-#include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
-#include "nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp"
-#include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
-#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
-#include "nautilus/compiler/ir/operations/CastOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
-#include "nautilus/compiler/ir/operations/ConstPtrOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp"
-#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/operations/IfOperation.hpp"
-#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/LoadOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
-#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
-#include "nautilus/compiler/ir/operations/Operation.hpp"
-#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
-#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
-#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
-#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <mlir/IR/PatternMatch.h>
 #include <unordered_set>
@@ -45,7 +17,7 @@ class FuncOp;
 namespace nautilus::compiler::mlir {
 
 class MLIRIntrinsicManager;
-class MLIRLoweringProvider {
+class MLIRLoweringProvider : public ir::OperationDispatcher<MLIRLoweringProvider> {
 public:
 	// A ValueFrame is hashmap that binds operation names to MLIR values.
 	// It is used to 'pass' values between mlir operations.
@@ -80,6 +52,9 @@ public:
 	std::vector<void*> getJitProxyTargetAddresses();
 
 private:
+	// Allow the CRTP dispatcher to call our private visitXxx hooks.
+	friend class ir::OperationDispatcher<MLIRLoweringProvider>;
+
 	MLIRIntrinsicManager& intrinsicManager;
 	// MLIR variables
 	::mlir::MLIRContext* context;
@@ -106,46 +81,38 @@ private:
 	 */
 	void generateMLIR(const ir::BasicBlock* basicBlock, ValueFrame& frame);
 
-	/**
-	 * @brief Calls the specific generate function based on currentNode's type.
-	 * @param Operation:  operation that the MLIRLoweringProvider generates MLIR code for.
-	 * @param frame: An unordered map that MLIR operations insert their resulting values, and identifiers in.
-	 */
-	void generateMLIR(const std::unique_ptr<ir::Operation>& operation, ValueFrame& frame);
-
 	void generateFunction(::mlir::func::FuncOp& mlirFunction, const ir::FunctionOperation& funcOp, ValueFrame& frame);
 	::mlir::func::FuncOp generateFunctionDefinitions(const ir::FunctionOperation& funcOp);
 
-	void generateMLIR(ir::ConstIntOperation* constIntOp, ValueFrame& frame);
+	// Per-operation hooks invoked by OperationDispatcher::dispatch.
+	void visitConstInt(ir::ConstIntOperation* constIntOp, ValueFrame& frame);
+	void visitConstFloat(ir::ConstFloatOperation* constFloatOp, ValueFrame& frame);
+	void visitConstBoolean(ir::ConstBooleanOperation* constBooleanOp, ValueFrame& frame);
+	void visitConstPtr(ir::ConstPtrOperation* constPtrOperation, ValueFrame& frame);
 
-	void generateMLIR(ir::ConstFloatOperation* constFloatOp, ValueFrame& frame);
-
-	void generateMLIR(ir::ConstBooleanOperation* constBooleanOp, ValueFrame& frame);
-	void generateMLIR(ir::ConstPtrOperation* constPtrOperation, ValueFrame& frame);
-
-	void generateMLIR(ir::AddOperation* addIntOp, ValueFrame& frame);
-	void generateMLIR(ir::SubOperation* subIntOp, ValueFrame& frame);
-	void generateMLIR(ir::MulOperation* mulIntOp, ValueFrame& frame);
-	void generateMLIR(ir::DivOperation* divFloatOp, ValueFrame& frame);
-	void generateMLIR(ir::ModOperation* divFloatOp, ValueFrame& frame);
-	void generateMLIR(ir::StoreOperation* storeOp, ValueFrame& frame);
-	void generateMLIR(ir::LoadOperation* loadOp, ValueFrame& frame);
-	void generateMLIR(ir::IfOperation* ifOp, ValueFrame& frame);
-	void generateMLIR(ir::CompareOperation* compareOp, ValueFrame& frame);
-	void generateMLIR(ir::BranchOperation* branchOp, ValueFrame& frame);
-	void generateMLIR(ir::ReturnOperation* returnOp, ValueFrame& frame);
-	void generateMLIR(ir::ProxyCallOperation* proxyCallOp, ValueFrame& frame);
-	void generateMLIR(ir::IndirectCallOperation* indirectCallOp, ValueFrame& frame);
-	void generateMLIR(ir::OrOperation* orOperation, ValueFrame& frame);
-	void generateMLIR(ir::AndOperation* andOperation, ValueFrame& frame);
-	void generateMLIR(ir::NegateOperation* negateOperation, ValueFrame& frame);
-	void generateMLIR(ir::NotOperation* notOperation, ValueFrame& frame);
-	void generateMLIR(ir::SelectOperation* selectOperation, ValueFrame& frame);
-	void generateMLIR(ir::CastOperation* castOperation, ValueFrame& frame);
-	void generateMLIR(ir::BinaryCompOperation* binaryCompOperation, ValueFrame& frame);
-	void generateMLIR(ir::ShiftOperation* shiftOperation, ValueFrame& frame);
-	void generateMLIR(ir::AllocaOperation* allocaOperation, ValueFrame& frame);
-	void generateMLIR(ir::FunctionAddressOfOperation* funcAddrOp, ValueFrame& frame);
+	void visitAdd(ir::AddOperation* addIntOp, ValueFrame& frame);
+	void visitSub(ir::SubOperation* subIntOp, ValueFrame& frame);
+	void visitMul(ir::MulOperation* mulIntOp, ValueFrame& frame);
+	void visitDiv(ir::DivOperation* divFloatOp, ValueFrame& frame);
+	void visitMod(ir::ModOperation* divFloatOp, ValueFrame& frame);
+	void visitStore(ir::StoreOperation* storeOp, ValueFrame& frame);
+	void visitLoad(ir::LoadOperation* loadOp, ValueFrame& frame);
+	void visitIf(ir::IfOperation* ifOp, ValueFrame& frame);
+	void visitCompare(ir::CompareOperation* compareOp, ValueFrame& frame);
+	void visitBranch(ir::BranchOperation* branchOp, ValueFrame& frame);
+	void visitReturn(ir::ReturnOperation* returnOp, ValueFrame& frame);
+	void visitProxyCall(ir::ProxyCallOperation* proxyCallOp, ValueFrame& frame);
+	void visitIndirectCall(ir::IndirectCallOperation* indirectCallOp, ValueFrame& frame);
+	void visitOr(ir::OrOperation* orOperation, ValueFrame& frame);
+	void visitAnd(ir::AndOperation* andOperation, ValueFrame& frame);
+	void visitNegate(ir::NegateOperation* negateOperation, ValueFrame& frame);
+	void visitNot(ir::NotOperation* notOperation, ValueFrame& frame);
+	void visitSelect(ir::SelectOperation* selectOperation, ValueFrame& frame);
+	void visitCast(ir::CastOperation* castOperation, ValueFrame& frame);
+	void visitBinaryComp(ir::BinaryCompOperation* binaryCompOperation, ValueFrame& frame);
+	void visitShift(ir::ShiftOperation* shiftOperation, ValueFrame& frame);
+	void visitAlloca(ir::AllocaOperation* allocaOperation, ValueFrame& frame);
+	void visitFunctionAddressOf(ir::FunctionAddressOfOperation* funcAddrOp, ValueFrame& frame);
 	/**
 	 * @brief Generates a basic block inside of the current MLIR module. Used for control flow (if,loop).
 	 * @param blockInvocation:  basic block that is invocated.

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -143,8 +143,7 @@ struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::s
 
 template <>
 struct formatter<nautilus::compiler::ir::BlockIdentifier> : formatter<std::string_view> {
-	static auto format(nautilus::compiler::ir::BlockIdentifier id,
-	                   format_context& ctx) -> format_context::iterator {
+	static auto format(nautilus::compiler::ir::BlockIdentifier id, format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}", id.getId());
 		return out;

--- a/nautilus/src/nautilus/compiler/ir/OperationDispatcher.hpp
+++ b/nautilus/src/nautilus/compiler/ir/OperationDispatcher.hpp
@@ -1,0 +1,321 @@
+#pragma once
+
+#include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
+#include "nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp"
+#include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
+#include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
+#include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
+#include "nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp"
+#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
+#include "nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp"
+#include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
+#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
+#include "nautilus/compiler/ir/operations/CastOperation.hpp"
+#include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
+#include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
+#include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
+#include "nautilus/compiler/ir/operations/ConstPtrOperation.hpp"
+#include "nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp"
+#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
+#include "nautilus/compiler/ir/operations/IfOperation.hpp"
+#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
+#include "nautilus/compiler/ir/operations/LoadOperation.hpp"
+#include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
+#include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
+#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
+#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
+#include "nautilus/compiler/ir/operations/Operation.hpp"
+#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
+#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
+#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
+#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
+#include "nautilus/exceptions/NotImplementedException.hpp"
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace nautilus::compiler::ir {
+
+/**
+ * @brief CRTP base that owns the single `switch (op->getOperationType())` for
+ * lowering IR to any backend.
+ *
+ * Each backend lowering provider inherits `OperationDispatcher<Self>` and
+ * overrides the `visitXxx` hooks it cares about. Extra per-backend arguments
+ * (e.g. a `short` block index, a frame reference) are forwarded verbatim via
+ * `Args&&...`, so every backend keeps its natural call signature.
+ *
+ * Why CRTP and not virtuals: the rest of the IR layer deliberately avoids
+ * virtual dispatch on `Operation` (see the LLVM-style `classof`/`as` helpers
+ * in `Operation.hpp`). Mirroring that philosophy here keeps the dispatch a
+ * single inlineable switch with zero indirect calls.
+ *
+ * Why the `switch` has no `default:` label: with `-Wswitch-enum` (or even
+ * the default warning level on Clang) this turns any newly-added
+ * `Operation::OperationType` enumerator into a compile error until every
+ * backend wires it in, replacing the previous "silently missing case" class
+ * of bug.
+ *
+ * Default behaviour:
+ *  - Non-structural ops (the 27 ops that actually carry semantics) fall back
+ *    to throwing `NotImplementedException` if a backend forgets to override.
+ *  - Structural ops (`FunctionOp`, `BasicBlockArgument`, `BlockInvocation`,
+ *    `MLIR_YIELD`) fall back to a no-op, since every current backend treats
+ *    them that way.
+ */
+template <typename Derived>
+class OperationDispatcher {
+public:
+	/// Dispatch a single operation to the matching `visitXxx` hook on Derived.
+	template <typename... Args>
+	void dispatch(const std::unique_ptr<Operation>& op, Args&&... args) {
+		using OT = Operation::OperationType;
+		auto& d = static_cast<Derived&>(*this);
+		switch (op->getOperationType()) {
+		// Arithmetic
+		case OT::AddOp:
+			d.visitAdd(as<AddOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::SubOp:
+			d.visitSub(as<SubOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::MulOp:
+			d.visitMul(as<MulOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::DivOp:
+			d.visitDiv(as<DivOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::ModOp:
+			d.visitMod(as<ModOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Logical / bitwise
+		case OT::AndOp:
+			d.visitAnd(as<AndOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::OrOp:
+			d.visitOr(as<OrOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::NotOp:
+			d.visitNot(as<NotOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::NegateOp:
+			d.visitNegate(as<NegateOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::ShiftOp:
+			d.visitShift(as<ShiftOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::BinaryComp:
+			d.visitBinaryComp(as<BinaryCompOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::CompareOp:
+			d.visitCompare(as<CompareOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Casts
+		case OT::CastOp:
+			d.visitCast(as<CastOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Constants
+		case OT::ConstIntOp:
+			d.visitConstInt(as<ConstIntOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::ConstFloatOp:
+			d.visitConstFloat(as<ConstFloatOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::ConstBooleanOp:
+			d.visitConstBoolean(as<ConstBooleanOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::ConstPtrOp:
+			d.visitConstPtr(as<ConstPtrOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Memory
+		case OT::LoadOp:
+			d.visitLoad(as<LoadOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::StoreOp:
+			d.visitStore(as<StoreOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::AllocaOp:
+			d.visitAlloca(as<AllocaOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Control flow
+		case OT::IfOp:
+			d.visitIf(as<IfOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::BranchOp:
+			d.visitBranch(as<BranchOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::ReturnOp:
+			d.visitReturn(as<ReturnOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::SelectOp:
+			d.visitSelect(as<SelectOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Calls
+		case OT::ProxyCallOp:
+			d.visitProxyCall(as<ProxyCallOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::IndirectCallOp:
+			d.visitIndirectCall(as<IndirectCallOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::FunctionAddressOfOp:
+			d.visitFunctionAddressOf(as<FunctionAddressOfOperation>(op), std::forward<Args>(args)...);
+			return;
+
+		// Structural ops: defaults are no-op; overridable if a backend cares.
+		case OT::FunctionOp:
+			d.visitFunction(as<FunctionOperation>(op), std::forward<Args>(args)...);
+			return;
+		case OT::BasicBlockArgument:
+			d.visitBasicBlockArgument(op.get(), std::forward<Args>(args)...);
+			return;
+		case OT::BlockInvocation:
+			d.visitBlockInvocation(op.get(), std::forward<Args>(args)...);
+			return;
+		case OT::MLIR_YIELD:
+			d.visitMlirYield(op.get(), std::forward<Args>(args)...);
+			return;
+		}
+		// No default: adding an enumerator to OperationType is a compile error
+		// (under -Wswitch-enum) until every backend wires it in. The throw is
+		// only reachable if a corrupted uint8_t ever slips in.
+		throw NotImplementedException("OperationDispatcher: unknown OperationType");
+	}
+
+	// ── Default hooks ────────────────────────────────────────────────────────
+	// Non-structural ops: throw if a backend forgot to override.
+	template <typename... Args>
+	void visitAdd(AddOperation*, Args&&...) {
+		unhandled("AddOp");
+	}
+	template <typename... Args>
+	void visitSub(SubOperation*, Args&&...) {
+		unhandled("SubOp");
+	}
+	template <typename... Args>
+	void visitMul(MulOperation*, Args&&...) {
+		unhandled("MulOp");
+	}
+	template <typename... Args>
+	void visitDiv(DivOperation*, Args&&...) {
+		unhandled("DivOp");
+	}
+	template <typename... Args>
+	void visitMod(ModOperation*, Args&&...) {
+		unhandled("ModOp");
+	}
+	template <typename... Args>
+	void visitAnd(AndOperation*, Args&&...) {
+		unhandled("AndOp");
+	}
+	template <typename... Args>
+	void visitOr(OrOperation*, Args&&...) {
+		unhandled("OrOp");
+	}
+	template <typename... Args>
+	void visitNot(NotOperation*, Args&&...) {
+		unhandled("NotOp");
+	}
+	template <typename... Args>
+	void visitNegate(NegateOperation*, Args&&...) {
+		unhandled("NegateOp");
+	}
+	template <typename... Args>
+	void visitShift(ShiftOperation*, Args&&...) {
+		unhandled("ShiftOp");
+	}
+	template <typename... Args>
+	void visitBinaryComp(BinaryCompOperation*, Args&&...) {
+		unhandled("BinaryComp");
+	}
+	template <typename... Args>
+	void visitCompare(CompareOperation*, Args&&...) {
+		unhandled("CompareOp");
+	}
+	template <typename... Args>
+	void visitCast(CastOperation*, Args&&...) {
+		unhandled("CastOp");
+	}
+	template <typename... Args>
+	void visitConstInt(ConstIntOperation*, Args&&...) {
+		unhandled("ConstIntOp");
+	}
+	template <typename... Args>
+	void visitConstFloat(ConstFloatOperation*, Args&&...) {
+		unhandled("ConstFloatOp");
+	}
+	template <typename... Args>
+	void visitConstBoolean(ConstBooleanOperation*, Args&&...) {
+		unhandled("ConstBooleanOp");
+	}
+	template <typename... Args>
+	void visitConstPtr(ConstPtrOperation*, Args&&...) {
+		unhandled("ConstPtrOp");
+	}
+	template <typename... Args>
+	void visitLoad(LoadOperation*, Args&&...) {
+		unhandled("LoadOp");
+	}
+	template <typename... Args>
+	void visitStore(StoreOperation*, Args&&...) {
+		unhandled("StoreOp");
+	}
+	template <typename... Args>
+	void visitAlloca(AllocaOperation*, Args&&...) {
+		unhandled("AllocaOp");
+	}
+	template <typename... Args>
+	void visitIf(IfOperation*, Args&&...) {
+		unhandled("IfOp");
+	}
+	template <typename... Args>
+	void visitBranch(BranchOperation*, Args&&...) {
+		unhandled("BranchOp");
+	}
+	template <typename... Args>
+	void visitReturn(ReturnOperation*, Args&&...) {
+		unhandled("ReturnOp");
+	}
+	template <typename... Args>
+	void visitSelect(SelectOperation*, Args&&...) {
+		unhandled("SelectOp");
+	}
+	template <typename... Args>
+	void visitProxyCall(ProxyCallOperation*, Args&&...) {
+		unhandled("ProxyCallOp");
+	}
+	template <typename... Args>
+	void visitIndirectCall(IndirectCallOperation*, Args&&...) {
+		unhandled("IndirectCallOp");
+	}
+	template <typename... Args>
+	void visitFunctionAddressOf(FunctionAddressOfOperation*, Args&&...) {
+		unhandled("FunctionAddressOfOp");
+	}
+
+	// Structural ops: no-op defaults (every current backend skips these).
+	template <typename... Args>
+	void visitFunction(FunctionOperation*, Args&&...) {
+	}
+	template <typename... Args>
+	void visitBasicBlockArgument(Operation*, Args&&...) {
+	}
+	template <typename... Args>
+	void visitBlockInvocation(Operation*, Args&&...) {
+	}
+	template <typename... Args>
+	void visitMlirYield(Operation*, Args&&...) {
+	}
+
+private:
+	[[noreturn]] static void unhandled(const char* name) {
+		throw NotImplementedException(std::string("OperationDispatcher: unhandled ") + name);
+	}
+};
+
+} // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp
+++ b/nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp
@@ -233,11 +233,13 @@ protected:
 					auto ifOp = as<IfOperation>(op);
 					auto trueBlock = std::to_string(ifOp->getTrueBlockInvocation().getBlock()->getIdentifier().getId());
 					writeEdge(fromId, trueBlock, "control", "true");
-					auto falseBlock = std::to_string(ifOp->getFalseBlockInvocation().getBlock()->getIdentifier().getId());
+					auto falseBlock =
+					    std::to_string(ifOp->getFalseBlockInvocation().getBlock()->getIdentifier().getId());
 					writeEdge(fromId, falseBlock, "control", "false");
 				} else if (op->getOperationType() == Operation::OperationType::BranchOp) {
 					auto branchOp = as<BranchOperation>(op);
-					auto falseBlock = std::to_string(branchOp->getNextBlockInvocation().getBlock()->getIdentifier().getId());
+					auto falseBlock =
+					    std::to_string(branchOp->getNextBlockInvocation().getBlock()->getIdentifier().getId());
 					writeEdge(fromId, falseBlock, "control", "");
 				}
 			} else {
@@ -280,15 +282,18 @@ protected:
 					if (op->getOperationType() == Operation::OperationType::IfOp) {
 						auto ifOp = as<IfOperation>(op);
 						std::string toTrue =
-						    "start_" + std::to_string(ifOp->getTrueBlockInvocation().getBlock()->getIdentifier().getId());
+						    "start_" +
+						    std::to_string(ifOp->getTrueBlockInvocation().getBlock()->getIdentifier().getId());
 						writeEdge(from, toTrue, "control", "true");
 						std::string toFalse =
-						    "start_" + std::to_string(ifOp->getFalseBlockInvocation().getBlock()->getIdentifier().getId());
+						    "start_" +
+						    std::to_string(ifOp->getFalseBlockInvocation().getBlock()->getIdentifier().getId());
 						writeEdge(from, toFalse, "control", "false");
 					} else if (op->getOperationType() == Operation::OperationType::BranchOp) {
 						auto branchOp = as<BranchOperation>(op);
 						std::string to =
-						    "start_" + std::to_string(branchOp->getNextBlockInvocation().getBlock()->getIdentifier().getId());
+						    "start_" +
+						    std::to_string(branchOp->getNextBlockInvocation().getBlock()->getIdentifier().getId());
 						writeEdge(from, to, "control", "");
 					}
 				}

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -352,8 +352,8 @@ auto formatter<nautilus::tracing::ExecutionTrace>::format(const nautilus::tracin
 	return out;
 }
 
-auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block& block, format_context& ctx)
-    -> format_context::iterator {
+auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block& block,
+                                                 format_context& ctx) -> format_context::iterator {
 	auto out = ctx.out();
 	fmt::format_to(out, "(");
 	for (size_t i = 0; i < block.arguments.size(); i++) {
@@ -375,8 +375,8 @@ auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block&
 
 template <>
 struct formatter<nautilus::tracing::TypedValueRef> : formatter<std::string_view> {
-	static auto format(const nautilus::tracing::TypedValueRef& typeValRef, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::tracing::TypedValueRef& typeValRef,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", typeValRef.ref);
 		return out;

--- a/nautilus/src/nautilus/tracing/TracingUtil.cpp
+++ b/nautilus/src/nautilus/tracing/TracingUtil.cpp
@@ -144,8 +144,8 @@ struct formatter<nautilus::ConstantLiteral> : formatter<std::string_view> {
 };
 } // namespace fmt
 
-auto fmt::formatter<nautilus::ConstantLiteral>::format(nautilus::ConstantLiteral lit, format_context& ctx) const
-    -> format_context::iterator {
+auto fmt::formatter<nautilus::ConstantLiteral>::format(nautilus::ConstantLiteral lit,
+                                                       format_context& ctx) const -> format_context::iterator {
 	auto out = ctx.out();
 	std::visit(
 	    [&](auto&& value) {

--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
@@ -112,7 +112,8 @@ __attribute__((noinline)) void* get_addr(size_t index) {
 		         (void(addr = __builtin_extract_return_addr(__builtin_return_address(ints + 2))), true)) ||
 		        ...);
 		return addr;
-	}(std::make_index_sequence<StackSize> {});
+	}
+	(std::make_index_sequence<StackSize> {});
 }
 
 static void* getReturnAddress(uint32_t offset) {

--- a/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
+++ b/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
@@ -23,8 +23,14 @@ TEST_CASE("Tiered Compilation Latency Benchmark") {
 
 	using BenchFunc = std::pair<std::string, std::function<void(NautilusModule&)>>;
 	std::vector<BenchFunc> testFuncs = {
-	    {"addOne", [](NautilusModule& m) { m.registerFunction<val<int32_t>(val<int32_t>)>("f", benchAddOne); }},
-	    {"sumLoop", [](NautilusModule& m) { m.registerFunction<val<int32_t>(val<int32_t>)>("f", benchSumLoop); }},
+	    {"addOne",
+	     [](NautilusModule& m) {
+		     m.registerFunction<val<int32_t>(val<int32_t>)>("f", benchAddOne);
+	     }},
+	    {"sumLoop",
+	     [](NautilusModule& m) {
+		     m.registerFunction<val<int32_t>(val<int32_t>)>("f", benchSumLoop);
+	     }},
 	};
 
 	for (auto& [name, registerFn] : testFuncs) {

--- a/nautilus/test/common/ExpressionFunctions.hpp
+++ b/nautilus/test/common/ExpressionFunctions.hpp
@@ -212,9 +212,7 @@ val<int32_t> constructComplexReturnObject(val<int32_t> a, val<int32_t> b) {
 
 val<int32_t> constructComplexReturnObject2(val<int32_t> a, val<int32_t> b) {
 	val<int32_t> t = 0;
-	{
-		t = constructComplexReturnObject(a, b);
-	}
+	{ t = constructComplexReturnObject(a, b); }
 	return t + 42;
 }
 

--- a/nautilus/test/common/NautilusFunction.hpp
+++ b/nautilus/test/common/NautilusFunction.hpp
@@ -163,7 +163,9 @@ val<int> nautilusFunctionInline(val<int> a, val<int> b) {
 
 // Test: Inline NautilusFunction with lambda
 val<int> nautilusFunctionInlineLambda(val<int> a, val<int> b) {
-	auto inlineMul = NautilusFunction {"inlineMul", [](val<int> x, val<int> y) -> val<int> { return x * y; }};
+	auto inlineMul = NautilusFunction {"inlineMul", [](val<int> x, val<int> y) -> val<int> {
+		                                   return x * y;
+	                                   }};
 	return inlineMul(a, b);
 }
 
@@ -184,7 +186,9 @@ val<int> nautilusFunctionInlineMember(val<int> a, val<int> b) {
 // Test: Multiple inline NautilusFunctions in one function
 val<int> nautilusFunctionMultipleInline(val<int> a, val<int> b) {
 	auto inlineAdd = NautilusFunction {"inlineAdd2", add_indirect};
-	auto inlineMul = NautilusFunction {"inlineMul2", [](val<int> x, val<int> y) -> val<int> { return x * y; }};
+	auto inlineMul = NautilusFunction {"inlineMul2", [](val<int> x, val<int> y) -> val<int> {
+		                                   return x * y;
+	                                   }};
 	auto sum = inlineAdd(a, b);
 	auto product = inlineMul(a, b);
 	return sum + product;


### PR DESCRIPTION
Add a single header-only OperationDispatcher<Derived> (under
src/nautilus/compiler/ir/) that owns the switch on
ir::Operation::OperationType and calls visitXxx hooks on the derived
backend. Migrate all four backends (MLIR, C++, bytecode, AsmJit x64/a64)
to inherit from it and delete their hand-rolled ~30-case switches.

Adding a new OperationType is now a single-point change: wire it into
the dispatcher's switch and each backend that needs it. The switch has
no default label, so missing a backend becomes a compile error under
-Wswitch-enum instead of a runtime NotImplementedException.

Pure mechanical refactor: no behavior changes, no new ops, no new tests.
Handler bodies are preserved verbatim; only method names change
(generateMLIR/process/processXxx → visitXxx) and the enclosing switch
is replaced by a one-line dispatch(op, ...) call.