### PR TITLE
Arena-back TraceOperation::input and make InputVariant trivial

### DIFF
--- a/nautilus/include/nautilus/tracing/Operations.hpp
+++ b/nautilus/include/nautilus/tracing/Operations.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "nautilus/tracing/Types.hpp"
 #include "nautilus/val_concepts.hpp"
 #include <cstdint>
 #include <iosfwd>
@@ -128,6 +129,63 @@ constexpr const char* toString(Op type) {
 	default:
 		__builtin_unreachable();
 	}
+}
+
+/**
+ * @brief Returns the number of inputs a TraceOperation of the given op/resultType has.
+ *
+ * For every op except RETURN the count is statically fixed by the op code.  RETURN
+ * carries the returned value as a single input when the traced function is non-void
+ * and no inputs for a void return; this mirrors the invariant enforced by
+ * ExecutionTrace::addReturn, which is the only site that creates RETURN ops.
+ */
+constexpr uint8_t inputCountFor(Op op, Type resultType) noexcept {
+	switch (op) {
+	case RETURN:
+		return resultType == Type::v ? 0 : 1;
+	case ALLOCA_TOMBSTONE:
+		return 0;
+	case CMP:
+		return 4;
+	case SELECT:
+		return 3;
+	case STORE:
+	case EQ:
+	case NEQ:
+	case LT:
+	case LTE:
+	case GT:
+	case GTE:
+	case AND:
+	case OR:
+	case ADD:
+	case MUL:
+	case DIV:
+	case SUB:
+	case MOD:
+	case LSH:
+	case RSH:
+	case BOR:
+	case BXOR:
+	case BAND:
+		return 2;
+	// Single-input ops: JMP, CALL, INDIRECT_CALL, ASSIGN, CONST, CAST, FREE,
+	// LOAD, NOT, NEGATE, ALLOCA, FUNC_ADDR.
+	case JMP:
+	case CALL:
+	case INDIRECT_CALL:
+	case ASSIGN:
+	case CONST:
+	case CAST:
+	case FREE:
+	case LOAD:
+	case NOT:
+	case NEGATE:
+	case ALLOCA:
+	case FUNC_ADDR:
+		return 1;
+	}
+	__builtin_unreachable();
 }
 
 } // namespace nautilus::tracing

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -107,7 +107,11 @@ TypedValueRef& ExceptionBasedTraceContext::traceOperation(Op op, OnCreation&& on
 }
 
 TypedValueRef& ExceptionBasedTraceContext::traceAlloca(size_t allocSize) {
-	return traceOperation(ALLOCA, Type::ptr, {allocSize});
+	auto op = Op::ALLOCA;
+	auto resultType = Type::ptr;
+	return traceOperation(op, [&, allocSize](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {AllocSize {allocSize}});
+	});
 }
 
 TypedValueRef& ExceptionBasedTraceContext::traceCopy(const TypedValueRef& ref) {
@@ -125,11 +129,12 @@ TypedValueRef& ExceptionBasedTraceContext::traceCall(void* fptn, Type resultType
 	auto functionName = getFunctionName(fptn, mangledName);
 	auto op = Op::CALL;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto functionArguments = FunctionCall {.functionName = functionName,
-		                                       .mangledName = mangledName,
-		                                       .ptr = fptn,
-		                                       .arguments = arguments,
-		                                       .fnAttrs = fnAttrs};
+		auto* functionArguments =
+		    state->executionTrace.getArena().create<FunctionCall>(FunctionCall {.functionName = functionName,
+		                                                                        .mangledName = mangledName,
+		                                                                        .ptr = fptn,
+		                                                                        .arguments = arguments,
+		                                                                        .fnAttrs = fnAttrs});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {functionArguments});
 	});
 }
@@ -139,7 +144,8 @@ TypedValueRef& ExceptionBasedTraceContext::traceIndirectCall(const TypedValueRef
                                                              FunctionAttributes fnAttrs) {
 	auto op = Op::INDIRECT_CALL;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto indirectCall = IndirectFunctionCall {.fnPtr = fnPtrRef, .arguments = arguments, .fnAttrs = fnAttrs};
+		auto* indirectCall = state->executionTrace.getArena().create<IndirectFunctionCall>(
+		    IndirectFunctionCall {.fnPtr = fnPtrRef, .arguments = arguments, .fnAttrs = fnAttrs});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {indirectCall});
 	});
 }
@@ -157,11 +163,12 @@ TypedValueRef& ExceptionBasedTraceContext::traceNautilusCall(const NautilusFunct
 	}
 	auto op = Op::CALL;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto functionArguments = FunctionCall {.functionName = functionName,
-		                                       .mangledName = functionName,
-		                                       .ptr = (void*) definition,
-		                                       .arguments = arguments,
-		                                       .fnAttrs = fnAttrs};
+		auto* functionArguments =
+		    state->executionTrace.getArena().create<FunctionCall>(FunctionCall {.functionName = functionName,
+		                                                                        .mangledName = functionName,
+		                                                                        .ptr = (void*) definition,
+		                                                                        .arguments = arguments,
+		                                                                        .fnAttrs = fnAttrs});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {functionArguments});
 	});
 }
@@ -177,11 +184,12 @@ TypedValueRef& ExceptionBasedTraceContext::traceNautilusFunctionPtr(const Nautil
 	auto op = Op::FUNC_ADDR;
 	auto resultType = Type::ptr;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto functionArguments = FunctionCall {.functionName = functionName,
-		                                       .mangledName = functionName,
-		                                       .ptr = (void*) definition,
-		                                       .arguments = {},
-		                                       .fnAttrs = {}};
+		auto* functionArguments =
+		    state->executionTrace.getArena().create<FunctionCall>(FunctionCall {.functionName = functionName,
+		                                                                        .mangledName = functionName,
+		                                                                        .ptr = (void*) definition,
+		                                                                        .arguments = {},
+		                                                                        .fnAttrs = {}});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {functionArguments});
 	});
 }
@@ -202,24 +210,24 @@ void ExceptionBasedTraceContext::traceReturnOperation(Type resultType, const Typ
 	}
 }
 
-TypedValueRef& ExceptionBasedTraceContext::traceOperation(Op op, Type resultType, std::vector<InputVariant> inputs) {
-	return traceOperation(op, [&, inputs = std::move(inputs)](Snapshot& tag) mutable -> TypedValueRef& {
-		return state->executionTrace.addOperationWithResult(tag, op, resultType, std::move(inputs));
+TypedValueRef& ExceptionBasedTraceContext::traceBinaryOp(Op op, Type resultType, const TypedValueRef& left,
+                                                         const TypedValueRef& right) {
+	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {left, right});
 	});
 }
 
-TypedValueRef& ExceptionBasedTraceContext::traceBinaryOp(Op op, Type resultType, const TypedValueRef& left,
-                                                         const TypedValueRef& right) {
-	return traceOperation(op, resultType, {left, right});
-}
-
 TypedValueRef& ExceptionBasedTraceContext::traceUnaryOp(Op op, Type resultType, const TypedValueRef& input) {
-	return traceOperation(op, resultType, {input});
+	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {input});
+	});
 }
 
 TypedValueRef& ExceptionBasedTraceContext::traceTernaryOp(Op op, Type resultType, const TypedValueRef& first,
                                                           const TypedValueRef& second, const TypedValueRef& third) {
-	return traceOperation(op, resultType, {first, second, third});
+	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {first, second, third});
+	});
 }
 
 std::string ExceptionBasedTraceContext::formatStaticVars() const {
@@ -270,9 +278,9 @@ bool ExceptionBasedTraceContext::traceBool(const TypedValueRef& value, const dou
 
 	uint16_t nextBlock;
 	if (result) {
-		nextBlock = std::get<BlockRef>(currentOperation.input[1]).block;
+		nextBlock = std::get<BlockRef*>(currentOperation.input[1])->block;
 	} else {
-		nextBlock = std::get<BlockRef>(currentOperation.input[2]).block;
+		nextBlock = std::get<BlockRef*>(currentOperation.input[2])->block;
 	}
 	state->executionTrace.setCurrentBlock(nextBlock);
 	return result;

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
@@ -282,9 +282,6 @@ public:
 	static std::unique_ptr<ExecutionTrace> trace(std::function<void()>& traceFunction, const engine::Options& options,
 	                                             Arena& arena);
 
-	/// Low-level entry point used by the internal tracing loop.
-	TypedValueRef& traceOperation(Op op, Type resultType, std::vector<InputVariant> inputRef);
-
 	/**
 	 * @brief Default constructor - public to allow thread_local storage.
 	 * Initializes with empty state (state == nullptr means not initialized).

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -134,11 +134,9 @@ void ExecutionTrace::addReturn(Snapshot& snapshot, Type resultType, const TypedV
 	auto op = Op::RETURN;
 	TraceOperation* newOp;
 	if (ref.type == Type::v) {
-		newOp = arena->create<TraceOperation>(snapshot, op, resultType, TypedValueRef(0, Type::v),
-		                                      std::vector<InputVariant> {});
+		newOp = makeTraceOp(*arena, snapshot, op, resultType, TypedValueRef(0, Type::v));
 	} else {
-		newOp = arena->create<TraceOperation>(snapshot, op, resultType, TypedValueRef(0, Type::v),
-		                                      std::vector<InputVariant> {ref});
+		newOp = makeTraceOp(*arena, snapshot, op, resultType, TypedValueRef(0, Type::v), ref);
 	}
 	operations.push_back(newOp);
 	auto operationIdentifier = getNextOperationIdentifier();
@@ -154,33 +152,31 @@ TypedValueRef& ExecutionTrace::addAssignmentOperation(Snapshot& snapshot, const 
 	}
 	auto& operations = blocks[currentBlockIndex]->operations;
 	auto op = ASSIGN;
-	auto* operation =
-	    arena->create<TraceOperation>(snapshot, op, resultType, targetRef, std::vector<InputVariant> {srcRef});
+	auto* operation = makeTraceOp(*arena, snapshot, op, resultType, targetRef, srcRef);
 	operations.push_back(operation);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
 	return operation->resultRef;
 }
 
-void ExecutionTrace::addOperation(Snapshot& snapshot, Op& operation, std::vector<InputVariant> inputs) {
+void ExecutionTrace::addOperation(Snapshot& snapshot, Op& operation, std::initializer_list<InputVariant> inputs) {
 	if (blocks.empty()) {
 		createBlock();
 	}
 	auto& operations = blocks[currentBlockIndex]->operations;
-	auto* newOp =
-	    arena->create<TraceOperation>(snapshot, operation, Type::v, TypedValueRef(0, Type::v), std::move(inputs));
+	auto* newOp = makeTraceOp(*arena, snapshot, operation, Type::v, TypedValueRef(0, Type::v), inputs);
 	operations.push_back(newOp);
 }
 
 TypedValueRef& ExecutionTrace::addOperationWithResult(Snapshot& snapshot, Op& operation, Type& resultType,
-                                                      std::vector<InputVariant> inputs) {
+                                                      std::initializer_list<InputVariant> inputs) {
 	if (blocks.empty()) {
 		createBlock();
 	}
 
 	auto& operations = blocks[currentBlockIndex]->operations;
-	auto* to = arena->create<TraceOperation>(snapshot, operation, resultType,
-	                                         TypedValueRef(getNextValueRef(), resultType), std::move(inputs));
+	auto* to =
+	    makeTraceOp(*arena, snapshot, operation, resultType, TypedValueRef(getNextValueRef(), resultType), inputs);
 	operations.push_back(to);
 
 	auto operationIdentifier = getNextOperationIdentifier();
@@ -201,9 +197,10 @@ void ExecutionTrace::addCmpOperation(Snapshot& snapshot, const TypedValueRef& co
 	auto falseBlock = createBlock();
 	getBlock(falseBlock).predecessors.emplace_back(getCurrentBlockIndex());
 	auto& operations = blocks[currentBlockIndex]->operations;
-	auto* cmpOp = arena->create<TraceOperation>(
-	    snapshot, CMP, Type::v, TypedValueRef(getNextValueRef(), Type::v),
-	    std::vector<InputVariant> {condition, BlockRef(trueBlock), BlockRef(falseBlock), probability});
+	auto* trueBlockRef = arena->create<BlockRef>(trueBlock);
+	auto* falseBlockRef = arena->create<BlockRef>(falseBlock);
+	auto* cmpOp = makeTraceOp(*arena, snapshot, CMP, Type::v, TypedValueRef(getNextValueRef(), Type::v), condition,
+	                          trueBlockRef, falseBlockRef, probability);
 	operations.push_back(cmpOp);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
@@ -217,8 +214,8 @@ void ExecutionTrace::nextOperation() {
 	}
 	auto* currentOp = block.operations[currentOperationIndex];
 	if (currentOp->op == JMP) {
-		auto& nextBlock = std::get<BlockRef>(currentOp->input[0]);
-		setCurrentBlock(nextBlock.block);
+		auto* nextBlock = std::get<BlockRef*>(currentOp->input[0]);
+		setCurrentBlock(nextBlock->block);
 	}
 }
 
@@ -227,8 +224,8 @@ TraceOperation& ExecutionTrace::getCurrentOperation() {
 		throw RuntimeException("Current operation index out of bounds: " + std::to_string(currentOperationIndex));
 	}
 	while (getCurrentBlock().operations[currentOperationIndex]->op == JMP) {
-		auto& nextBlock = std::get<BlockRef>(getCurrentBlock().operations[currentOperationIndex]->input[0]);
-		setCurrentBlock(nextBlock.block);
+		auto* nextBlock = std::get<BlockRef*>(getCurrentBlock().operations[currentOperationIndex]->input[0]);
+		setCurrentBlock(nextBlock->block);
 		if (currentOperationIndex >= getCurrentBlock().operations.size()) {
 			throw RuntimeException("Current operation index out of bounds after JMP: " +
 			                       std::to_string(currentOperationIndex));
@@ -285,12 +282,13 @@ Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
 	referenceBlock.operations.erase(referenceBlock.operations.begin() + oi.operationIndex,
 	                                referenceBlock.operations.end());
 
-	// add jump from referenced block to merge block
-	auto mergeBlockRef = BlockRef(mergedBlockId);
-	referenceBlock.addOperation(arena->create<TraceOperation>(Op::JMP, std::vector<InputVariant> {mergeBlockRef}));
+	// add jump from referenced block to merge block.  Each JMP gets its own
+	// arena-allocated BlockRef so that later phases (e.g. SSA construction)
+	// can mutate the arguments lists independently.
+	referenceBlock.addOperation(makeTraceOp(*arena, Op::JMP, arena->create<BlockRef>(mergedBlockId)));
 
 	// add jump from current block to merge block
-	currentBlock.addOperation(arena->create<TraceOperation>(Op::JMP, std::vector<InputVariant> {mergeBlockRef}));
+	currentBlock.addOperation(makeTraceOp(*arena, Op::JMP, arena->create<BlockRef>(mergedBlockId)));
 
 	mergeBlock.predecessors.emplace_back(oi.blockIndex);
 	mergeBlock.predecessors.emplace_back(currentBlockIndex);
@@ -300,8 +298,8 @@ Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
 	auto* lastMergeOperation = mergeBlock.operations[mergeBlock.operations.size() - 1];
 	if (lastMergeOperation->op == Op::CMP || lastMergeOperation->op == Op::JMP) {
 		for (auto& input : lastMergeOperation->input) {
-			if (auto blockRef = std::get_if<BlockRef>(&input)) {
-				auto& blockPredecessor = getBlock(blockRef->block).predecessors;
+			if (auto* blockRefPtr = std::get_if<BlockRef*>(&input)) {
+				auto& blockPredecessor = getBlock((*blockRefPtr)->block).predecessors;
 				std::replace(blockPredecessor.begin(), blockPredecessor.end(), oi.blockIndex, mergedBlockId);
 				std::replace(blockPredecessor.begin(), blockPredecessor.end(), currentBlockIndex, mergedBlockId);
 			}
@@ -462,10 +460,10 @@ auto formatter<nautilus::tracing::TraceOperation>::format(const nautilus::tracin
 	for (const auto& opInput : operation.input) {
 		if (auto inputRef = std::get_if<nautilus::tracing::TypedValueRef>(&opInput)) {
 			fmt::format_to(out, "{}\t", *inputRef);
-		} else if (auto blockRef = std::get_if<nautilus::tracing::BlockRef>(&opInput)) {
-			fmt::format_to(out, "{}\t", *blockRef);
-		} else if (auto fCall = std::get_if<nautilus::tracing::FunctionCall>(&opInput)) {
-			fmt::format_to(out, "{}\t", *fCall);
+		} else if (auto blockRefPtr = std::get_if<nautilus::tracing::BlockRef*>(&opInput)) {
+			fmt::format_to(out, "{}\t", **blockRefPtr);
+		} else if (auto fCallPtr = std::get_if<nautilus::tracing::FunctionCall*>(&opInput)) {
+			fmt::format_to(out, "{}\t", **fCallPtr);
 		} else if (auto constant = std::get_if<nautilus::ConstantLiteral>(&opInput)) {
 			fmt::format_to(out, "{}", *constant);
 		}

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
@@ -5,6 +5,7 @@
 #include "TraceOperation.hpp"
 #include "nautilus/common/Arena.hpp"
 #include "tag/TagRecorder.hpp"
+#include <initializer_list>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -170,7 +171,7 @@ public:
 	 * @return TypedValueRef& Reference to the resulting value
 	 */
 	TypedValueRef& addOperationWithResult(Snapshot& snapshot, Op& operation, Type& resultType,
-	                                      std::vector<InputVariant> inputs);
+	                                      std::initializer_list<InputVariant> inputs);
 
 	/**
 	 * @brief Adds a comparison operation to the trace with branch probability
@@ -271,7 +272,7 @@ public:
 	 * @param operation The operation to add
 	 * @param inputs The input operands for the operation
 	 */
-	void addOperation(Snapshot& snapshot, Op& operation, std::vector<InputVariant> inputs);
+	void addOperation(Snapshot& snapshot, Op& operation, std::initializer_list<InputVariant> inputs);
 
 	/**
 	 * @brief Returns the current block

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -101,7 +101,7 @@ TypedValueRef& LazyTraceContext::traceAlloca(size_t allocSize) {
 	auto op = Op::ALLOCA;
 	auto resultType = Type::ptr;
 	return traceOperation(op, [&, allocSize](Snapshot& tag) -> TypedValueRef& {
-		return state->executionTrace.addOperationWithResult(tag, op, resultType, {allocSize});
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {AllocSize {allocSize}});
 	});
 }
 
@@ -126,11 +126,12 @@ TypedValueRef& LazyTraceContext::traceCall(void* fptn, Type resultType,
 	auto functionName = getFunctionName(fptn, mangledName);
 	auto op = Op::CALL;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto functionArguments = FunctionCall {.functionName = functionName,
-		                                       .mangledName = mangledName,
-		                                       .ptr = fptn,
-		                                       .arguments = arguments,
-		                                       .fnAttrs = fnAttrs};
+		auto* functionArguments =
+		    state->executionTrace.getArena().create<FunctionCall>(FunctionCall {.functionName = functionName,
+		                                                                        .mangledName = mangledName,
+		                                                                        .ptr = fptn,
+		                                                                        .arguments = arguments,
+		                                                                        .fnAttrs = fnAttrs});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {functionArguments});
 	});
 }
@@ -143,7 +144,8 @@ TypedValueRef& LazyTraceContext::traceIndirectCall(const TypedValueRef& fnPtrRef
 	}
 	auto op = Op::INDIRECT_CALL;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto indirectCall = IndirectFunctionCall {.fnPtr = fnPtrRef, .arguments = arguments, .fnAttrs = fnAttrs};
+		auto* indirectCall = state->executionTrace.getArena().create<IndirectFunctionCall>(
+		    IndirectFunctionCall {.fnPtr = fnPtrRef, .arguments = arguments, .fnAttrs = fnAttrs});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {indirectCall});
 	});
 }
@@ -164,11 +166,12 @@ TypedValueRef& LazyTraceContext::traceNautilusCall(const NautilusFunctionDefinit
 	}
 	auto op = Op::CALL;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto functionArguments = FunctionCall {.functionName = functionName,
-		                                       .mangledName = functionName,
-		                                       .ptr = (void*) definition,
-		                                       .arguments = arguments,
-		                                       .fnAttrs = fnAttrs};
+		auto* functionArguments =
+		    state->executionTrace.getArena().create<FunctionCall>(FunctionCall {.functionName = functionName,
+		                                                                        .mangledName = functionName,
+		                                                                        .ptr = (void*) definition,
+		                                                                        .arguments = arguments,
+		                                                                        .fnAttrs = fnAttrs});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {functionArguments});
 	});
 }
@@ -187,11 +190,12 @@ TypedValueRef& LazyTraceContext::traceNautilusFunctionPtr(const NautilusFunction
 	auto op = Op::FUNC_ADDR;
 	auto resultType = Type::ptr;
 	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
-		auto functionArguments = FunctionCall {.functionName = functionName,
-		                                       .mangledName = functionName,
-		                                       .ptr = (void*) definition,
-		                                       .arguments = {},
-		                                       .fnAttrs = {}};
+		auto* functionArguments =
+		    state->executionTrace.getArena().create<FunctionCall>(FunctionCall {.functionName = functionName,
+		                                                                        .mangledName = functionName,
+		                                                                        .ptr = (void*) definition,
+		                                                                        .arguments = {},
+		                                                                        .fnAttrs = {}});
 		return state->executionTrace.addOperationWithResult(tag, op, resultType, {functionArguments});
 	});
 }
@@ -222,18 +226,17 @@ TypedValueRef& LazyTraceContext::traceBinaryOp(Op op, Type resultType, const Typ
 	if (paused_) {
 		return dummyRef_;
 	}
-	return traceOperation(
-	    op, [&, inputs = std::vector<InputVariant> {left, right}](Snapshot& tag) mutable -> TypedValueRef& {
-		    return state->executionTrace.addOperationWithResult(tag, op, resultType, std::move(inputs));
-	    });
+	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {left, right});
+	});
 }
 
 TypedValueRef& LazyTraceContext::traceUnaryOp(Op op, Type resultType, const TypedValueRef& input) {
 	if (paused_) {
 		return dummyRef_;
 	}
-	return traceOperation(op, [&, inputs = std::vector<InputVariant> {input}](Snapshot& tag) mutable -> TypedValueRef& {
-		return state->executionTrace.addOperationWithResult(tag, op, resultType, std::move(inputs));
+	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {input});
 	});
 }
 
@@ -242,10 +245,9 @@ TypedValueRef& LazyTraceContext::traceTernaryOp(Op op, Type resultType, const Ty
 	if (paused_) {
 		return dummyRef_;
 	}
-	return traceOperation(
-	    op, [&, inputs = std::vector<InputVariant> {first, second, third}](Snapshot& tag) mutable -> TypedValueRef& {
-		    return state->executionTrace.addOperationWithResult(tag, op, resultType, std::move(inputs));
-	    });
+	return traceOperation(op, [&](Snapshot& tag) -> TypedValueRef& {
+		return state->executionTrace.addOperationWithResult(tag, op, resultType, {first, second, third});
+	});
 }
 
 bool LazyTraceContext::traceBool(const TypedValueRef& value, const double probability) {
@@ -288,9 +290,9 @@ bool LazyTraceContext::traceBool(const TypedValueRef& value, const double probab
 
 	uint32_t nextBlock;
 	if (result) {
-		nextBlock = std::get<BlockRef>(currentOperation.input[1]).block;
+		nextBlock = std::get<BlockRef*>(currentOperation.input[1])->block;
 	} else {
-		nextBlock = std::get<BlockRef>(currentOperation.input[2]).block;
+		nextBlock = std::get<BlockRef*>(currentOperation.input[2])->block;
 	}
 	state->executionTrace.setCurrentBlock(nextBlock);
 	return result;

--- a/nautilus/src/nautilus/tracing/TraceOperation.cpp
+++ b/nautilus/src/nautilus/tracing/TraceOperation.cpp
@@ -1,17 +1,54 @@
 #include "nautilus/tracing/TraceOperation.hpp"
+#include "nautilus/common/Arena.hpp"
+#include <new>
 
 namespace nautilus::tracing {
 
 BlockRef::BlockRef(uint32_t block) : block(block) {
 }
 
-TraceOperation::TraceOperation(Snapshot& tag, Op op, Type resultType, TypedValueRef ref,
-                               std::vector<InputVariant>&& input)
-    : tag(tag), op(op), resultType(resultType), resultRef(ref), input(std::move(input)) {
+TraceOperation::TraceOperation(Snapshot& tag, Op op, Type resultType, TypedValueRef ref, std::span<InputVariant> input)
+    : tag(tag), op(op), resultType(resultType), resultRef(ref), input(input) {
 }
 
-TraceOperation::TraceOperation(Op op, std::vector<InputVariant>&& input)
-    : tag(), op(op), resultType(Type::v), resultRef(), input(std::move(input)) {
+TraceOperation::TraceOperation(Op op, std::span<InputVariant> input)
+    : tag(), op(op), resultType(Type::v), resultRef(), input(input) {
+}
+
+static_assert(std::is_trivially_destructible_v<TraceOperation>,
+              "TraceOperation must be trivially destructible so the Arena skips destructor tracking");
+
+TraceOperation* makeTraceOp(common::Arena& arena, Snapshot& tag, Op op, Type resultType, TypedValueRef ref,
+                            std::initializer_list<InputVariant> inputs) {
+	assert(inputs.size() == inputCountFor(op, resultType) &&
+	       "TraceOperation input count disagrees with inputCountFor(op, resultType)");
+	auto* buffer = detail::allocateInputArray(arena, inputs.size());
+	size_t i = 0;
+	for (const auto& in : inputs) {
+		::new (&buffer[i++]) InputVariant(in);
+	}
+	return arena.create<TraceOperation>(tag, op, resultType, ref, std::span<InputVariant> {buffer, inputs.size()});
+}
+
+TraceOperation* makeTraceOp(common::Arena& arena, Op op, std::initializer_list<InputVariant> inputs) {
+	assert(inputs.size() == inputCountFor(op, Type::v) &&
+	       "Tag-less TraceOperation input count disagrees with inputCountFor");
+	auto* buffer = detail::allocateInputArray(arena, inputs.size());
+	size_t i = 0;
+	for (const auto& in : inputs) {
+		::new (&buffer[i++]) InputVariant(in);
+	}
+	return arena.create<TraceOperation>(op, std::span<InputVariant> {buffer, inputs.size()});
+}
+
+TraceOperation* cloneTraceOp(common::Arena& arena, const TraceOperation& source) {
+	auto* buffer = detail::allocateInputArray(arena, source.input.size());
+	for (size_t i = 0; i < source.input.size(); ++i) {
+		::new (&buffer[i]) InputVariant(source.input[i]);
+	}
+	std::span<InputVariant> span(buffer, source.input.size());
+	Snapshot copiedTag = source.tag;
+	return arena.create<TraceOperation>(copiedTag, source.op, source.resultType, source.resultRef, span);
 }
 
 } // namespace nautilus::tracing

--- a/nautilus/src/nautilus/tracing/TraceOperation.hpp
+++ b/nautilus/src/nautilus/tracing/TraceOperation.hpp
@@ -1,12 +1,18 @@
 
 #pragma once
 
+#include "nautilus/common/Arena.hpp"
 #include "nautilus/tracing/Snapshot.hpp"
 #include "nautilus/tracing/TracingUtil.hpp"
 #include "nautilus/tracing/tag/Tag.hpp"
 #include <any>
+#include <cassert>
+#include <concepts>
 #include <cstddef>
+#include <initializer_list>
 #include <nautilus/common/FunctionAttributes.hpp>
+#include <new>
+#include <span>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -52,21 +58,149 @@ struct BlockRef {
 	std::vector<TypedValueRef> arguments;
 };
 
-using InputVariant = std::variant<TypedValueRef, None, ConstantLiteral, BlockRef, FunctionCall, BranchProbability,
-                                  AllocSize, IndirectFunctionCall>;
+/**
+ * @brief Operand type carried in a TraceOperation's input array.
+ *
+ * The three heavyweight alternatives (BlockRef, FunctionCall,
+ * IndirectFunctionCall) each carry std::vector / std::string members and are
+ * therefore stored by raw pointer into the Arena rather than inline.  The
+ * pointed-to objects are allocated via Arena::create, which registers their
+ * destructors with the Arena so their internal containers are cleaned up on
+ * Arena::softReset / Arena destruction.
+ *
+ * Storing pointers makes InputVariant trivially destructible: an array of
+ * InputVariants requires no per-element cleanup, so the array's Arena bytes
+ * can simply be reclaimed in bulk with the rest of the Arena.
+ */
+using InputVariant = std::variant<TypedValueRef, None, ConstantLiteral, BlockRef*, FunctionCall*, BranchProbability,
+                                  AllocSize, IndirectFunctionCall*>;
+
+static_assert(std::is_trivially_destructible_v<InputVariant>,
+              "InputVariant must stay trivially destructible so TraceOperation input arrays need no dtor sweep");
 
 /**
  * @brief Represents an individual operation in a trace.
+ *
+ * The input operand array is backed by the same common::Arena that owns the
+ * TraceOperation itself: it is a plain pointer + length (std::span) rather than
+ * a std::vector, so creating an operation no longer performs a per-op heap
+ * allocation.  The array length is statically derived from the op code (see
+ * @ref inputCountFor) and exposed via @ref inputCount.
+ *
+ * Because InputVariant (and every other member) is trivially destructible,
+ * TraceOperation is itself trivially destructible and the Arena skips
+ * destructor tracking for it.
+ *
+ * TraceOperation instances must be constructed through the @ref makeTraceOp /
+ * @ref cloneTraceOp factory functions below, which are responsible for
+ * allocating the input storage in the Arena before invoking the constructor.
  */
 class TraceOperation {
 public:
-	TraceOperation(Snapshot& tag, Op op, Type resultType, TypedValueRef ref, std::vector<InputVariant>&& input);
-	TraceOperation(Op op, std::vector<InputVariant>&& input);
+	TraceOperation(Snapshot& tag, Op op, Type resultType, TypedValueRef ref, std::span<InputVariant> input);
+	TraceOperation(Op op, std::span<InputVariant> input);
+
+	// TraceOperation lives in an Arena and is referenced by stable pointers;
+	// copying or moving would invalidate those references and desynchronise the
+	// input span from its arena-allocated storage.  Use cloneTraceOp to create
+	// an independent copy in a target arena.
+	TraceOperation(const TraceOperation&) = delete;
+	TraceOperation& operator=(const TraceOperation&) = delete;
+	TraceOperation(TraceOperation&&) = delete;
+	TraceOperation& operator=(TraceOperation&&) = delete;
+
+	/// Number of operand slots this operation has.  Derived purely from the op
+	/// code (and, for RETURN, the result type).
+	[[nodiscard]] uint8_t inputCount() const noexcept {
+		return inputCountFor(op, resultType);
+	}
+
 	Snapshot tag;
 	Op op;
 	Type resultType;
 	TypedValueRef resultRef;
-	std::vector<InputVariant> input;
+	/// View over the Arena-allocated input array.  The storage is adjacent to
+	/// (and has the same lifetime as) this TraceOperation.
+	std::span<InputVariant> input;
 };
+
+namespace detail {
+
+/// Allocates an uninitialised array of @p count InputVariants from @p arena.
+/// Returns nullptr when @p count is zero to avoid touching the bump pointer
+/// for a zero-length allocation.
+inline InputVariant* allocateInputArray(common::Arena& arena, std::size_t count) {
+	if (count == 0) {
+		return nullptr;
+	}
+	return static_cast<InputVariant*>(arena.allocate(sizeof(InputVariant) * count, alignof(InputVariant)));
+}
+
+} // namespace detail
+
+/**
+ * @brief Allocates an input array in @p arena, constructs an InputVariant for
+ * each forwarded @p inputs directly in that storage, and wires up a new
+ * TraceOperation referencing the array.
+ *
+ * Perfect-forwards every argument into the Arena-backed storage in a single
+ * placement-new per input: no intermediate initializer_list copy.  The number
+ * of inputs is derived from the pack size at compile time; the runtime
+ * assertion just verifies it matches the op's declared arity.
+ *
+ * The returned TraceOperation and its input storage all live in @p arena and
+ * share its lifetime.
+ */
+template <typename... Inputs>
+    requires(std::constructible_from<InputVariant, Inputs &&> && ...)
+TraceOperation* makeTraceOp(common::Arena& arena, Snapshot& tag, Op op, Type resultType, TypedValueRef ref,
+                            Inputs&&... inputs) {
+	constexpr std::size_t count = sizeof...(Inputs);
+	assert(count == inputCountFor(op, resultType) &&
+	       "TraceOperation input count disagrees with inputCountFor(op, resultType)");
+	InputVariant* buffer = detail::allocateInputArray(arena, count);
+	if constexpr (count > 0) {
+		std::size_t i = 0;
+		(::new (&buffer[i++]) InputVariant(std::forward<Inputs>(inputs)), ...);
+	}
+	return arena.create<TraceOperation>(tag, op, resultType, ref, std::span<InputVariant> {buffer, count});
+}
+
+/**
+ * @brief Tag-less variadic overload for operations that do not participate in
+ * the tag map (e.g. the synthetic JMPs inserted during control-flow merging).
+ */
+template <typename... Inputs>
+    requires(std::constructible_from<InputVariant, Inputs &&> && ...)
+TraceOperation* makeTraceOp(common::Arena& arena, Op op, Inputs&&... inputs) {
+	constexpr std::size_t count = sizeof...(Inputs);
+	assert(count == inputCountFor(op, Type::v) && "Tag-less TraceOperation input count disagrees with inputCountFor");
+	InputVariant* buffer = detail::allocateInputArray(arena, count);
+	if constexpr (count > 0) {
+		std::size_t i = 0;
+		(::new (&buffer[i++]) InputVariant(std::forward<Inputs>(inputs)), ...);
+	}
+	return arena.create<TraceOperation>(op, std::span<InputVariant> {buffer, count});
+}
+
+/**
+ * @brief initializer_list overload used when the caller forwards an already-
+ * built list of inputs (e.g. ExecutionTrace::addOperationWithResult).  Prefer
+ * the variadic templates above at direct call sites to avoid the extra
+ * InputVariant copy the initializer_list backing array entails.
+ */
+TraceOperation* makeTraceOp(common::Arena& arena, Snapshot& tag, Op op, Type resultType, TypedValueRef ref,
+                            std::initializer_list<InputVariant> inputs);
+
+TraceOperation* makeTraceOp(common::Arena& arena, Op op, std::initializer_list<InputVariant> inputs);
+
+/**
+ * @brief Deep-copies @p source (including its input array) into @p arena.
+ *
+ * Replaces the previous `arena.create<TraceOperation>(*source)` idiom: the
+ * copy-constructor is deleted because it would silently share the source's
+ * input span with the destination.
+ */
+TraceOperation* cloneTraceOp(common::Arena& arena, const TraceOperation& source);
 
 } // namespace nautilus::tracing

--- a/nautilus/src/nautilus/tracing/phases/SSACreationPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/SSACreationPhase.cpp
@@ -59,7 +59,7 @@ Block& SSACreationPhase::SSACreationPhaseContext::getReturnBlock() {
 	// Allocate a copy of the default return op in the arena so that both
 	// the return block and any subsequent in-place modifications of the
 	// original operation stay independent.
-	returnBlock.operations.push_back(trace->getArena().create<TraceOperation>(*defaultReturnOp));
+	returnBlock.operations.push_back(cloneTraceOp(trace->getArena(), *defaultReturnOp));
 	for (auto returnOp : returns) {
 		auto& returnOpBlock = trace->getBlock(returnOp.blockIndex);
 		auto* returnValue = returnOpBlock.operations[returnOp.operationIndex];
@@ -68,12 +68,12 @@ Block& SSACreationPhase::SSACreationPhaseContext::getReturnBlock() {
 			returnOpBlock.operations.erase(returnOpBlock.operations.cbegin() + returnOp.operationIndex);
 		} else {
 			auto snap = Snapshot();
-			returnOpBlock.operations[returnOp.operationIndex] = trace->getArena().create<TraceOperation>(
-			    snap, ASSIGN, defaultReturnOp->resultType, std::get<TypedValueRef>(defaultReturnOp->input[0]),
-			    std::vector<InputVariant> {returnValue->input[0]});
+			returnOpBlock.operations[returnOp.operationIndex] =
+			    makeTraceOp(trace->getArena(), snap, ASSIGN, defaultReturnOp->resultType,
+			                std::get<TypedValueRef>(defaultReturnOp->input[0]), returnValue->input[0]);
 		}
-		returnOpBlock.addOperation(trace->getArena().create<TraceOperation>(
-		    Op::JMP, std::vector<InputVariant> {BlockRef(returnBlock.blockId)}));
+		returnOpBlock.addOperation(
+		    makeTraceOp(trace->getArena(), Op::JMP, trace->getArena().create<BlockRef>(returnBlock.blockId)));
 		returnBlock.predecessors.emplace_back(returnOp.blockIndex);
 	}
 
@@ -95,7 +95,7 @@ void SSACreationPhase::SSACreationPhaseContext::hoistAllocaOperations() {
 	for (auto* block : blocks) {
 		for (auto* op : block->operations) {
 			if (op->op == Op::ALLOCA) {
-				allocaOps.push_back(trace->getArena().create<TraceOperation>(*op));
+				allocaOps.push_back(cloneTraceOp(trace->getArena(), *op));
 				op->op = Op::ALLOCA_TOMBSTONE;
 			}
 		}
@@ -178,15 +178,16 @@ void SSACreationPhase::SSACreationPhaseContext::processBlock(Block& startBlock) 
 			for (auto& input : operation.input) {
 				if (auto* valueRef = std::get_if<TypedValueRef>(&input)) {
 					processValueRef(block, *valueRef, operation.resultType, i);
-				} else if (auto* blockRef = std::get_if<BlockRef>(&input)) {
-					processBlockRef(block, *blockRef, i);
-				} else if (auto* fcallRef = std::get_if<FunctionCall>(&input)) {
-					for (auto valueRef : fcallRef->arguments) {
+				} else if (auto* blockRefPtr = std::get_if<BlockRef*>(&input)) {
+					processBlockRef(block, **blockRefPtr, i);
+				} else if (auto* fcallRefPtr = std::get_if<FunctionCall*>(&input)) {
+					for (auto valueRef : (*fcallRefPtr)->arguments) {
 						processValueRef(block, valueRef, valueRef.type, i);
 					}
-				} else if (auto* indirectCallRef = std::get_if<IndirectFunctionCall>(&input)) {
-					processValueRef(block, indirectCallRef->fnPtr, indirectCallRef->fnPtr.type, i);
-					for (auto& valueRef : indirectCallRef->arguments) {
+				} else if (auto* indirectCallRefPtr = std::get_if<IndirectFunctionCall*>(&input)) {
+					IndirectFunctionCall& indirectCallRef = **indirectCallRefPtr;
+					processValueRef(block, indirectCallRef.fnPtr, indirectCallRef.fnPtr.type, i);
+					for (auto& valueRef : indirectCallRef.arguments) {
 						processValueRef(block, valueRef, valueRef.type, i);
 					}
 				}
@@ -253,11 +254,12 @@ void SSACreationPhase::SSACreationPhaseContext::propagateValue(Block& block, Typ
 			auto& lastOperation = *predBlock.operations.back();
 			if (lastOperation.op == Op::JMP || lastOperation.op == Op::CMP) {
 				for (auto& input : lastOperation.input) {
-					if (auto blockRef = std::get_if<BlockRef>(&input)) {
-						if (blockRef->block == curBlockId) {
-							if (std::find(blockRef->arguments.begin(), blockRef->arguments.end(), ref) ==
-							    blockRef->arguments.end()) {
-								blockRef->arguments.emplace_back(ref);
+					if (auto* blockRefPtr = std::get_if<BlockRef*>(&input)) {
+						BlockRef& blockRef = **blockRefPtr;
+						if (blockRef.block == curBlockId) {
+							if (std::find(blockRef.arguments.begin(), blockRef.arguments.end(), ref) ==
+							    blockRef.arguments.end()) {
+								blockRef.arguments.emplace_back(ref);
 							}
 						}
 					}
@@ -321,26 +323,27 @@ void SSACreationPhase::SSACreationPhaseContext::removeAssignOperations() {
 						if (foundAssignment != assignmentMap.end()) {
 							valueRef->ref = foundAssignment->second;
 						}
-					} else if (auto* blockRef = std::get_if<BlockRef>(&input)) {
-						for (auto& blockArgument : blockRef->arguments) {
+					} else if (auto* blockRefPtr = std::get_if<BlockRef*>(&input)) {
+						for (auto& blockArgument : (*blockRefPtr)->arguments) {
 							auto foundAssignment = assignmentMap.find(blockArgument.ref);
 							if (foundAssignment != assignmentMap.end()) {
 								blockArgument.ref = foundAssignment->second;
 							}
 						}
-					} else if (auto* fcallRef = std::get_if<FunctionCall>(&input)) {
-						for (auto& funcArg : fcallRef->arguments) {
+					} else if (auto* fcallRefPtr = std::get_if<FunctionCall*>(&input)) {
+						for (auto& funcArg : (*fcallRefPtr)->arguments) {
 							auto foundAssignment = assignmentMap.find(funcArg.ref);
 							if (foundAssignment != assignmentMap.end()) {
 								funcArg.ref = foundAssignment->second;
 							}
 						}
-					} else if (auto* indirectCallRef = std::get_if<IndirectFunctionCall>(&input)) {
-						auto foundFnPtr = assignmentMap.find(indirectCallRef->fnPtr.ref);
+					} else if (auto* indirectCallRefPtr = std::get_if<IndirectFunctionCall*>(&input)) {
+						IndirectFunctionCall& indirectCallRef = **indirectCallRefPtr;
+						auto foundFnPtr = assignmentMap.find(indirectCallRef.fnPtr.ref);
 						if (foundFnPtr != assignmentMap.end()) {
-							indirectCallRef->fnPtr.ref = foundFnPtr->second;
+							indirectCallRef.fnPtr.ref = foundFnPtr->second;
 						}
-						for (auto& funcArg : indirectCallRef->arguments) {
+						for (auto& funcArg : indirectCallRef.arguments) {
 							auto foundAssignment = assignmentMap.find(funcArg.ref);
 							if (foundAssignment != assignmentMap.end()) {
 								funcArg.ref = foundAssignment->second;
@@ -386,8 +389,8 @@ void SSACreationPhase::SSACreationPhaseContext::makeBlockArgumentsUnique() {
 						// valueRef->blockId = foundAssignment->second.blockId;
 						// valueRef->operationId = foundAssignment->second.operationId;
 					}
-				} else if (auto* blockRef = std::get_if<BlockRef>(&input)) {
-					for (auto& blockArgument : blockRef->arguments) {
+				} else if (auto* blockRefPtr = std::get_if<BlockRef*>(&input)) {
+					for (auto& blockArgument : (*blockRefPtr)->arguments) {
 						auto foundAssignment = blockArgumentMap.find(blockArgument.ref);
 						if (foundAssignment != blockArgumentMap.end()) {
 							// valueRef = &foundAssignment->second;

--- a/nautilus/src/nautilus/tracing/phases/SSAVerifier.cpp
+++ b/nautilus/src/nautilus/tracing/phases/SSAVerifier.cpp
@@ -78,10 +78,10 @@ SSAVerificationResult VerifySSA(const ExecutionTrace& trace) {
 			for (const auto& input : operation.input) {
 				if (const auto* valueRef = std::get_if<TypedValueRef>(&input)) {
 					checkRef(*valueRef, "input");
-				} else if (const auto* blockRef = std::get_if<BlockRef>(&input)) {
-					checkBlockRef(*blockRef);
-				} else if (const auto* fcall = std::get_if<FunctionCall>(&input)) {
-					for (const auto& arg : fcall->arguments) {
+				} else if (const auto* blockRefPtr = std::get_if<BlockRef*>(&input)) {
+					checkBlockRef(**blockRefPtr);
+				} else if (const auto* fcallPtr = std::get_if<FunctionCall*>(&input)) {
+					for (const auto& arg : (*fcallPtr)->arguments) {
 						checkRef(arg, "function call argument");
 					}
 				}

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -28,12 +28,12 @@
 namespace nautilus::tracing {
 using namespace compiler::ir;
 
-OperationIdentifier createValueIdentifier(TypedValueRef& val) {
+OperationIdentifier createValueIdentifier(const TypedValueRef& val) {
 	return {val.ref};
 }
 
-OperationIdentifier createValueIdentifier(InputVariant& val) {
-	if (auto* valRef = std::get_if<TypedValueRef>(&val)) {
+OperationIdentifier createValueIdentifier(const InputVariant& val) {
+	if (const auto* valRef = std::get_if<TypedValueRef>(&val)) {
 		return {valRef->ref};
 	}
 	throw NotImplementedException("wrong input variant");
@@ -281,7 +281,7 @@ void TraceToIRConversionPhase::IRConversionContext::processTernaryOperator(Value
 
 void TraceToIRConversionPhase::IRConversionContext::processJMP(ValueFrame& frame, BasicBlock* block,
                                                                TraceOperation& operation) {
-	auto blockRef = get<BlockRef>(operation.input[0]);
+	const BlockRef& blockRef = *get<BlockRef*>(operation.input[0]);
 	BasicBlockInvocation blockInvocation;
 	createBlockArguments(frame, blockInvocation, blockRef);
 
@@ -300,8 +300,8 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
                                                                TraceOperation& operation) {
 	assert(operation.input.size() == 4);
 	auto valueRef = get<TypedValueRef>(operation.input[0]);
-	auto trueCaseBlockRef = get<BlockRef>(operation.input[1]);
-	auto falseCaseBlockRef = get<BlockRef>(operation.input[2]);
+	const BlockRef& trueCaseBlockRef = *get<BlockRef*>(operation.input[1]);
+	const BlockRef& falseCaseBlockRef = *get<BlockRef*>(operation.input[2]);
 	auto probability = get<BranchProbability>(operation.input[3]);
 
 	auto booleanValue = frame.getValue(createValueIdentifier(valueRef));
@@ -319,8 +319,8 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
 
 void TraceToIRConversionPhase::IRConversionContext::createBlockArguments(ValueFrame& frame,
                                                                          BasicBlockInvocation& blockInvocation,
-                                                                         BlockRef val) {
-	for (auto& arg : val.arguments) {
+                                                                         const BlockRef& val) {
+	for (const auto& arg : val.arguments) {
 		auto valueIdentifier = createValueIdentifier(arg);
 		blockInvocation.addArgument(frame.getValue(valueIdentifier));
 	}
@@ -378,9 +378,9 @@ void TraceToIRConversionPhase::IRConversionContext::processStore(ValueFrame& fra
 
 void TraceToIRConversionPhase::IRConversionContext::processCall(ValueFrame& frame, BasicBlock* currentBlock,
                                                                 TraceOperation& operation) {
-	auto functionCallTarget = std::get<FunctionCall>(operation.input[0]);
+	const FunctionCall& functionCallTarget = *std::get<FunctionCall*>(operation.input[0]);
 	auto inputArguments = std::vector<Operation*> {};
-	for (auto& argument : functionCallTarget.arguments) {
+	for (const auto& argument : functionCallTarget.arguments) {
 		auto input = frame.getValue(createValueIdentifier(argument));
 		inputArguments.emplace_back(input);
 	}
@@ -397,10 +397,10 @@ void TraceToIRConversionPhase::IRConversionContext::processCall(ValueFrame& fram
 
 void TraceToIRConversionPhase::IRConversionContext::processIndirectCall(ValueFrame& frame, BasicBlock* currentBlock,
                                                                         TraceOperation& operation) {
-	auto indirectCall = std::get<IndirectFunctionCall>(operation.input[0]);
+	const IndirectFunctionCall& indirectCall = *std::get<IndirectFunctionCall*>(operation.input[0]);
 	auto fnPtrOperand = frame.getValue(createValueIdentifier(indirectCall.fnPtr));
 	auto inputArguments = std::vector<Operation*> {};
-	for (auto& argument : indirectCall.arguments) {
+	for (const auto& argument : indirectCall.arguments) {
 		inputArguments.emplace_back(frame.getValue(createValueIdentifier(argument)));
 	}
 	auto resultType = operation.resultType;
@@ -414,7 +414,7 @@ void TraceToIRConversionPhase::IRConversionContext::processIndirectCall(ValueFra
 
 void TraceToIRConversionPhase::IRConversionContext::processFuncAddr(ValueFrame& frame, BasicBlock* currentBlock,
                                                                     TraceOperation& operation) {
-	auto functionCallTarget = std::get<FunctionCall>(operation.input[0]);
+	const FunctionCall& functionCallTarget = *std::get<FunctionCall*>(operation.input[0]);
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
 	auto funcAddrOp = currentBlock->addOperation<FunctionAddressOfOperation>(
 	    functionCallTarget.mangledName, functionCallTarget.functionName, functionCallTarget.ptr, resultIdentifier);

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
@@ -105,7 +105,8 @@ private:
 
 		void processCast(ValueFrame& frame, compiler::ir::BasicBlock* currentBlock, TraceOperation& operation);
 
-		void createBlockArguments(ValueFrame& frame, compiler::ir::BasicBlockInvocation& blockInvocation, BlockRef val);
+		void createBlockArguments(ValueFrame& frame, compiler::ir::BasicBlockInvocation& blockInvocation,
+		                          const BlockRef& val);
 
 		template <typename OpType>
 		void processBinaryOperator(ValueFrame& frame, compiler::ir::BasicBlock* currentBlock,


### PR DESCRIPTION
Replace the std::vector<InputVariant> on every TraceOperation with a
std::span over arena-allocated storage.  The array length is derived
from the op code via the new constexpr inputCountFor(Op, Type) helper,
so the length no longer has to be stored per op.

The three heavy variant alternatives (BlockRef, FunctionCall,
IndirectFunctionCall) are now carried as pointers into the Arena rather
than inline, which makes InputVariant - and therefore TraceOperation
itself - trivially destructible.  The Arena runs the destructors of the
pointed-to objects on softReset / destruction, so their internal
std::vector / std::string members are still cleaned up correctly.

Together this eliminates the per-op heap allocation that the vector
used to perform on every traced op and drops TraceOperation from the
Arena's dtor tracking list.

Also threads std::initializer_list<InputVariant> through
addOperation / addOperationWithResult and the trace contexts so the
callers no longer build a temporary std::vector for each op.