### PR TITLE
Allocate IR graph nodes from an arena

### DIFF
--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -17,6 +17,7 @@
 
 namespace nautilus::common {
 class Arena;
+class ArenaPool;
 } // namespace nautilus::common
 
 namespace nautilus::engine {
@@ -203,6 +204,17 @@ private:
 	 * lifetime.
 	 */
 	std::unique_ptr<common::Arena> arena_;
+	/**
+	 * @brief Pool of IR-graph arenas owned by the engine.
+	 *
+	 * Each IRGraph created during compilation acquires its arena from
+	 * here and returns it on destruction (including async tier-1
+	 * promotion paths in TieredJITCompiler).  Recycling chunk memory
+	 * across IR graphs amortises the per-IRGraph heap allocation that
+	 * would otherwise dominate compile times for tiny IRs.  Declared
+	 * before @ref jit_ so the compiler's reference outlives every IR.
+	 */
+	std::unique_ptr<common::ArenaPool> irArenaPool_;
 	std::unique_ptr<compiler::JITCompiler> jit_;
 	const Options options;
 };

--- a/nautilus/src/nautilus/common/Arena.hpp
+++ b/nautilus/src/nautilus/common/Arena.hpp
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <memory>
+#include <mutex>
 #include <new>
 #include <type_traits>
 #include <utility>
@@ -256,5 +258,117 @@ private:
 	std::vector<Chunk> chunks;
 	std::vector<DtorEntry> dtors;
 };
+
+/**
+ * @brief A pool of independent Arenas with recycled storage.
+ *
+ * Hands out @ref Handle objects that own an Arena for some scope (e.g. one
+ * IRGraph, one compile cycle).  When a Handle is destroyed the Arena is
+ * @ref Arena::softReset reset and pushed back into the pool, so the next
+ * call to @ref acquire reuses that Arena's already-allocated heap chunks
+ * instead of going through @c malloc again.  This amortises the per-Arena
+ * heap-allocation cost across many compiles, which is the main reason
+ * to use the pool over per-call standalone Arenas.
+ *
+ * The pool itself is internally synchronized with a mutex so callers from
+ * different threads (e.g. main compile thread and tiered-promotion thread)
+ * may share a single pool.  Acquired Handles are not thread-safe and must
+ * not be shared across threads concurrently.
+ *
+ * Standalone use is supported: a default-constructed @ref Handle (or one
+ * created without a backing pool, for example in tests) just deletes its
+ * Arena on destruction instead of recycling it.  This means @ref Handle
+ * is the universal Arena-owning smart pointer in the codebase.
+ */
+class ArenaPool {
+public:
+	/// Default cap on the number of spare Arenas held in the pool.  Excess
+	/// released Arenas are freed instead of pushed back.
+	static constexpr std::size_t DEFAULT_MAX_SPARES = 8;
+
+	/// Custom deleter used by @ref Handle.  When @c pool is non-null the
+	/// Arena is recycled into the pool; otherwise the Arena is deleted.
+	struct Returner {
+		ArenaPool* pool = nullptr;
+		void operator()(Arena* arena) const noexcept;
+	};
+
+	/// Owning, RAII handle to an Arena.  When destroyed it either returns
+	/// the Arena to its pool (if backed by one) or deletes it.
+	using Handle = std::unique_ptr<Arena, Returner>;
+
+	/// Constructs a Handle that owns a freshly heap-allocated Arena and is
+	/// not backed by any pool.  Use this when you need an Arena outside
+	/// the engine context (tests, benchmarks, ad-hoc compilations).
+	static Handle makeStandalone() {
+		return Handle(new Arena, Returner {});
+	}
+
+	explicit ArenaPool(std::size_t maxSpares = DEFAULT_MAX_SPARES) noexcept : maxSpares_(maxSpares) {
+	}
+
+	~ArenaPool() = default;
+
+	ArenaPool(const ArenaPool&) = delete;
+	ArenaPool& operator=(const ArenaPool&) = delete;
+	ArenaPool(ArenaPool&&) = delete;
+	ArenaPool& operator=(ArenaPool&&) = delete;
+
+	/**
+	 * @brief Acquires an Arena.  Returns a recycled Arena (with its chunks
+	 * intact, ready to be bumped into) if one is available, or allocates a
+	 * fresh one if the pool is empty.  The returned Handle returns the
+	 * Arena to this pool when destroyed.
+	 */
+	Handle acquire() {
+		std::unique_ptr<Arena> arena;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			if (!spares_.empty()) {
+				arena = std::move(spares_.back());
+				spares_.pop_back();
+			}
+		}
+		if (!arena) {
+			arena = std::make_unique<Arena>();
+		}
+		return Handle(arena.release(), Returner {this});
+	}
+
+	/// Returns the current number of spare Arenas held in the pool.
+	std::size_t spareCount() const noexcept {
+		std::lock_guard<std::mutex> lock(mutex_);
+		return spares_.size();
+	}
+
+private:
+	friend struct Returner;
+
+	void release(Arena* arena) noexcept {
+		// Reset before pushing so the next acquirer sees an empty arena.
+		arena->softReset();
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (spares_.size() < maxSpares_) {
+			spares_.emplace_back(arena);
+		} else {
+			delete arena;
+		}
+	}
+
+	mutable std::mutex mutex_;
+	std::vector<std::unique_ptr<Arena>> spares_;
+	std::size_t maxSpares_;
+};
+
+inline void ArenaPool::Returner::operator()(Arena* arena) const noexcept {
+	if (arena == nullptr) {
+		return;
+	}
+	if (pool != nullptr) {
+		pool->release(arena);
+	} else {
+		delete arena;
+	}
+}
 
 } // namespace nautilus::common

--- a/nautilus/src/nautilus/compiler/Engine.cpp
+++ b/nautilus/src/nautilus/compiler/Engine.cpp
@@ -9,29 +9,34 @@ namespace nautilus::engine {
 /**
  * @brief Creates the appropriate JITCompiler implementation based on options.
  *
- * The engine-owned @p arena is injected into the compiler so every trace
- * allocation across every compile() call shares a single pool of chunks.
+ * The engine-owned @p arena and @p irArenaPool are injected into the
+ * compiler so every trace allocation across every compile() call shares a
+ * single pool of chunks (trace), and every IR-graph allocation likewise
+ * recycles its arena across compiles (IR pool).
  */
-inline std::unique_ptr<compiler::JITCompiler> createJITCompiler(const Options& options, common::Arena& arena) {
+inline std::unique_ptr<compiler::JITCompiler> createJITCompiler(const Options& options, common::Arena& arena,
+                                                                common::ArenaPool& irArenaPool) {
 	// If the user explicitly selected a backend, use the legacy single-tier compiler
 	// so the requested backend is honoured directly.
 	auto explicitBackend = options.getOptionOrDefault<std::string>("engine.backend", "");
 	if (!explicitBackend.empty()) {
-		return std::make_unique<compiler::LegacyCompiler>(options, arena);
+		return std::make_unique<compiler::LegacyCompiler>(options, arena, irArenaPool);
 	}
 	std::string compilerStrategy = options.getOptionOrDefault("engine.compilationStrategy", std::string("tiered"));
 	if (compilerStrategy == "tiered") {
-		return std::make_unique<compiler::TieredJITCompiler>(options, arena);
+		return std::make_unique<compiler::TieredJITCompiler>(options, arena, irArenaPool);
 	}
-	return std::make_unique<compiler::LegacyCompiler>(options, arena);
+	return std::make_unique<compiler::LegacyCompiler>(options, arena, irArenaPool);
 }
 
 NautilusEngine::NautilusEngine(const Options& options)
-    : arena_(std::make_unique<common::Arena>()), jit_(createJITCompiler(options, *arena_)), options(options) {
+    : arena_(std::make_unique<common::Arena>()), irArenaPool_(std::make_unique<common::ArenaPool>()),
+      jit_(createJITCompiler(options, *arena_, *irArenaPool_)), options(options) {
 }
 
 NautilusEngine::NautilusEngine(std::unique_ptr<compiler::JITCompiler> jit, const Options& options)
-    : arena_(std::make_unique<common::Arena>()), jit_(std::move(jit)), options(options) {
+    : arena_(std::make_unique<common::Arena>()), irArenaPool_(std::make_unique<common::ArenaPool>()),
+      jit_(std::move(jit)), options(options) {
 }
 
 NautilusEngine::~NautilusEngine() = default;

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
@@ -26,8 +26,9 @@
 
 namespace nautilus::compiler {
 
-LegacyCompiler::LegacyCompiler(engine::Options options, common::Arena& arena)
-    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()), arena_(&arena) {
+LegacyCompiler::LegacyCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool)
+    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()), arena_(&arena),
+      irArenaPool_(&irArenaPool) {
 }
 
 LegacyCompiler::~LegacyCompiler() = default;
@@ -106,7 +107,7 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 
 	auto t2 = log::now();
 	auto irGenerationPhase = tracing::TraceToIRConversionPhase();
-	auto ir = irGenerationPhase.apply(afterSSAModule, compilationId);
+	auto ir = irGenerationPhase.apply(afterSSAModule, *irArenaPool_, compilationId);
 	statsLogger.logTiming(t2, "IR generation completed");
 	dumpHandler.dump("after_ir_creation", "ir", [&]() { return ir->toString(); });
 	if (options.getOptionOrDefault("dump.graph", false)) {

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.hpp
@@ -25,9 +25,10 @@ namespace nautilus::compiler {
  */
 class LegacyCompiler : public JITCompiler {
 public:
-	/// Construct a compiler that uses the supplied Arena for every trace.
-	/// The arena must outlive the compiler.
-	LegacyCompiler(engine::Options options, common::Arena& arena);
+	/// Construct a compiler that uses the supplied Arena for every trace
+	/// and the supplied ArenaPool for IR-graph arenas.  Both must outlive
+	/// the compiler.
+	LegacyCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool);
 	~LegacyCompiler() override;
 
 	[[nodiscard]] std::unique_ptr<Executable> compile(wrapper_function function) const override;
@@ -61,5 +62,9 @@ private:
 	/// at the start of each compile() invocation.  Marked mutable because
 	/// compile() is const but needs to recycle the arena between calls.
 	mutable common::Arena* arena_;
+	/// Non-owning pointer to the externally supplied IR-arena pool.  Each
+	/// IRGraph created during compileToIR acquires its arena from here, so
+	/// successive compiles reuse heap chunks across IR graphs.
+	mutable common::ArenaPool* irArenaPool_;
 };
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/TieredCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.cpp
@@ -26,7 +26,8 @@ static std::string createPromotionUnitID() {
 
 // --- TieredJITCompiler ---
 
-TieredJITCompiler::TieredJITCompiler(engine::Options options, common::Arena& arena) : baseCompiler_(options, arena) {
+TieredJITCompiler::TieredJITCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool)
+    : baseCompiler_(options, arena, irArenaPool) {
 	auto tier0 = options.getOptionOrDefault<std::string>("engine.tier0.backend", "");
 	auto tier1 = options.getOptionOrDefault<std::string>("engine.tier1.backend", "");
 	if (!tier0.empty() && !tier1.empty()) {
@@ -36,8 +37,8 @@ TieredJITCompiler::TieredJITCompiler(engine::Options options, common::Arena& are
 }
 
 TieredJITCompiler::TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config,
-                                     common::Arena& arena)
-    : baseCompiler_(options, arena), config_(std::move(config)) {
+                                     common::Arena& arena, common::ArenaPool& irArenaPool)
+    : baseCompiler_(options, arena, irArenaPool), config_(std::move(config)) {
 }
 
 TieredJITCompiler::~TieredJITCompiler() {
@@ -130,10 +131,12 @@ const engine::Options& TieredJITCompiler::getOptions() const {
 
 namespace nautilus::compiler {
 
-TieredJITCompiler::TieredJITCompiler(engine::Options, common::Arena& arena) : baseCompiler_(engine::Options(), arena) {
+TieredJITCompiler::TieredJITCompiler(engine::Options, common::Arena& arena, common::ArenaPool& irArenaPool)
+    : baseCompiler_(engine::Options(), arena, irArenaPool) {
 }
-TieredJITCompiler::TieredJITCompiler(engine::Options, engine::TieredCompilationConfig, common::Arena& arena)
-    : baseCompiler_(engine::Options(), arena) {
+TieredJITCompiler::TieredJITCompiler(engine::Options, engine::TieredCompilationConfig, common::Arena& arena,
+                                     common::ArenaPool& irArenaPool)
+    : baseCompiler_(engine::Options(), arena, irArenaPool) {
 }
 TieredJITCompiler::~TieredJITCompiler() = default;
 std::unique_ptr<Executable> TieredJITCompiler::compile(wrapper_function) const {

--- a/nautilus/src/nautilus/compiler/TieredCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.hpp
@@ -52,10 +52,11 @@ namespace nautilus::compiler {
 class TieredJITCompiler : public JITCompiler {
 public:
 	/// Construct a tiered compiler that borrows the supplied Arena for
-	/// every tier-0 trace-and-compile cycle.  The arena must outlive the
-	/// compiler.
-	TieredJITCompiler(engine::Options options, common::Arena& arena);
-	TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config, common::Arena& arena);
+	/// every tier-0 trace-and-compile cycle and the supplied ArenaPool
+	/// for IR-graph arenas.  Both must outlive the compiler.
+	TieredJITCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool);
+	TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config, common::Arena& arena,
+	                  common::ArenaPool& irArenaPool);
 	~TieredJITCompiler() override;
 
 	[[nodiscard]] std::unique_ptr<Executable> compile(wrapper_function function) const override;

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -168,7 +168,7 @@ void AsmJitLoweringProvider::LoweringContext::processAll() {
 		blockLabels.clear();
 		processedBlocks.clear();
 
-		for (auto& block : funcOp->getBasicBlocks()) {
+		for (auto* block : funcOp->getBasicBlocks()) {
 			getOrCreateLabel(block->getIdentifier());
 		}
 
@@ -219,7 +219,7 @@ void AsmJitLoweringProvider::LoweringContext::processBlock(const ir::BasicBlock*
 
 	cc.bind(getOrCreateLabel(id));
 
-	for (auto& op : block->getOperations()) {
+	for (auto* op : block->getOperations()) {
 		dispatch(op, frame);
 	}
 }

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -182,7 +182,7 @@ void AsmJitLoweringProvider::LoweringContext::processAll() {
 		processedBlocks.clear();
 
 		// Pre-create labels for all blocks in this function so forward jumps resolve.
-		for (auto& block : funcOp->getBasicBlocks()) {
+		for (auto* block : funcOp->getBasicBlocks()) {
 			getOrCreateLabel(block->getIdentifier());
 		}
 
@@ -234,7 +234,7 @@ void AsmJitLoweringProvider::LoweringContext::processBlock(const ir::BasicBlock*
 	// Bind the pre-created label for this block.
 	cc.bind(getOrCreateLabel(id));
 
-	for (auto& op : block->getOperations()) {
+	for (auto* op : block->getOperations()) {
 		dispatch(op, frame);
 	}
 }

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -80,20 +80,20 @@ std::tuple<Code, RegisterFile> BCLoweringProvider::LoweringContext::process() {
 
 	// Find the target function by name, or use the first function as fallback
 	const ir::FunctionOperation* targetFunction = nullptr;
-	for (const auto& funcOp : functionOperations) {
+	for (auto* funcOp : functionOperations) {
 		if (funcOp->getName() == targetFunctionName) {
-			targetFunction = funcOp.get();
+			targetFunction = funcOp;
 			break;
 		}
 	}
 	if (targetFunction == nullptr) {
-		targetFunction = functionOperations.front().get();
+		targetFunction = functionOperations.front();
 	}
 
 	RegisterFrame rootFrame;
 	const auto& functionBasicBlock = targetFunction->getFunctionBasicBlock();
 	for (auto i = 0ull; i < functionBasicBlock.getArguments().size(); i++) {
-		auto& argument = functionBasicBlock.getArguments()[i];
+		auto* argument = functionBasicBlock.getArguments()[i];
 		auto argumentRegister = registerProvider.allocRegister();
 		rootFrame.setValue(argument->getIdentifier(), argumentRegister);
 		program.arguments.emplace_back(argumentRegister);
@@ -116,7 +116,7 @@ short BCLoweringProvider::LoweringContext::process(const ir::BasicBlock* block, 
 		countUsages(block);
 		// create bytecode block;
 		program.blocks.emplace_back();
-		for (auto& opt : block->getOperations()) {
+		for (auto* opt : block->getOperations()) {
 			this->dispatch(opt, blockIndex, frame);
 		}
 		return blockIndex;
@@ -1844,7 +1844,7 @@ short BCLoweringProvider::LoweringContext::getResultRegister(ir::Operation*, Reg
 
 void BCLoweringProvider::LoweringContext::countUsages(const ir::BasicBlock* block) {
 	// Count how many times each value is used in this block
-	for (const auto& opt : block->getOperations()) {
+	for (auto* opt : block->getOperations()) {
 		// Count inputs to this operation
 		auto countInput = [this](const ir::Operation* input) {
 			if (input) {
@@ -1858,7 +1858,7 @@ void BCLoweringProvider::LoweringContext::countUsages(const ir::BasicBlock* bloc
 		case ir::Operation::OperationType::MulOp:
 		case ir::Operation::OperationType::DivOp:
 		case ir::Operation::OperationType::ModOp: {
-			auto binOp = dynamic_cast<ir::Operation*>(opt.get());
+			auto binOp = static_cast<ir::Operation*>(opt);
 			if (auto addOp = dynamic_cast<ir::AddOperation*>(binOp)) {
 				countInput(addOp->getLeftInput());
 				countInput(addOp->getRightInput());
@@ -1878,29 +1878,29 @@ void BCLoweringProvider::LoweringContext::countUsages(const ir::BasicBlock* bloc
 			break;
 		}
 		case ir::Operation::OperationType::CompareOp: {
-			auto cmpOp = dynamic_cast<ir::CompareOperation*>(opt.get());
+			auto cmpOp = dynamic_cast<ir::CompareOperation*>(opt);
 			countInput(cmpOp->getLeftInput());
 			countInput(cmpOp->getRightInput());
 			break;
 		}
 		case ir::Operation::OperationType::LoadOp: {
-			auto loadOp = dynamic_cast<ir::LoadOperation*>(opt.get());
+			auto loadOp = dynamic_cast<ir::LoadOperation*>(opt);
 			countInput(loadOp->getAddress());
 			break;
 		}
 		case ir::Operation::OperationType::StoreOp: {
-			auto storeOp = dynamic_cast<ir::StoreOperation*>(opt.get());
+			auto storeOp = dynamic_cast<ir::StoreOperation*>(opt);
 			countInput(storeOp->getAddress());
 			countInput(storeOp->getValue());
 			break;
 		}
 		case ir::Operation::OperationType::CastOp: {
-			auto castOp = dynamic_cast<ir::CastOperation*>(opt.get());
+			auto castOp = dynamic_cast<ir::CastOperation*>(opt);
 			countInput(castOp->getInput());
 			break;
 		}
 		case ir::Operation::OperationType::ReturnOp: {
-			auto retOp = dynamic_cast<ir::ReturnOperation*>(opt.get());
+			auto retOp = dynamic_cast<ir::ReturnOperation*>(opt);
 			if (retOp->hasReturnValue()) {
 				countInput(retOp->getReturnValue());
 			}

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -88,7 +88,7 @@ std::stringstream CPPLoweringProvider::LoweringContext::process() {
 		const auto& functionBasicBlock = functionOperation.getFunctionBasicBlock();
 
 		for (auto i = 0ull; i < functionBasicBlock.getArguments().size(); i++) {
-			auto argument = functionBasicBlock.getArguments()[i].get();
+			auto* argument = functionBasicBlock.getArguments()[i];
 			auto var = getVariable(argument->getIdentifier());
 			rootFrame.setValue(argument->getIdentifier(), var);
 			arguments.emplace_back(getType(argument->getStamp()) + " " + var);
@@ -147,7 +147,7 @@ std::string CPPLoweringProvider::LoweringContext::process(const ir::BasicBlock* 
 	auto entry = activeBlocks.find(block->getIdentifier());
 	if (entry == activeBlocks.end()) {
 
-		for (auto& arg : block->getArguments()) {
+		for (auto* arg : block->getArguments()) {
 			if (!frame.contains(arg->getIdentifier())) {
 				auto var = getVariable(arg->getIdentifier());
 				blockArguments << getType(arg->getStamp()) << " " << var << ";\n";
@@ -160,7 +160,7 @@ std::string CPPLoweringProvider::LoweringContext::process(const ir::BasicBlock* 
 		auto& currentBlock = blocks.emplace_back();
 		currentBlock << blockName << ":\n";
 		activeBlocks.emplace(block->getIdentifier(), blockName);
-		for (auto& opt : block->getOperations()) {
+		for (auto* opt : block->getOperations()) {
 			this->dispatch(opt, blockIndex, frame);
 		}
 		return blockName;

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -363,7 +363,7 @@ mlir::OwningOpRef<mlir::ModuleOp> MLIRLoweringProvider::generateModuleFromIR(std
 }
 
 void MLIRLoweringProvider::generateMLIR(const ir::BasicBlock* basicBlock, ValueFrame& frame) {
-	for (const auto& operation : basicBlock->getOperations()) {
+	for (auto* operation : basicBlock->getOperations()) {
 		dispatch(operation, frame);
 	}
 }

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -24,7 +24,11 @@
 
 namespace nautilus::compiler::ir {
 
-IRGraph::IRGraph(const compiler::CompilationUnitID& id) : arena_(std::make_unique<common::Arena>()), id(id) {
+IRGraph::IRGraph(const compiler::CompilationUnitID& id) : arena_(common::ArenaPool::makeStandalone()), id(id) {
+}
+
+IRGraph::IRGraph(common::ArenaPool::Handle arena, const compiler::CompilationUnitID& id)
+    : arena_(std::move(arena)), id(id) {
 }
 
 FunctionOperation* IRGraph::addFunctionOperation(FunctionOperation* functionOperation) {

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -24,17 +24,16 @@
 
 namespace nautilus::compiler::ir {
 
-IRGraph::IRGraph(const compiler::CompilationUnitID& id) : id(id) {
+IRGraph::IRGraph(const compiler::CompilationUnitID& id) : arena_(std::make_unique<common::Arena>()), id(id) {
 }
 
-std::unique_ptr<FunctionOperation>&
-IRGraph::addFunctionOperation(std::unique_ptr<FunctionOperation> functionOperation) {
-	auto& slot = functionOperations.emplace_back(std::move(functionOperation));
-	functionOperationsByName.emplace(std::string_view {slot->getName()}, slot.get());
-	return slot;
+FunctionOperation* IRGraph::addFunctionOperation(FunctionOperation* functionOperation) {
+	functionOperations.emplace_back(functionOperation);
+	functionOperationsByName.emplace(std::string_view {functionOperation->getName()}, functionOperation);
+	return functionOperation;
 }
 
-const std::vector<std::unique_ptr<FunctionOperation>>& IRGraph::getFunctionOperations() const {
+const std::vector<FunctionOperation*>& IRGraph::getFunctionOperations() const {
 	return functionOperations;
 }
 
@@ -326,7 +325,7 @@ struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_vie
 			}
 		}
 		fmt::format_to(out, "):\n");
-		for (auto& operation : block.getOperations()) {
+		for (auto* operation : block.getOperations()) {
 			fmt::format_to(out, "\t{}\n", *operation);
 		}
 		return out;
@@ -343,7 +342,7 @@ struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::str
 			fmt::format_to(out, "{} ", arg);
 		}
 		fmt::format_to(out, ") {{");
-		for (const auto& block : func.getBasicBlocks()) {
+		for (const auto* block : func.getBasicBlocks()) {
 			fmt::format_to(out, "{}", *block);
 		}
 		fmt::format_to(out, "}}\n");
@@ -358,7 +357,7 @@ auto fmt::formatter<nautilus::compiler::ir::IRGraph>::format(const nautilus::com
 	fmt::format_to(out, "NautilusIr {{\n");
 
 	// Print all function operations
-	for (const auto& func : graph.getFunctionOperations()) {
+	for (const auto* func : graph.getFunctionOperations()) {
 		fmt::format_to(out, "{}", *func);
 	}
 

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "nautilus/JITCompiler.hpp"
+#include "nautilus/common/Arena.hpp"
 #include <memory>
 #include <string>
 #include <string_view>
@@ -13,25 +14,40 @@ class FunctionOperation;
 
 /**
  * @brief The IRGraph represents a fragment of nautilus ir.
+ *
+ * All IR nodes (FunctionOperation, BasicBlock, Operation subclasses,
+ * BasicBlockArgument) referenced by this graph are allocated from an
+ * internal `common::Arena` that the graph owns for its full lifetime.
+ * The graph itself owns no IR node directly: it only stores raw pointers
+ * into the arena. When the IRGraph is destroyed the arena is destroyed
+ * along with it, freeing every IR node in bulk.
+ *
+ * Each IRGraph gets its own Arena — distinct from the engine-scoped trace
+ * Arena — so the IR survives across `compile()` cycles (e.g. while the
+ * tiered compiler caches it for asynchronous tier-1 promotion) without
+ * being invalidated by the trace arena's `softReset()`.
+ *
+ * Arena is non-movable, so the graph stores it through a `unique_ptr`
+ * to keep its address stable.
  */
 class IRGraph {
 public:
-	IRGraph(const CompilationUnitID& id);
+	explicit IRGraph(const CompilationUnitID& id);
 
 	~IRGraph() = default;
 
 	/**
 	 * @brief Adds a function operation to the IR graph
-	 * @param functionOperation The function operation to add
-	 * @return Reference to the added function operation
+	 * @param functionOperation Pointer to the arena-allocated function op
+	 * @return The same pointer, for convenience
 	 */
-	std::unique_ptr<FunctionOperation>& addFunctionOperation(std::unique_ptr<FunctionOperation> functionOperation);
+	FunctionOperation* addFunctionOperation(FunctionOperation* functionOperation);
 
 	/**
 	 * @brief Gets all function operations in the IR graph
 	 * @return Vector of function operations
 	 */
-	const std::vector<std::unique_ptr<FunctionOperation>>& getFunctionOperations() const;
+	const std::vector<FunctionOperation*>& getFunctionOperations() const;
 
 	/**
 	 * @brief Gets a specific function operation by name in O(1) via an internal index.
@@ -44,10 +60,19 @@ public:
 
 	[[nodiscard]] const CompilationUnitID& getId() const;
 
+	/// Returns the arena that backs every IR node in this graph.  Phases
+	/// that mint new nodes (e.g. TraceToIRConversionPhase) allocate through
+	/// this arena.
+	[[nodiscard]] common::Arena& getArena() const {
+		return *arena_;
+	}
+
 private:
-	std::vector<std::unique_ptr<FunctionOperation>> functionOperations;
-	// Name -> function index. The string_view is backed by the name field owned
-	// by FunctionOperation, which is stable for the lifetime of the graph.
+	std::unique_ptr<common::Arena> arena_;
+	std::vector<FunctionOperation*> functionOperations;
+	// Name -> function pointer. The string_view is backed by the name field
+	// owned by FunctionOperation, which is stable for the lifetime of the
+	// graph (the FunctionOperation itself lives in the arena).
 	std::unordered_map<std::string_view, FunctionOperation*> functionOperationsByName;
 	const CompilationUnitID id;
 };

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
@@ -16,23 +16,28 @@ class FunctionOperation;
  * @brief The IRGraph represents a fragment of nautilus ir.
  *
  * All IR nodes (FunctionOperation, BasicBlock, Operation subclasses,
- * BasicBlockArgument) referenced by this graph are allocated from an
- * internal `common::Arena` that the graph owns for its full lifetime.
- * The graph itself owns no IR node directly: it only stores raw pointers
- * into the arena. When the IRGraph is destroyed the arena is destroyed
- * along with it, freeing every IR node in bulk.
+ * BasicBlockArgument) referenced by this graph are allocated from a
+ * `common::Arena` that the graph owns through a `common::ArenaPool::Handle`
+ * for its full lifetime.  The graph itself owns no IR node directly: it
+ * only stores raw pointers into the arena.  When the IRGraph is destroyed
+ * the Handle is destroyed; depending on whether the Handle is pool-backed
+ * the Arena is either recycled into its pool (typical, engine path) or
+ * deleted outright (standalone path, used by tests and benchmarks).
  *
- * Each IRGraph gets its own Arena — distinct from the engine-scoped trace
+ * Each IRGraph holds its own Arena — distinct from the engine-scoped trace
  * Arena — so the IR survives across `compile()` cycles (e.g. while the
  * tiered compiler caches it for asynchronous tier-1 promotion) without
  * being invalidated by the trace arena's `softReset()`.
- *
- * Arena is non-movable, so the graph stores it through a `unique_ptr`
- * to keep its address stable.
  */
 class IRGraph {
 public:
+	/// Constructs an IR graph backed by a freshly heap-allocated standalone
+	/// Arena (no pool).  Used by tests and benchmarks.
 	explicit IRGraph(const CompilationUnitID& id);
+
+	/// Constructs an IR graph backed by the supplied Arena Handle.  When
+	/// the Handle is pool-backed the Arena is recycled on destruction.
+	IRGraph(common::ArenaPool::Handle arena, const CompilationUnitID& id);
 
 	~IRGraph() = default;
 
@@ -68,7 +73,7 @@ public:
 	}
 
 private:
-	std::unique_ptr<common::Arena> arena_;
+	common::ArenaPool::Handle arena_;
 	std::vector<FunctionOperation*> functionOperations;
 	// Name -> function pointer. The string_view is backed by the name field
 	// owned by FunctionOperation, which is stable for the lifetime of the

--- a/nautilus/src/nautilus/compiler/ir/OperationDispatcher.hpp
+++ b/nautilus/src/nautilus/compiler/ir/OperationDispatcher.hpp
@@ -68,7 +68,7 @@ class OperationDispatcher {
 public:
 	/// Dispatch a single operation to the matching `visitXxx` hook on Derived.
 	template <typename... Args>
-	void dispatch(const std::unique_ptr<Operation>& op, Args&&... args) {
+	void dispatch(Operation* op, Args&&... args) {
 		using OT = Operation::OperationType;
 		auto& d = static_cast<Derived&>(*this);
 		switch (op->getOperationType()) {
@@ -172,13 +172,13 @@ public:
 			d.visitFunction(as<FunctionOperation>(op), std::forward<Args>(args)...);
 			return;
 		case OT::BasicBlockArgument:
-			d.visitBasicBlockArgument(op.get(), std::forward<Args>(args)...);
+			d.visitBasicBlockArgument(op, std::forward<Args>(args)...);
 			return;
 		case OT::BlockInvocation:
-			d.visitBlockInvocation(op.get(), std::forward<Args>(args)...);
+			d.visitBlockInvocation(op, std::forward<Args>(args)...);
 			return;
 		case OT::MLIR_YIELD:
-			d.visitMlirYield(op.get(), std::forward<Args>(args)...);
+			d.visitMlirYield(op, std::forward<Args>(args)...);
 			return;
 		}
 		// No default: adding an enumerator to OperationType is a compile error

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
@@ -3,22 +3,21 @@
 #include "nautilus/compiler/ir/operations/BranchOperation.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
 #include "nautilus/exceptions/NotImplementedException.hpp"
-#include <memory>
 #include <utility>
 
 namespace nautilus::compiler::ir {
-BasicBlock::BasicBlock(BlockIdentifier identifier, std::vector<std::unique_ptr<BasicBlockArgument>> arguments)
-    : identifier(identifier), operations(), arguments(std::move(arguments)) {
+BasicBlock::BasicBlock(common::Arena& arena, BlockIdentifier identifier, std::vector<BasicBlockArgument*> arguments)
+    : arena_(&arena), identifier(identifier), operations(), arguments(std::move(arguments)) {
 }
 
 void BasicBlock::addNextBlock(BasicBlock* nextBlock, const std::vector<Operation*>& ops) {
-	auto branchOp = std::make_unique<BranchOperation>();
+	auto* branchOp = arena_->create<BranchOperation>();
 	auto& nextBlockIn = branchOp->getNextBlockInvocation();
 	nextBlockIn.setBlock(nextBlock);
 	for (auto op : ops) {
 		nextBlockIn.addArgument(op);
 	}
-	addOperation(std::move(branchOp));
+	addOperation(branchOp);
 }
 
 BasicBlock::~BasicBlock() = default;
@@ -27,25 +26,25 @@ BlockIdentifier BasicBlock::getIdentifier() const {
 	return identifier;
 }
 
-const std::vector<std::unique_ptr<Operation>>& BasicBlock::getOperations() const {
+const std::vector<Operation*>& BasicBlock::getOperations() const {
 	return operations;
 }
 
 [[nodiscard]] Operation* BasicBlock::getOperationAt(size_t index) {
-	return operations.at(index).get();
+	return operations.at(index);
 }
 
 Operation* BasicBlock::getTerminatorOp() {
-	return operations.back().get();
+	return operations.back();
 }
 
-const std::vector<std::unique_ptr<BasicBlockArgument>>& BasicBlock::getArguments() const {
+const std::vector<BasicBlockArgument*>& BasicBlock::getArguments() const {
 	return arguments;
 }
 
 uint64_t BasicBlock::getIndexOfArgument(Operation* arg) {
 	for (uint64_t i = 0; i < arguments.size(); i++) {
-		if (arguments[i].get() == arg) {
+		if (arguments[i] == arg) {
 			return i;
 		}
 	}
@@ -57,49 +56,9 @@ void BasicBlock::replaceTerminatorOperation(Operation* loopOperation) {
 	operations.emplace_back(loopOperation);
 }
 
-BasicBlock* BasicBlock::addOperation(std::unique_ptr<Operation> operation) {
-	operations.emplace_back(std::move(operation));
+BasicBlock* BasicBlock::addOperation(Operation* operation) {
+	operations.emplace_back(operation);
 	return this;
 }
-
-/* void BasicBlock::replaceOperation(size_t operationIndex, Operation
- *operation) { operations.at(operationIndex) = operation;
- }
-
- void BasicBlock::removeOperation(Operation *operation) {
-     auto pos = std::find(operations.begin(), operations.end(), operation);
-     operations.erase();
- }
-
- void BasicBlock::removeArgument(BasicBlockArgument* argument) {
-     arguments.erase(std::find(arguments.begin(), arguments.end(), argument));
- }
-
- void BasicBlock::addOperationBefore(Operation *before,
- std::unique_ptr<Operation>& operation) { auto position =
- std::find(operations.begin(), operations.end(), before);
-     operations.insert(position, std::move(operation));
- }
-
- [[nodiscard]] std::pair<const BasicBlock *, const BasicBlock *>
- BasicBlock::getNextBlocks() {
-     // std::pair<std::shared_ptr<BasicBlock>, std::shared_ptr<BasicBlock>>
- nextBlocks; if (operations.back()->getOperationType() ==
- Operation::OperationType::BranchOp) { auto branchOp =
- std::static_pointer_cast<BranchOperation>(operations.back()); return
- std::make_pair(branchOp->getNextBlockInvocation().getBlock(), nullptr); } else
- if (operations.back()->getOperationType() == Operation::OperationType::IfOp) {
-         auto ifOp = std::static_pointer_cast<IfOperation>(operations.back());
-         return std::make_pair(ifOp->getTrueBlockInvocation().getBlock(),
-                               ifOp->getFalseBlockInvocation().getBlock());
-     } else if
- (operations.back()->getOperationType() == Operation::OperationType::ReturnOp) {
-         return {};
-     } else {
-         throw NotImplementedException(
-                 "BasicBlock::getNextBlocks: Tried to get next block for
- unsupported operation type.");
-     }
- }*/
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "nautilus/common/Arena.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlockArgument.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
 #include <compare>
@@ -36,35 +37,56 @@ private:
 	uint32_t id;
 };
 
+/**
+ * @brief A BasicBlock used for control flow in Nautilus IR.
+ *
+ * A BasicBlock owns a list of `Operation*` and `BasicBlockArgument*`
+ * pointers. The pointed-to objects are not owned by the block: every
+ * Operation and BasicBlockArgument is allocated from the `common::Arena`
+ * that is passed in at construction and lives for as long as that arena
+ * lives. Destroying a BasicBlock therefore does not free the operations
+ * it contains; the arena does, in bulk, when it is reset or destroyed.
+ *
+ * Rationale: the IR graph is produced once per compile and discarded at
+ * the next compile cycle. Bulk arena deallocation is both faster and more
+ * cache-friendly than per-op `delete`, and since every edge in the IR is
+ * already a raw `Operation*` (`Operation::inputs`, `BasicBlockInvocation::
+ * basicBlock`) the arena's stable-pointer guarantee matches the existing
+ * invariants exactly.
+ */
 class BasicBlock {
 public:
 	/**
-	 * @brief BasicBlock used for control flow in NES IR
-	 * @param Operations: A list of Operations that are executed in the BasicBlock.
-	 * @param nextBlocks : The BasicBlock that is next in the control flow of the execution.
+	 * @brief Constructs an (empty) BasicBlock.
+	 *
+	 * All subsequent Operations minted via @ref addOperation are allocated
+	 * from @p arena.  The arena must outlive the block.
 	 */
-	explicit BasicBlock(BlockIdentifier identifier, std::vector<std::unique_ptr<BasicBlockArgument>> arguments);
+	explicit BasicBlock(common::Arena& arena, BlockIdentifier identifier, std::vector<BasicBlockArgument*> arguments);
 
-	virtual ~BasicBlock();
+	~BasicBlock();
 
 	[[nodiscard]] BlockIdentifier getIdentifier() const;
 
-	[[nodiscard]] const std::vector<std::unique_ptr<Operation>>& getOperations() const;
+	[[nodiscard]] const std::vector<Operation*>& getOperations() const;
 
 	[[nodiscard]] Operation* getOperationAt(size_t index);
 
 	[[nodiscard]] Operation* getTerminatorOp();
 
-	[[nodiscard]] const std::vector<std::unique_ptr<BasicBlockArgument>>& getArguments() const;
+	[[nodiscard]] const std::vector<BasicBlockArgument*>& getArguments() const;
 
+	/// Allocates a new operation of type T in the arena and appends it to
+	/// this block. Returns the freshly created operation.
 	template <typename T, typename... Args>
-	T* addOperation(Args&&... operation) {
-		auto op = std::make_unique<T>(std::forward<Args>(operation)...);
-		auto& ref = this->operations.emplace_back(std::move(op));
-		return as<T>(ref);
+	T* addOperation(Args&&... args) {
+		auto* op = arena_->create<T>(std::forward<Args>(args)...);
+		operations.push_back(op);
+		return op;
 	}
 
-	BasicBlock* addOperation(std::unique_ptr<Operation> operation);
+	/// Appends an already-arena-allocated operation to this block.
+	BasicBlock* addOperation(Operation* operation);
 
 	BasicBlock* addNextBlock(BasicBlock* nextBlock);
 
@@ -78,9 +100,7 @@ public:
 
 	void removeOperation(Operation* operation);
 
-	void removeArgument(std::shared_ptr<BasicBlockArgument> argument);
-
-	void addOperationBefore(Operation* before, std::unique_ptr<Operation>& operation);
+	void addOperationBefore(Operation* before, Operation* operation);
 
 	uint64_t getIndexOfArgument(Operation* arg);
 
@@ -89,12 +109,11 @@ public:
 	[[nodiscard]] std::pair<const BasicBlock*, const BasicBlock*> getNextBlocks();
 
 private:
+	common::Arena* arena_;
 	BlockIdentifier identifier;
-	std::vector<std::unique_ptr<Operation>> operations;
-	std::vector<std::unique_ptr<BasicBlockArgument>> arguments;
+	std::vector<Operation*> operations;
+	std::vector<BasicBlockArgument*> arguments;
 };
-
-using BasicBlockPtr = std::shared_ptr<BasicBlock>;
 
 } // namespace nautilus::compiler::ir
 

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.cpp
@@ -4,7 +4,7 @@
 
 namespace nautilus::compiler::ir {
 
-FunctionOperation::FunctionOperation(std::string name, std::vector<std::unique_ptr<BasicBlock>> functionBasicBlocks,
+FunctionOperation::FunctionOperation(std::string name, std::vector<BasicBlock*> functionBasicBlocks,
                                      std::vector<Type> inputArgs, std::vector<std::string> inputArgNames,
                                      Type outputArg)
     : Operation(OperationType::FunctionOp, outputArg), name(std::move(name)),
@@ -24,7 +24,7 @@ const std::vector<Type>& FunctionOperation::getInputArgs() const {
 	return inputArgs;
 }
 
-const std::vector<std::unique_ptr<BasicBlock>>& FunctionOperation::getBasicBlocks() const {
+const std::vector<BasicBlock*>& FunctionOperation::getBasicBlocks() const {
 	return functionBasicBlocks;
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
@@ -7,17 +7,15 @@
 namespace nautilus::compiler::ir {
 class FunctionOperation : public Operation {
 public:
-	explicit FunctionOperation(std::string name, std::vector<std::unique_ptr<BasicBlock>> functionBasicBlocks,
+	explicit FunctionOperation(std::string name, std::vector<BasicBlock*> functionBasicBlocks,
 	                           std::vector<Type> inputArgs, std::vector<std::string> inputArgNames, Type outputArg);
 
 	~FunctionOperation() override = default;
 
 	[[nodiscard]] const std::string& getName() const;
 
-	BasicBlock* addFunctionBasicBlock(BasicBlockPtr functionBasicBlock);
-
 	const BasicBlock& getFunctionBasicBlock() const;
-	const std::vector<std::unique_ptr<BasicBlock>>& getBasicBlocks() const;
+	const std::vector<BasicBlock*>& getBasicBlocks() const;
 
 	[[nodiscard]] const std::vector<Type>& getInputArgs() const;
 
@@ -29,7 +27,7 @@ public:
 
 private:
 	std::string name;
-	std::vector<std::unique_ptr<BasicBlock>> functionBasicBlocks;
+	std::vector<BasicBlock*> functionBasicBlocks;
 	std::vector<Type> inputArgs;
 	std::vector<std::string> inputArgNames;
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/IfOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IfOperation.cpp
@@ -35,8 +35,8 @@ void IfOperation::setFalseBlockInvocation(BasicBlock* falseBlockInvocation) {
 	this->falseBlockInvocation.setBlock(falseBlockInvocation);
 }
 
-BasicBlockPtr IfOperation::getMergeBlock() {
-	return mergeBlock.lock();
+BasicBlock* IfOperation::getMergeBlock() {
+	return mergeBlock;
 }
 
 Operation* IfOperation::getBooleanValue() {
@@ -47,7 +47,7 @@ void IfOperation::setBooleanValue(Operation* newBooleanValue) {
 	this->inputs[0] = newBooleanValue;
 }
 
-void IfOperation::setMergeBlock(BasicBlockPtr mergeBlock) {
+void IfOperation::setMergeBlock(BasicBlock* mergeBlock) {
 	this->mergeBlock = mergeBlock;
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/IfOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IfOperation.hpp
@@ -13,13 +13,13 @@ public:
 
 	Operation* getValue() const;
 
-	BasicBlockPtr getMergeBlock();
+	BasicBlock* getMergeBlock();
 
 	Operation* getBooleanValue();
 
 	void setBooleanValue(Operation* newBooleanValue);
 
-	void setMergeBlock(BasicBlockPtr mergeBlock);
+	void setMergeBlock(BasicBlock* mergeBlock);
 
 	BasicBlockInvocation& getTrueBlockInvocation();
 	const BasicBlockInvocation& getTrueBlockInvocation() const;
@@ -39,7 +39,7 @@ public:
 private:
 	BasicBlockInvocation trueBlockInvocation;
 	BasicBlockInvocation falseBlockInvocation;
-	std::weak_ptr<BasicBlock> mergeBlock;
+	BasicBlock* mergeBlock = nullptr;
 	double probability;
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
@@ -82,8 +82,6 @@ public:
 
 	const std::vector<Operation*>& getInputs() const;
 
-	void replaceInput(Operation* toReplace, std::shared_ptr<Operation> replaceWith);
-
 	template <typename OP>
 	const OP* dynCast() const {
 		return OP::classof(this) ? static_cast<const OP*>(this) : nullptr;
@@ -127,13 +125,13 @@ T* cast(Operation* op) {
 }
 
 template <typename T>
-T* as(const Operation* op) {
+T* as(Operation* op) {
 	return static_cast<T*>(op);
 }
 
 template <typename T>
-T* as(const std::unique_ptr<Operation>& op) {
-	return static_cast<T*>(op.get());
+const T* as(const Operation* op) {
+	return static_cast<const T*>(op);
 }
 
 class BinaryOperation : public Operation {

--- a/nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp
+++ b/nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp
@@ -122,26 +122,20 @@ protected:
 	std::vector<std::tuple<BasicBlock*, BasicBlockInvocation*>>
 	getPredecessorBlocks(const std::shared_ptr<IRGraph>& graph, const BasicBlock* targetBlock) {
 		std::vector<std::tuple<BasicBlock*, BasicBlockInvocation*>> predeccessor;
-		for (const auto& block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
-			auto& op = block->getOperations().back();
+		for (auto* block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
+			auto* op = block->getOperations().back();
 			if (op->getOperationType() == Operation::OperationType::IfOp) {
 				auto ifOp = as<IfOperation>(op);
 				if (ifOp->getFalseBlockInvocation().getBlock() == targetBlock) {
-					auto tup = std::make_tuple<BasicBlock*, BasicBlockInvocation*>(block.get(),
-					                                                               &ifOp->getFalseBlockInvocation());
-					predeccessor.emplace_back(tup);
+					predeccessor.emplace_back(block, &ifOp->getFalseBlockInvocation());
 				}
 				if (ifOp->getTrueBlockInvocation().getBlock() == targetBlock) {
-					auto tup = std::make_tuple<BasicBlock*, BasicBlockInvocation*>(block.get(),
-					                                                               &ifOp->getTrueBlockInvocation());
-					predeccessor.emplace_back(tup);
+					predeccessor.emplace_back(block, &ifOp->getTrueBlockInvocation());
 				}
 			} else if (op->getOperationType() == Operation::OperationType::BranchOp) {
 				auto branchOp = as<BranchOperation>(op);
 				if (branchOp->getNextBlockInvocation().getBlock() == targetBlock) {
-					auto tup = std::make_tuple<BasicBlock*, BasicBlockInvocation*>(block.get(),
-					                                                               &branchOp->getNextBlockInvocation());
-					predeccessor.emplace_back(tup);
+					predeccessor.emplace_back(block, &branchOp->getNextBlockInvocation());
 				}
 			}
 		}
@@ -157,7 +151,7 @@ protected:
 			[[maybe_unused]] const auto* arg = as<const BasicBlockArgument>(input);
 			size_t index = 0;
 			for (size_t i = 0; i < block->getArguments().size(); i++) {
-				if (block->getArguments()[i].get() == input) {
+				if (block->getArguments()[i] == input) {
 					index = i;
 					break;
 				}
@@ -178,7 +172,7 @@ protected:
 	void addToBlockArgumentMap(const BasicBlockInvocation* bi, std::map<Operation*, std::vector<Operation*>>& map) {
 		for (size_t i = 0; i < bi->getArguments().size(); i++) {
 			const auto& from = bi->getArguments()[i];
-			const auto& to = bi->getBlock()->getArguments()[i].get();
+			Operation* const to = bi->getBlock()->getArguments()[i];
 			std::vector<Operation*> inputs;
 			if (map.contains(to)) {
 				auto srcInput = map[to];
@@ -206,7 +200,7 @@ protected:
 		}
 		visitedBlocks.emplace(block);
 
-		auto& op = block->getOperations().back();
+		auto* op = block->getOperations().back();
 		if (op->getOperationType() == Operation::OperationType::IfOp) {
 			auto ifOp = as<IfOperation>(op);
 			addToBlockArgumentMap(&ifOp->getTrueBlockInvocation(), map);
@@ -221,13 +215,13 @@ protected:
 	}
 	void writeEdges(const std::shared_ptr<IRGraph>& graph, bool hideIntermediateBlockArguments, bool writeBlocksOnly) {
 		std::map<Operation*, std::vector<Operation*>> operatorDataflowMapping;
-		auto& rootBlock = graph->getFunctionOperations()[0]->getBasicBlocks()[0];
+		auto* rootBlock = graph->getFunctionOperations()[0]->getBasicBlocks()[0];
 		std::set<const BasicBlock*> vistedBlocks;
-		getBlockArgumentMap(rootBlock.get(), vistedBlocks, operatorDataflowMapping);
+		getBlockArgumentMap(rootBlock, vistedBlocks, operatorDataflowMapping);
 		// crate dataflow edges
-		for (const auto& block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
+		for (auto* block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
 			if (writeBlocksOnly) {
-				auto& op = block->getOperations().back();
+				auto* op = block->getOperations().back();
 				const auto fromId = std::to_string(block->getIdentifier().getId());
 				if (op->getOperationType() == Operation::OperationType::IfOp) {
 					auto ifOp = as<IfOperation>(op);
@@ -243,8 +237,8 @@ protected:
 					writeEdge(fromId, falseBlock, "control", "");
 				}
 			} else {
-				for (const auto& op : block->getOperations()) {
-					const auto& to = nodeIdMap[op.get()];
+				for (auto* op : block->getOperations()) {
+					const auto& to = nodeIdMap[op];
 					// process inputs of node
 					for (const auto* input : op->getInputs()) {
 						const auto& from = nodeIdMap[input];
@@ -270,11 +264,11 @@ protected:
 		if (!writeBlocksOnly) {
 
 			// create control-flow edges
-			for (const auto& blocks : graph->getFunctionOperations()[0]->getBasicBlocks()) {
+			for (auto* blocks : graph->getFunctionOperations()[0]->getBasicBlocks()) {
 				std::string from = "start_" + std::to_string(blocks->getIdentifier().getId());
-				for (const auto& op : blocks->getOperations()) {
-					if (isControlFlowOp(op.get())) {
-						const auto& to = nodeIdMap[op.get()];
+				for (auto* op : blocks->getOperations()) {
+					if (isControlFlowOp(op)) {
+						const auto& to = nodeIdMap[op];
 						writeEdge(from, to, "control", "");
 						from = to;
 					}
@@ -356,7 +350,7 @@ protected:
 		std::string id = block + "_o" + std::to_string(nodeIdMap.size());
 		nodeIdMap[bi] = id;
 		for (size_t i = 0; i < bi->getArguments().size(); i++) {
-			auto& targetArg = bi->getBlock()->getArguments()[i];
+			auto* targetArg = bi->getBlock()->getArguments()[i];
 			auto lable = "Output(" + targetArg->getIdentifier().toString() + ")";
 			writeNode(indent, lable, id + "_" + std::to_string(i), "input");
 		}
@@ -373,17 +367,17 @@ protected:
 		stream << "    fillcolor=\"" << LIGHT_YELLOW << "\";" << std::endl;
 	}
 
-	void writeNodesForBlock(const std::unique_ptr<BasicBlock>& block) {
+	void writeNodesForBlock(BasicBlock* block) {
 		const auto blockIdStr = std::to_string(block->getIdentifier().getId());
 		writeNode("  ", "Start", "start_" + blockIdStr, "control");
-		for (const auto& op : block->getArguments()) {
+		for (auto* op : block->getArguments()) {
 			std::string indent = "  ";
-			writeNodeForOp(indent, blockIdStr, op.get());
+			writeNodeForOp(indent, blockIdStr, op);
 		}
 
-		for (const auto& op : block->getOperations()) {
+		for (auto* op : block->getOperations()) {
 			std::string indent = "  ";
-			writeNodeForOp(indent, blockIdStr, op.get());
+			writeNodeForOp(indent, blockIdStr, op);
 
 			if (op->getOperationType() == Operation::OperationType::IfOp) {
 				auto ifOp = as<IfOperation>(op);
@@ -399,7 +393,7 @@ protected:
 
 		if (draw_blocks) {
 			// Assuming you have a way to divide nodes into blocks
-			for (const auto& block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
+			for (auto* block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
 				const auto blockIdStr = std::to_string(block->getIdentifier().getId());
 				if (!drawBlocksOnly) {
 					startSubgraph(blockIdStr);
@@ -410,7 +404,7 @@ protected:
 				}
 			}
 		} else {
-			for (const auto& block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
+			for (auto* block : graph->getFunctionOperations()[0]->getBasicBlocks()) {
 				writeNodesForBlock(block);
 			}
 		}

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -53,9 +53,31 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<TraceMo
 	return ir;
 }
 
+std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<TraceModule> traceModule,
+                                                         common::ArenaPool& pool,
+                                                         const compiler::CompilationUnitID& id) {
+	auto ir = std::make_shared<compiler::ir::IRGraph>(pool.acquire(), id);
+
+	for (const auto& functionName : traceModule->getFunctionNames()) {
+		auto* trace = traceModule->getFunction(functionName);
+		auto phaseContext = IRConversionContext(trace, ir, id);
+		ir->addFunctionOperation(phaseContext.processFunction(functionName));
+	}
+
+	return ir;
+}
+
 std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<ExecutionTrace> trace,
                                                          const compiler::CompilationUnitID& id) {
 	auto ir = std::make_shared<compiler::ir::IRGraph>(id);
+	auto phaseContext = IRConversionContext(trace.get(), ir, id);
+	return phaseContext.process();
+}
+
+std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<ExecutionTrace> trace,
+                                                         common::ArenaPool& pool,
+                                                         const compiler::CompilationUnitID& id) {
+	auto ir = std::make_shared<compiler::ir::IRGraph>(pool.acquire(), id);
 	auto phaseContext = IRConversionContext(trace.get(), ir, id);
 	return phaseContext.process();
 }

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<TraceMo
 	// Process all functions in sorted order for deterministic IR output.
 	for (const auto& functionName : traceModule->getFunctionNames()) {
 		auto* trace = traceModule->getFunction(functionName);
-		auto phaseContext = IRConversionContext(trace, id);
+		auto phaseContext = IRConversionContext(trace, ir, id);
 		ir->addFunctionOperation(phaseContext.processFunction(functionName));
 	}
 
@@ -55,25 +55,26 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<TraceMo
 
 std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<ExecutionTrace> trace,
                                                          const compiler::CompilationUnitID& id) {
-	auto phaseContext = IRConversionContext(trace.get(), id);
+	auto ir = std::make_shared<compiler::ir::IRGraph>(id);
+	auto phaseContext = IRConversionContext(trace.get(), ir, id);
 	return phaseContext.process();
 }
 
 TraceToIRConversionPhase::IRConversionContext::IRConversionContext(ExecutionTrace* trace,
-                                                                   const compiler::CompilationUnitID& id)
-    : trace(trace), ir(std::make_shared<compiler::ir::IRGraph>(id)) {
+                                                                   std::shared_ptr<compiler::ir::IRGraph> ir,
+                                                                   const compiler::CompilationUnitID&)
+    : trace(trace), ir(std::move(ir)) {
 }
 
 std::shared_ptr<IRGraph> TraceToIRConversionPhase::IRConversionContext::process() {
 	processBlock(*trace->getBlocks().front());
-	auto functionOperation = std::make_unique<FunctionOperation>(
+	auto* functionOperation = ir->getArena().create<FunctionOperation>(
 	    "execute", std::move(currentBasicBlocks), std::vector<Type> {}, std::vector<std::string> {}, returnType);
-	ir->addFunctionOperation(std::move(functionOperation));
+	ir->addFunctionOperation(functionOperation);
 	return ir;
 }
 
-std::unique_ptr<FunctionOperation>
-TraceToIRConversionPhase::IRConversionContext::processFunction(const std::string& functionName) {
+FunctionOperation* TraceToIRConversionPhase::IRConversionContext::processFunction(const std::string& functionName) {
 	// Clear state for this function
 	currentBasicBlocks.clear();
 	blockMap.clear();
@@ -83,24 +84,24 @@ TraceToIRConversionPhase::IRConversionContext::processFunction(const std::string
 	processBlock(*trace->getBlocks().front());
 
 	// Create and return the function operation
-	auto functionOperation = std::make_unique<FunctionOperation>(
-	    functionName, std::move(currentBasicBlocks), std::vector<Type> {}, std::vector<std::string> {}, returnType);
-	return functionOperation;
+	return ir->getArena().create<FunctionOperation>(functionName, std::move(currentBasicBlocks), std::vector<Type> {},
+	                                                std::vector<std::string> {}, returnType);
 }
 
 BasicBlock* TraceToIRConversionPhase::IRConversionContext::processBlock(Block& block) {
 	// create new frame and block
+	auto& arena = ir->getArena();
 	ValueFrame blockFrame;
-	std::vector<std::unique_ptr<BasicBlockArgument>> blockArguments;
+	std::vector<BasicBlockArgument*> blockArguments;
+	blockArguments.reserve(block.arguments.size());
 	for (auto& arg : block.arguments) {
 		auto argumentIdentifier = createValueIdentifier(arg);
-		auto blockArgument = std::make_unique<BasicBlockArgument>(argumentIdentifier, arg.type);
-		blockFrame.setValue(argumentIdentifier, blockArgument.get());
-		blockArguments.emplace_back(std::move(blockArgument));
+		auto* blockArgument = arena.create<BasicBlockArgument>(argumentIdentifier, arg.type);
+		blockFrame.setValue(argumentIdentifier, blockArgument);
+		blockArguments.emplace_back(blockArgument);
 	}
-	auto& irBasicBlock =
-	    currentBasicBlocks.emplace_back(std::make_unique<BasicBlock>(block.blockId, std::move(blockArguments)));
-	auto irBasicBlockPtr = irBasicBlock.get();
+	auto* irBasicBlockPtr = arena.create<BasicBlock>(arena, block.blockId, std::move(blockArguments));
+	currentBasicBlocks.emplace_back(irBasicBlockPtr);
 
 	blockMap[block.blockId] = irBasicBlockPtr;
 	for (auto* operation : block.operations) {
@@ -305,7 +306,7 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
 	auto probability = get<BranchProbability>(operation.input[3]);
 
 	auto booleanValue = frame.getValue(createValueIdentifier(valueRef));
-	auto ifOperation = std::make_unique<IfOperation>(booleanValue, probability);
+	auto* ifOperation = ir->getArena().create<IfOperation>(booleanValue, probability);
 	auto trueCaseBlock = processBlock(trace->getBlock(trueCaseBlockRef.block));
 
 	ifOperation->getTrueBlockInvocation().setBlock(trueCaseBlock);
@@ -314,7 +315,7 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
 	auto falseCaseBlock = processBlock(trace->getBlock(falseCaseBlockRef.block));
 	ifOperation->getFalseBlockInvocation().setBlock(falseCaseBlock);
 	createBlockArguments(frame, ifOperation->getFalseBlockInvocation(), falseCaseBlockRef);
-	currentIrBlock->addOperation(std::move(ifOperation));
+	currentIrBlock->addOperation(ifOperation);
 }
 
 void TraceToIRConversionPhase::IRConversionContext::createBlockArguments(ValueFrame& frame,
@@ -364,9 +365,9 @@ void TraceToIRConversionPhase::IRConversionContext::processLoad(ValueFrame& fram
 	auto address = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
 	auto resultType = operation.resultType;
-	auto loadOperation = std::make_unique<LoadOperation>(resultIdentifier, address, resultType);
-	frame.setValue(resultIdentifier, loadOperation.get());
-	currentBlock->addOperation(std::move(loadOperation));
+	auto* loadOperation = ir->getArena().create<LoadOperation>(resultIdentifier, address, resultType);
+	frame.setValue(resultIdentifier, loadOperation);
+	currentBlock->addOperation(loadOperation);
 }
 
 void TraceToIRConversionPhase::IRConversionContext::processStore(ValueFrame& frame, BasicBlock* currentBlock,

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
@@ -56,16 +56,17 @@ private:
 	 */
 	class IRConversionContext {
 	public:
-		IRConversionContext(ExecutionTrace* trace, const compiler::CompilationUnitID& id);
+		IRConversionContext(ExecutionTrace* trace, std::shared_ptr<compiler::ir::IRGraph> ir,
+		                    const compiler::CompilationUnitID& id);
 
 		std::shared_ptr<compiler::ir::IRGraph> process();
 
 		/**
 		 * @brief Processes a single function trace and returns a FunctionOperation
 		 * @param functionName The name of the function being processed
-		 * @return Unique pointer to the generated FunctionOperation
+		 * @return Arena-allocated pointer to the generated FunctionOperation
 		 */
-		std::unique_ptr<compiler::ir::FunctionOperation> processFunction(const std::string& functionName);
+		compiler::ir::FunctionOperation* processFunction(const std::string& functionName);
 
 	private:
 		compiler::ir::BasicBlock* processBlock(Block& block);
@@ -122,7 +123,7 @@ private:
 		Type returnType;
 		std::shared_ptr<compiler::ir::IRGraph> ir;
 		std::unordered_map<uint32_t, compiler::ir::BasicBlock*> blockMap;
-		std::vector<std::unique_ptr<compiler::ir::BasicBlock>> currentBasicBlocks;
+		std::vector<compiler::ir::BasicBlock*> currentBasicBlocks;
 	};
 };
 

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
@@ -41,11 +41,25 @@ public:
 	                                             const compiler::CompilationUnitID& id = "");
 
 	/**
+	 * @brief Pool-backed variant of @ref apply.  The IR graph's arena is
+	 * acquired from @p pool and recycled into it when the IR graph dies,
+	 * amortising the per-IRGraph heap allocation across many compiles.
+	 */
+	std::shared_ptr<compiler::ir::IRGraph> apply(std::shared_ptr<TraceModule> traceModule, common::ArenaPool& pool,
+	                                             const compiler::CompilationUnitID& id = "");
+
+	/**
 	 * @brief Performs the conversion and returns a IR fragment for the given trace (legacy method)
 	 * @param trace Single execution trace
 	 * @return IR graph containing a single function
 	 */
 	std::shared_ptr<compiler::ir::IRGraph> apply(std::shared_ptr<ExecutionTrace> trace,
+	                                             const compiler::CompilationUnitID& id = "");
+
+	/**
+	 * @brief Pool-backed variant of the single-trace @ref apply.
+	 */
+	std::shared_ptr<compiler::ir::IRGraph> apply(std::shared_ptr<ExecutionTrace> trace, common::ArenaPool& pool,
 	                                             const compiler::CompilationUnitID& id = "");
 
 private:

--- a/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
+++ b/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
@@ -43,8 +43,9 @@ TEST_CASE("Tiered Compilation Latency Benchmark") {
 				    config.tier0.backend = "bc";
 				    config.tier1.backend = "mlir";
 				    common::Arena arena;
-				    auto engine =
-				        NautilusEngine(std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena));
+				    common::ArenaPool irArenaPool;
+				    auto engine = NautilusEngine(
+				        std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool));
 				    auto module = engine.createModule();
 				    registerFn(module);
 				    return module.compile();
@@ -125,7 +126,8 @@ TEST_CASE("Tiered End-to-End Benchmark") {
 			config.tier0.backend = "bc";
 			config.tier1.backend = "mlir";
 			common::Arena arena;
-			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
+			common::ArenaPool irArenaPool;
+			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
 			auto* jit = tieredJit.get();
 			auto engine = NautilusEngine(std::move(tieredJit));
 			auto module = engine.createModule();

--- a/nautilus/test/benchmark/TracingBenchmark.cpp
+++ b/nautilus/test/benchmark/TracingBenchmark.cpp
@@ -127,6 +127,32 @@ TEST_CASE("IR Creation Benchmark") {
 	}
 }
 
+TEST_CASE("IR Creation Benchmark (pooled arena)") {
+	// Mirrors the IR Creation Benchmark but routes every IRGraph's arena
+	// through a single ArenaPool.  The first sample pays the usual heap
+	// allocation; subsequent samples reuse the recycled Arena (chunks and
+	// inline buffer already sized), isolating the pool's amortisation
+	// benefit from the one-shot arena-construction cost.
+	for (auto& test : tests) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+
+		Catch::Benchmark::Benchmark("ir_pooled_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
+			common::Arena traceArena;
+			std::shared_ptr<tracing::ExecutionTrace> trace =
+			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), traceArena);
+			auto ssaCreationPhase = tracing::SSACreationPhase();
+			auto afterSSAModule = ssaCreationPhase.apply(std::move(trace));
+
+			common::ArenaPool irArenaPool;
+			meter.measure([&] {
+				auto irConversionPhase = tracing::TraceToIRConversionPhase();
+				return irConversionPhase.apply(afterSSAModule, irArenaPool);
+			});
+		});
+	}
+}
+
 TEST_CASE("Backend Compilation Benchmark") {
 
 	auto registry = compiler::CompilationBackendRegistry::getInstance();

--- a/nautilus/test/execution-tests/TieredCompilationTest.cpp
+++ b/nautilus/test/execution-tests/TieredCompilationTest.cpp
@@ -44,7 +44,8 @@ TEST_CASE("Tiered Compilation - Tier 0 Executes Correctly") {
 	config.tier1.backend = tier1Backend;
 
 	common::Arena arena;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
+	common::ArenaPool irArenaPool;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -82,7 +83,8 @@ TEST_CASE("Tiered Compilation - Background Promotion Completes") {
 	config.tier1.backend = tier1Backend;
 
 	common::Arena arena;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
+	common::ArenaPool irArenaPool;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -115,7 +117,8 @@ TEST_CASE("Tiered Compilation - Results Correct After Promotion") {
 	config.tier1.backend = tier1Backend;
 
 	common::Arena arena;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
+	common::ArenaPool irArenaPool;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -164,7 +167,8 @@ TEST_CASE("Tiered Compilation - Custom Backend Per Tier") {
 			config.tier1.backend = t1;
 
 			common::Arena arena;
-			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
+			common::ArenaPool irArenaPool;
+			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
 			auto* jit = tieredJit.get();
 			auto engine = NautilusEngine(std::move(tieredJit));
 			auto module = engine.createModule();
@@ -222,7 +226,8 @@ TEST_CASE("Tiered Compilation - Multiple Functions In Module") {
 	config.tier1.backend = tier1Backend;
 
 	common::Arena arena;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena);
+	common::ArenaPool irArenaPool;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();


### PR DESCRIPTION
Extend the bump-pointer Arena introduced for the trace layer in 3fa0dab
to also cover the downstream IRGraph.  Every FunctionOperation,
BasicBlock, Operation subclass and BasicBlockArgument is now allocated
through `common::Arena::create<T>`, and owned containers switch from
`std::vector<std::unique_ptr<X>>` to `std::vector<X*>`.  IR nodes are
freed in bulk when the arena (and hence the IRGraph) is destroyed
instead of through one `delete` per node.

Design notes:
- Each IRGraph owns its own `std::unique_ptr<common::Arena>`, distinct
  from the engine-scoped trace arena.  This keeps the IR alive across
  `softReset()` cycles on the trace arena, so the tiered compiler's
  async tier-1 promotion (`lastCachedIR_` in TieredJITCompiler) keeps
  working unchanged.
- `Operation::inputs` was already `std::vector<Operation*>`; the
  arena's stable-pointer guarantee matches the invariants the existing
  IR already relied on, so no edge-fixup work is required.
- `BasicBlock::addOperation<T>(...)` mints nodes via the arena and
  stores raw pointers, eliminating per-node heap allocations during
  IR construction.
- Dead `BasicBlockPtr` / `std::weak_ptr<BasicBlock>` plumbing on
  `IfOperation::mergeBlock` collapses to a raw `BasicBlock*`, and the
  unused `Operation::replaceInput(..., std::shared_ptr<Operation>)`
  declaration is removed.
- `OperationDispatcher::dispatch` now takes `Operation*` directly,
  since the iterated container no longer hands out `unique_ptr`s.
- All five lowering providers (MLIR, C++, BC, X64, A64), the IR
  formatters and GraphVizUtil are updated for the new pointer-based
  ownership model; most touches are just dropping `.get()`.

The change is NFC on the IR shape, so the data-driven IR/LLVM-IR
reference tests continue to pass unchanged (141/141 ctest green).