### PR TITLE
Use ArenaPool in all tracing benchmarks

### DIFF
--- a/nautilus/test/benchmark/TracingBenchmark.cpp
+++ b/nautilus/test/benchmark/TracingBenchmark.cpp
@@ -50,22 +50,23 @@ static auto traceContexts = std::vector<std::tuple<std::string, TraceFn>> {
 };
 
 TEST_CASE("Tracing Benchmark") {
-	// Always reuse a single arena across all samples and iterations of every
-	// benchmark by softResetting between calls.  This matches the intended
-	// Engine/JIT integration where a long-lived arena serves many compilations.
+	// Route every sample's arena through a single ArenaPool so chunk memory
+	// is recycled across samples (and across the many iterations within each
+	// sample).  This matches the intended Engine/JIT integration where a
+	// long-lived ArenaPool serves many compilations.
 	for (auto& [name, func] : tests) {
 		for (auto& [ctxName, traceFn] : traceContexts) {
 			auto benchName = ctxName + "_" + name;
 			auto fn = traceFn;
-			common::Arena arena;
+			common::ArenaPool pool;
 			Catch::Benchmark::Benchmark(std::string(benchName))
-			    .operator=([&func, fn, &arena](Catch::Benchmark::Chronometer meter) {
-				    meter.measure([&func, fn, &arena] {
-					    auto trace = fn(func, engine::Options(), arena);
-					    // Drop the trace here so its destructors run; then
-					    // softReset recycles the arena for the next iteration.
+			    .operator=([&func, fn, &pool](Catch::Benchmark::Chronometer meter) {
+				    meter.measure([&func, fn, &pool] {
+					    auto arena = pool.acquire();
+					    auto trace = fn(func, engine::Options(), *arena);
+					    // Drop the trace first; then the arena handle goes
+					    // out of scope and is recycled into the pool.
 					    trace.reset();
-					    arena.softReset();
 					    return 0;
 				    });
 			    });
@@ -85,70 +86,49 @@ TEST_CASE("SSA Creation Benchmark") {
 			continue;
 		}
 
-		// Reuse a single arena across all samples of this benchmark.  A fresh
-		// trace is built per sample and the arena is softReset between samples.
-		common::Arena arena;
-		Catch::Benchmark::Benchmark("ssa_" + name).operator=([&func, &arena](Catch::Benchmark::Chronometer meter) {
+		// Route the per-sample trace arena through a single ArenaPool so
+		// chunk memory is recycled across samples.
+		common::ArenaPool pool;
+		Catch::Benchmark::Benchmark("ssa_" + name).operator=([&func, &pool](Catch::Benchmark::Chronometer meter) {
+			auto arena = pool.acquire();
 			std::shared_ptr<tracing::ExecutionTrace> trace =
-			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), arena);
+			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), *arena);
 			meter.measure([&] {
 				auto ssaCreationPhase = tracing::SSACreationPhase();
 				return ssaCreationPhase.apply(trace);
 			});
-			// Drop the trace before recycling the arena for the next sample.
+			// Drop the trace before the arena handle is recycled into the
+			// pool at the end of this sample.
 			trace.reset();
-			arena.softReset();
 		});
 	}
 }
 
 TEST_CASE("IR Creation Benchmark") {
-
+	// Route both the trace arena and every IRGraph's arena through a single
+	// ArenaPool.  The first sample pays the usual heap allocation; subsequent
+	// samples (and iterations within a sample) recycle Arenas whose chunks
+	// and inline buffers are already sized for the workload, matching the
+	// amortisation pattern the engine relies on in production.
 	for (auto& test : tests) {
 		auto func = std::get<1>(test);
 		auto name = std::get<0>(test);
 
-		// Reuse a single arena across all samples of this benchmark.
-		common::Arena arena;
-		Catch::Benchmark::Benchmark("ir_" + name).operator=([&func, &arena](Catch::Benchmark::Chronometer meter) {
+		common::ArenaPool pool;
+		Catch::Benchmark::Benchmark("ir_" + name).operator=([&func, &pool](Catch::Benchmark::Chronometer meter) {
+			auto traceArena = pool.acquire();
 			std::shared_ptr<tracing::ExecutionTrace> trace =
-			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), arena);
+			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), *traceArena);
 			auto ssaCreationPhase = tracing::SSACreationPhase();
 			auto afterSSAModule = ssaCreationPhase.apply(std::move(trace));
 
 			meter.measure([&] {
 				auto irConversionPhase = tracing::TraceToIRConversionPhase();
-				return irConversionPhase.apply(afterSSAModule);
+				return irConversionPhase.apply(afterSSAModule, pool);
 			});
-			// Drop trace state before recycling the arena for the next sample.
+			// Drop trace state before the trace-arena handle is recycled
+			// into the pool at the end of this sample.
 			afterSSAModule.reset();
-			arena.softReset();
-		});
-	}
-}
-
-TEST_CASE("IR Creation Benchmark (pooled arena)") {
-	// Mirrors the IR Creation Benchmark but routes every IRGraph's arena
-	// through a single ArenaPool.  The first sample pays the usual heap
-	// allocation; subsequent samples reuse the recycled Arena (chunks and
-	// inline buffer already sized), isolating the pool's amortisation
-	// benefit from the one-shot arena-construction cost.
-	for (auto& test : tests) {
-		auto func = std::get<1>(test);
-		auto name = std::get<0>(test);
-
-		Catch::Benchmark::Benchmark("ir_pooled_" + name).operator=([&func](Catch::Benchmark::Chronometer meter) {
-			common::Arena traceArena;
-			std::shared_ptr<tracing::ExecutionTrace> trace =
-			    tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), traceArena);
-			auto ssaCreationPhase = tracing::SSACreationPhase();
-			auto afterSSAModule = ssaCreationPhase.apply(std::move(trace));
-
-			common::ArenaPool irArenaPool;
-			meter.measure([&] {
-				auto irConversionPhase = tracing::TraceToIRConversionPhase();
-				return irConversionPhase.apply(afterSSAModule, irArenaPool);
-			});
 		});
 	}
 }
@@ -175,28 +155,30 @@ TEST_CASE("Backend Compilation Benchmark") {
 			auto func = std::get<1>(test);
 			auto name = std::get<0>(test);
 
-			// Reuse a single arena across all samples of this benchmark.
-			common::Arena arena;
+			// Route both the trace arena and every IRGraph's arena through a
+			// single ArenaPool so chunk memory is recycled across samples.
+			common::ArenaPool pool;
 			Catch::Benchmark::Benchmark("comp_" + backend + "_" + name)
-			    .operator=([&func, &registry, backend, &arena](Catch::Benchmark::Chronometer meter) {
+			    .operator=([&func, &registry, backend, &pool](Catch::Benchmark::Chronometer meter) {
+				    auto traceArena = pool.acquire();
 				    std::shared_ptr<tracing::ExecutionTrace> trace =
-				        tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), arena);
+				        tracing::ExceptionBasedTraceContext::trace(func, engine::Options(), *traceArena);
 				    auto ssaCreationPhase = tracing::SSACreationPhase();
 				    auto afterSSAModule = ssaCreationPhase.apply(std::move(trace));
 
 				    auto backendBackend = registry->getBackend(backend);
 				    auto irConversionPhase = tracing::TraceToIRConversionPhase();
-				    auto ir = irConversionPhase.apply(afterSSAModule);
+				    auto ir = irConversionPhase.apply(afterSSAModule, pool);
 				    auto op = engine::Options();
 				    // force compilation for the MLIR backend.
 				    op.setOption("mlir.eager_compilation", true);
 				    op.setOption("engine.backend", backend);
 				    auto dh = compiler::DumpHandler(op, "");
 				    meter.measure([&] { return backendBackend->compile(ir, dh, op); });
-				    // Drop trace state before recycling the arena for the next sample.
+				    // Drop trace/IR state before the trace-arena handle is
+				    // recycled into the pool at the end of this sample.
 				    ir.reset();
 				    afterSSAModule.reset();
-				    arena.softReset();
 			    });
 		}
 	}


### PR DESCRIPTION
Route every benchmark's trace arena (and every IRGraph's arena, where
applicable) through a per-test ArenaPool so chunk memory and inline
buffers are recycled across samples and iterations.  This matches the
amortisation pattern the engine relies on in production.

Removes the dedicated "IR Creation Benchmark (pooled arena)" case,
which is now redundant because the main IR Creation Benchmark routes
IR arenas through a pool as well.