### PR TITLE
Arena-allocate IR Operation inputs and drop vtable

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -1859,48 +1859,48 @@ void BCLoweringProvider::LoweringContext::countUsages(const ir::BasicBlock* bloc
 		case ir::Operation::OperationType::DivOp:
 		case ir::Operation::OperationType::ModOp: {
 			auto binOp = static_cast<ir::Operation*>(opt);
-			if (auto addOp = dynamic_cast<ir::AddOperation*>(binOp)) {
+			if (auto addOp = ir::dyn_cast<ir::AddOperation>(binOp)) {
 				countInput(addOp->getLeftInput());
 				countInput(addOp->getRightInput());
-			} else if (auto subOp = dynamic_cast<ir::SubOperation*>(binOp)) {
+			} else if (auto subOp = ir::dyn_cast<ir::SubOperation>(binOp)) {
 				countInput(subOp->getLeftInput());
 				countInput(subOp->getRightInput());
-			} else if (auto mulOp = dynamic_cast<ir::MulOperation*>(binOp)) {
+			} else if (auto mulOp = ir::dyn_cast<ir::MulOperation>(binOp)) {
 				countInput(mulOp->getLeftInput());
 				countInput(mulOp->getRightInput());
-			} else if (auto divOp = dynamic_cast<ir::DivOperation*>(binOp)) {
+			} else if (auto divOp = ir::dyn_cast<ir::DivOperation>(binOp)) {
 				countInput(divOp->getLeftInput());
 				countInput(divOp->getRightInput());
-			} else if (auto modOp = dynamic_cast<ir::ModOperation*>(binOp)) {
+			} else if (auto modOp = ir::dyn_cast<ir::ModOperation>(binOp)) {
 				countInput(modOp->getLeftInput());
 				countInput(modOp->getRightInput());
 			}
 			break;
 		}
 		case ir::Operation::OperationType::CompareOp: {
-			auto cmpOp = dynamic_cast<ir::CompareOperation*>(opt);
+			auto cmpOp = ir::cast<ir::CompareOperation>(opt);
 			countInput(cmpOp->getLeftInput());
 			countInput(cmpOp->getRightInput());
 			break;
 		}
 		case ir::Operation::OperationType::LoadOp: {
-			auto loadOp = dynamic_cast<ir::LoadOperation*>(opt);
+			auto loadOp = ir::cast<ir::LoadOperation>(opt);
 			countInput(loadOp->getAddress());
 			break;
 		}
 		case ir::Operation::OperationType::StoreOp: {
-			auto storeOp = dynamic_cast<ir::StoreOperation*>(opt);
+			auto storeOp = ir::cast<ir::StoreOperation>(opt);
 			countInput(storeOp->getAddress());
 			countInput(storeOp->getValue());
 			break;
 		}
 		case ir::Operation::OperationType::CastOp: {
-			auto castOp = dynamic_cast<ir::CastOperation*>(opt);
+			auto castOp = ir::cast<ir::CastOperation>(opt);
 			countInput(castOp->getInput());
 			break;
 		}
 		case ir::Operation::OperationType::ReturnOp: {
-			auto retOp = dynamic_cast<ir::ReturnOperation*>(opt);
+			auto retOp = ir::cast<ir::ReturnOperation>(opt);
 			if (retOp->hasReturnValue()) {
 				countInput(retOp->getReturnValue());
 			}

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -63,9 +63,10 @@ using namespace ::mlir;
 	throw NotImplementedException("No matching type for stamp ");
 }
 
-std::vector<mlir::Type> MLIRLoweringProvider::getMLIRType(const std::vector<ir::Operation*>& types) {
+std::vector<mlir::Type> MLIRLoweringProvider::getMLIRType(std::span<ir::Operation* const> types) {
 	std::vector<mlir::Type> resultTypes;
-	for (auto& type : types) {
+	resultTypes.reserve(types.size());
+	for (auto* type : types) {
 		resultTypes.push_back(getMLIRType(type->getStamp()));
 	}
 	return resultTypes;

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -8,6 +8,7 @@
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <mlir/IR/PatternMatch.h>
+#include <span>
 #include <unordered_set>
 
 namespace mlir { namespace func {
@@ -152,7 +153,7 @@ private:
 	 * @param types: Vector of basic  types.
 	 * @return mlir::Type: Vector of MLIR types.
 	 */
-	std::vector<::mlir::Type> getMLIRType(const std::vector<ir::Operation*>& types);
+	std::vector<::mlir::Type> getMLIRType(std::span<ir::Operation* const> types);
 
 	/**
 	 * @brief Get a constant MLIR Integer.

--- a/nautilus/src/nautilus/compiler/backends/mlir/intrinsics/MLIRMemoryIntrinsics.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/intrinsics/MLIRMemoryIntrinsics.cpp
@@ -21,9 +21,9 @@ public:
 /// Helper for memcpy intrinsic (3 arguments: dest, src, count)
 bool replaceWithMemcpyIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                 const compiler::ir::ProxyCallOperation* call, MLIRLoweringProvider::ValueFrame& frame) {
-	auto dest = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto src = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto count = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto dest = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto src = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto count = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 
 	// Create memcpy intrinsic: llvm.memcpy(dest, src, len, isVolatile)
 	auto isVolatile = builder->create<::mlir::LLVM::ConstantOp>(builder->getUnknownLoc(), builder->getI1Type(),
@@ -40,9 +40,9 @@ bool replaceWithMemcpyIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 bool replaceWithMemmoveIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                  const compiler::ir::ProxyCallOperation* call,
                                  MLIRLoweringProvider::ValueFrame& frame) {
-	auto dest = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto src = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto count = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto dest = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto src = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto count = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 
 	// Create memmove intrinsic: llvm.memmove(dest, src, len, isVolatile)
 	auto isVolatile = builder->create<::mlir::LLVM::ConstantOp>(builder->getUnknownLoc(), builder->getI1Type(),
@@ -58,9 +58,9 @@ bool replaceWithMemmoveIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 /// Helper for memset intrinsic (3 arguments: dest, value, count)
 bool replaceWithMemsetIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                 const compiler::ir::ProxyCallOperation* call, MLIRLoweringProvider::ValueFrame& frame) {
-	auto dest = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto value = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto count = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto dest = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto value = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto count = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 
 	// LLVM memset intrinsic requires the value to be i8, so truncate from i32 to i8
 	auto i8Type = builder->getIntegerType(8);

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -159,12 +159,12 @@ struct formatter<nautilus::compiler::ir::BasicBlockInvocation> : formatter<std::
 	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "Block_{}(", op.getBlock()->getIdentifier());
-		const auto& args = op.getArguments();
+		const auto args = op.getArguments();
 		for (size_t i = 0; i < args.size(); ++i) {
 			if (i > 0) {
 				fmt::format_to(out, ", ");
 			}
-			fmt::format_to(out, "{}", args.at(i)->getIdentifier());
+			fmt::format_to(out, "{}", args[i]->getIdentifier());
 		}
 		fmt::format_to(out, ")");
 		return out;
@@ -195,12 +195,12 @@ struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::st
 		} else {
 			fmt::format_to(out, "func_*(");
 		}
-		const auto& args = op.getInputArguments();
+		const auto args = op.getInputArguments();
 		for (size_t i = 0; i < args.size(); ++i) {
 			if (i > 0) {
 				fmt::format_to(out, ",");
 			}
-			fmt::format_to(out, "{}", args.at(i)->getIdentifier());
+			fmt::format_to(out, "{}", args[i]->getIdentifier());
 		}
 		fmt::format_to(out, ")");
 		return out;

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
@@ -10,12 +10,12 @@ BasicBlock::BasicBlock(common::Arena& arena, BlockIdentifier identifier, std::ve
     : arena_(&arena), identifier(identifier), operations(), arguments(std::move(arguments)) {
 }
 
-void BasicBlock::addNextBlock(BasicBlock* nextBlock, const std::vector<Operation*>& ops) {
+void BasicBlock::addNextBlock(BasicBlock* nextBlock, std::span<Operation* const> ops) {
 	auto* branchOp = arena_->create<BranchOperation>();
 	auto& nextBlockIn = branchOp->getNextBlockInvocation();
 	nextBlockIn.setBlock(nextBlock);
-	for (auto op : ops) {
-		nextBlockIn.addArgument(op);
+	for (auto* op : ops) {
+		nextBlockIn.addArgument(*arena_, op);
 	}
 	addOperation(branchOp);
 }

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
@@ -80,22 +80,16 @@ public:
 	/// Allocates a new operation of type T in the arena and appends it to
 	/// this block. Returns the freshly created operation.
 	///
-	/// When T's constructor accepts an Arena& as its first argument, the
-	/// owning arena is injected automatically so the operation can allocate
-	/// its inputs array from it; constructors that don't need it (the
-	/// no-input operations such as BranchOp / Const*) keep their original
-	/// signature.
+	/// The owning arena is always injected as the first constructor
+	/// argument so operations that need it (to allocate their inputs
+	/// buffer) have it and those that don't simply ignore the reference.
+	/// This keeps the factory uniform and makes the call site the
+	/// single source of truth for where the arena comes from.
 	template <typename T, typename... Args>
 	T* addOperation(Args&&... args) {
-		if constexpr (std::is_constructible_v<T, common::Arena&, Args&&...>) {
-			auto* op = arena_->create<T>(*arena_, std::forward<Args>(args)...);
-			operations.push_back(op);
-			return op;
-		} else {
-			auto* op = arena_->create<T>(std::forward<Args>(args)...);
-			operations.push_back(op);
-			return op;
-		}
+		auto* op = arena_->create<T>(*arena_, std::forward<Args>(args)...);
+		operations.push_back(op);
+		return op;
 	}
 
 	/// Appends an already-arena-allocated operation to this block.

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
@@ -7,6 +7,7 @@
 #include <compare>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace nautilus::compiler::ir {
@@ -78,11 +79,23 @@ public:
 
 	/// Allocates a new operation of type T in the arena and appends it to
 	/// this block. Returns the freshly created operation.
+	///
+	/// When T's constructor accepts an Arena& as its first argument, the
+	/// owning arena is injected automatically so the operation can allocate
+	/// its inputs array from it; constructors that don't need it (the
+	/// no-input operations such as BranchOp / Const*) keep their original
+	/// signature.
 	template <typename T, typename... Args>
 	T* addOperation(Args&&... args) {
-		auto* op = arena_->create<T>(std::forward<Args>(args)...);
-		operations.push_back(op);
-		return op;
+		if constexpr (std::is_constructible_v<T, common::Arena&, Args&&...>) {
+			auto* op = arena_->create<T>(*arena_, std::forward<Args>(args)...);
+			operations.push_back(op);
+			return op;
+		} else {
+			auto* op = arena_->create<T>(std::forward<Args>(args)...);
+			operations.push_back(op);
+			return op;
+		}
 	}
 
 	/// Appends an already-arena-allocated operation to this block.
@@ -90,7 +103,7 @@ public:
 
 	BasicBlock* addNextBlock(BasicBlock* nextBlock);
 
-	void addNextBlock(BasicBlock* nextBlock, const std::vector<Operation*>& inputArguments);
+	void addNextBlock(BasicBlock* nextBlock, std::span<Operation* const> inputArguments);
 
 	BasicBlock* addTrueBlock(BasicBlock* thenBlock);
 

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockArgument.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockArgument.hpp
@@ -11,7 +11,7 @@ class BasicBlockArgument : public Operation {
 public:
 	explicit BasicBlockArgument(const OperationIdentifier identifier, Type stamp);
 
-	~BasicBlockArgument() override = default;
+	~BasicBlockArgument() = default;
 
 	friend std::ostream& operator<<(std::ostream& os, const BasicBlockArgument& argument);
 

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.cpp
@@ -16,32 +16,37 @@ const BasicBlock* BasicBlockInvocation::getBlock() const {
 }
 
 void BasicBlockInvocation::addArgument(common::Arena& arena, Operation* argument) {
-	if (numInputs == capacity_) {
+	const std::size_t size = inputs.size();
+	if (size == capacity_) {
 		// Grow geometrically so back-to-back appends amortise to O(1).
 		// Block invocations very rarely exceed a handful of arguments, so
 		// the initial small bucket avoids allocating a chunk for the
 		// common case where only one or two arguments are added.
 		uint32_t newCap = capacity_ == 0 ? 4u : capacity_ * 2u;
 		auto* newInputs = static_cast<Operation**>(arena.allocate(sizeof(Operation*) * newCap, alignof(Operation*)));
-		if (numInputs > 0) {
-			std::copy(inputs, inputs + numInputs, newInputs);
+		if (size > 0) {
+			std::copy(inputs.begin(), inputs.end(), newInputs);
 		}
-		inputs = newInputs;
+		inputs = std::span<Operation*>(newInputs, size);
 		capacity_ = newCap;
 	}
-	inputs[numInputs++] = argument;
+	// Extend the span by one slot and fill it. The underlying buffer has
+	// `capacity_` elements, so widening the view is always in-bounds.
+	Operation** data = inputs.data();
+	inputs = std::span<Operation*>(data, size + 1);
+	data[size] = argument;
 }
 
 void BasicBlockInvocation::replaceArgument(Operation* toReplace, Operation* replaceWith) {
-	std::replace(inputs, inputs + numInputs, toReplace, replaceWith);
+	std::replace(inputs.begin(), inputs.end(), toReplace, replaceWith);
 }
 
 void BasicBlockInvocation::replaceArgument(const Operation* toReplace, Operation* replaceWith) {
-	std::replace(inputs, inputs + numInputs, const_cast<Operation*>(toReplace), replaceWith);
+	std::replace(inputs.begin(), inputs.end(), const_cast<Operation*>(toReplace), replaceWith);
 }
 
 int BasicBlockInvocation::getOperationArgIndex(Operation* arg) {
-	for (uint32_t i = 0; i < numInputs; i++) {
+	for (std::size_t i = 0; i < inputs.size(); i++) {
 		if (inputs[i] == arg) {
 			return static_cast<int>(i);
 		}

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.cpp
@@ -15,33 +15,42 @@ const BasicBlock* BasicBlockInvocation::getBlock() const {
 	return basicBlock;
 }
 
-void BasicBlockInvocation::addArgument(Operation* argument) {
-	inputs.emplace_back(argument);
-}
-
-void BasicBlockInvocation::removeArgument(uint64_t argumentIndex) {
-	inputs.erase(inputs.begin() + argumentIndex);
+void BasicBlockInvocation::addArgument(common::Arena& arena, Operation* argument) {
+	if (numInputs == capacity_) {
+		// Grow geometrically so back-to-back appends amortise to O(1).
+		// Block invocations very rarely exceed a handful of arguments, so
+		// the initial small bucket avoids allocating a chunk for the
+		// common case where only one or two arguments are added.
+		uint32_t newCap = capacity_ == 0 ? 4u : capacity_ * 2u;
+		auto* newInputs = static_cast<Operation**>(arena.allocate(sizeof(Operation*) * newCap, alignof(Operation*)));
+		if (numInputs > 0) {
+			std::copy(inputs, inputs + numInputs, newInputs);
+		}
+		inputs = newInputs;
+		capacity_ = newCap;
+	}
+	inputs[numInputs++] = argument;
 }
 
 void BasicBlockInvocation::replaceArgument(Operation* toReplace, Operation* replaceWith) {
-	std::replace(inputs.begin(), inputs.end(), toReplace, replaceWith);
+	std::replace(inputs, inputs + numInputs, toReplace, replaceWith);
 }
 
 void BasicBlockInvocation::replaceArgument(const Operation* toReplace, Operation* replaceWith) {
-	std::replace(inputs.begin(), inputs.end(), const_cast<Operation*>(toReplace), replaceWith);
+	std::replace(inputs, inputs + numInputs, const_cast<Operation*>(toReplace), replaceWith);
 }
 
 int BasicBlockInvocation::getOperationArgIndex(Operation* arg) {
-	for (uint64_t i = 0; i < inputs.size(); i++) {
+	for (uint32_t i = 0; i < numInputs; i++) {
 		if (inputs[i] == arg) {
-			return i;
+			return static_cast<int>(i);
 		}
 	}
 	return -1;
 }
 
-const std::vector<Operation*>& BasicBlockInvocation::getArguments() const {
-	return inputs;
+std::span<Operation* const> BasicBlockInvocation::getArguments() const {
+	return getInputs();
 }
 
 bool BasicBlockInvocation::classof(const Operation* op) {

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp
@@ -2,26 +2,47 @@
 
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
+#include <span>
 
 namespace nautilus::compiler::ir {
 
+/**
+ * @brief Argument list passed when control flow enters a successor block.
+ *
+ * BasicBlockInvocation is always an embedded sub-object of a terminator
+ * Operation (BranchOperation, IfOperation): both branches of an `if` and
+ * the single successor of a `br` each own one. The argument array is built
+ * incrementally during IR construction (one argument is appended per
+ * matching block-argument slot) and frozen once the terminator is fully
+ * wired.
+ *
+ * Storage is allocated from the surrounding `common::Arena`. Each
+ * `addArgument` walks into a fresh, doubled buffer when the existing
+ * one runs out of room; the previous buffer is released back to the
+ * arena on the next `softReset` (the arena owns it, not the
+ * invocation), so the small amount of fragmentation is bounded by the
+ * arena lifetime. In practice block invocations have 0–4 arguments so
+ * the doubling growth never advances past the second buffer.
+ */
 class BasicBlockInvocation : public Operation {
 public:
 	BasicBlockInvocation();
+
+	~BasicBlockInvocation() = default;
 
 	void setBlock(BasicBlock* block);
 
 	[[nodiscard]] const BasicBlock* getBlock() const;
 
-	void addArgument(Operation* argument);
-
-	void removeArgument(uint64_t argumentIndex);
+	/// Appends @p argument, allocating a larger backing buffer from
+	/// @p arena when the current one is full.
+	void addArgument(common::Arena& arena, Operation* argument);
 
 	void replaceArgument(Operation* toReplace, Operation* replaceWith);
 
 	void replaceArgument(const Operation* toReplace, Operation* replaceWith);
 
-	const std::vector<Operation*>& getArguments() const;
+	std::span<Operation* const> getArguments() const;
 
 	/**
 	 * @brief Iterate over args, find arg that matches Operation* and return index.
@@ -33,10 +54,13 @@ public:
 	static bool classof(const Operation* op);
 
 private:
-	// Arguments are stored in the base Operation::inputs vector — block-argument
+	// Arguments are stored in the base Operation::inputs buffer — block-argument
 	// edges are real SSA value edges, so generic passes that walk getInputs()
-	// see them automatically without a special case.
-	BasicBlock* basicBlock;
+	// see them automatically without a special case. `capacity_` tracks the
+	// physical buffer size so growth can avoid reallocating per push when the
+	// caller appends multiple arguments back-to-back.
+	BasicBlock* basicBlock = nullptr;
+	uint32_t capacity_ = 0;
 };
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.cpp
@@ -5,7 +5,7 @@
 
 namespace nautilus::compiler::ir {
 
-AllocaOperation::AllocaOperation(OperationIdentifier id, size_t allocationSize)
+AllocaOperation::AllocaOperation(common::Arena& /*arena*/, OperationIdentifier id, size_t allocationSize)
     : Operation(OperationType::AllocaOp, id, Type::ptr), allocationSize(allocationSize) {
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.cpp
@@ -6,7 +6,7 @@
 namespace nautilus::compiler::ir {
 
 AllocaOperation::AllocaOperation(OperationIdentifier id, size_t allocationSize)
-    : Operation(OperationType::AllocaOp, id, Type::ptr, {}), allocationSize(allocationSize) {
+    : Operation(OperationType::AllocaOp, id, Type::ptr), allocationSize(allocationSize) {
 }
 
 size_t AllocaOperation::getSize() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.hpp
@@ -6,7 +6,7 @@
 namespace nautilus::compiler::ir {
 class AllocaOperation : public Operation {
 public:
-	AllocaOperation(OperationIdentifier id, size_t allocationSize);
+	AllocaOperation(common::Arena& arena, OperationIdentifier id, size_t allocationSize);
 
 	~AllocaOperation() = default;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/AllocaOperation.hpp
@@ -8,7 +8,7 @@ class AllocaOperation : public Operation {
 public:
 	AllocaOperation(OperationIdentifier id, size_t allocationSize);
 
-	~AllocaOperation() override = default;
+	~AllocaOperation() = default;
 
 	size_t getSize() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.cpp
@@ -3,8 +3,9 @@
 
 namespace nautilus::compiler::ir {
 
-AddOperation::AddOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::AddOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
+AddOperation::AddOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                           Operation* rightInput)
+    : BinaryOperation(arena, OperationType::AddOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
 }
 
 bool AddOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/AddOperation.hpp
@@ -5,9 +5,9 @@ namespace nautilus::compiler::ir {
 
 class AddOperation final : public BinaryOperation {
 public:
-	AddOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	AddOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~AddOperation() override = default;
+	~AddOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.cpp
@@ -3,8 +3,9 @@
 #include <string>
 
 namespace nautilus::compiler::ir {
-DivOperation::DivOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::DivOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
+DivOperation::DivOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                           Operation* rightInput)
+    : BinaryOperation(arena, OperationType::DivOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
 }
 
 bool DivOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp
@@ -5,9 +5,9 @@ namespace nautilus::compiler::ir {
 
 class DivOperation final : public BinaryOperation {
 public:
-	DivOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	DivOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~DivOperation() override = default;
+	~DivOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.cpp
@@ -4,8 +4,9 @@
 #include <string>
 
 namespace nautilus::compiler::ir {
-ModOperation::ModOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::ModOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
+ModOperation::ModOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                           Operation* rightInput)
+    : BinaryOperation(arena, OperationType::ModOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
 }
 
 bool ModOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp
@@ -7,9 +7,9 @@ namespace nautilus::compiler::ir {
 
 class ModOperation final : public BinaryOperation {
 public:
-	ModOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	ModOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~ModOperation() override = default;
+	~ModOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.cpp
@@ -4,8 +4,9 @@
 #include <string>
 
 namespace nautilus::compiler::ir {
-MulOperation::MulOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::MulOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
+MulOperation::MulOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                           Operation* rightInput)
+    : BinaryOperation(arena, OperationType::MulOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
 }
 
 bool MulOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp
@@ -6,9 +6,9 @@ namespace nautilus::compiler::ir {
 
 class MulOperation final : public BinaryOperation {
 public:
-	MulOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	MulOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~MulOperation() override = default;
+	~MulOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.cpp
@@ -3,8 +3,9 @@
 #include <string>
 
 namespace nautilus::compiler::ir {
-SubOperation::SubOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::SubOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
+SubOperation::SubOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                           Operation* rightInput)
+    : BinaryOperation(arena, OperationType::SubOp, identifier, leftInput->getStamp(), leftInput, rightInput) {
 }
 
 bool SubOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ArithmeticOperations/SubOperation.hpp
@@ -7,9 +7,9 @@ namespace nautilus::compiler::ir {
 
 class SubOperation final : public BinaryOperation {
 public:
-	SubOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	SubOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~SubOperation() override = default;
+	~SubOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.cpp
@@ -4,9 +4,10 @@
 
 namespace nautilus::compiler::ir {
 
-BinaryCompOperation::BinaryCompOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput,
-                                         Type type)
-    : BinaryOperation(OperationType::BinaryComp, identifier, leftInput->getStamp(), leftInput, rightInput), type(type) {
+BinaryCompOperation::BinaryCompOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                                         Operation* rightInput, Type type)
+    : BinaryOperation(arena, OperationType::BinaryComp, identifier, leftInput->getStamp(), leftInput, rightInput),
+      type(type) {
 }
 
 BinaryCompOperation::Type BinaryCompOperation::getType() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp
@@ -10,9 +10,10 @@ class BinaryCompOperation final : public BinaryOperation {
 public:
 	enum Type { BAND, BOR, XOR };
 
-	BinaryCompOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput, Type type);
+	BinaryCompOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+	                    Operation* rightInput, Type type);
 
-	~BinaryCompOperation() override = default;
+	~BinaryCompOperation() = default;
 
 	static bool classof(const Operation* Op);
 

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.cpp
@@ -3,8 +3,8 @@
 
 namespace nautilus::compiler::ir {
 
-NegateOperation::NegateOperation(OperationIdentifier identifier, Operation* input)
-    : Operation(OperationType::NegateOp, identifier, input->getStamp(), {input}) {
+NegateOperation::NegateOperation(common::Arena& arena, OperationIdentifier identifier, Operation* input)
+    : Operation(arena, OperationType::NegateOp, identifier, input->getStamp(), {input}) {
 }
 
 bool NegateOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/NegateOperation.hpp
@@ -5,9 +5,9 @@ namespace nautilus::compiler::ir {
 
 class NegateOperation : public Operation {
 public:
-	NegateOperation(OperationIdentifier identifier, Operation* input);
+	NegateOperation(common::Arena& arena, OperationIdentifier identifier, Operation* input);
 
-	~NegateOperation() override = default;
+	~NegateOperation() = default;
 
 	Operation* getInput() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.cpp
@@ -4,9 +4,10 @@
 
 namespace nautilus::compiler::ir {
 
-ShiftOperation::ShiftOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput,
-                               ShiftType type)
-    : BinaryOperation(OperationType::ShiftOp, identifier, leftInput->getStamp(), leftInput, rightInput), type(type) {
+ShiftOperation::ShiftOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                               Operation* rightInput, ShiftType type)
+    : BinaryOperation(arena, OperationType::ShiftOp, identifier, leftInput->getStamp(), leftInput, rightInput),
+      type(type) {
 }
 
 ShiftOperation::ShiftType ShiftOperation::getType() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp
@@ -9,9 +9,10 @@ class ShiftOperation final : public BinaryOperation {
 public:
 	enum ShiftType { LS, RS };
 
-	ShiftOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput, ShiftType type);
+	ShiftOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput,
+	               ShiftType type);
 
-	~ShiftOperation() override = default;
+	~ShiftOperation() = default;
 
 	static bool classof(const Operation* Op);
 

--- a/nautilus/src/nautilus/compiler/ir/operations/BranchOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/BranchOperation.hpp
@@ -11,7 +11,7 @@ class BranchOperation : public Operation {
 public:
 	explicit BranchOperation();
 
-	~BranchOperation() override = default;
+	~BranchOperation() = default;
 
 	const BasicBlockInvocation& getNextBlockInvocation() const;
 	BasicBlockInvocation& getNextBlockInvocation();

--- a/nautilus/src/nautilus/compiler/ir/operations/CastOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/CastOperation.cpp
@@ -3,8 +3,8 @@
 
 namespace nautilus::compiler::ir {
 
-CastOperation::CastOperation(OperationIdentifier identifier, Operation* input, Type targetStamp)
-    : Operation(OperationType::CastOp, identifier, targetStamp, {input}) {
+CastOperation::CastOperation(common::Arena& arena, OperationIdentifier identifier, Operation* input, Type targetStamp)
+    : Operation(arena, OperationType::CastOp, identifier, targetStamp, {input}) {
 }
 
 Operation* CastOperation::getInput() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/CastOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/CastOperation.hpp
@@ -7,9 +7,9 @@ namespace nautilus::compiler::ir {
 
 class CastOperation : public Operation {
 public:
-	explicit CastOperation(OperationIdentifier identifier, Operation* input, Type targetStamp);
+	explicit CastOperation(common::Arena& arena, OperationIdentifier identifier, Operation* input, Type targetStamp);
 
-	~CastOperation() override = default;
+	~CastOperation() = default;
 
 	Operation* getInput() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstBooleanOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstBooleanOperation.cpp
@@ -5,7 +5,8 @@
 
 namespace nautilus::compiler::ir {
 
-ConstBooleanOperation::ConstBooleanOperation(OperationIdentifier identifier, bool constantValue)
+ConstBooleanOperation::ConstBooleanOperation(common::Arena& /*arena*/, OperationIdentifier identifier,
+                                             bool constantValue)
     : Operation(OperationType::ConstBooleanOp, identifier, Type::b), constantValue(constantValue) {
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstBooleanOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstBooleanOperation.hpp
@@ -9,7 +9,7 @@ class ConstBooleanOperation : public Operation {
 public:
 	explicit ConstBooleanOperation(OperationIdentifier identifier, bool value);
 
-	~ConstBooleanOperation() override = default;
+	~ConstBooleanOperation() = default;
 
 	bool getValue() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstBooleanOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstBooleanOperation.hpp
@@ -7,7 +7,7 @@ namespace nautilus::compiler::ir {
 
 class ConstBooleanOperation : public Operation {
 public:
-	explicit ConstBooleanOperation(OperationIdentifier identifier, bool value);
+	explicit ConstBooleanOperation(common::Arena& arena, OperationIdentifier identifier, bool value);
 
 	~ConstBooleanOperation() = default;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.cpp
@@ -5,7 +5,8 @@
 
 namespace nautilus::compiler::ir {
 
-ConstFloatOperation::ConstFloatOperation(OperationIdentifier identifier, double constantValue, Type stamp)
+ConstFloatOperation::ConstFloatOperation(common::Arena& /*arena*/, OperationIdentifier identifier, double constantValue,
+                                         Type stamp)
     : Operation(OperationType::ConstFloatOp, identifier, stamp), constantValue(constantValue) {
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.hpp
@@ -9,7 +9,7 @@ class ConstFloatOperation : public Operation {
 public:
 	explicit ConstFloatOperation(OperationIdentifier identifier, double constantValue, Type stamp);
 
-	~ConstFloatOperation() override = default;
+	~ConstFloatOperation() = default;
 
 	double getValue() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstFloatOperation.hpp
@@ -7,7 +7,8 @@ namespace nautilus::compiler::ir {
 
 class ConstFloatOperation : public Operation {
 public:
-	explicit ConstFloatOperation(OperationIdentifier identifier, double constantValue, Type stamp);
+	explicit ConstFloatOperation(common::Arena& arena, OperationIdentifier identifier, double constantValue,
+	                             Type stamp);
 
 	~ConstFloatOperation() = default;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.cpp
@@ -6,7 +6,8 @@
 
 namespace nautilus::compiler::ir {
 
-ConstIntOperation::ConstIntOperation(OperationIdentifier identifier, int64_t constantValue, Type stamp)
+ConstIntOperation::ConstIntOperation(common::Arena& /*arena*/, OperationIdentifier identifier, int64_t constantValue,
+                                     Type stamp)
     : Operation(OperationType::ConstIntOp, identifier, stamp), constantValue(constantValue) {
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.hpp
@@ -8,7 +8,7 @@ class ConstIntOperation : public Operation {
 public:
 	explicit ConstIntOperation(OperationIdentifier identifier, int64_t constantValue, Type stamp);
 
-	~ConstIntOperation() override = default;
+	~ConstIntOperation() = default;
 
 	int64_t getValue() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstIntOperation.hpp
@@ -6,7 +6,7 @@ namespace nautilus::compiler::ir {
 
 class ConstIntOperation : public Operation {
 public:
-	explicit ConstIntOperation(OperationIdentifier identifier, int64_t constantValue, Type stamp);
+	explicit ConstIntOperation(common::Arena& arena, OperationIdentifier identifier, int64_t constantValue, Type stamp);
 
 	~ConstIntOperation() = default;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.cpp
@@ -6,7 +6,7 @@
 
 namespace nautilus::compiler::ir {
 
-ConstPtrOperation::ConstPtrOperation(OperationIdentifier identifier, void* constantValue)
+ConstPtrOperation::ConstPtrOperation(common::Arena& /*arena*/, OperationIdentifier identifier, void* constantValue)
     : Operation(OperationType::ConstPtrOp, identifier, Type::ptr), constantValue(constantValue) {
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.hpp
@@ -9,7 +9,7 @@ class ConstPtrOperation : public Operation {
 public:
 	explicit ConstPtrOperation(OperationIdentifier identifier, void* value);
 
-	~ConstPtrOperation() override = default;
+	~ConstPtrOperation() = default;
 
 	void* getValue() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ConstPtrOperation.hpp
@@ -7,7 +7,7 @@ namespace nautilus::compiler::ir {
 
 class ConstPtrOperation : public Operation {
 public:
-	explicit ConstPtrOperation(OperationIdentifier identifier, void* value);
+	explicit ConstPtrOperation(common::Arena& arena, OperationIdentifier identifier, void* value);
 
 	~ConstPtrOperation() = default;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.cpp
@@ -6,8 +6,8 @@ namespace nautilus::compiler::ir {
 FunctionAddressOfOperation::FunctionAddressOfOperation(const std::string& functionSymbol,
                                                        const std::string& functionName, void* functionPtr,
                                                        OperationIdentifier identifier)
-    : Operation(Operation::OperationType::FunctionAddressOfOp, identifier, Type::ptr, {}),
-      functionSymbol(functionSymbol), functionName(functionName), functionPtr(functionPtr) {
+    : Operation(Operation::OperationType::FunctionAddressOfOp, identifier, Type::ptr), functionSymbol(functionSymbol),
+      functionName(functionName), functionPtr(functionPtr) {
 }
 
 const std::string& FunctionAddressOfOperation::getFunctionSymbol() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.cpp
@@ -3,7 +3,7 @@
 
 namespace nautilus::compiler::ir {
 
-FunctionAddressOfOperation::FunctionAddressOfOperation(const std::string& functionSymbol,
+FunctionAddressOfOperation::FunctionAddressOfOperation(common::Arena& /*arena*/, const std::string& functionSymbol,
                                                        const std::string& functionName, void* functionPtr,
                                                        OperationIdentifier identifier)
     : Operation(Operation::OperationType::FunctionAddressOfOp, identifier, Type::ptr), functionSymbol(functionSymbol),

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp
@@ -13,7 +13,7 @@ public:
 	FunctionAddressOfOperation(const std::string& functionSymbol, const std::string& functionName, void* functionPtr,
 	                           OperationIdentifier identifier);
 
-	~FunctionAddressOfOperation() override = default;
+	~FunctionAddressOfOperation() = default;
 
 	const std::string& getFunctionSymbol() const;
 	const std::string& getFunctionName() const;

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionAddressOfOperation.hpp
@@ -10,8 +10,8 @@ namespace nautilus::compiler::ir {
 /// Used to get function pointers for Nautilus functions that can be passed to runtime calls.
 class FunctionAddressOfOperation : public Operation {
 public:
-	FunctionAddressOfOperation(const std::string& functionSymbol, const std::string& functionName, void* functionPtr,
-	                           OperationIdentifier identifier);
+	FunctionAddressOfOperation(common::Arena& arena, const std::string& functionSymbol, const std::string& functionName,
+	                           void* functionPtr, OperationIdentifier identifier);
 
 	~FunctionAddressOfOperation() = default;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
@@ -10,7 +10,7 @@ public:
 	explicit FunctionOperation(std::string name, std::vector<BasicBlock*> functionBasicBlocks,
 	                           std::vector<Type> inputArgs, std::vector<std::string> inputArgNames, Type outputArg);
 
-	~FunctionOperation() override = default;
+	~FunctionOperation() = default;
 
 	[[nodiscard]] const std::string& getName() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/IfOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IfOperation.cpp
@@ -3,8 +3,9 @@
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 
 namespace nautilus::compiler::ir {
-IfOperation::IfOperation(Operation* booleanValue, double probability)
-    : Operation(Operation::OperationType::IfOp, Type::v, {booleanValue}), probability(probability) {
+IfOperation::IfOperation(common::Arena& arena, Operation* booleanValue, double probability)
+    : Operation(arena, Operation::OperationType::IfOp, OperationIdentifier {0}, Type::v, {booleanValue}),
+      probability(probability) {
 }
 
 Operation* IfOperation::getValue() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/IfOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IfOperation.hpp
@@ -7,9 +7,9 @@
 namespace nautilus::compiler::ir {
 class IfOperation : public Operation {
 public:
-	IfOperation(Operation* booleanValue, double probability);
+	IfOperation(common::Arena& arena, Operation* booleanValue, double probability);
 
-	~IfOperation() override = default;
+	~IfOperation() = default;
 
 	Operation* getValue() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.cpp
@@ -7,15 +7,15 @@ namespace nautilus::compiler::ir {
 namespace {
 // Builds a contiguous arena-allocated input array of the form
 // `[functionPtrOperand, inputArguments[0], inputArguments[1], ...]` and returns
-// it. We can't use the Operation constructor's initializer_list overload here
-// because the argument count is dynamic.
-Operation** buildIndirectCallInputs(common::Arena& arena, Operation* functionPtrOperand,
-                                    std::span<Operation* const> inputArguments) {
+// a span over it. We can't use the Operation constructor's initializer_list
+// overload here because the argument count is dynamic.
+std::span<Operation*> buildIndirectCallInputs(common::Arena& arena, Operation* functionPtrOperand,
+                                              std::span<Operation* const> inputArguments) {
 	const std::size_t total = 1 + inputArguments.size();
 	auto* buffer = static_cast<Operation**>(arena.allocate(sizeof(Operation*) * total, alignof(Operation*)));
 	buffer[0] = functionPtrOperand;
 	std::copy(inputArguments.begin(), inputArguments.end(), buffer + 1);
-	return buffer;
+	return {buffer, total};
 }
 } // namespace
 
@@ -25,7 +25,6 @@ IndirectCallOperation::IndirectCallOperation(common::Arena& arena, OperationIden
     : Operation(Operation::OperationType::IndirectCallOp, identifier, resultType), fnAttrs(std::move(fnAttrs)) {
 	// inputs[0] = function pointer operand; inputs[1..] = call arguments
 	this->inputs = buildIndirectCallInputs(arena, functionPtrOperand, inputArguments);
-	this->numInputs = static_cast<uint32_t>(1 + inputArguments.size());
 }
 
 Operation* IndirectCallOperation::getFunctionPtrOperand() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.cpp
@@ -4,22 +4,36 @@
 
 namespace nautilus::compiler::ir {
 
-IndirectCallOperation::IndirectCallOperation(OperationIdentifier identifier, Operation* functionPtrOperand,
-                                             std::vector<Operation*> inputArguments, Type resultType,
-                                             FunctionAttributes fnAttrs)
+namespace {
+// Builds a contiguous arena-allocated input array of the form
+// `[functionPtrOperand, inputArguments[0], inputArguments[1], ...]` and returns
+// it. We can't use the Operation constructor's initializer_list overload here
+// because the argument count is dynamic.
+Operation** buildIndirectCallInputs(common::Arena& arena, Operation* functionPtrOperand,
+                                    std::span<Operation* const> inputArguments) {
+	const std::size_t total = 1 + inputArguments.size();
+	auto* buffer = static_cast<Operation**>(arena.allocate(sizeof(Operation*) * total, alignof(Operation*)));
+	buffer[0] = functionPtrOperand;
+	std::copy(inputArguments.begin(), inputArguments.end(), buffer + 1);
+	return buffer;
+}
+} // namespace
+
+IndirectCallOperation::IndirectCallOperation(common::Arena& arena, OperationIdentifier identifier,
+                                             Operation* functionPtrOperand, std::span<Operation* const> inputArguments,
+                                             Type resultType, FunctionAttributes fnAttrs)
     : Operation(Operation::OperationType::IndirectCallOp, identifier, resultType), fnAttrs(std::move(fnAttrs)) {
 	// inputs[0] = function pointer operand; inputs[1..] = call arguments
-	inputs.reserve(1 + inputArguments.size());
-	inputs.push_back(functionPtrOperand);
-	inputs.insert(inputs.end(), inputArguments.begin(), inputArguments.end());
+	this->inputs = buildIndirectCallInputs(arena, functionPtrOperand, inputArguments);
+	this->numInputs = static_cast<uint32_t>(1 + inputArguments.size());
 }
 
 Operation* IndirectCallOperation::getFunctionPtrOperand() const {
 	return inputs[0];
 }
 
-std::vector<Operation*> IndirectCallOperation::getInputArguments() const {
-	return std::vector<Operation*>(inputs.begin() + 1, inputs.end());
+std::span<Operation* const> IndirectCallOperation::getInputArguments() const {
+	return getInputs().subspan(1);
 }
 
 const FunctionAttributes& IndirectCallOperation::getFunctionAttributes() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/IndirectCallOperation.hpp
@@ -3,6 +3,7 @@
 
 #include "nautilus/common/FunctionAttributes.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
+#include <span>
 #include <vector>
 
 namespace nautilus::compiler::ir {
@@ -14,16 +15,16 @@ namespace nautilus::compiler::ir {
 /// first element of inputs[] — followed by the call arguments.
 class IndirectCallOperation : public Operation {
 public:
-	IndirectCallOperation(OperationIdentifier identifier, Operation* functionPtrOperand,
-	                      std::vector<Operation*> inputArguments, Type resultType, FunctionAttributes fnAttrs);
+	IndirectCallOperation(common::Arena& arena, OperationIdentifier identifier, Operation* functionPtrOperand,
+	                      std::span<Operation* const> inputArguments, Type resultType, FunctionAttributes fnAttrs);
 
-	~IndirectCallOperation() override = default;
+	~IndirectCallOperation() = default;
 
 	/// The SSA operand that holds the runtime function pointer (inputs[0]).
 	Operation* getFunctionPtrOperand() const;
 
 	/// The call arguments (inputs[1..]).
-	std::vector<Operation*> getInputArguments() const;
+	std::span<Operation* const> getInputArguments() const;
 
 	[[nodiscard]] const FunctionAttributes& getFunctionAttributes() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.cpp
@@ -3,8 +3,8 @@
 
 namespace nautilus::compiler::ir {
 
-LoadOperation::LoadOperation(OperationIdentifier identifier, Operation* address, Type type)
-    : Operation(OperationType::LoadOp, identifier, type, {address}) {
+LoadOperation::LoadOperation(common::Arena& arena, OperationIdentifier identifier, Operation* address, Type type)
+    : Operation(arena, OperationType::LoadOp, identifier, type, {address}) {
 }
 
 const Operation* LoadOperation::getAddress() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LoadOperation.hpp
@@ -5,9 +5,9 @@
 namespace nautilus::compiler::ir {
 class LoadOperation : public Operation {
 public:
-	explicit LoadOperation(OperationIdentifier identifier, Operation* address, Type stamp);
+	explicit LoadOperation(common::Arena& arena, OperationIdentifier identifier, Operation* address, Type stamp);
 
-	~LoadOperation() override = default;
+	~LoadOperation() = default;
 
 	const Operation* getAddress() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.cpp
@@ -3,8 +3,9 @@
 
 namespace nautilus::compiler::ir {
 
-AndOperation::AndOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::AndOp, identifier, Type::b, leftInput, rightInput) {
+AndOperation::AndOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                           Operation* rightInput)
+    : BinaryOperation(arena, OperationType::AndOp, identifier, Type::b, leftInput, rightInput) {
 }
 
 bool AndOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp
@@ -5,9 +5,9 @@ namespace nautilus::compiler::ir {
 
 class AndOperation : public BinaryOperation {
 public:
-	AndOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	AndOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~AndOperation() override = default;
+	~AndOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.cpp
@@ -3,9 +3,9 @@
 #include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
 
 namespace nautilus::compiler::ir {
-CompareOperation::CompareOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput,
-                                   Comparator comparator)
-    : BinaryOperation(Operation::OperationType::CompareOp, identifier, Type::b, leftInput, rightInput),
+CompareOperation::CompareOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                                   Operation* rightInput, Comparator comparator)
+    : BinaryOperation(arena, Operation::OperationType::CompareOp, identifier, Type::b, leftInput, rightInput),
       comparator(comparator) {
 }
 

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp
@@ -13,10 +13,10 @@ public:
 		GE = 5,
 	};
 
-	CompareOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput,
+	CompareOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput,
 	                 Comparator comparator);
 
-	~CompareOperation() override = default;
+	~CompareOperation() = default;
 
 	Comparator getComparator() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/NotOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/NotOperation.cpp
@@ -3,8 +3,8 @@
 
 namespace nautilus::compiler::ir {
 
-NotOperation::NotOperation(OperationIdentifier identifier, Operation* input)
-    : Operation(OperationType::NotOp, identifier, Type::b, {input}) {
+NotOperation::NotOperation(common::Arena& arena, OperationIdentifier identifier, Operation* input)
+    : Operation(arena, OperationType::NotOp, identifier, Type::b, {input}) {
 }
 
 bool NotOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp
@@ -5,9 +5,9 @@ namespace nautilus::compiler::ir {
 
 class NotOperation : public Operation {
 public:
-	NotOperation(OperationIdentifier identifier, Operation* input);
+	NotOperation(common::Arena& arena, OperationIdentifier identifier, Operation* input);
 
-	~NotOperation() override = default;
+	~NotOperation() = default;
 
 	Operation* getInput() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.cpp
@@ -3,8 +3,9 @@
 
 namespace nautilus::compiler::ir {
 
-OrOperation::OrOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput)
-    : BinaryOperation(OperationType::OrOp, identifier, Type::b, leftInput, rightInput) {
+OrOperation::OrOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput,
+                         Operation* rightInput)
+    : BinaryOperation(arena, OperationType::OrOp, identifier, Type::b, leftInput, rightInput) {
 }
 
 bool OrOperation::classof(const Operation* Op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp
@@ -5,9 +5,9 @@ namespace nautilus::compiler::ir {
 
 class OrOperation : public BinaryOperation {
 public:
-	OrOperation(OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
+	OrOperation(common::Arena& arena, OperationIdentifier identifier, Operation* leftInput, Operation* rightInput);
 
-	~OrOperation() override = default;
+	~OrOperation() = default;
 
 	static bool classof(const Operation* Op);
 };

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.cpp
@@ -3,32 +3,6 @@
 #include "nautilus/compiler/ir/operations/OperationProperties.hpp"
 
 namespace nautilus::compiler::ir {
-Operation::Operation(OperationType opType, OperationIdentifier identifier, Type stamp,
-                     const std::vector<Operation*>& inputs)
-    : opType(opType), identifier(identifier), stamp(stamp), inputs(inputs) {
-}
-
-Operation::Operation(OperationType opType, Type stamp, const std::vector<Operation*>& inputs)
-    : opType(opType), identifier(0), stamp(stamp), inputs(inputs) {
-}
-
-Operation::~Operation() noexcept = default;
-
-Operation::OperationType Operation::getOperationType() const {
-	return opType;
-}
-
-const std::vector<Operation*>& Operation::getInputs() const {
-	return inputs;
-}
-
-const OperationIdentifier& Operation::getIdentifier() const {
-	return identifier;
-}
-
-const Type& Operation::getStamp() const {
-	return stamp;
-}
 
 std::string OperationIdentifier::toString() const {
 	return "$" + std::to_string(id);
@@ -41,9 +15,9 @@ bool Operation::isConstOperation() const {
 	return opType != OperationType::ConstPtrOp && isConstantOp(opType);
 }
 
-BinaryOperation::BinaryOperation(OperationType opType, OperationIdentifier identifier, Type type, Operation* left,
-                                 Operation* right)
-    : Operation(opType, identifier, type, {left, right}) {
+BinaryOperation::BinaryOperation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
+                                 Operation* left, Operation* right)
+    : Operation(arena, opType, identifier, type, {left, right}) {
 }
 
 bool BinaryOperation::classof(const Operation* op) {

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
@@ -1,12 +1,15 @@
 
 #pragma once
 
+#include "nautilus/common/Arena.hpp"
 #include "nautilus/tracing/Types.hpp"
+#include <algorithm>
 #include <compare>
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
+#include <span>
 #include <string>
-#include <vector>
 
 namespace nautilus::compiler::ir {
 
@@ -28,6 +31,26 @@ private:
 	uint32_t id;
 };
 
+/**
+ * @brief Base class for all IR operations.
+ *
+ * Operation inputs are stored as a raw pointer / count pair into an
+ * Operation* array that is allocated from the surrounding `common::Arena`.
+ * The pointer is stable for the lifetime of the arena (the same lifetime
+ * the Operation itself enjoys), so storing inputs out-of-line costs the
+ * IR no extra cache pressure compared to a `std::vector` while removing
+ * the per-operation heap allocation, capacity word, and dynamic
+ * destruction the vector previously required.
+ *
+ * Operation has a non-virtual destructor: every derived type knows its
+ * own static type at construction time (the arena's `create<T>` call
+ * captures it via the destroyThunk), so polymorphic deletion through
+ * `Operation*` is never needed. Removing the virtual destructor lets
+ * the simple, fixed-arity Operation subclasses (the vast majority:
+ * Add, Sub, Cast, Load, Store, Const*, ...) become trivially
+ * destructible — the arena then skips registering destructors for
+ * them entirely, which both saves memory and accelerates `softReset`.
+ */
 class Operation {
 public:
 	enum class OperationType : uint8_t {
@@ -64,23 +87,53 @@ public:
 		FunctionAddressOfOp,
 	};
 
-	explicit Operation(OperationType opType, OperationIdentifier identifier, Type type,
-	                   const std::vector<Operation*>& inputs = {});
+	/// Constructs an Operation that has no SSA inputs.
+	Operation(OperationType opType, OperationIdentifier identifier, Type type) noexcept
+	    : opType(opType), identifier(identifier), stamp(type), inputs(nullptr), numInputs(0) {
+	}
 
-	explicit Operation(OperationType opType, Type type, const std::vector<Operation*>& inputs = {});
+	/// Convenience constructor (no identifier, no inputs).
+	Operation(OperationType opType, Type type) noexcept : Operation(opType, OperationIdentifier {0}, type) {
+	}
 
-	virtual ~Operation() noexcept;
+	/// Constructs an Operation whose inputs are copied into a freshly
+	/// arena-allocated array.
+	Operation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
+	          std::initializer_list<Operation*> ins)
+	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins.size())),
+	      numInputs(static_cast<uint32_t>(ins.size())) {
+		std::copy(ins.begin(), ins.end(), inputs);
+	}
 
-	const OperationIdentifier& getIdentifier() const;
+	/// Variable-length input constructor (used by call-like operations).
+	Operation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
+	          std::span<Operation* const> ins)
+	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins.size())),
+	      numInputs(static_cast<uint32_t>(ins.size())) {
+		std::copy(ins.begin(), ins.end(), inputs);
+	}
 
-	OperationType getOperationType() const;
+	/// Non-virtual destructor (see class comment).
+	~Operation() = default;
 
-	// std::string getOperationTypeAsString() const;
-	const Type& getStamp() const;
+	const OperationIdentifier& getIdentifier() const {
+		return identifier;
+	}
+
+	OperationType getOperationType() const {
+		return opType;
+	}
+
+	const Type& getStamp() const {
+		return stamp;
+	}
 
 	bool isConstOperation() const;
 
-	const std::vector<Operation*>& getInputs() const;
+	/// Returns a non-owning view over the SSA inputs of this operation.
+	std::span<Operation* const> getInputs() const noexcept {
+		return {inputs, numInputs};
+	}
 
 	template <typename OP>
 	const OP* dynCast() const {
@@ -88,10 +141,29 @@ public:
 	}
 
 protected:
+	/// Allocates a fresh, uninitialised Operation* array of the requested
+	/// size from @p arena.  Returns nullptr when @p count is zero so the
+	/// arena does not get hit with an empty allocation.
+	static Operation** allocateInputs(common::Arena& arena, std::size_t count) {
+		if (count == 0) {
+			return nullptr;
+		}
+		return static_cast<Operation**>(arena.allocate(sizeof(Operation*) * count, alignof(Operation*)));
+	}
+
+	Operation* getInput(std::size_t i) const {
+		return inputs[i];
+	}
+
+	void setInput(std::size_t i, Operation* op) {
+		inputs[i] = op;
+	}
+
 	const OperationType opType;
 	const OperationIdentifier identifier;
 	const Type stamp;
-	std::vector<Operation*> inputs;
+	Operation** inputs;
+	uint32_t numInputs;
 };
 
 /**
@@ -136,7 +208,8 @@ const T* as(const Operation* op) {
 
 class BinaryOperation : public Operation {
 public:
-	BinaryOperation(OperationType opType, OperationIdentifier identifier, Type type, Operation* left, Operation* right);
+	BinaryOperation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
+	                Operation* left, Operation* right);
 
 	Operation* getLeftInput() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
@@ -34,13 +34,22 @@ private:
 /**
  * @brief Base class for all IR operations.
  *
- * Operation inputs are stored as a raw pointer / count pair into an
- * Operation* array that is allocated from the surrounding `common::Arena`.
- * The pointer is stable for the lifetime of the arena (the same lifetime
- * the Operation itself enjoys), so storing inputs out-of-line costs the
- * IR no extra cache pressure compared to a `std::vector` while removing
+ * Operation inputs are stored as a `std::span<Operation*>` that points
+ * into a buffer allocated from the surrounding `common::Arena`. The
+ * buffer is stable for the arena's lifetime (the same lifetime the
+ * Operation itself enjoys), so storing inputs out-of-line costs the IR
+ * no extra cache pressure compared to a `std::vector` while removing
  * the per-operation heap allocation, capacity word, and dynamic
  * destruction the vector previously required.
+ *
+ * The vast majority of IR operations have a fixed arity — `AddOp` is
+ * always binary, `CastOp` is always unary, `SelectOp` is always
+ * ternary. The span is assigned once in the constructor and then only
+ * the individual `Operation*` slots are mutated (by `setLeftInput` and
+ * friends). Only `BasicBlockInvocation` (which grows via `addArgument`)
+ * and `ProxyCallOperation::setInputArguments` ever re-seat the span
+ * itself; they do so by re-assigning the protected `inputs` member to
+ * a span over a freshly allocated arena buffer.
  *
  * Operation has a non-virtual destructor: every derived type knows its
  * own static type at construction time (the arena's `create<T>` call
@@ -89,7 +98,7 @@ public:
 
 	/// Constructs an Operation that has no SSA inputs.
 	Operation(OperationType opType, OperationIdentifier identifier, Type type) noexcept
-	    : opType(opType), identifier(identifier), stamp(type), inputs(nullptr), numInputs(0) {
+	    : opType(opType), identifier(identifier), stamp(type), inputs() {
 	}
 
 	/// Convenience constructor (no identifier, no inputs).
@@ -100,17 +109,13 @@ public:
 	/// arena-allocated array.
 	Operation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
 	          std::initializer_list<Operation*> ins)
-	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins.size())),
-	      numInputs(static_cast<uint32_t>(ins.size())) {
-		std::copy(ins.begin(), ins.end(), inputs);
+	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins)) {
 	}
 
 	/// Variable-length input constructor (used by call-like operations).
 	Operation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
 	          std::span<Operation* const> ins)
-	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins.size())),
-	      numInputs(static_cast<uint32_t>(ins.size())) {
-		std::copy(ins.begin(), ins.end(), inputs);
+	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins)) {
 	}
 
 	/// Non-virtual destructor (see class comment).
@@ -132,7 +137,7 @@ public:
 
 	/// Returns a non-owning view over the SSA inputs of this operation.
 	std::span<Operation* const> getInputs() const noexcept {
-		return {inputs, numInputs};
+		return inputs;
 	}
 
 	template <typename OP>
@@ -141,29 +146,29 @@ public:
 	}
 
 protected:
-	/// Allocates a fresh, uninitialised Operation* array of the requested
-	/// size from @p arena.  Returns nullptr when @p count is zero so the
-	/// arena does not get hit with an empty allocation.
-	static Operation** allocateInputs(common::Arena& arena, std::size_t count) {
+	/// Copies @p ins into a fresh arena-allocated buffer and returns a
+	/// span over it.  Returns an empty span when @p ins is empty so the
+	/// arena is not hit with a zero-length allocation.
+	template <typename Range>
+	static std::span<Operation*> allocateInputs(common::Arena& arena, const Range& ins) {
+		const std::size_t count = std::size(ins);
 		if (count == 0) {
-			return nullptr;
+			return {};
 		}
-		return static_cast<Operation**>(arena.allocate(sizeof(Operation*) * count, alignof(Operation*)));
-	}
-
-	Operation* getInput(std::size_t i) const {
-		return inputs[i];
-	}
-
-	void setInput(std::size_t i, Operation* op) {
-		inputs[i] = op;
+		auto* buf = static_cast<Operation**>(arena.allocate(sizeof(Operation*) * count, alignof(Operation*)));
+		std::copy(std::begin(ins), std::end(ins), buf);
+		return {buf, count};
 	}
 
 	const OperationType opType;
 	const OperationIdentifier identifier;
 	const Type stamp;
-	Operation** inputs;
-	uint32_t numInputs;
+	/// View into the arena-allocated inputs buffer. Fixed-arity ops leave
+	/// this span untouched after construction and only mutate the pointers
+	/// it refers to; the two re-sizing ops (BasicBlockInvocation,
+	/// ProxyCallOperation::setInputArguments) re-seat it onto a fresh
+	/// arena buffer.
+	std::span<Operation*> inputs;
 };
 
 /**

--- a/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.cpp
@@ -3,25 +3,36 @@
 #include <utility>
 
 namespace nautilus::compiler::ir {
-ProxyCallOperation::ProxyCallOperation(OperationIdentifier identifier, const std::vector<Operation*>& inputArguments,
-                                       Type resultType)
-    : Operation(Operation::OperationType::ProxyCallOp, identifier, resultType, inputArguments) {
+ProxyCallOperation::ProxyCallOperation(common::Arena& arena, OperationIdentifier identifier,
+                                       std::span<Operation* const> inputArguments, Type resultType)
+    : Operation(arena, Operation::OperationType::ProxyCallOp, identifier, resultType, inputArguments) {
 }
 
-ProxyCallOperation::ProxyCallOperation(const std::string& functionSymbol, const std::string& functionName,
-                                       void* functionPtr, OperationIdentifier identifier,
-                                       std::vector<Operation*> inputArguments, Type resultType,
-                                       const FunctionAttributes fnAttrs)
-    : Operation(Operation::OperationType::ProxyCallOp, identifier, resultType, std::move(inputArguments)),
+ProxyCallOperation::ProxyCallOperation(common::Arena& arena, const std::string& functionSymbol,
+                                       const std::string& functionName, void* functionPtr,
+                                       OperationIdentifier identifier, std::span<Operation* const> inputArguments,
+                                       Type resultType, const FunctionAttributes fnAttrs)
+    : Operation(arena, Operation::OperationType::ProxyCallOp, identifier, resultType, inputArguments),
       mangedFunctionSymbol(functionSymbol), functionName(functionName), functionPtr(functionPtr), fnAttrs(fnAttrs) {
 }
 
-const std::vector<Operation*>& ProxyCallOperation::getInputArguments() const {
-	return inputs;
+std::span<Operation* const> ProxyCallOperation::getInputArguments() const {
+	return getInputs();
 }
 
-void ProxyCallOperation::setInputArguments(std::vector<Operation*>& newInputArguments) {
-	this->inputs = newInputArguments;
+void ProxyCallOperation::setInputArguments(common::Arena& arena, std::span<Operation* const> newInputArguments) {
+	// Re-allocate a new buffer of the requested size from the arena and
+	// rebind the inputs view. The previous buffer is left in the arena
+	// (it is reclaimed in bulk on the next reset).
+	if (newInputArguments.empty()) {
+		this->inputs = nullptr;
+		this->numInputs = 0;
+		return;
+	}
+	auto* newInputs = allocateInputs(arena, newInputArguments.size());
+	std::copy(newInputArguments.begin(), newInputArguments.end(), newInputs);
+	this->inputs = newInputs;
+	this->numInputs = static_cast<uint32_t>(newInputArguments.size());
 }
 
 const std::string& ProxyCallOperation::getFunctionName() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.cpp
@@ -22,17 +22,9 @@ std::span<Operation* const> ProxyCallOperation::getInputArguments() const {
 
 void ProxyCallOperation::setInputArguments(common::Arena& arena, std::span<Operation* const> newInputArguments) {
 	// Re-allocate a new buffer of the requested size from the arena and
-	// rebind the inputs view. The previous buffer is left in the arena
+	// rebind the inputs span. The previous buffer is left in the arena
 	// (it is reclaimed in bulk on the next reset).
-	if (newInputArguments.empty()) {
-		this->inputs = nullptr;
-		this->numInputs = 0;
-		return;
-	}
-	auto* newInputs = allocateInputs(arena, newInputArguments.size());
-	std::copy(newInputArguments.begin(), newInputArguments.end(), newInputs);
-	this->inputs = newInputs;
-	this->numInputs = static_cast<uint32_t>(newInputArguments.size());
+	this->inputs = allocateInputs(arena, newInputArguments);
 }
 
 const std::string& ProxyCallOperation::getFunctionName() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ProxyCallOperation.hpp
@@ -1,23 +1,25 @@
 
 #include "nautilus/common/FunctionAttributes.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
+#include <span>
 #include <string>
 #include <vector>
 
 namespace nautilus::compiler::ir {
 class ProxyCallOperation : public Operation {
 public:
-	ProxyCallOperation(OperationIdentifier identifier, const std::vector<Operation*>& inputArguments, Type resultType);
+	ProxyCallOperation(common::Arena& arena, OperationIdentifier identifier, std::span<Operation* const> inputArguments,
+	                   Type resultType);
 
-	ProxyCallOperation(const std::string& functionSymbol, const std::string& functionName, void* functionPtr,
-	                   OperationIdentifier identifier, std::vector<Operation*> inputArguments, Type resultType,
-	                   FunctionAttributes fnAttrs);
+	ProxyCallOperation(common::Arena& arena, const std::string& functionSymbol, const std::string& functionName,
+	                   void* functionPtr, OperationIdentifier identifier, std::span<Operation* const> inputArguments,
+	                   Type resultType, FunctionAttributes fnAttrs);
 
-	~ProxyCallOperation() override = default;
+	~ProxyCallOperation() = default;
 
-	const std::vector<Operation*>& getInputArguments() const;
+	std::span<Operation* const> getInputArguments() const;
 
-	void setInputArguments(std::vector<Operation*>& newInputArguments);
+	void setInputArguments(common::Arena& arena, std::span<Operation* const> newInputArguments);
 
 	const std::string& getFunctionSymbol() const;
 	const std::string& getFunctionName() const;

--- a/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace nautilus::compiler::ir {
-ReturnOperation::ReturnOperation() : Operation(Operation::OperationType::ReturnOp, Type::v) {
+ReturnOperation::ReturnOperation(common::Arena& /*arena*/) : Operation(Operation::OperationType::ReturnOp, Type::v) {
 }
 
 ReturnOperation::ReturnOperation(common::Arena& arena, Operation* returnValue)

--- a/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.cpp
@@ -7,8 +7,9 @@ namespace nautilus::compiler::ir {
 ReturnOperation::ReturnOperation() : Operation(Operation::OperationType::ReturnOp, Type::v) {
 }
 
-ReturnOperation::ReturnOperation(Operation* returnValue)
-    : Operation(Operation::OperationType::ReturnOp, returnValue->getStamp(), {returnValue}) {
+ReturnOperation::ReturnOperation(common::Arena& arena, Operation* returnValue)
+    : Operation(arena, Operation::OperationType::ReturnOp, OperationIdentifier {0}, returnValue->getStamp(),
+                {returnValue}) {
 }
 
 Operation* ReturnOperation::getReturnValue() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.hpp
@@ -6,11 +6,15 @@
 namespace nautilus::compiler::ir {
 class ReturnOperation : public Operation {
 public:
+	/// Void return: no SSA value to thread back, no inputs to allocate, so
+	/// the no-input Operation constructor is used and no Arena is required.
 	ReturnOperation();
 
-	ReturnOperation(Operation* returnValue);
+	/// Value return: the returned value is stored as the single input,
+	/// allocated from @p arena.
+	ReturnOperation(common::Arena& arena, Operation* returnValue);
 
-	~ReturnOperation() override = default;
+	~ReturnOperation() = default;
 
 	Operation* getReturnValue() const;
 

--- a/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/ReturnOperation.hpp
@@ -6,9 +6,10 @@
 namespace nautilus::compiler::ir {
 class ReturnOperation : public Operation {
 public:
-	/// Void return: no SSA value to thread back, no inputs to allocate, so
-	/// the no-input Operation constructor is used and no Arena is required.
-	ReturnOperation();
+	/// Void return: no SSA value to thread back, no inputs to allocate.
+	/// The arena is accepted uniformly (matching the @ref
+	/// BasicBlock::addOperation factory) but unused.
+	ReturnOperation(common::Arena& arena);
 
 	/// Value return: the returned value is stored as the single input,
 	/// allocated from @p arena.

--- a/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.cpp
@@ -2,9 +2,9 @@
 
 namespace nautilus::compiler::ir {
 
-SelectOperation::SelectOperation(OperationIdentifier identifier, Operation* condition, Operation* trueValue,
-                                 Operation* falseValue, Type resultStamp)
-    : Operation(OperationType::SelectOp, identifier, resultStamp, {condition, trueValue, falseValue}) {
+SelectOperation::SelectOperation(common::Arena& arena, OperationIdentifier identifier, Operation* condition,
+                                 Operation* trueValue, Operation* falseValue, Type resultStamp)
+    : Operation(arena, OperationType::SelectOp, identifier, resultStamp, {condition, trueValue, falseValue}) {
 }
 
 Operation* SelectOperation::getCondition() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/SelectOperation.hpp
@@ -19,10 +19,10 @@ namespace nautilus::compiler::ir {
  */
 class SelectOperation : public Operation {
 public:
-	explicit SelectOperation(OperationIdentifier identifier, Operation* condition, Operation* trueValue,
-	                         Operation* falseValue, Type resultStamp);
+	explicit SelectOperation(common::Arena& arena, OperationIdentifier identifier, Operation* condition,
+	                         Operation* trueValue, Operation* falseValue, Type resultStamp);
 
-	~SelectOperation() override = default;
+	~SelectOperation() = default;
 
 	Operation* getCondition() const;
 	Operation* getTrueValue() const;

--- a/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.cpp
@@ -4,8 +4,8 @@
 
 namespace nautilus::compiler::ir {
 
-StoreOperation::StoreOperation(Operation* value, Operation* address)
-    : Operation(OperationType::StoreOp, Type::v, {value, address}) {
+StoreOperation::StoreOperation(common::Arena& arena, Operation* value, Operation* address)
+    : Operation(arena, OperationType::StoreOp, OperationIdentifier {0}, Type::v, {value, address}) {
 }
 
 Operation* StoreOperation::getValue() const {

--- a/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/StoreOperation.hpp
@@ -6,9 +6,9 @@
 namespace nautilus::compiler::ir {
 class StoreOperation : public Operation {
 public:
-	explicit StoreOperation(Operation* value, Operation* address);
+	explicit StoreOperation(common::Arena& arena, Operation* value, Operation* address);
 
-	~StoreOperation() override = default;
+	~StoreOperation() = default;
 
 	Operation* getValue() const;
 

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -74,8 +74,7 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<Executi
 	return phaseContext.process();
 }
 
-std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<ExecutionTrace> trace,
-                                                         common::ArenaPool& pool,
+std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<ExecutionTrace> trace, common::ArenaPool& pool,
                                                          const compiler::CompilationUnitID& id) {
 	auto ir = std::make_shared<compiler::ir::IRGraph>(pool.acquire(), id);
 	auto phaseContext = IRConversionContext(trace.get(), ir, id);
@@ -328,7 +327,8 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
 	auto probability = get<BranchProbability>(operation.input[3]);
 
 	auto booleanValue = frame.getValue(createValueIdentifier(valueRef));
-	auto* ifOperation = ir->getArena().create<IfOperation>(booleanValue, probability);
+	auto& arena = ir->getArena();
+	auto* ifOperation = arena.create<IfOperation>(arena, booleanValue, probability);
 	auto trueCaseBlock = processBlock(trace->getBlock(trueCaseBlockRef.block));
 
 	ifOperation->getTrueBlockInvocation().setBlock(trueCaseBlock);
@@ -343,9 +343,10 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
 void TraceToIRConversionPhase::IRConversionContext::createBlockArguments(ValueFrame& frame,
                                                                          BasicBlockInvocation& blockInvocation,
                                                                          const BlockRef& val) {
+	auto& arena = ir->getArena();
 	for (const auto& arg : val.arguments) {
 		auto valueIdentifier = createValueIdentifier(arg);
-		blockInvocation.addArgument(frame.getValue(valueIdentifier));
+		blockInvocation.addArgument(arena, frame.getValue(valueIdentifier));
 	}
 }
 
@@ -387,7 +388,8 @@ void TraceToIRConversionPhase::IRConversionContext::processLoad(ValueFrame& fram
 	auto address = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
 	auto resultType = operation.resultType;
-	auto* loadOperation = ir->getArena().create<LoadOperation>(resultIdentifier, address, resultType);
+	auto& arena = ir->getArena();
+	auto* loadOperation = arena.create<LoadOperation>(arena, resultIdentifier, address, resultType);
 	frame.setValue(resultIdentifier, loadOperation);
 	currentBlock->addOperation(loadOperation);
 }

--- a/plugins/simd/src/MLIRVectorIntrinsics.cpp
+++ b/plugins/simd/src/MLIRVectorIntrinsics.cpp
@@ -76,8 +76,8 @@ static ::mlir::Value storeVecToAlloca(std::unique_ptr<::mlir::OpBuilder>& builde
 template <typename MLIROp, typename ElemT, int64_t N>
 bool vectorBinaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                            MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto ptrB = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto ptrB = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -103,7 +103,7 @@ bool vectorBinaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const co
 template <typename MLIROp, typename ElemT, int64_t N>
 bool vectorUnaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                           MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -128,9 +128,9 @@ bool vectorUnaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const com
 template <typename MLIROp, typename ElemT, int64_t N>
 bool vectorTernaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                             MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto ptrB = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto ptrC = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto ptrB = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto ptrC = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -157,7 +157,7 @@ bool vectorTernaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const c
 template <typename ElemT, int64_t N>
 bool vectorLoadIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                          MLIRLoweringProvider::ValueFrame& frame) {
-	auto srcPtr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto srcPtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -186,8 +186,8 @@ bool vectorLoadIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const comp
 template <typename ElemT, int64_t N>
 bool vectorStoreIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                           MLIRLoweringProvider::ValueFrame& frame) {
-	auto destPtr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto vecPtr = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto destPtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto vecPtr = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -217,7 +217,7 @@ bool vectorStoreIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const com
 template <typename ElemT, int64_t N>
 bool vectorNegFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                              MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -238,7 +238,7 @@ bool vectorNegFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const 
 template <typename ElemT, int64_t N>
 bool vectorNegIntIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                            MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, int32_t>) {
@@ -263,7 +263,7 @@ template <typename ElemT, int64_t N>
 bool vectorReduceAddFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                    const compiler::ir::ProxyCallOperation* call,
                                    MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -288,7 +288,7 @@ template <typename ElemT, int64_t N>
 bool vectorReduceAddIntIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                  const compiler::ir::ProxyCallOperation* call,
                                  MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, int32_t>) {
@@ -308,7 +308,7 @@ bool vectorReduceAddIntIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 template <typename ReduceOp, typename ElemT, int64_t N>
 bool vectorReduceFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                 const compiler::ir::ProxyCallOperation* call, MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -328,7 +328,7 @@ bool vectorReduceFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 template <typename ReduceOp, typename ElemT, int64_t N>
 bool vectorReduceIntIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                               MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, int32_t>) {
@@ -348,8 +348,8 @@ bool vectorReduceIntIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const
 template <::mlir::LLVM::FCmpPredicate Pred, typename ElemT, int64_t N>
 bool vectorFCmpIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                          MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto ptrB = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto ptrB = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -382,8 +382,8 @@ bool vectorFCmpIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const comp
 template <::mlir::LLVM::ICmpPredicate Pred, typename ElemT, int64_t N>
 bool vectorICmpIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                          MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto ptrB = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto ptrB = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, int32_t>) {
@@ -412,8 +412,8 @@ template <typename MLIROp, typename ElemT, int64_t N>
 bool vectorBitwiseFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                  const compiler::ir::ProxyCallOperation* call,
                                  MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrA = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto ptrB = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto ptrB = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -447,9 +447,9 @@ bool vectorBitwiseFloatIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 template <typename ElemT, int64_t N>
 bool vectorBlendIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                           MLIRLoweringProvider::ValueFrame& frame) {
-	auto ptrMask = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto ptrA = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto ptrB = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto ptrMask = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto ptrA = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto ptrB = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 
 	::mlir::Type elemTy;
 	if constexpr (std::is_same_v<ElemT, float>) {
@@ -518,7 +518,7 @@ static ::mlir::Type getElemType(::mlir::OpBuilder& builder) {
 template <typename ElemT, int64_t N>
 bool vectorBroadcastIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                               MLIRLoweringProvider::ValueFrame& frame) {
-	auto scalar = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto scalar = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 	auto loc = builder->getUnknownLoc();
 
 	auto elemTy = getElemType<ElemT>(*builder);
@@ -545,8 +545,8 @@ bool vectorBroadcastIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const
 template <typename ElemT, int64_t N>
 bool vectorGatherIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                            MLIRLoweringProvider::ValueFrame& frame) {
-	auto basePtr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto idxPtr = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto basePtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto idxPtr = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 	auto loc = builder->getUnknownLoc();
 
 	auto elemTy = getElemType<ElemT>(*builder);
@@ -581,9 +581,9 @@ bool vectorGatherIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const co
 template <typename ElemT, int64_t N>
 bool vectorScatterIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                             MLIRLoweringProvider::ValueFrame& frame) {
-	auto basePtr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto idxPtr = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto dataPtr = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto basePtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto idxPtr = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto dataPtr = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 	auto loc = builder->getUnknownLoc();
 
 	auto elemTy = getElemType<ElemT>(*builder);
@@ -617,8 +617,8 @@ bool vectorScatterIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const c
 template <typename ElemT, int64_t N>
 bool vectorExtractIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                             MLIRLoweringProvider::ValueFrame& frame) {
-	auto vecPtr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto idx = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto vecPtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto idx = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 	auto loc = builder->getUnknownLoc();
 
 	auto elemTy = getElemType<ElemT>(*builder);
@@ -638,9 +638,9 @@ bool vectorExtractIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const c
 template <typename ElemT, int64_t N>
 bool vectorInsertIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                            MLIRLoweringProvider::ValueFrame& frame) {
-	auto vecPtr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto value = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto idx = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto vecPtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto value = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto idx = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 	auto loc = builder->getUnknownLoc();
 
 	auto elemTy = getElemType<ElemT>(*builder);

--- a/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
+++ b/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
@@ -14,8 +14,8 @@ public:
 		    reinterpret_cast<void*>(&nautlis_assume_stub),
 		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
 		       [[maybe_unused]] MLIRLoweringProvider::ValueFrame& frame) -> bool {
-			    builder->create<::mlir::LLVM::AssumeOp>(
-			        builder->getUnknownLoc(), frame.getValue(call->getInputArguments().at(0)->getIdentifier()));
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(),
+			                                            frame.getValue(call->getInputArguments()[0]->getIdentifier()));
 			    return true;
 		    });
 		manager.addIntrinsic(
@@ -25,8 +25,8 @@ public:
 			    auto constOp =
 			        builder->create<::mlir::arith::ConstantOp>(builder->getUnknownLoc(), builder->getI1Type(),
 			                                                   builder->getIntegerAttr(builder->getI1Type(), true));
-			    auto ptr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-			    auto align = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+			    auto ptr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+			    auto align = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), constOp,
 			                                            ::mlir::LLVM::AssumeAlignTag {}, ptr, align);
 			    return true;

--- a/plugins/std/src/MLIRAtomicIntrinsics.cpp
+++ b/plugins/std/src/MLIRAtomicIntrinsics.cpp
@@ -84,7 +84,7 @@ using TypeFactory = std::function<::mlir::Type(::mlir::OpBuilder&)>;
 IntrinsicFunction makeAtomicLoadLowering(AtomicOrdering ord, TypeFactory tyFn) {
 	return [ord, tyFn](std::unique_ptr<::mlir::OpBuilder>& b, const compiler::ir::ProxyCallOperation* call,
 	                   MLIRLoweringProvider::ValueFrame& frame) -> bool {
-		auto ptr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+		auto ptr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 		auto resultTy = tyFn(*b);
 		auto op = b->create<::mlir::LLVM::LoadOp>(b->getUnknownLoc(), resultTy, ptr,
 		                                          /*alignment=*/0, /*isVolatile=*/false, /*isNonTemporal=*/false,
@@ -97,8 +97,8 @@ IntrinsicFunction makeAtomicLoadLowering(AtomicOrdering ord, TypeFactory tyFn) {
 IntrinsicFunction makeAtomicStoreLowering(AtomicOrdering ord) {
 	return [ord](std::unique_ptr<::mlir::OpBuilder>& b, const compiler::ir::ProxyCallOperation* call,
 	             MLIRLoweringProvider::ValueFrame& frame) -> bool {
-		auto ptr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-		auto value = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+		auto ptr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+		auto value = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 		b->create<::mlir::LLVM::StoreOp>(b->getUnknownLoc(), value, ptr,
 		                                 /*alignment=*/0, /*isVolatile=*/false, /*isNonTemporal=*/false,
 		                                 /*isInvariantGroup=*/false, ord);
@@ -109,8 +109,8 @@ IntrinsicFunction makeAtomicStoreLowering(AtomicOrdering ord) {
 IntrinsicFunction makeAtomicRMWLowering(AtomicBinOp binOp, AtomicOrdering ord) {
 	return [binOp, ord](std::unique_ptr<::mlir::OpBuilder>& b, const compiler::ir::ProxyCallOperation* call,
 	                    MLIRLoweringProvider::ValueFrame& frame) -> bool {
-		auto ptr = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-		auto value = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+		auto ptr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+		auto value = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 		auto op = b->create<::mlir::LLVM::AtomicRMWOp>(b->getUnknownLoc(), binOp, ptr, value, ord);
 		frame.setValue(call->getIdentifier(), op);
 		return true;

--- a/plugins/std/src/MLIRBitIntrinsics.cpp
+++ b/plugins/std/src/MLIRBitIntrinsics.cpp
@@ -56,7 +56,7 @@ template <typename MLIROp>
 bool replaceWithUnaryBitIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                   const compiler::ir::ProxyCallOperation* call,
                                   MLIRLoweringProvider::ValueFrame& frame) {
-	auto inputArg = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto inputArg = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 	auto result = builder->create<MLIROp>(builder->getUnknownLoc(), inputArg.getType(), inputArg);
 	frame.setValue(call->getIdentifier(), result);
 	return true;
@@ -67,8 +67,8 @@ template <typename MLIROp>
 bool replaceWithBinaryBitIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                    const compiler::ir::ProxyCallOperation* call,
                                    MLIRLoweringProvider::ValueFrame& frame) {
-	auto arg1 = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto arg2 = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto arg1 = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto arg2 = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 	auto result = builder->create<MLIROp>(builder->getUnknownLoc(), arg1.getType(), arg1, arg2);
 	frame.setValue(call->getIdentifier(), result);
 	return true;
@@ -78,7 +78,7 @@ bool replaceWithBinaryBitIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 /// LLVM CTLZ takes a second boolean argument indicating if zero is undefined
 bool replaceWithCtlzIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                               MLIRLoweringProvider::ValueFrame& frame) {
-	auto inputArg = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto inputArg = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 	// Second argument: is_zero_undef = false (zero is defined)
 	auto isZeroUndefAttr = builder->getBoolAttr(false);
 	auto result = builder->create<::mlir::LLVM::CountLeadingZerosOp>(builder->getUnknownLoc(), inputArg.getType(),
@@ -91,7 +91,7 @@ bool replaceWithCtlzIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const
 /// LLVM CTTZ takes a second boolean argument indicating if zero is undefined
 bool replaceWithCttzIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                               MLIRLoweringProvider::ValueFrame& frame) {
-	auto inputArg = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto inputArg = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 	// Second argument: is_zero_undef = false (zero is defined)
 	auto isZeroUndefAttr = builder->getBoolAttr(false);
 	auto result = builder->create<::mlir::LLVM::CountTrailingZerosOp>(builder->getUnknownLoc(), inputArg.getType(),
@@ -104,8 +104,8 @@ bool replaceWithCttzIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const
 /// rotl(x, s) = fshl(x, x, s)
 bool replaceWithRotlIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                               MLIRLoweringProvider::ValueFrame& frame) {
-	auto x = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto s = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto x = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto s = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 	// fshl(x, x, s) performs a rotate left
 	auto result = builder->create<::mlir::LLVM::FshlOp>(builder->getUnknownLoc(), x.getType(), x, x, s);
 	frame.setValue(call->getIdentifier(), result);
@@ -116,8 +116,8 @@ bool replaceWithRotlIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const
 /// rotr(x, s) = fshr(x, x, s)
 bool replaceWithRotrIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
                               MLIRLoweringProvider::ValueFrame& frame) {
-	auto x = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto s = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto x = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto s = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 	// fshr(x, x, s) performs a rotate right
 	auto result = builder->create<::mlir::LLVM::FshrOp>(builder->getUnknownLoc(), x.getType(), x, x, s);
 	frame.setValue(call->getIdentifier(), result);

--- a/plugins/std/src/MLIRMathIntrinsics.cpp
+++ b/plugins/std/src/MLIRMathIntrinsics.cpp
@@ -26,7 +26,7 @@ public:
 template <typename MLIROp>
 bool replaceWithUnaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                const compiler::ir::ProxyCallOperation* call, MLIRLoweringProvider::ValueFrame& frame) {
-	auto inputArg = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto inputArg = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 	auto result = builder->create<MLIROp>(builder->getUnknownLoc(), inputArg);
 	frame.setValue(call->getIdentifier(), result);
 	return true;
@@ -36,8 +36,8 @@ bool replaceWithUnaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
 template <typename MLIROp>
 bool replaceWithBinaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                 const compiler::ir::ProxyCallOperation* call, MLIRLoweringProvider::ValueFrame& frame) {
-	auto arg1 = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto arg2 = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
+	auto arg1 = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto arg2 = frame.getValue(call->getInputArguments()[1]->getIdentifier());
 	auto result = builder->create<MLIROp>(builder->getUnknownLoc(), arg1, arg2);
 	frame.setValue(call->getIdentifier(), result);
 	return true;
@@ -48,9 +48,9 @@ template <typename MLIROp>
 bool replaceWithTernaryIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                  const compiler::ir::ProxyCallOperation* call,
                                  MLIRLoweringProvider::ValueFrame& frame) {
-	auto arg1 = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
-	auto arg2 = frame.getValue(call->getInputArguments().at(1)->getIdentifier());
-	auto arg3 = frame.getValue(call->getInputArguments().at(2)->getIdentifier());
+	auto arg1 = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto arg2 = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto arg3 = frame.getValue(call->getInputArguments()[2]->getIdentifier());
 	auto result = builder->create<MLIROp>(builder->getUnknownLoc(), arg1, arg2, arg3);
 	frame.setValue(call->getIdentifier(), result);
 	return true;
@@ -108,7 +108,7 @@ template <typename RoundOp>
 bool replaceWithIntegerRoundIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
                                       const compiler::ir::ProxyCallOperation* call,
                                       MLIRLoweringProvider::ValueFrame& frame) {
-	auto inputArg = frame.getValue(call->getInputArguments().at(0)->getIdentifier());
+	auto inputArg = frame.getValue(call->getInputArguments()[0]->getIdentifier());
 	auto rounded = builder->create<RoundOp>(builder->getUnknownLoc(), inputArg);
 	auto result = castRoundedValue(builder, rounded, call);
 	frame.setValue(call->getIdentifier(), result);


### PR DESCRIPTION
Every Operation subclass's arity is knowable at construction time, so
the std::vector<Operation*> that previously held SSA inputs on every
operation was paying for a heap allocation, capacity word and dtor
registration for no benefit. Replace it with a raw
  Operation** inputs + uint32_t numInputs
pair backed by the surrounding common::Arena. The input array is
allocated once, in the operation's constructor, from the same arena
that owns the operation; lifetime is therefore already correct and
growth is only needed for the one genuinely variable-length case,
BasicBlockInvocation, which geometrically grows its buffer in place.

Dropping the vector makes it viable to also drop Operation's virtual
destructor: the arena's destroyThunk captures the static derived type
at create<T> time, so polymorphic deletion through Operation* was
never actually used. With no vtable and no vector, 23 of the IR
operation types (Add, Sub, Mul, Div, Mod, And, Or, Not, Negate, Shift,
Compare, BinaryComp, Cast, Load, Store, Select, Return, ConstInt,
ConstBool, ConstFloat, ConstPtr, Alloca, If, Branch, IndirectCall,
BasicBlockArgument, BasicBlockInvocation) become trivially
destructible, which in turn lets Arena::create<T> skip dtor
bookkeeping for them entirely.

getInputs / getInputArguments / BasicBlockInvocation::getArguments
now return std::span<Operation* const>; the few .at() call sites were
moved to operator[] (span doesn't expose .at() in C++20). The BC
backend's dynamic_cast path switches to the codebase's classof-based
dyn_cast helper, matching what the rest of the IR already used.