### PR TITLE
Enable integer and float interface type tests

### DIFF
--- a/nautilus/src/nautilus/compiler/CompilationStatistics.cpp
+++ b/nautilus/src/nautilus/compiler/CompilationStatistics.cpp
@@ -164,8 +164,7 @@ std::string CompilationStatistics::formatReport(std::string_view compilationId, 
 
 	// Inside each group: total* subkeys first, then insertion order.
 	for (auto& [_, list] : groups) {
-		std::stable_partition(list.begin(), list.end(),
-		                      [](const Entry& e) { return isTotalSubkey(e.first); });
+		std::stable_partition(list.begin(), list.end(), [](const Entry& e) { return isTotalSubkey(e.first); });
 	}
 
 	// Column width per group for aligned `key = value`.

--- a/nautilus/test/val-tests/CMakeLists.txt
+++ b/nautilus/test/val-tests/CMakeLists.txt
@@ -7,10 +7,12 @@ add_executable(nautilus-value-tests
         ValConceptTest.cpp
         StaticValTypeTest.cpp
         CompilationStatisticsTest.cpp
-        #  Interface/IntegerTypeTest.cpp
-        #   Interface/FloatTypeTest.cpp
+        Interface/IntegerTypeTest.cpp
+        Interface/FloatTypeTest.cpp
 )
 
 target_link_libraries(nautilus-value-tests PRIVATE nautilus Catch2::Catch2WithMain nautilus-sanitizer-suppressions)
+target_include_directories(nautilus-value-tests PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 catch_discover_tests(nautilus-value-tests EXTRA_ARGS --allow-running-no-tests)

--- a/nautilus/test/val-tests/Interface/FloatTypeTest.cpp
+++ b/nautilus/test/val-tests/Interface/FloatTypeTest.cpp
@@ -1,0 +1,166 @@
+
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include <catch2/catch_all.hpp>
+#include <cmath>
+#include <limits>
+
+namespace nautilus::engine {
+
+template <typename T>
+val<T> floatAdd(val<T> a, val<T> b) {
+	return a + b;
+}
+
+template <typename T>
+val<T> floatSub(val<T> a, val<T> b) {
+	return a - b;
+}
+
+template <typename T>
+val<T> floatMul(val<T> a, val<T> b) {
+	return a * b;
+}
+
+template <typename T>
+val<T> floatDiv(val<T> a, val<T> b) {
+	return a / b;
+}
+
+template <typename T>
+val<bool> floatEq(val<T> a, val<T> b) {
+	return a == b;
+}
+
+template <typename T>
+val<bool> floatNe(val<T> a, val<T> b) {
+	return a != b;
+}
+
+template <typename T>
+val<bool> floatLt(val<T> a, val<T> b) {
+	return a < b;
+}
+
+template <typename T>
+val<bool> floatGt(val<T> a, val<T> b) {
+	return a > b;
+}
+
+template <typename T>
+val<bool> floatLe(val<T> a, val<T> b) {
+	return a <= b;
+}
+
+template <typename T>
+val<bool> floatGe(val<T> a, val<T> b) {
+	return a >= b;
+}
+
+template <typename T>
+void floatTest(NautilusEngine& eng) {
+	SECTION("arithmetic") {
+		SECTION("add") {
+			auto f = eng.registerFunction(floatAdd<T>);
+			REQUIRE(f(static_cast<T>(5.0), static_cast<T>(3.0)) == static_cast<T>(8.0));
+			REQUIRE(f(static_cast<T>(0.0), static_cast<T>(0.0)) == static_cast<T>(0.0));
+		}
+		SECTION("sub") {
+			auto f = eng.registerFunction(floatSub<T>);
+			REQUIRE(f(static_cast<T>(5.0), static_cast<T>(3.0)) == static_cast<T>(2.0));
+			REQUIRE(f(static_cast<T>(5.0), static_cast<T>(5.0)) == static_cast<T>(0.0));
+		}
+		SECTION("mul") {
+			auto f = eng.registerFunction(floatMul<T>);
+			REQUIRE(f(static_cast<T>(5.0), static_cast<T>(2.0)) == static_cast<T>(10.0));
+			REQUIRE(f(static_cast<T>(5.0), static_cast<T>(0.0)) == static_cast<T>(0.0));
+		}
+		SECTION("div") {
+			auto f = eng.registerFunction(floatDiv<T>);
+			REQUIRE(f(static_cast<T>(6.0), static_cast<T>(2.0)) == static_cast<T>(3.0));
+			REQUIRE(f(static_cast<T>(10.0), static_cast<T>(1.0)) == static_cast<T>(10.0));
+		}
+	}
+	SECTION("comparison") {
+		SECTION("eq") {
+			auto f = eng.registerFunction(floatEq<T>);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(42.0)) == true);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(1.0)) == false);
+		}
+		SECTION("ne") {
+			auto f = eng.registerFunction(floatNe<T>);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(1.0)) == true);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(42.0)) == false);
+		}
+		SECTION("lt") {
+			auto f = eng.registerFunction(floatLt<T>);
+			REQUIRE(f(static_cast<T>(1.0), static_cast<T>(42.0)) == true);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(1.0)) == false);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(42.0)) == false);
+		}
+		SECTION("gt") {
+			auto f = eng.registerFunction(floatGt<T>);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(1.0)) == true);
+			REQUIRE(f(static_cast<T>(1.0), static_cast<T>(42.0)) == false);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(42.0)) == false);
+		}
+		SECTION("le") {
+			auto f = eng.registerFunction(floatLe<T>);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(42.0)) == true);
+			REQUIRE(f(static_cast<T>(1.0), static_cast<T>(42.0)) == true);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(1.0)) == false);
+		}
+		SECTION("ge") {
+			auto f = eng.registerFunction(floatGe<T>);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(42.0)) == true);
+			REQUIRE(f(static_cast<T>(42.0), static_cast<T>(1.0)) == true);
+			REQUIRE(f(static_cast<T>(1.0), static_cast<T>(42.0)) == false);
+		}
+	}
+	SECTION("special values") {
+		SECTION("positive infinity") {
+			auto f = eng.registerFunction(floatAdd<T>);
+			auto inf = std::numeric_limits<T>::infinity();
+			auto result = f(inf, static_cast<T>(1.0));
+			REQUIRE(std::isinf(result));
+			REQUIRE(result > static_cast<T>(0));
+		}
+		SECTION("NaN comparison is always false") {
+			auto f = eng.registerFunction(floatEq<T>);
+			auto nan = std::numeric_limits<T>::quiet_NaN();
+			REQUIRE(f(nan, nan) == false);
+		}
+		SECTION("NaN ne is always true") {
+			auto f = eng.registerFunction(floatNe<T>);
+			auto nan = std::numeric_limits<T>::quiet_NaN();
+			REQUIRE(f(nan, nan) == true);
+		}
+		SECTION("negative zero equals zero") {
+			auto f = eng.registerFunction(floatEq<T>);
+			REQUIRE(f(static_cast<T>(-0.0), static_cast<T>(0.0)) == true);
+		}
+	}
+}
+
+TEMPLATE_TEST_CASE("Float Interface Interpreter Test", "[value][interface][template]", float, double) {
+	auto eng = nautilus::testing::makeEngine("interpreter");
+	floatTest<TestType>(eng);
+}
+
+#ifdef ENABLE_TRACING
+TEMPLATE_TEST_CASE("Float Interface Compiler Test", "[value][interface][template]", float, double) {
+	const std::vector<std::string> traceModes = {"exceptionBasedTracing", "lazyTracing"};
+	for (const auto& backend : nautilus::testing::availableBackends()) {
+		for (const auto& traceMode : traceModes) {
+			DYNAMIC_SECTION(backend + "_" + traceMode) {
+				auto eng = nautilus::testing::makeEngine(
+				    backend, [&](engine::Options& options) { options.setOption("engine.traceMode", traceMode); });
+				floatTest<TestType>(eng);
+			}
+		}
+	}
+}
+#endif
+
+} // namespace nautilus::engine

--- a/nautilus/test/val-tests/Interface/IntegerTypeTest.cpp
+++ b/nautilus/test/val-tests/Interface/IntegerTypeTest.cpp
@@ -1,0 +1,210 @@
+
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include <catch2/catch_all.hpp>
+#include <limits>
+
+namespace nautilus::engine {
+
+template <typename T>
+val<T> integerAdd(val<T> a, val<T> b) {
+	return a + b;
+}
+
+template <typename T>
+val<T> integerSub(val<T> a, val<T> b) {
+	return a - b;
+}
+
+template <typename T>
+val<T> integerMul(val<T> a, val<T> b) {
+	return a * b;
+}
+
+template <typename T>
+val<T> integerDiv(val<T> a, val<T> b) {
+	return a / b;
+}
+
+template <typename T>
+val<T> integerMod(val<T> a, val<T> b) {
+	return a % b;
+}
+
+template <typename T>
+val<bool> integerEq(val<T> a, val<T> b) {
+	return a == b;
+}
+
+template <typename T>
+val<bool> integerNe(val<T> a, val<T> b) {
+	return a != b;
+}
+
+template <typename T>
+val<bool> integerLt(val<T> a, val<T> b) {
+	return a < b;
+}
+
+template <typename T>
+val<bool> integerGt(val<T> a, val<T> b) {
+	return a > b;
+}
+
+template <typename T>
+val<bool> integerLe(val<T> a, val<T> b) {
+	return a <= b;
+}
+
+template <typename T>
+val<bool> integerGe(val<T> a, val<T> b) {
+	return a >= b;
+}
+
+template <typename T>
+val<T> integerBitAnd(val<T> a, val<T> b) {
+	return a & b;
+}
+
+template <typename T>
+val<T> integerBitOr(val<T> a, val<T> b) {
+	return a | b;
+}
+
+template <typename T>
+val<T> integerBitXor(val<T> a, val<T> b) {
+	return a ^ b;
+}
+
+template <typename T>
+val<T> integerShl(val<T> a, val<T> b) {
+	return a << b;
+}
+
+template <typename T>
+val<T> integerShr(val<T> a, val<T> b) {
+	return a >> b;
+}
+
+template <typename T>
+void integerTest(NautilusEngine& eng) {
+	SECTION("arithmetic") {
+		SECTION("add") {
+			auto f = eng.registerFunction(integerAdd<T>);
+			REQUIRE(f(static_cast<T>(2), static_cast<T>(3)) == static_cast<T>(5));
+			REQUIRE(f(static_cast<T>(0), static_cast<T>(0)) == static_cast<T>(0));
+			REQUIRE(f(static_cast<T>(10), static_cast<T>(5)) == static_cast<T>(15));
+		}
+		SECTION("sub") {
+			auto f = eng.registerFunction(integerSub<T>);
+			REQUIRE(f(static_cast<T>(10), static_cast<T>(3)) == static_cast<T>(7));
+			REQUIRE(f(static_cast<T>(5), static_cast<T>(5)) == static_cast<T>(0));
+		}
+		SECTION("mul") {
+			auto f = eng.registerFunction(integerMul<T>);
+			REQUIRE(f(static_cast<T>(3), static_cast<T>(4)) == static_cast<T>(12));
+			REQUIRE(f(static_cast<T>(5), static_cast<T>(0)) == static_cast<T>(0));
+			REQUIRE(f(static_cast<T>(1), static_cast<T>(42)) == static_cast<T>(42));
+		}
+		SECTION("div") {
+			auto f = eng.registerFunction(integerDiv<T>);
+			REQUIRE(f(static_cast<T>(12), static_cast<T>(4)) == static_cast<T>(3));
+			REQUIRE(f(static_cast<T>(10), static_cast<T>(1)) == static_cast<T>(10));
+			REQUIRE(f(static_cast<T>(7), static_cast<T>(2)) == static_cast<T>(3));
+		}
+		SECTION("mod") {
+			auto f = eng.registerFunction(integerMod<T>);
+			REQUIRE(f(static_cast<T>(13), static_cast<T>(5)) == static_cast<T>(3));
+			REQUIRE(f(static_cast<T>(10), static_cast<T>(5)) == static_cast<T>(0));
+			REQUIRE(f(static_cast<T>(3), static_cast<T>(10)) == static_cast<T>(3));
+		}
+	}
+	SECTION("comparison") {
+		SECTION("eq") {
+			auto f = eng.registerFunction(integerEq<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == true);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(1)) == false);
+		}
+		SECTION("ne") {
+			auto f = eng.registerFunction(integerNe<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(1)) == true);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == false);
+		}
+		SECTION("lt") {
+			auto f = eng.registerFunction(integerLt<T>);
+			REQUIRE(f(static_cast<T>(1), static_cast<T>(42)) == true);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(1)) == false);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == false);
+		}
+		SECTION("gt") {
+			auto f = eng.registerFunction(integerGt<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(1)) == true);
+			REQUIRE(f(static_cast<T>(1), static_cast<T>(42)) == false);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == false);
+		}
+		SECTION("le") {
+			auto f = eng.registerFunction(integerLe<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == true);
+			REQUIRE(f(static_cast<T>(1), static_cast<T>(42)) == true);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(1)) == false);
+		}
+		SECTION("ge") {
+			auto f = eng.registerFunction(integerGe<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == true);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(1)) == true);
+			REQUIRE(f(static_cast<T>(1), static_cast<T>(42)) == false);
+		}
+	}
+	SECTION("bitwise") {
+		SECTION("and") {
+			auto f = eng.registerFunction(integerBitAnd<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == static_cast<T>(42));
+			REQUIRE(f(static_cast<T>(0), static_cast<T>(42)) == static_cast<T>(0));
+		}
+		SECTION("or") {
+			auto f = eng.registerFunction(integerBitOr<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(0)) == static_cast<T>(42));
+			REQUIRE(f(static_cast<T>(0), static_cast<T>(0)) == static_cast<T>(0));
+		}
+		SECTION("xor") {
+			auto f = eng.registerFunction(integerBitXor<T>);
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(42)) == static_cast<T>(0));
+			REQUIRE(f(static_cast<T>(42), static_cast<T>(0)) == static_cast<T>(42));
+		}
+		SECTION("shl") {
+			auto f = eng.registerFunction(integerShl<T>);
+			REQUIRE(f(static_cast<T>(1), static_cast<T>(2)) == static_cast<T>(4));
+			REQUIRE(f(static_cast<T>(8), static_cast<T>(1)) == static_cast<T>(16));
+		}
+		SECTION("shr") {
+			auto f = eng.registerFunction(integerShr<T>);
+			REQUIRE(f(static_cast<T>(8), static_cast<T>(2)) == static_cast<T>(2));
+			REQUIRE(f(static_cast<T>(16), static_cast<T>(1)) == static_cast<T>(8));
+		}
+	}
+}
+
+TEMPLATE_TEST_CASE("Integer Interface Interpreter Test", "[value][interface][template]", int8_t, int16_t, int32_t,
+                   int64_t, uint8_t, uint16_t, uint32_t, uint64_t) {
+	auto eng = nautilus::testing::makeEngine("interpreter");
+	integerTest<TestType>(eng);
+}
+
+#ifdef ENABLE_TRACING
+TEMPLATE_TEST_CASE("Integer Interface Compiler Test", "[value][interface][template]", int8_t, int16_t, int32_t, int64_t,
+                   uint8_t, uint16_t, uint32_t, uint64_t) {
+	const std::vector<std::string> traceModes = {"exceptionBasedTracing", "lazyTracing"};
+	for (const auto& backend : nautilus::testing::availableBackends()) {
+		for (const auto& traceMode : traceModes) {
+			DYNAMIC_SECTION(backend + "_" + traceMode) {
+				auto eng = nautilus::testing::makeEngine(
+				    backend, [&](engine::Options& options) { options.setOption("engine.traceMode", traceMode); });
+				integerTest<TestType>(eng);
+			}
+		}
+	}
+}
+#endif
+
+} // namespace nautilus::engine


### PR DESCRIPTION
Create Interface/IntegerTypeTest.cpp and Interface/FloatTypeTest.cpp,
which test all integer (int8_t–uint64_t) and floating-point (float,
double) val<T> operations through the Nautilus engine — covering
arithmetic, comparison, bitwise, and special float values — across
the interpreter and all compiled backends.

Update val-tests/CMakeLists.txt to enable the previously commented-out
files and add the common test include directory so ExecutionTest.hpp
utilities are accessible.

https://claude.ai/code/session_01T4LctiVoSm51mtPMfqUcgT