### PR TITLE
Introduce MLIRJit wrapper around mlir::ExecutionEngine

### DIFF
--- a/nautilus/include/nautilus/options.hpp
+++ b/nautilus/include/nautilus/options.hpp
@@ -5,6 +5,14 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <vector>
+
+// Forward-declared so the Nautilus public header does not pull in LLVM.
+// Only the MLIR backend dereferences these pointers; if MLIR is disabled,
+// the list simply stays empty.
+namespace llvm {
+class JITEventListener;
+} // namespace llvm
 
 namespace nautilus::engine {
 
@@ -30,7 +38,21 @@ public:
 		return defaultValue;
 	}
 
+	// Register a JITEventListener to attach to the MLIR backend's JIT.
+	// The caller retains ownership; the listener must outlive every
+	// Executable produced by an Engine configured with this Options.
+	void addMLIRJitEventListener(llvm::JITEventListener* listener) {
+		if (listener != nullptr) {
+			mlir_jit_event_listeners_.push_back(listener);
+		}
+	}
+
+	const std::vector<llvm::JITEventListener*>& getMLIRJitEventListeners() const {
+		return mlir_jit_event_listeners_;
+	}
+
 private:
 	std::unordered_map<std::string, OptionValue> options;
+	std::vector<llvm::JITEventListener*> mlir_jit_event_listeners_;
 };
 } // namespace nautilus::engine

--- a/nautilus/src/nautilus/compiler/backends/mlir/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/CMakeLists.txt
@@ -25,7 +25,8 @@ if (ENABLE_MLIR_BACKEND)
             MLIRReconcileUnrealizedCasts
     )
     
-    add_subdirectory(intrinsics)    
+    add_subdirectory(intrinsics)
+    add_subdirectory(jit)
     add_source_files(nautilus
             MLIRLoweringProvider.cpp
             MLIRCompilationBackend.cpp

--- a/nautilus/src/nautilus/compiler/backends/mlir/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/CMakeLists.txt
@@ -15,10 +15,24 @@ if (ENABLE_MLIR_BACKEND)
     message(STATUS "dialect_libs: ${dialect_libs}")
     message(STATUS "conversion_libs: ${conversion_libs}")
     message(STATUS "extension_libs: ${extension_libs}")
+    # Native codegen libs (host target backend + asm printer); used to be
+    # pulled in transitively via MLIRExecutionEngine.
+    llvm_map_components_to_libnames(nautilus_llvm_native_libs native)
+
     target_link_libraries(nautilus
             PRIVATE
-            MLIRExecutionEngine
+            # MLIRExecutionEngine is deliberately NOT linked: Nautilus drives
+            # LLJIT directly via our own MLIRJit wrapper (see jit/).
+            MLIRTargetLLVMIRExport                  # translateModuleToLLVMIR
+            MLIRBuiltinToLLVMIRTranslation          # registerBuiltinDialectTranslation
+            MLIRLLVMToLLVMIRTranslation             # registerLLVMDialectTranslation
+            MLIRExecutionEngineUtils                # makeOptimizingTransformer (OptUtils)
             MLIRFuncAllExtensions
+            # LLVM libs for our direct LLJIT build.
+            LLVMOrcJIT
+            LLVMExecutionEngine
+            LLVMRuntimeDyld                         # SectionMemoryManager
+            ${nautilus_llvm_native_libs}
             # Dialects
             MLIRMathToLLVM
             MLIRFuncToLLVM

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
@@ -10,24 +10,22 @@
 
 namespace nautilus::compiler::mlir {
 
-std::unique_ptr<::mlir::ExecutionEngine>
-JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
-                              const llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
-                              const std::vector<std::string>& jitProxyFunctionSymbols,
-                              const std::vector<void*>& jitProxyFunctionTargetAddresses) {
+std::unique_ptr<MLIRJit> JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
+                                                       llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
+                                                       const std::vector<std::string>& jitProxyFunctionSymbols,
+                                                       const std::vector<void*>& jitProxyFunctionTargetAddresses) {
 
 	// Register the translation from MLIR to LLVM IR, which must happen before we
 	// can JIT-compile.
 	::mlir::registerBuiltinDialectTranslation(*mlirModule->getContext());
 	::mlir::registerLLVMDialectTranslation(*mlirModule->getContext());
 
-	// Create MLIR execution engine (wrapper around LLVM ExecutionEngine).
-	::mlir::ExecutionEngineOptions options;
-	options.jitCodeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
-	options.transformer = optPipeline;
-	auto maybeEngine = ::mlir::ExecutionEngine::create(*mlirModule, options);
+	MLIRJit::Options jitOptions;
+	jitOptions.codeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
+	jitOptions.transformer = optPipeline;
 
-	assert(maybeEngine && "failed to construct an execution engine");
+	auto maybeJit = MLIRJit::create(*mlirModule, jitOptions);
+	assert(maybeJit && "failed to construct an execution engine");
 
 	// We register all external functions (symbols) that we do not inline.
 	const auto runtimeSymbolMap = [&](llvm::orc::MangleAndInterner interner) {
@@ -48,8 +46,8 @@ JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
 		}
 		return symbolMap;
 	};
-	auto& engine = maybeEngine.get();
-	engine->registerSymbols(runtimeSymbolMap);
-	return std::move(engine);
+	auto& jit = maybeJit.get();
+	jit->registerSymbols(runtimeSymbolMap);
+	return std::move(jit);
 }
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
@@ -13,7 +13,8 @@ namespace nautilus::compiler::mlir {
 std::unique_ptr<MLIRJit> JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
                                                        llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
                                                        const std::vector<std::string>& jitProxyFunctionSymbols,
-                                                       const std::vector<void*>& jitProxyFunctionTargetAddresses) {
+                                                       const std::vector<void*>& jitProxyFunctionTargetAddresses,
+                                                       const std::vector<llvm::JITEventListener*>& eventListeners) {
 
 	// Register the translation from MLIR to LLVM IR, which must happen before we
 	// can JIT-compile.
@@ -23,6 +24,7 @@ std::unique_ptr<MLIRJit> JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mli
 	MLIRJit::Options jitOptions;
 	jitOptions.codeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
 	jitOptions.transformer = optPipeline;
+	jitOptions.eventListeners = eventListeners;
 
 	auto maybeJit = MLIRJit::create(*mlirModule, jitOptions);
 	assert(maybeJit && "failed to construct an execution engine");

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp"
+#include "nautilus/compiler/backends/mlir/jit/MLIRJit.hpp"
 #include <llvm/IR/Module.h>
-#include <mlir/ExecutionEngine/ExecutionEngine.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/Pass.h>
 #include <vector>
@@ -18,10 +18,9 @@ public:
 	JITCompiler() = delete;  // Disable default constructor
 	~JITCompiler() = delete; // Disable default destructor
 
-	static std::unique_ptr<::mlir::ExecutionEngine>
-	jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
-	                 const llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
-	                 const std::vector<std::string>& jitProxyFunctionSymbols,
-	                 const std::vector<void*>& jitProxyFunctionTargetAddresses);
+	static std::unique_ptr<MLIRJit> jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
+	                                                 llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
+	                                                 const std::vector<std::string>& jitProxyFunctionSymbols,
+	                                                 const std::vector<void*>& jitProxyFunctionTargetAddresses);
 };
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.hpp
@@ -2,6 +2,7 @@
 
 #include "nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp"
 #include "nautilus/compiler/backends/mlir/jit/MLIRJit.hpp"
+#include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/IR/Module.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/Pass.h>
@@ -21,6 +22,7 @@ public:
 	static std::unique_ptr<MLIRJit> jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
 	                                                 llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
 	                                                 const std::vector<std::string>& jitProxyFunctionSymbols,
-	                                                 const std::vector<void*>& jitProxyFunctionTargetAddresses);
+	                                                 const std::vector<void*>& jitProxyFunctionTargetAddresses,
+	                                                 const std::vector<llvm::JITEventListener*>& eventListeners);
 };
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
@@ -109,7 +109,8 @@ std::unique_ptr<Executable> MLIRCompilationBackend::compile(const std::shared_pt
 	// compiled execute function.
 	const auto jitStart = std::chrono::steady_clock::now();
 	auto engine = JITCompiler::jitCompileModule(mlirModule, optPipeline, loweringProvider->getJitProxyFunctionSymbols(),
-	                                            loweringProvider->getJitProxyTargetAddresses());
+	                                            loweringProvider->getJitProxyTargetAddresses(),
+	                                            options.getMLIRJitEventListeners());
 	if (options.getOptionOrDefault("mlir.eager_compilation", false)) {
 		auto result = engine->lookupPacked("execute");
 		if (!result) {

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
@@ -11,6 +11,7 @@
 #include "nautilus/compiler/backends/mlir/intrinsics/MLIRMemoryIntrinsics.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
 #include <chrono>
+#include <llvm/Support/TargetSelect.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/Extensions/AllExtensions.h>
@@ -27,8 +28,8 @@ namespace nautilus::compiler::mlir {
 
 MLIRCompilationBackend::MLIRCompilationBackend() {
 	// Initialize information about the local machine in LLVM.
-	LLVMInitializeNativeTarget();
-	LLVMInitializeNativeAsmPrinter();
+	llvm::InitializeNativeTarget();
+	llvm::InitializeNativeTargetAsmPrinter();
 
 	// Register default MLIR intrinsics
 	RegisterMLIRMemoryIntrinsicPlugin();

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.cpp
@@ -8,25 +8,25 @@
 namespace nautilus::compiler::mlir {
 static std::mutex llvm_jit_mutex {};
 
-MLIRExecutable::MLIRExecutable(std::unique_ptr<::mlir::ExecutionEngine> engine) : engine(std::move(engine)) {
+MLIRExecutable::MLIRExecutable(std::unique_ptr<MLIRJit> jit) : jit(std::move(jit)) {
 }
 MLIRExecutable::~MLIRExecutable() {
-	if (engine) {
+	if (jit) {
 		std::scoped_lock lock(llvm_jit_mutex);
-		engine.reset();
+		jit.reset();
 	}
 }
-MLIRExecutable::MLIRExecutable(MLIRExecutable&& other) noexcept : engine(std::move(other.engine)) {
+MLIRExecutable::MLIRExecutable(MLIRExecutable&& other) noexcept : jit(std::move(other.jit)) {
 }
 MLIRExecutable& MLIRExecutable::operator=(MLIRExecutable&& other) noexcept {
 	if (this == &other)
 		return *this;
-	engine = std::move(other.engine);
+	jit = std::move(other.jit);
 	return *this;
 }
 void* MLIRExecutable::getInvocableFunctionPtr(const std::string& member) {
 	std::scoped_lock lock(llvm_jit_mutex);
-	return engine->lookup(member).get();
+	return jit->lookup(member).get();
 }
 bool MLIRExecutable::hasInvocableFunctionPtr() {
 	return true;

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRExecutable.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "nautilus/Executable.hpp"
-#include <mlir/ExecutionEngine/ExecutionEngine.h>
+#include "nautilus/compiler/backends/mlir/jit/MLIRJit.hpp"
 
 namespace nautilus::compiler::mlir {
 
@@ -10,7 +10,7 @@ namespace nautilus::compiler::mlir {
  */
 class MLIRExecutable : public Executable {
 public:
-	MLIRExecutable(std::unique_ptr<::mlir::ExecutionEngine> engine);
+	MLIRExecutable(std::unique_ptr<MLIRJit> jit);
 	~MLIRExecutable() override;
 	MLIRExecutable(const MLIRExecutable& other) = delete;
 	MLIRExecutable(MLIRExecutable&& other) noexcept;
@@ -24,6 +24,6 @@ public:
 	bool hasInvocableFunctionPtr() override;
 
 private:
-	std::unique_ptr<::mlir::ExecutionEngine> engine;
+	std::unique_ptr<MLIRJit> jit;
 };
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_source_files(nautilus
         MLIRJit.cpp
+        PackFunctionArguments.cpp
 )

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_source_files(nautilus
+        MLIRJit.cpp
+)

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
@@ -1,10 +1,30 @@
 
 #include "nautilus/compiler/backends/mlir/jit/MLIRJit.hpp"
-#include <mlir/ExecutionEngine/ExecutionEngine.h>
+#include "nautilus/compiler/backends/mlir/jit/PackFunctionArguments.hpp"
+#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
+#include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
+#include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/Support/Error.h>
+#include <llvm/TargetParser/Triple.h>
+#include <mlir/Target/LLVMIR/Export.h>
 
 namespace nautilus::compiler::mlir {
 
-MLIRJit::MLIRJit(std::unique_ptr<::mlir::ExecutionEngine> engine) : engine_(std::move(engine)) {
+namespace {
+
+// Non-templated error factory. We deliberately avoid llvm::make_error<StringError>
+// because it instantiates llvm::ErrorInfo<...> in our TU and requires typeinfo
+// for llvm::ErrorInfoBase, which LLVM (built with -fno-rtti) does not export.
+llvm::Error makeStringError(const llvm::Twine& message) {
+	return llvm::createStringError(llvm::inconvertibleErrorCode(), message);
+}
+
+} // namespace
+
+MLIRJit::MLIRJit(std::unique_ptr<llvm::orc::LLJIT> jit, llvm::orc::RTDyldObjectLinkingLayer* objectLayer)
+    : jit_(std::move(jit)), objectLayer_(objectLayer) {
 }
 
 MLIRJit::~MLIRJit() = default;
@@ -12,27 +32,132 @@ MLIRJit::MLIRJit(MLIRJit&&) noexcept = default;
 MLIRJit& MLIRJit::operator=(MLIRJit&&) noexcept = default;
 
 llvm::Expected<std::unique_ptr<MLIRJit>> MLIRJit::create(::mlir::ModuleOp module, const Options& options) {
-	::mlir::ExecutionEngineOptions engineOptions;
-	engineOptions.jitCodeGenOptLevel = options.codeGenOptLevel;
-	engineOptions.transformer = options.transformer;
-
-	auto maybeEngine = ::mlir::ExecutionEngine::create(module, engineOptions);
-	if (!maybeEngine) {
-		return maybeEngine.takeError();
+	auto ctx = std::make_unique<llvm::LLVMContext>();
+	auto llvmModule = ::mlir::translateModuleToLLVMIR(module, *ctx);
+	if (!llvmModule) {
+		return makeStringError("could not convert to LLVM IR");
 	}
-	return std::unique_ptr<MLIRJit>(new MLIRJit(std::move(*maybeEngine)));
+
+	auto tmBuilderOrError = llvm::orc::JITTargetMachineBuilder::detectHost();
+	if (!tmBuilderOrError) {
+		return tmBuilderOrError.takeError();
+	}
+	tmBuilderOrError->setCodeGenOptLevel(options.codeGenOptLevel);
+
+	// Build a one-shot TargetMachine only to seed the module's data layout and
+	// triple; LLJIT constructs its own TargetMachines via the builder below.
+	auto tmOrError = tmBuilderOrError->createTargetMachine();
+	if (!tmOrError) {
+		return tmOrError.takeError();
+	}
+	llvmModule->setDataLayout((*tmOrError)->createDataLayout());
+	llvmModule->setTargetTriple((*tmOrError)->getTargetTriple());
+
+	detail::packFunctionArguments(llvmModule.get());
+
+	const auto dataLayout = llvmModule->getDataLayout();
+	const auto targetTriple = llvmModule->getTargetTriple();
+
+	// Stash the layer pointer from inside the object-layer creator so we can
+	// reach it after LLJIT construction for addEventListener().
+	llvm::orc::RTDyldObjectLinkingLayer* rawLayer = nullptr;
+
+	auto objectLinkingLayerCreator =
+	    [&rawLayer, &options,
+	     &targetTriple](llvm::orc::ExecutionSession& session) -> std::unique_ptr<llvm::orc::ObjectLayer> {
+		auto layer = std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(
+		    session, [](const llvm::MemoryBuffer&) { return std::make_unique<llvm::SectionMemoryManager>(); });
+
+		for (auto* listener : options.eventListeners) {
+			if (listener != nullptr) {
+				layer->registerJITEventListener(*listener);
+			}
+		}
+
+		// COFF binaries (Windows) need special handling for exported symbol
+		// visibility. Mirrors upstream mlir::ExecutionEngine.
+		if (targetTriple.isOSBinFormatCOFF()) {
+			layer->setOverrideObjectFlagsWithResponsibilityFlags(true);
+			layer->setAutoClaimResponsibilityForObjectSymbols(true);
+		}
+
+		rawLayer = layer.get();
+		return layer;
+	};
+
+	// Let LLJIT build its own ConcurrentIRCompiler from the JITTargetMachineBuilder.
+	// We avoid constructing llvm::orc::TMOwningSimpleCompiler directly because
+	// LLVM is compiled with -fno-rtti and exporting RTTI for its polymorphic
+	// types across TU boundaries would require us to match.
+	auto jitOrErr = llvm::orc::LLJITBuilder()
+	                    .setJITTargetMachineBuilder(std::move(*tmBuilderOrError))
+	                    .setObjectLinkingLayerCreator(objectLinkingLayerCreator)
+	                    .create();
+	if (!jitOrErr) {
+		return jitOrErr.takeError();
+	}
+	auto jit = std::move(*jitOrErr);
+
+	llvm::orc::ThreadSafeModule tsm(std::move(llvmModule), std::move(ctx));
+	if (options.transformer) {
+		auto transformErr =
+		    tsm.withModuleDo([&options](llvm::Module& m) -> llvm::Error { return options.transformer(&m); });
+		if (transformErr) {
+			return std::move(transformErr);
+		}
+	}
+	if (auto err = jit->addIRModule(std::move(tsm))) {
+		return std::move(err);
+	}
+
+	// Resolve symbols that are statically linked in the current process.
+	auto& mainJD = jit->getMainJITDylib();
+	auto generatorOrErr = llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(dataLayout.getGlobalPrefix());
+	if (!generatorOrErr) {
+		return generatorOrErr.takeError();
+	}
+	mainJD.addGenerator(std::move(*generatorOrErr));
+
+	// Execute the module's global constructors. Upstream skips this on AArch64
+	// due to a known LLVM bug (llvm/llvm-project#71963); mirror that.
+	if (!jit->getTargetTriple().isAArch64()) {
+		if (auto err = jit->initialize(mainJD)) {
+			return std::move(err);
+		}
+	}
+
+	return std::unique_ptr<MLIRJit>(new MLIRJit(std::move(jit), rawLayer));
 }
 
 void MLIRJit::registerSymbols(llvm::function_ref<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMapFn) {
-	engine_->registerSymbols(symbolMapFn);
+	auto& mainJD = jit_->getMainJITDylib();
+	llvm::cantFail(mainJD.define(llvm::orc::absoluteSymbols(
+	    symbolMapFn(llvm::orc::MangleAndInterner(mainJD.getExecutionSession(), jit_->getDataLayout())))));
 }
 
 llvm::Expected<void*> MLIRJit::lookup(llvm::StringRef name) {
-	return engine_->lookup(name);
+	auto expectedSymbol = jit_->lookup(name);
+	if (!expectedSymbol) {
+		return expectedSymbol.takeError();
+	}
+	if (void* fptr = expectedSymbol->toPtr<void*>()) {
+		return fptr;
+	}
+	return makeStringError("looked up function is null");
 }
 
 llvm::Expected<void (*)(void**)> MLIRJit::lookupPacked(llvm::StringRef name) {
-	return engine_->lookupPacked(name);
+	auto result = lookup(detail::makePackedFunctionName(name));
+	if (!result) {
+		return result.takeError();
+	}
+	return reinterpret_cast<void (*)(void**)>(*result);
+}
+
+void MLIRJit::addEventListener(llvm::JITEventListener* listener) {
+	if (listener != nullptr && objectLayer_ != nullptr) {
+		objectLayer_->registerJITEventListener(*listener);
+	}
 }
 
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
@@ -1,0 +1,38 @@
+
+#include "nautilus/compiler/backends/mlir/jit/MLIRJit.hpp"
+#include <mlir/ExecutionEngine/ExecutionEngine.h>
+
+namespace nautilus::compiler::mlir {
+
+MLIRJit::MLIRJit(std::unique_ptr<::mlir::ExecutionEngine> engine) : engine_(std::move(engine)) {
+}
+
+MLIRJit::~MLIRJit() = default;
+MLIRJit::MLIRJit(MLIRJit&&) noexcept = default;
+MLIRJit& MLIRJit::operator=(MLIRJit&&) noexcept = default;
+
+llvm::Expected<std::unique_ptr<MLIRJit>> MLIRJit::create(::mlir::ModuleOp module, const Options& options) {
+	::mlir::ExecutionEngineOptions engineOptions;
+	engineOptions.jitCodeGenOptLevel = options.codeGenOptLevel;
+	engineOptions.transformer = options.transformer;
+
+	auto maybeEngine = ::mlir::ExecutionEngine::create(module, engineOptions);
+	if (!maybeEngine) {
+		return maybeEngine.takeError();
+	}
+	return std::unique_ptr<MLIRJit>(new MLIRJit(std::move(*maybeEngine)));
+}
+
+void MLIRJit::registerSymbols(llvm::function_ref<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMapFn) {
+	engine_->registerSymbols(symbolMapFn);
+}
+
+llvm::Expected<void*> MLIRJit::lookup(llvm::StringRef name) {
+	return engine_->lookup(name);
+}
+
+llvm::Expected<void (*)(void**)> MLIRJit::lookupPacked(llvm::StringRef name) {
+	return engine_->lookupPacked(name);
+}
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
@@ -103,11 +103,11 @@ llvm::Expected<std::unique_ptr<MLIRJit>> MLIRJit::create(::mlir::ModuleOp module
 		auto transformErr =
 		    tsm.withModuleDo([&options](llvm::Module& m) -> llvm::Error { return options.transformer(&m); });
 		if (transformErr) {
-			return std::move(transformErr);
+			return transformErr;
 		}
 	}
 	if (auto err = jit->addIRModule(std::move(tsm))) {
-		return std::move(err);
+		return err;
 	}
 
 	// Resolve symbols that are statically linked in the current process.
@@ -122,7 +122,7 @@ llvm::Expected<std::unique_ptr<MLIRJit>> MLIRJit::create(::mlir::ModuleOp module
 	// due to a known LLVM bug (llvm/llvm-project#71963); mirror that.
 	if (!jit->getTargetTriple().isAArch64()) {
 		if (auto err = jit->initialize(mainJD)) {
-			return std::move(err);
+			return err;
 		}
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.cpp
@@ -112,7 +112,18 @@ llvm::Expected<std::unique_ptr<MLIRJit>> MLIRJit::create(::mlir::ModuleOp module
 
 	// Resolve symbols that are statically linked in the current process.
 	auto& mainJD = jit->getMainJITDylib();
+	// GCC 12+ at -O3 (and with asan) raises a spurious -Wmaybe-uninitialized
+	// inside the inlined move constructor of llvm::unique_function for the
+	// defaulted AddAbsoluteSymbolsFn parameter. The warning is a known
+	// false positive in gcc's inliner; suppress locally.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 	auto generatorOrErr = llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(dataLayout.getGlobalPrefix());
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 	if (!generatorOrErr) {
 		return generatorOrErr.takeError();
 	}

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.hpp
@@ -1,39 +1,38 @@
 #pragma once
 
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/Mangling.h>
+#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/CodeGen.h>
 #include <llvm/Support/Error.h>
 #include <memory>
 #include <mlir/IR/BuiltinOps.h>
-
-// Forward declaration so callers don't transitively pull in MLIR's upstream
-// ExecutionEngine header. Phase 1 delegates to it internally; later phases
-// drop the dependency entirely.
-namespace mlir {
-class ExecutionEngine;
-}
+#include <vector>
 
 namespace nautilus::compiler::mlir {
 
 /**
  * Nautilus-owned JIT engine for a single compiled MLIR module.
  *
- * Phase 1: thin wrapper around mlir::ExecutionEngine, preserving existing
- * behavior (one engine per compiled module). Phase 2 replaces the internals
- * with a direct llvm::orc::LLJIT build so we can expose JITEventListener
- * registration, a caller-supplied ObjectCache, and the underlying LLJIT&
- * for advanced use — none of which upstream mlir::ExecutionEngine exposes.
+ * Replaces mlir::ExecutionEngine so we control the pieces that upstream
+ * hides behind a private LLJIT member: in particular, arbitrary
+ * JITEventListener attachment against the object-linking layer (upstream
+ * exposes only a boolean for the built-in perf/gdb listeners) and direct
+ * access to the underlying LLJIT for extension use.
  */
 class MLIRJit {
 public:
 	struct Options {
 		llvm::CodeGenOptLevel codeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
 		llvm::function_ref<llvm::Error(llvm::Module*)> transformer = nullptr;
-		// Phase 2 additions will live here: eventListeners, objectCache,
-		// targetMachine, enableGDBListener.
+		// Listeners attached to the object-linking layer before the module is
+		// materialized. Supports custom profiling (VTune, perf maps, in-process
+		// callbacks) which upstream mlir::ExecutionEngine disallows.
+		std::vector<llvm::JITEventListener*> eventListeners;
 	};
 
 	~MLIRJit();
@@ -49,10 +48,22 @@ public:
 	llvm::Expected<void*> lookup(llvm::StringRef name);
 	llvm::Expected<void (*)(void**)> lookupPacked(llvm::StringRef name);
 
-private:
-	explicit MLIRJit(std::unique_ptr<::mlir::ExecutionEngine> engine);
+	// Escape hatches. Upstream mlir::ExecutionEngine refuses to expose these;
+	// the reason for this class's existence is that they are public here.
+	llvm::orc::LLJIT& getLLJIT() {
+		return *jit_;
+	}
+	llvm::orc::ExecutionSession& getExecutionSession() {
+		return jit_->getExecutionSession();
+	}
+	// Attach a listener after construction. The listener must outlive this JIT.
+	void addEventListener(llvm::JITEventListener* listener);
 
-	std::unique_ptr<::mlir::ExecutionEngine> engine_;
+private:
+	MLIRJit(std::unique_ptr<llvm::orc::LLJIT> jit, llvm::orc::RTDyldObjectLinkingLayer* objectLayer);
+
+	std::unique_ptr<llvm::orc::LLJIT> jit_;
+	llvm::orc::RTDyldObjectLinkingLayer* objectLayer_ = nullptr;
 };
 
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/MLIRJit.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/Mangling.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/CodeGen.h>
+#include <llvm/Support/Error.h>
+#include <memory>
+#include <mlir/IR/BuiltinOps.h>
+
+// Forward declaration so callers don't transitively pull in MLIR's upstream
+// ExecutionEngine header. Phase 1 delegates to it internally; later phases
+// drop the dependency entirely.
+namespace mlir {
+class ExecutionEngine;
+}
+
+namespace nautilus::compiler::mlir {
+
+/**
+ * Nautilus-owned JIT engine for a single compiled MLIR module.
+ *
+ * Phase 1: thin wrapper around mlir::ExecutionEngine, preserving existing
+ * behavior (one engine per compiled module). Phase 2 replaces the internals
+ * with a direct llvm::orc::LLJIT build so we can expose JITEventListener
+ * registration, a caller-supplied ObjectCache, and the underlying LLJIT&
+ * for advanced use — none of which upstream mlir::ExecutionEngine exposes.
+ */
+class MLIRJit {
+public:
+	struct Options {
+		llvm::CodeGenOptLevel codeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
+		llvm::function_ref<llvm::Error(llvm::Module*)> transformer = nullptr;
+		// Phase 2 additions will live here: eventListeners, objectCache,
+		// targetMachine, enableGDBListener.
+	};
+
+	~MLIRJit();
+	MLIRJit(const MLIRJit&) = delete;
+	MLIRJit& operator=(const MLIRJit&) = delete;
+	MLIRJit(MLIRJit&&) noexcept;
+	MLIRJit& operator=(MLIRJit&&) noexcept;
+
+	static llvm::Expected<std::unique_ptr<MLIRJit>> create(::mlir::ModuleOp module, const Options& options);
+
+	void registerSymbols(llvm::function_ref<llvm::orc::SymbolMap(llvm::orc::MangleAndInterner)> symbolMapFn);
+
+	llvm::Expected<void*> lookup(llvm::StringRef name);
+	llvm::Expected<void (*)(void**)> lookupPacked(llvm::StringRef name);
+
+private:
+	explicit MLIRJit(std::unique_ptr<::mlir::ExecutionEngine> engine);
+
+	std::unique_ptr<::mlir::ExecutionEngine> engine_;
+};
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/PackFunctionArguments.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/PackFunctionArguments.cpp
@@ -3,7 +3,6 @@
 // See https://llvm.org/LICENSE.txt (Apache-2.0 with LLVM exception).
 
 #include "nautilus/compiler/backends/mlir/jit/PackFunctionArguments.hpp"
-
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/PackFunctionArguments.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/PackFunctionArguments.cpp
@@ -1,0 +1,83 @@
+// Ported verbatim from llvm-project llvmorg-21.1.2:
+//   mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+// See https://llvm.org/LICENSE.txt (Apache-2.0 with LLVM exception).
+
+#include "nautilus/compiler/backends/mlir/jit/PackFunctionArguments.hpp"
+
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/Value.h>
+
+namespace nautilus::compiler::mlir::detail {
+
+std::string makePackedFunctionName(llvm::StringRef name) {
+	return "_mlir_" + name.str();
+}
+
+// For each function in the LLVM module, define an interface function that wraps
+// all the arguments of the original function and all its results into an i8**
+// pointer to provide a unified invocation interface.
+void packFunctionArguments(llvm::Module* module) {
+	auto& ctx = module->getContext();
+	llvm::IRBuilder<> builder(ctx);
+	llvm::DenseSet<llvm::Function*> interfaceFunctions;
+	for (auto& func : module->getFunctionList()) {
+		if (func.isDeclaration()) {
+			continue;
+		}
+		if (interfaceFunctions.count(&func)) {
+			continue;
+		}
+
+		// Given a function `foo(<...>)`, define the interface function
+		// `mlir_foo(i8**)`.
+		auto* newType = llvm::FunctionType::get(builder.getVoidTy(), builder.getPtrTy(),
+		                                        /*isVarArg=*/false);
+		auto newName = makePackedFunctionName(func.getName());
+		auto funcCst = module->getOrInsertFunction(newName, newType);
+		auto* interfaceFunc = llvm::cast<llvm::Function>(funcCst.getCallee());
+		interfaceFunctions.insert(interfaceFunc);
+
+		// Extract the arguments from the type-erased argument list and cast them
+		// to the proper types.
+		auto* bb = llvm::BasicBlock::Create(ctx);
+		bb->insertInto(interfaceFunc);
+		builder.SetInsertPoint(bb);
+		llvm::Value* argList = interfaceFunc->arg_begin();
+		llvm::SmallVector<llvm::Value*, 8> args;
+		args.reserve(llvm::size(func.args()));
+		for (auto [index, arg] : llvm::enumerate(func.args())) {
+			llvm::Value* argIndex = llvm::Constant::getIntegerValue(builder.getInt64Ty(), llvm::APInt(64, index));
+			llvm::Value* argPtrPtr = builder.CreateGEP(builder.getPtrTy(), argList, argIndex);
+			llvm::Value* argPtr = builder.CreateLoad(builder.getPtrTy(), argPtrPtr);
+			llvm::Type* argTy = arg.getType();
+			llvm::Value* load = builder.CreateLoad(argTy, argPtr);
+			args.push_back(load);
+		}
+
+		// Call the implementation function with the extracted arguments.
+		llvm::Value* result = builder.CreateCall(&func, args);
+
+		// Assuming the result is one value, potentially of type `void`.
+		if (!result->getType()->isVoidTy()) {
+			llvm::Value* retIndex =
+			    llvm::Constant::getIntegerValue(builder.getInt64Ty(), llvm::APInt(64, llvm::size(func.args())));
+			llvm::Value* retPtrPtr = builder.CreateGEP(builder.getPtrTy(), argList, retIndex);
+			llvm::Value* retPtr = builder.CreateLoad(builder.getPtrTy(), retPtrPtr);
+			builder.CreateStore(result, retPtr);
+		}
+
+		// The interface function returns void.
+		builder.CreateRetVoid();
+	}
+}
+
+} // namespace nautilus::compiler::mlir::detail

--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/PackFunctionArguments.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/PackFunctionArguments.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <llvm/ADT/StringRef.h>
+#include <string>
+
+namespace llvm {
+class Module;
+} // namespace llvm
+
+namespace nautilus::compiler::mlir::detail {
+
+// For each non-declaration function in the module, add a wrapper function
+// named "_mlir_<name>" with signature `void(void**)` that unpacks arguments
+// from the type-erased argument array and forwards to the original.
+//
+// Ported from llvm-project mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+// (Apache-2.0 with LLVM exception). Kept in its own translation unit for
+// clean attribution; logic is preserved verbatim.
+void packFunctionArguments(llvm::Module* module);
+
+std::string makePackedFunctionName(llvm::StringRef name);
+
+} // namespace nautilus::compiler::mlir::detail

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 include(Catch)
-add_executable(nautilus-execution-tests
+set(NAUTILUS_EXECUTION_TEST_SOURCES
         ExecutionTest.cpp
         BoolExecutionTest.cpp
         CastExecutionTest.cpp
@@ -15,9 +15,29 @@ add_executable(nautilus-execution-tests
         SelectExecutionTest.cpp
 )
 
+if (ENABLE_MLIR_BACKEND)
+    list(APPEND NAUTILUS_EXECUTION_TEST_SOURCES
+            MLIRJitEventListenerTest.cpp
+            MLIRJitEventListenerTestFixture.cpp)
+endif ()
+
+add_executable(nautilus-execution-tests ${NAUTILUS_EXECUTION_TEST_SOURCES})
+
 target_link_libraries(nautilus-execution-tests PUBLIC nautilus Catch2::Catch2WithMain nautilus-sanitizer-suppressions)
 if (ENABLE_LOGGING)
     target_link_libraries(nautilus-execution-tests PRIVATE spdlog::spdlog)
+endif ()
+if (ENABLE_MLIR_BACKEND)
+    # The fixture TU subclasses llvm::JITEventListener. Match how LLVM itself
+    # is built (-fno-rtti) so the derived vtable does not reference typeinfo
+    # symbols that the LLVM libs never export. The test TU itself still needs
+    # RTTI (val<T> uses typeid).
+    find_package(MLIR QUIET CONFIG)
+    if (MLIR_INCLUDE_DIRS)
+        target_include_directories(nautilus-execution-tests SYSTEM PRIVATE ${MLIR_INCLUDE_DIRS})
+    endif ()
+    set_source_files_properties(MLIRJitEventListenerTestFixture.cpp
+            PROPERTIES COMPILE_OPTIONS -fno-rtti)
 endif ()
 target_include_directories(nautilus-execution-tests PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>

--- a/nautilus/test/execution-tests/MLIRJitEventListenerTest.cpp
+++ b/nautilus/test/execution-tests/MLIRJitEventListenerTest.cpp
@@ -1,0 +1,67 @@
+#include "nautilus/config.hpp"
+
+#if defined(ENABLE_TRACING) && defined(ENABLE_MLIR_BACKEND)
+
+#include "ExecutionTest.hpp"
+#include "MLIRJitEventListenerTestFixture.hpp"
+#include "nautilus/Engine.hpp"
+#include <catch2/catch_all.hpp>
+
+namespace nautilus::engine {
+
+namespace {
+
+val<int32_t> listenerAddOne(val<int32_t> x) {
+	return x + 1;
+}
+
+} // namespace
+
+TEST_CASE("MLIR JIT event listener receives object-loaded notifications") {
+	nautilus::testing::CountingJITEventListenerHandle handle;
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.addMLIRJitEventListener(handle.listener());
+
+	{
+		NautilusEngine engine(options);
+		auto fn = engine.registerFunction(listenerAddOne);
+		REQUIRE(fn(41) == 42);
+	}
+
+	REQUIRE(handle.numObjectsLoaded() > 0);
+}
+
+TEST_CASE("MLIR JIT event listener: multiple listeners all receive events") {
+	nautilus::testing::CountingJITEventListenerHandle first;
+	nautilus::testing::CountingJITEventListenerHandle second;
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.addMLIRJitEventListener(first.listener());
+	options.addMLIRJitEventListener(second.listener());
+
+	{
+		NautilusEngine engine(options);
+		auto fn = engine.registerFunction(listenerAddOne);
+		REQUIRE(fn(0) == 1);
+	}
+
+	REQUIRE(first.numObjectsLoaded() > 0);
+	REQUIRE(second.numObjectsLoaded() == first.numObjectsLoaded());
+}
+
+TEST_CASE("MLIR JIT event listener: null entries are ignored") {
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.addMLIRJitEventListener(nullptr);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(listenerAddOne);
+	REQUIRE(fn(7) == 8);
+}
+
+} // namespace nautilus::engine
+
+#endif // ENABLE_TRACING && ENABLE_MLIR_BACKEND

--- a/nautilus/test/execution-tests/MLIRJitEventListenerTestFixture.cpp
+++ b/nautilus/test/execution-tests/MLIRJitEventListenerTestFixture.cpp
@@ -1,0 +1,54 @@
+// This TU is intentionally built with -fno-rtti (see CMakeLists.txt), matching
+// how LLVM itself is built. The listener subclass's vtable would otherwise
+// reference typeinfo symbols that LLVM does not export.
+
+#include "MLIRJitEventListenerTestFixture.hpp"
+
+#include <atomic>
+#include <llvm/ExecutionEngine/JITEventListener.h>
+
+namespace nautilus::testing {
+
+namespace {
+
+class CountingJITEventListener : public llvm::JITEventListener {
+public:
+	std::atomic<int> num_objects_loaded {0};
+	std::atomic<int> num_objects_freed {0};
+
+	void notifyObjectLoaded(ObjectKey, const llvm::object::ObjectFile&,
+	                        const llvm::RuntimeDyld::LoadedObjectInfo&) override {
+		num_objects_loaded.fetch_add(1);
+	}
+
+	void notifyFreeingObject(ObjectKey) override {
+		num_objects_freed.fetch_add(1);
+	}
+};
+
+} // namespace
+
+struct CountingJITEventListenerHandle::Impl {
+	CountingJITEventListener listener;
+};
+
+CountingJITEventListenerHandle::CountingJITEventListenerHandle() : impl_(new Impl()) {
+}
+
+CountingJITEventListenerHandle::~CountingJITEventListenerHandle() {
+	delete impl_;
+}
+
+llvm::JITEventListener* CountingJITEventListenerHandle::listener() const {
+	return &impl_->listener;
+}
+
+int CountingJITEventListenerHandle::numObjectsLoaded() const {
+	return impl_->listener.num_objects_loaded.load();
+}
+
+int CountingJITEventListenerHandle::numObjectsFreed() const {
+	return impl_->listener.num_objects_freed.load();
+}
+
+} // namespace nautilus::testing

--- a/nautilus/test/execution-tests/MLIRJitEventListenerTestFixture.hpp
+++ b/nautilus/test/execution-tests/MLIRJitEventListenerTestFixture.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace llvm {
+class JITEventListener;
+} // namespace llvm
+
+namespace nautilus::testing {
+
+// Owns a JITEventListener subclass that counts object-loaded / freed
+// notifications. The subclass itself is defined in a separate TU built with
+// -fno-rtti (to match how LLVM is built); this lets Catch2 tests keep RTTI
+// enabled for typeid-based val<T> machinery while still poking into LLVM's
+// listener interface.
+class CountingJITEventListenerHandle {
+public:
+	CountingJITEventListenerHandle();
+	~CountingJITEventListenerHandle();
+	CountingJITEventListenerHandle(const CountingJITEventListenerHandle&) = delete;
+	CountingJITEventListenerHandle& operator=(const CountingJITEventListenerHandle&) = delete;
+
+	llvm::JITEventListener* listener() const;
+	int numObjectsLoaded() const;
+	int numObjectsFreed() const;
+
+private:
+	struct Impl;
+	Impl* impl_;
+};
+
+} // namespace nautilus::testing


### PR DESCRIPTION
Phase 1 of reimplementing the MLIR execution engine inside Nautilus.
Adds MLIRJit as the single point through which the rest of the backend
reaches the underlying JIT. Currently delegates to mlir::ExecutionEngine;
later phases will replace the internals with a direct llvm::orc::LLJIT
build so we can expose JITEventListener registration, a caller-supplied
ObjectCache, and the underlying LLJIT& for advanced use — none of which
upstream mlir::ExecutionEngine makes reachable.

No behavior change: one engine per compiled module, same symbol
registration, same lookup paths.

Also switches the LLVM target-init calls in MLIRCompilationBackend from
the C-style LLVMInitializeNative* entry points to llvm::InitializeNative*;
they were previously resolved transitively through the now-removed
<mlir/ExecutionEngine/ExecutionEngine.h> include chain.