### PR TITLE
Add DWARF debug info for MLIR-backend JIT'd code

### DIFF
--- a/nautilus/src/nautilus/compiler/DumpHandler.cpp
+++ b/nautilus/src/nautilus/compiler/DumpHandler.cpp
@@ -25,6 +25,7 @@ bool DumpHandler::shallCreateFolder() const {
 	generallyDump = generallyDump or shouldDump("after_ssa");
 	generallyDump = generallyDump or shouldDump("after_ir_creation");
 	generallyDump = generallyDump or shouldDump("after_mlir_generation");
+	generallyDump = generallyDump or shouldDump("before_llvm_optimization");
 	generallyDump = generallyDump or shouldDump("after_llvm_generation");
 	generallyDump = generallyDump or shouldDump("after_cpp_generation");
 	generallyDump = generallyDump or shouldDump("after_bc_generation");

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
@@ -152,7 +152,7 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 		statistics->set("ir.blocks", static_cast<int64_t>(snapshot.numBlocks));
 		statistics->set("ir.operations", static_cast<int64_t>(snapshot.numOperations));
 	}
-	dumpHandler.dump("after_ir_creation", "ir", [&]() { return ir->toString(irPrintOptions); });
+	dumpHandler.dump("after_ir_creation", "nautilus", [&]() { return ir->toString(irPrintOptions); });
 	if (options.getOptionOrDefault("dump.graph", false)) {
 		ir::createGraphVizFromIr(ir, options, dumpHandler);
 	}
@@ -166,7 +166,7 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 			passManager.addPass(std::make_unique<ir::EmptyBlockEliminationPass>());
 		}
 		passManager.run(*ir);
-		dumpHandler.dump("after_ir_passes", "ir", [&]() { return ir->toString(irPrintOptions); });
+		dumpHandler.dump("after_ir_passes", "nautilus", [&]() { return ir->toString(irPrintOptions); });
 	}
 
 	if (statistics != nullptr) {

--- a/nautilus/src/nautilus/compiler/backends/mlir/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/CMakeLists.txt
@@ -37,8 +37,12 @@ if (ENABLE_MLIR_BACKEND)
             MLIRMathToLLVM
             MLIRFuncToLLVM
             MLIRReconcileUnrealizedCasts
+            # Debug info: LocationSnapshot in MLIRTransforms, DIScopeForLLVMFuncOp in MLIRLLVMIRTransforms.
+            MLIRTransforms
+            MLIRLLVMIRTransforms
     )
-    
+
+    add_subdirectory(debug)
     add_subdirectory(intrinsics)
     add_subdirectory(jit)
     add_source_files(nautilus

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.cpp
@@ -14,7 +14,8 @@ std::unique_ptr<MLIRJit> JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mli
                                                        llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
                                                        const std::vector<std::string>& jitProxyFunctionSymbols,
                                                        const std::vector<void*>& jitProxyFunctionTargetAddresses,
-                                                       const std::vector<llvm::JITEventListener*>& eventListeners) {
+                                                       const std::vector<llvm::JITEventListener*>& eventListeners,
+                                                       llvm::CodeGenOptLevel codeGenOptLevel) {
 
 	// Register the translation from MLIR to LLVM IR, which must happen before we
 	// can JIT-compile.
@@ -22,7 +23,7 @@ std::unique_ptr<MLIRJit> JITCompiler::jitCompileModule(::mlir::OwningOpRef<::mli
 	::mlir::registerLLVMDialectTranslation(*mlirModule->getContext());
 
 	MLIRJit::Options jitOptions;
-	jitOptions.codeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
+	jitOptions.codeGenOptLevel = codeGenOptLevel;
 	jitOptions.transformer = optPipeline;
 	jitOptions.eventListeners = eventListeners;
 

--- a/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/JITCompiler.hpp
@@ -4,6 +4,7 @@
 #include "nautilus/compiler/backends/mlir/jit/MLIRJit.hpp"
 #include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Support/CodeGen.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/Pass.h>
 #include <vector>
@@ -19,10 +20,12 @@ public:
 	JITCompiler() = delete;  // Disable default constructor
 	~JITCompiler() = delete; // Disable default destructor
 
-	static std::unique_ptr<MLIRJit> jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
-	                                                 llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
-	                                                 const std::vector<std::string>& jitProxyFunctionSymbols,
-	                                                 const std::vector<void*>& jitProxyFunctionTargetAddresses,
-	                                                 const std::vector<llvm::JITEventListener*>& eventListeners);
+	static std::unique_ptr<MLIRJit>
+	jitCompileModule(::mlir::OwningOpRef<::mlir::ModuleOp>& mlirModule,
+	                 llvm::function_ref<llvm::Error(llvm::Module*)> optPipeline,
+	                 const std::vector<std::string>& jitProxyFunctionSymbols,
+	                 const std::vector<void*>& jitProxyFunctionTargetAddresses,
+	                 const std::vector<llvm::JITEventListener*>& eventListeners,
+	                 llvm::CodeGenOptLevel codeGenOptLevel = llvm::CodeGenOptLevel::Aggressive);
 };
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/LLVMIROptimizer.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/LLVMIROptimizer.cpp
@@ -3,8 +3,11 @@
 #include "nautilus/compiler/backends/mlir/LLVMIROptimizer.hpp"
 #include "nautilus/compiler/DumpHandler.hpp"
 #include "nautilus/compiler/backends/mlir/LLVMBackendHooks.hpp"
+#include "nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp"
 #include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
 #include <llvm/IR/Attributes.h>
+#include <llvm/IR/DebugInfoMetadata.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/FileCollector.h>
 #include <mlir/ExecutionEngine/OptUtils.h>
@@ -12,7 +15,17 @@
 namespace nautilus::compiler::mlir {
 
 int getOptimizationLevel(const engine::Options& options) {
-	return options.getOptionOrDefault("mlir.optimizationLevel", 3);
+	// When debug info is active, clamp to -O0 regardless of the user's
+	// request.  At -O3 the IR pipeline runs SROA/DSE/GVN and codegen runs
+	// aggressive register allocation — every $N SSA value lives only as
+	// long as the single register holding it, so once the next add
+	// overwrites that register GDB reads the wrong value for the earlier
+	// variable.  -O0 skips those passes and keeps a one-to-one mapping
+	// between our dbg.value records and the values the user sees.  The
+	// explicit `mlir.optimizationLevel` option still takes precedence so
+	// a caller can override this for diagnostic purposes.
+	const int defaultLevel = debugInfoOptionsFromEngineOptions(options).enable ? 0 : 3;
+	return options.getOptionOrDefault("mlir.optimizationLevel", defaultLevel);
 }
 
 LLVMIROptimizer::LLVMIROptimizer() = default;
@@ -29,7 +42,14 @@ std::function<llvm::Error(llvm::Module*)> LLVMIROptimizer::getLLVMOptimizerPipel
 		auto tmBuilderOrError = llvm::orc::JITTargetMachineBuilder::detectHost();
 		auto targetMachine = tmBuilderOrError->createTargetMachine();
 		llvm::TargetMachine* targetMachinePtr = targetMachine->get();
-		targetMachinePtr->setOptLevel(llvm::CodeGenOptLevel::Aggressive);
+		// With debug info active, lower the codegen opt level to `Less`
+		// (-O1 equivalent) so the register allocator does not collapse
+		// separate SSA values into the same physical register.
+		// `None` triggers fast-regalloc which spills everything to stack
+		// and breaks LLVM's DWARF emission for dbg.value expressions.
+		const auto debugInfoForCodegen = debugInfoOptionsFromEngineOptions(options);
+		targetMachinePtr->setOptLevel(debugInfoForCodegen.enable ? llvm::CodeGenOptLevel::Less
+		                                                         : llvm::CodeGenOptLevel::Aggressive);
 
 		// Add target-specific attributes to all non-declaration functions in the module.
 		for (auto& func : *llvmIRModule) {
@@ -44,6 +64,23 @@ std::function<llvm::Error(llvm::Module*)> LLVMIROptimizer::getLLVMOptimizerPipel
 			    ~0, llvm::Attribute::get(llvmIRModule->getContext(), "tune-cpu", targetMachinePtr->getTargetCPU()));
 		}
 
+		// When debug info was requested during MLIR lowering, the translated
+		// LLVM module needs the `Debug Info Version` and `Dwarf Version` module
+		// flags so LLVM's codegen emits the DWARF sections that GDB's JIT
+		// interface reads.  MLIR's DebugTranslation only sets these when a
+		// DICompileUnit is present in the module; we defensively add them
+		// regardless so that a bare function with only FileLineColLocs still
+		// yields a valid line table.
+		const auto debugInfo = debugInfoOptionsFromEngineOptions(options);
+		if (debugInfo.enable) {
+			if (!llvmIRModule->getModuleFlag("Debug Info Version")) {
+				llvmIRModule->addModuleFlag(llvm::Module::Warning, "Debug Info Version", llvm::DEBUG_METADATA_VERSION);
+			}
+			if (!llvmIRModule->getModuleFlag("Dwarf Version")) {
+				llvmIRModule->addModuleFlag(llvm::Module::Warning, "Dwarf Version", debugInfo.dwarfVersion);
+			}
+		}
+
 		// Apply optional pre-optimization module transforms installed by plugins
 		// (e.g. the inlining plugin's JIT-time LLVM inliner).
 		if (options.getOptionOrDefault("mlir.inline_invoke_calls", false)) {
@@ -51,6 +88,16 @@ std::function<llvm::Error(llvm::Module*)> LLVMIROptimizer::getLLVMOptimizerPipel
 				hook(*llvmIRModule);
 			}
 		}
+
+		// Dump LLVM IR BEFORE optimization so tests / developers can see
+		// which debug intrinsics survived MLIR -> LLVM translation but
+		// before LLVM's opt pipeline potentially strips them.
+		handler.dump("before_llvm_optimization", "ll", [&]() {
+			std::string llvmIRString;
+			llvm::raw_string_ostream llvmStringStream(llvmIRString);
+			llvmIRModule->print(llvmStringStream, nullptr);
+			return llvmIRString;
+		});
 
 		auto optPipeline =
 		    ::mlir::makeOptimizingTransformer(getOptimizationLevel(options), SIZE_LEVEL, targetMachinePtr);

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRCompilationBackend.cpp
@@ -7,10 +7,14 @@
 #include "nautilus/compiler/backends/mlir/MLIRExecutable.hpp"
 #include "nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp"
 #include "nautilus/compiler/backends/mlir/MLIRPassManager.hpp"
+#include "nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp"
+#include "nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp"
 #include "nautilus/compiler/backends/mlir/intrinsics/MLIRBackendIntrinsic.hpp"
 #include "nautilus/compiler/backends/mlir/intrinsics/MLIRMemoryIntrinsics.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
 #include <chrono>
+#include <fstream>
+#include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/Support/TargetSelect.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
@@ -63,7 +67,26 @@ std::unique_ptr<Executable> MLIRCompilationBackend::compile(const std::shared_pt
 		MLIRIntrinsicPluginRegistry::instance().registerAllIntrinsics(intrinsicManager);
 	}
 
+	// Build debug-info options once; downstream steps read from this struct.
+	const auto debugInfo = debugInfoOptionsFromEngineOptions(options);
+
+	// Prepare the Nautilus-IR "source file" used for debugging in
+	// "nautilus-ir" mode.  The file must exist before lowering runs so
+	// the FileLineColLocs attached by MLIRLoweringProvider point at real
+	// content that GDB/LLDB can read on `list`.
+	std::shared_ptr<IRSourceMap> irSourceMap;
+	if (debugInfo.enable && debugInfo.sourceMode == "nautilus-ir") {
+		irSourceMap = std::make_shared<IRSourceMap>(dumpIRWithSourceMap(*ir));
+		if (!debugInfo.sourceFile.empty()) {
+			std::ofstream out(debugInfo.sourceFile);
+			out << irSourceMap->text;
+		}
+	}
+
 	auto loweringProvider = std::make_unique<MLIRLoweringProvider>(context, options, intrinsicManager);
+	if (debugInfo.enable && debugInfo.sourceMode == "nautilus-ir" && irSourceMap) {
+		loweringProvider->setDebugInfo(debugInfo, irSourceMap);
+	}
 
 	const auto loweringStart = std::chrono::steady_clock::now();
 	auto mlirModule = loweringProvider->generateModuleFromIR(ir);
@@ -91,7 +114,7 @@ std::unique_ptr<Executable> MLIRCompilationBackend::compile(const std::shared_pt
 	// 2.b Take the MLIR module from the MLIRLoweringProvider and apply lowering
 	// and optimization passes.
 	const auto pipelineStart = std::chrono::steady_clock::now();
-	if (mlir::MLIRPassManager::lowerAndOptimizeMLIRModule(mlirModule, {})) {
+	if (mlir::MLIRPassManager::lowerAndOptimizeMLIRModule(mlirModule, {}, debugInfo)) {
 		throw RuntimeException("Could not lower and optimize MLIR module.");
 	}
 	if (statistics != nullptr) {
@@ -108,9 +131,28 @@ std::unique_ptr<Executable> MLIRCompilationBackend::compile(const std::shared_pt
 	// 4. JIT compile LLVM IR module and return engine that provides access
 	// compiled execute function.
 	const auto jitStart = std::chrono::steady_clock::now();
-	auto engine = JITCompiler::jitCompileModule(mlirModule, optPipeline, loweringProvider->getJitProxyFunctionSymbols(),
-	                                            loweringProvider->getJitProxyTargetAddresses(),
-	                                            options.getMLIRJitEventListeners());
+
+	// Compose event listeners: user-provided plus, when debug is enabled
+	// with auto-register, LLVM's GDB JIT interface listener.  The GDB
+	// listener is a stateless process-wide singleton so repeated calls
+	// are cheap and safe.
+	std::vector<llvm::JITEventListener*> eventListeners = options.getMLIRJitEventListeners();
+	if (debugInfo.enable && debugInfo.autoRegisterGdbListener) {
+		if (auto* gdb = llvm::JITEventListener::createGDBRegistrationListener()) {
+			eventListeners.push_back(gdb);
+		}
+	}
+
+	// With debug info active the IR optimizer is clamped to -O0; match
+	// that in the JIT's MC layer at -O1-equivalent (`Less`) so the
+	// register allocator does not fold distinct $N SSA values into the
+	// same physical register.  `None` triggers fast-regalloc which
+	// spills every SSA value and confuses LLVM's DWARF asmprinter when
+	// dbg.value operands live on the stack rather than in registers.
+	const auto jitCodeGenLevel = debugInfo.enable ? llvm::CodeGenOptLevel::Less : llvm::CodeGenOptLevel::Aggressive;
+	auto engine =
+	    JITCompiler::jitCompileModule(mlirModule, optPipeline, loweringProvider->getJitProxyFunctionSymbols(),
+	                                  loweringProvider->getJitProxyTargetAddresses(), eventListeners, jitCodeGenLevel);
 	if (options.getOptionOrDefault("mlir.eager_compilation", false)) {
 		auto result = engine->lookupPacked("execute");
 		if (!result) {

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp"
 #include "nautilus/compiler/backends/mlir/LLVMBackendHooks.hpp"
+#include "nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp"
 #include "nautilus/compiler/backends/mlir/intrinsics/MLIRBackendIntrinsic.hpp"
 #include "nautilus/compiler/ir/operations/AllocaOperation.hpp"
 #include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
@@ -82,11 +83,131 @@ mlir::Value MLIRLoweringProvider::getConstBool(const std::string& location, bool
 	                                               builder->getIntegerAttr(builder->getIndexType(), value));
 }
 
-// FileLineLoc name. Moreover,
-//      the provided 'name' often is not meaningful either.
 mlir::Location MLIRLoweringProvider::getNameLoc(const std::string& name) {
+	// When debug info is active:
+	//  * If we know which Nautilus op is currently being lowered, tag the
+	//    NameLoc with the "$N" identifier and point at the op's line in
+	//    the IR source dump so EmitDbgValuePass can attach the matching
+	//    llvm.intr.dbg.declare.
+	//  * Otherwise (locations created outside dispatch) fall back to the
+	//    IR source file with line 0 so DIScopeForLLVMFuncOpPass still
+	//    builds a DISubprogram whose DIFile refers to the real IR dump.
+	if (debugInfo_.enable && irSourceMap_ != nullptr) {
+		::mlir::StringAttr fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+		if (currentOp_ != nullptr && currentFunctionLines_ != nullptr) {
+			const uint32_t id = currentOp_->getIdentifier().getId();
+			if (auto it = currentFunctionLines_->operationLines.find(id);
+			    it != currentFunctionLines_->operationLines.end()) {
+				const std::string dollarName = "$" + std::to_string(id);
+				auto baseLocation = mlir::FileLineColLoc::get(fileAttr, it->second, 1);
+				return mlir::NameLoc::get(builder->getStringAttr(dollarName), baseLocation);
+			}
+		}
+		// Terminators (br / if / return) have no `$N = ...` line to
+		// consult, but `generateMLIR` set `currentOpLine_` from the
+		// block's positional op-line list.  Use it so the translated
+		// instruction carries a real !dbg and GDB stops on the
+		// terminator line rather than skipping the whole block.
+		if (currentOpLine_ != 0) {
+			auto baseLocation = mlir::FileLineColLoc::get(fileAttr, currentOpLine_, 1);
+			return mlir::NameLoc::get(builder->getStringAttr(name), baseLocation);
+		}
+		auto baseLocation = mlir::FileLineColLoc::get(fileAttr, 0, 0);
+		return mlir::NameLoc::get(builder->getStringAttr(name), baseLocation);
+	}
 	auto baseLocation = mlir::FileLineColLoc::get(builder->getStringAttr("Query_1"), 0, 0);
 	return mlir::NameLoc::get(builder->getStringAttr(name), baseLocation);
+}
+
+mlir::Location MLIRLoweringProvider::makeDollarLoc(uint32_t id, llvm::StringRef fallbackName) {
+	if (!debugInfo_.enable || irSourceMap_ == nullptr || currentFunctionLines_ == nullptr) {
+		return getNameLoc(fallbackName.str());
+	}
+	uint32_t line = 0;
+	if (auto it = currentFunctionLines_->operationLines.find(id);
+	    it != currentFunctionLines_->operationLines.end()) {
+		line = it->second;
+	}
+	auto fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+	auto fileLine = mlir::FileLineColLoc::get(fileAttr, line, 1);
+	return mlir::NameLoc::get(builder->getStringAttr("$" + std::to_string(id)), fileLine);
+}
+
+mlir::Value MLIRLoweringProvider::ensureDebugAlloca(uint32_t id, mlir::Type type) {
+	if (auto it = debugAllocas_.find(id); it != debugAllocas_.end()) {
+		return it->second;
+	}
+	// Walk up to the enclosing func.func.  The alloca goes at the
+	// entry block — a dynamic alloca in a loop body would leak stack
+	// every iteration and isn't what DWARF expects for a local.
+	auto* currentBlock = builder->getInsertionBlock();
+	auto* funcOp = currentBlock ? currentBlock->getParentOp() : nullptr;
+	while (funcOp != nullptr && !llvm::isa<mlir::func::FuncOp>(funcOp)) {
+		funcOp = funcOp->getParentOp();
+	}
+	if (funcOp == nullptr) {
+		return {};
+	}
+	auto& entryBlock = llvm::cast<mlir::func::FuncOp>(funcOp).getBody().front();
+
+	// Two lines matter here:
+	//  * prologueLine — the !dbg line on the alloca itself, kept at the
+	//    function header so GDB collapses every alloca into a single
+	//    "function entry" stop rather than bouncing between each
+	//    variable's later decl line.
+	//  * declLine — where the variable was introduced in the IR dump;
+	//    surfaces as DILocalVariable.line, attached below as a side
+	//    attribute so EmitDbgValuePass can find it without needing a
+	//    handle to the IRSourceMap.
+	uint32_t declLine = 0;
+	if (currentFunctionLines_ != nullptr) {
+		if (auto it = currentFunctionLines_->operationLines.find(id);
+		    it != currentFunctionLines_->operationLines.end()) {
+			declLine = it->second;
+		}
+	}
+	const uint32_t prologueLine = currentFunctionHeaderLine_ != 0 ? currentFunctionHeaderLine_ : declLine;
+
+	auto savedIP = builder->saveInsertionPoint();
+	builder->setInsertionPointToStart(&entryBlock);
+	auto ptrTy = mlir::LLVM::LLVMPointerType::get(context);
+	auto i64Ty = mlir::IntegerType::get(context, 64);
+	auto fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+	auto prologueFileLine = mlir::FileLineColLoc::get(fileAttr, prologueLine, 1);
+	auto allocaLoc = mlir::NameLoc::get(builder->getStringAttr("$" + std::to_string(id)), prologueFileLine);
+	auto one = builder->create<mlir::LLVM::ConstantOp>(allocaLoc, i64Ty, builder->getI64IntegerAttr(1));
+	auto alloca = builder->create<mlir::LLVM::AllocaOp>(allocaLoc, ptrTy, type, one.getResult(), /*align=*/0u);
+	alloca->setAttr("nautilus.debug.decl_line", builder->getI32IntegerAttr(declLine));
+	builder->restoreInsertionPoint(savedIP);
+	debugAllocas_[id] = alloca.getResult();
+	return alloca.getResult();
+}
+
+void MLIRLoweringProvider::storeDebugValue(uint32_t id, mlir::Value value, mlir::Location loc) {
+	if (!debugInfo_.enable || !value) {
+		return;
+	}
+	auto alloca = ensureDebugAlloca(id, value.getType());
+	if (!alloca) {
+		return;
+	}
+	builder->create<mlir::LLVM::StoreOp>(loc, value, alloca);
+}
+
+void MLIRLoweringProvider::setDebugInfo(DebugInfoOptions debugInfo, std::shared_ptr<const IRSourceMap> sourceMap) {
+	debugInfo_ = std::move(debugInfo);
+	irSourceMap_ = std::move(sourceMap);
+	// Retag the already-created ModuleOp with a location pointing at the
+	// IR source dump.  DIScopeForLLVMFuncOpPass derives the
+	// DICompileUnit's DW_AT_name / DW_AT_comp_dir from the module's
+	// location, and without this step it would inherit the "Query_1"
+	// placeholder that getNameLoc() produced at construction time, which
+	// breaks GDB's ability to resolve the compilation-unit source path.
+	if (debugInfo_.enable && !debugInfo_.sourceFile.empty() && theModule) {
+		auto fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+		auto loc = mlir::FileLineColLoc::get(fileAttr, 1, 1);
+		theModule->setLoc(loc);
+	}
 }
 
 mlir::arith::CmpIPredicate convertToIntMLIRComparison(ir::CompareOperation::Comparator comparisonType, Type& stamp) {
@@ -364,8 +485,38 @@ mlir::OwningOpRef<mlir::ModuleOp> MLIRLoweringProvider::generateModuleFromIR(std
 }
 
 void MLIRLoweringProvider::generateMLIR(const ir::BasicBlock* basicBlock, ValueFrame& frame) {
+	// Pull the positional op-line list for this block — used to give
+	// terminators (`br`, `if`, `return`) a non-zero !dbg even though
+	// they have no `$N` id to look up in operationLines.
+	const std::vector<uint32_t>* opLines = nullptr;
+	if (debugInfo_.enable && currentFunctionLines_ != nullptr) {
+		if (auto it = currentFunctionLines_->blockOpLines.find(basicBlock->getIdentifier().getId());
+		    it != currentFunctionLines_->blockOpLines.end()) {
+			opLines = &it->second;
+		}
+	}
+	size_t opIdx = 0;
 	for (auto* operation : basicBlock->getOperations()) {
+		// Record which Nautilus op is currently being lowered so
+		// getNameLoc() can produce a FileLineColLoc pointing at the
+		// right line of the IR source dump.  Cleared after dispatch so
+		// helper ops created outside the visitXxx hooks don't inherit
+		// a stale location.
+		currentOp_ = operation;
+		currentOpLine_ = (opLines && opIdx < opLines->size()) ? (*opLines)[opIdx] : 0;
 		dispatch(operation, frame);
+		currentOp_ = nullptr;
+		currentOpLine_ = 0;
+
+		// Shadow-store the op's result into its $N alloca.  Control-flow
+		// ops (branch, return) don't register a value and are skipped.
+		if (debugInfo_.enable && frame.contains(operation->getIdentifier())) {
+			const uint32_t id = operation->getIdentifier().getId();
+			if (auto produced = frame.getValue(operation->getIdentifier())) {
+				storeDebugValue(id, produced, makeDollarLoc(id, "debug.store"));
+			}
+		}
+		++opIdx;
 	}
 }
 
@@ -424,7 +575,33 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 	}
 
 	auto functionInOutTypes = builder->getFunctionType(inputTypes, outputTypes);
-	auto loc = getNameLoc("EntryPoint");
+
+	// Locate the function on the line where its header appears in the IR
+	// source dump.  Without this, DIScopeForLLVMFuncOpPass synthesizes a
+	// DISubprogram with `line: 0`, which DWARF treats as "no location" —
+	// GDB's `step` cannot land inside the function even though per-op
+	// !dbg metadata on the body is correct.  `functionLines` is populated
+	// by dumpIRWithSourceMap for exactly this purpose.
+	::mlir::Location loc = getNameLoc("EntryPoint");
+	if (debugInfo_.enable && irSourceMap_ != nullptr) {
+		uint32_t line = 0;
+		if (auto it = irSourceMap_->functionLines.find(functionOp.getName()); it != irSourceMap_->functionLines.end()) {
+			line = it->second;
+		}
+		auto fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+		auto fileLoc = mlir::FileLineColLoc::get(fileAttr, line, 1);
+		loc = mlir::NameLoc::get(builder->getStringAttr(functionOp.getName()), fileLoc);
+	}
+
+	// Intentionally do NOT attach a DISubprogramAttr via FusedLoc here.
+	// The `llvm.emit_c_interface` attribute makes convert-func-to-llvm
+	// generate both `execute` and `_mlir_ciface_execute`; both get the
+	// function's source location, which would end up sharing the same
+	// DISubprogram node and fail LLVM's "DISubprogram attached to more
+	// than one function" verification.  DIScopeForLLVMFuncOpPass, which
+	// runs after conversion, materializes a distinct DISubprogram on
+	// every llvm.func that lacks one — correct for both functions.
+
 	auto mlirFunction = builder->create<mlir::func::FuncOp>(loc, functionOp.getName(), functionInOutTypes);
 
 	// Avoid function name mangling.
@@ -452,6 +629,18 @@ void MLIRLoweringProvider::generateFunction(mlir::func::FuncOp& mlirFunction, co
 	// function.
 	blockMapping.clear();
 	inductionVars.clear();
+	debugAllocas_.clear();
+	currentFunctionHeaderLine_ = 0;
+	currentFunctionLines_ = nullptr;
+	if (debugInfo_.enable && irSourceMap_ != nullptr) {
+		if (auto it = irSourceMap_->functionLines.find(functionOp.getName());
+		    it != irSourceMap_->functionLines.end()) {
+			currentFunctionHeaderLine_ = it->second;
+		}
+		if (auto it = irSourceMap_->functions.find(functionOp.getName()); it != irSourceMap_->functions.end()) {
+			currentFunctionLines_ = &it->second;
+		}
+	}
 
 	// add entry block for the function
 	mlirFunction.addEntryBlock();
@@ -461,8 +650,22 @@ void MLIRLoweringProvider::generateFunction(mlir::func::FuncOp& mlirFunction, co
 
 	// Store references to function args in the valueMap map.
 	auto valueMapIterator = mlirFunction.args_begin();
-	for (int i = 0; i < (int) functionOp.getFunctionBasicBlock().getArguments().size(); ++i) {
-		frame.setValue(functionOp.getFunctionBasicBlock().getArguments().at(i)->getIdentifier(), valueMapIterator[i]);
+	const auto& irArgs = functionOp.getFunctionBasicBlock().getArguments();
+	for (int i = 0; i < (int) irArgs.size(); ++i) {
+		frame.setValue(irArgs.at(i)->getIdentifier(), valueMapIterator[i]);
+		// When debug info is active, tag the entry-block argument with a
+		// `$N` NameLoc and emit a store into its shadow alloca.  The
+		// store's !dbg points at the function header line — we want the
+		// prologue (allocas + param saves) to collapse into one GDB
+		// stop instead of bouncing through each param's later decl line.
+		if (debugInfo_.enable && irSourceMap_ != nullptr) {
+			const uint32_t id = irArgs.at(i)->getIdentifier().getId();
+			auto argNameLoc = makeDollarLoc(id, "arg");
+			mlirFunction.getArgument(i).setLoc(argNameLoc);
+			auto fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+			auto storeLoc = mlir::FileLineColLoc::get(fileAttr, currentFunctionHeaderLine_, 1);
+			storeDebugValue(id, mlirFunction.getArgument(i), storeLoc);
+		}
 	}
 
 	// Generate MLIR for operations in function body (BasicBlock).
@@ -782,6 +985,12 @@ void MLIRLoweringProvider::visitCompare(ir::CompareOperation* compareOp, ValueFr
 void MLIRLoweringProvider::visitIf(ir::IfOperation* ifOp, ValueFrame& frame) {
 	auto parentBlockInsertionPoint = builder->saveInsertionPoint();
 
+	// Capture the branch's source location BEFORE generating the
+	// successor blocks — those recursions will reassign
+	// `currentOpLine_` as they lower each nested op and leave it at 0
+	// by the time control returns here.
+	auto branchLoc = getNameLoc("branch");
+
 	// create true block and set block arguments
 	std::vector<mlir::Value> trueBlockArgs;
 	mlir::Block* trueBlock = generateBasicBlock(ifOp->getTrueBlockInvocation(), frame);
@@ -799,8 +1008,8 @@ void MLIRLoweringProvider::visitIf(ir::IfOperation* ifOp, ValueFrame& frame) {
 	builder->restoreInsertionPoint(parentBlockInsertionPoint);
 	// create cond branch operation, which evaluates the condition and branches to the true or false block
 	auto mlirOp =
-	    builder->create<mlir::cf::CondBranchOp>(getNameLoc("branch"), frame.getValue(ifOp->getValue()->getIdentifier()),
-	                                            trueBlock, trueBlockArgs, elseBlock, elseBlockArgs);
+	    builder->create<mlir::cf::CondBranchOp>(branchLoc, frame.getValue(ifOp->getValue()->getIdentifier()), trueBlock,
+	                                            trueBlockArgs, elseBlock, elseBlockArgs);
 
 	// set the branch weights for branches by using the branch probabilities
 	// The if probability indicates how likely the true branch is taken and is derived from the val<bool> condition
@@ -815,12 +1024,15 @@ void MLIRLoweringProvider::visitIf(ir::IfOperation* ifOp, ValueFrame& frame) {
 }
 
 void MLIRLoweringProvider::visitBranch(ir::BranchOperation* branchOp, ValueFrame& frame) {
+	// Capture before recursion so the generated `cf.br` carries the
+	// terminator line rather than the last nested op's line 0 reset.
+	auto branchLoc = getNameLoc("branch");
 	std::vector<mlir::Value> mlirTargetBlockArguments;
 	for (auto targetBlockArgument : branchOp->getNextBlockInvocation().getArguments()) {
 		mlirTargetBlockArguments.push_back(frame.getValue(targetBlockArgument->getIdentifier()));
 	}
 	auto* mlirTargetBlock = generateBasicBlock(branchOp->getNextBlockInvocation(), frame);
-	builder->create<mlir::cf::BranchOp>(getNameLoc("branch"), mlirTargetBlock, mlirTargetBlockArguments);
+	builder->create<mlir::cf::BranchOp>(branchLoc, mlirTargetBlock, mlirTargetBlockArguments);
 }
 
 mlir::Block* MLIRLoweringProvider::generateBasicBlock(ir::BasicBlockInvocation& blockInvocation, ValueFrame&) {
@@ -834,10 +1046,15 @@ mlir::Block* MLIRLoweringProvider::generateBasicBlock(ir::BasicBlockInvocation& 
 	// Create new block.
 	auto mlirBasicBlock = builder->createBlock(builder->getBlock()->getParent());
 
+	// Tag each block arg with a `$N` NameLoc (when debug info is on)
+	// so the store at block entry below and the dbg.declare emitted by
+	// EmitDbgValuePass line up with the right shadow alloca.
 	auto& targetBlockArguments = targetBlock->getArguments();
-	// Add attributes as arguments to block.
-	for (auto& headBlockHeadTypes : targetBlockArguments) {
-		mlirBasicBlock->addArgument(getMLIRType(headBlockHeadTypes->getStamp()), getNameLoc("arg"));
+	for (auto& blockArg : targetBlockArguments) {
+		auto argLoc = debugInfo_.enable && irSourceMap_ != nullptr
+		                  ? makeDollarLoc(blockArg->getIdentifier().getId(), "arg")
+		                  : getNameLoc("arg");
+		mlirBasicBlock->addArgument(getMLIRType(blockArg->getStamp()), argLoc);
 	}
 	ValueFrame blockFrame;
 	for (uint32_t i = 0; i < targetBlockArguments.size(); i++) {
@@ -846,6 +1063,25 @@ mlir::Block* MLIRLoweringProvider::generateBasicBlock(ir::BasicBlockInvocation& 
 
 	blockMapping[blockInvocation.getBlock()->getIdentifier()] = mlirBasicBlock;
 	builder->setInsertionPointToStart(mlirBasicBlock);
+
+	// Refresh each block arg's shadow alloca at block entry, tagged
+	// with the block's header line — not the variable's original decl
+	// line — so GDB advances to the block header on branch-in rather
+	// than jumping back to wherever $N was first introduced.
+	if (debugInfo_.enable && currentFunctionLines_ != nullptr) {
+		uint32_t blockLine = 0;
+		if (auto it = currentFunctionLines_->blockHeaderLines.find(targetBlock->getIdentifier().getId());
+		    it != currentFunctionLines_->blockHeaderLines.end()) {
+			blockLine = it->second;
+		}
+		auto fileAttr = builder->getStringAttr(debugInfo_.sourceFile);
+		auto storeLoc = mlir::FileLineColLoc::get(fileAttr, blockLine, 1);
+		for (uint32_t i = 0; i < targetBlockArguments.size(); i++) {
+			const uint32_t id = targetBlockArguments[i]->getIdentifier().getId();
+			storeDebugValue(id, mlirBasicBlock->getArgument(i), storeLoc);
+		}
+	}
+
 	generateMLIR(targetBlock, blockFrame);
 	builder->restoreInsertionPoint(parentBlockInsertionPoint);
 

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -3,10 +3,13 @@
 
 #include "nautilus/compiler/Frame.hpp"
 #include "nautilus/compiler/backends/mlir/ProxyFunctions.hpp"
+#include "nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp"
+#include "nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
 #include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 #include <llvm/ExecutionEngine/JITSymbol.h>
+#include <memory>
 #include <mlir/IR/PatternMatch.h>
 #include <span>
 #include <unordered_set>
@@ -43,6 +46,19 @@ public:
 	::mlir::OwningOpRef<::mlir::ModuleOp> generateModuleFromIR(std::shared_ptr<ir::IRGraph>);
 
 	/**
+	 * @brief Enable emission of FileLineColLocs tied to a Nautilus IR dump.
+	 *
+	 * When set, getNameLoc() returns a FileLineColLoc pointing into
+	 * debugInfo.sourceFile using the line numbers in sourceMap.  The
+	 * DIScopeForLLVMFuncOpPass that runs later in the pipeline then
+	 * materializes DISubprograms referencing those locations, giving
+	 * GDB/LLDB a valid file/line mapping to step through.  The caller
+	 * is responsible for having written `sourceMap->text` to
+	 * `debugInfo.sourceFile` before invoking generateModuleFromIR.
+	 */
+	void setDebugInfo(DebugInfoOptions debugInfo, std::shared_ptr<const IRSourceMap> sourceMap);
+
+	/**
 	 * @return std::vector<std::string>: All proxy function symbols used in the module.
 	 */
 	std::vector<std::string> getJitProxyFunctionSymbols();
@@ -74,6 +90,43 @@ private:
 	    blockMapping; // Keeps track of already created basic blocks.
 	const engine::Options* options;
 
+	// Debug-info state.  When debugInfo_.enable is false, all debug
+	// paths are no-ops and the lowering produces byte-identical output
+	// to a build without debug support.
+	DebugInfoOptions debugInfo_;
+	std::shared_ptr<const IRSourceMap> irSourceMap_;
+	// The Nautilus IR op currently being lowered.  Set in generateMLIR
+	// just before each dispatch() so that the ~73 existing
+	// getNameLoc(name) call sites automatically produce a FileLineColLoc
+	// pointing at the correct Nautilus IR line.
+	const ir::Operation* currentOp_ = nullptr;
+	// Dump line of the currently-lowered op — set positionally from
+	// the enclosing block's blockOpLines.  Provides a line to
+	// terminator ops (`br`, `if`, `return`) that have no `$N` id to
+	// look up in `operationLines`, so GDB can stop on the terminator.
+	uint32_t currentOpLine_ = 0;
+	// One shadow alloca per Nautilus $N id used in the current function.
+	// Allocated at function entry when debug info is active, refreshed
+	// by a store at every site that (re)defines the identifier (function
+	// param, body op, non-entry block arg).  EmitDbgValuePass later
+	// emits a single dbg.declare per alloca so GDB can resolve $N by
+	// reading its stack slot at any PC inside the function — no
+	// dependency on register liveness.  The map is cleared in
+	// generateFunction before each function's body is lowered.
+	std::unordered_map<uint32_t, ::mlir::Value> debugAllocas_;
+	// Line of the current function's header in the IR dump.  Used as
+	// the `!dbg` location of the prologue (allocas, function-parameter
+	// stores) so GDB treats it as a single source line at function
+	// entry rather than jumping through each variable's eventual
+	// declaration line during the prologue.
+	uint32_t currentFunctionHeaderLine_ = 0;
+	// Per-function line tables for the function currently being
+	// lowered.  Nautilus IR re-uses `$N` ids and `Block_N` indices
+	// across functions, so we must scope lookups to the current
+	// function — consulting the global IRSourceMap by id alone would
+	// return the wrong caller/callee line.
+	const IRSourceMap::FunctionLines* currentFunctionLines_ = nullptr;
+
 	/**
 	 * @brief Generates MLIR from a  basic block. Iterates over basic block operations and calls generate.
 	 *
@@ -84,6 +137,23 @@ private:
 
 	void generateFunction(::mlir::func::FuncOp& mlirFunction, const ir::FunctionOperation& funcOp, ValueFrame& frame);
 	::mlir::func::FuncOp generateFunctionDefinitions(const ir::FunctionOperation& funcOp);
+
+	/// Build a `$N` NameLoc wrapping a FileLineColLoc at the IR dump line
+	/// of the given identifier.  Returns a plain NameLoc("arg") location
+	/// when debug info is disabled so the caller can use the result
+	/// unconditionally.
+	::mlir::Location makeDollarLoc(uint32_t id, llvm::StringRef fallbackName);
+
+	/// Lazily create an `llvm.alloca` at the entry block of the currently
+	/// enclosing `func.func` for shadow-storing $N's value.  The alloca
+	/// is cached in `debugAllocas_` so subsequent stores reuse the same
+	/// slot.  No-op when `debugInfo_.enable` is false.
+	::mlir::Value ensureDebugAlloca(uint32_t id, ::mlir::Type type);
+
+	/// Emit a store of `value` into $id's shadow alloca at the builder's
+	/// current insertion point.  Creates the alloca on first use.  No-op
+	/// when `debugInfo_.enable` is false.
+	void storeDebugValue(uint32_t id, ::mlir::Value value, ::mlir::Location loc);
 
 	// Per-operation hooks invoked by OperationDispatcher::dispatch.
 	void visitConstInt(ir::ConstIntOperation* constIntOp, ValueFrame& frame);
@@ -138,6 +208,11 @@ private:
 	/**
 	 * @brief Generates a Name(d)Loc(ation) that is attached to the operation.
 	 * @param name: Name of the location. Used for debugging.
+	 *
+	 * When setDebugInfo() has been called with a non-null source map and
+	 * currentOp_ is set, returns a FileLineColLoc pointing at the line in
+	 * the source file where the current op is defined, wrapped in a
+	 * NameLoc.  Otherwise returns the legacy Query_1:0:0 placeholder.
 	 */
 	::mlir::Location getNameLoc(const std::string& name);
 

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRPassManager.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRPassManager.cpp
@@ -1,14 +1,17 @@
 
 
 #include "nautilus/compiler/backends/mlir/MLIRPassManager.hpp"
+#include "nautilus/compiler/backends/mlir/debug/EmitDbgValuePass.hpp"
 #include "nautilus/exceptions/NotImplementedException.hpp"
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
 #include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
 #include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h>
 #include <mlir/Conversion/MathToLLVM/MathToLLVM.h>
 #include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
+#include <mlir/Dialect/LLVMIR/Transforms/Passes.h>
 #include <mlir/ExecutionEngine/OptUtils.h>
 #include <mlir/Pass/PassManager.h>
+#include <mlir/Transforms/LocationSnapshot.h>
 #include <mlir/Transforms/Passes.h>
 
 namespace nautilus::compiler::mlir {
@@ -32,23 +35,66 @@ std::unique_ptr<mlir::Pass> getMLIROptimizationPass(MLIRPassManager::Optimizatio
 }
 
 int MLIRPassManager::lowerAndOptimizeMLIRModule(mlir::OwningOpRef<mlir::ModuleOp>& module,
-                                                const std::vector<OptimizationPass>& optimizationPasses) {
+                                                const std::vector<OptimizationPass>& optimizationPasses,
+                                                const DebugInfoOptions& debugInfo) {
 	mlir::PassManager passManager(module->getContext());
 
-	// Apply optimization passes.
-	if (!optimizationPasses.empty()) {
-		for (auto optimizationPass : optimizationPasses) {
-			passManager.addPass(getMLIROptimizationPass(optimizationPass));
+	const bool debugEnabled = debugInfo.enable;
+	// Tier 1 ("nautilus-ir" mode) depends on FileLineColLocs attached by
+	// MLIRLoweringProvider that reference positions in the Nautilus IR dump.
+	// MLIR's inliner rewrites locations into inlinedAt chains and the
+	// interaction with a non-MLIR source file is not yet validated, so we
+	// skip the inliner in that mode to keep stepping predictable.
+	const bool skipInliner = debugEnabled && debugInfo.sourceMode == "nautilus-ir";
+
+	if (!skipInliner) {
+		if (!optimizationPasses.empty()) {
+			for (auto optimizationPass : optimizationPasses) {
+				passManager.addPass(getMLIROptimizationPass(optimizationPass));
+			}
+		} else {
+			passManager.addPass(mlir::createInlinerPass());
 		}
-	} else {
-		passManager.addPass(mlir::createInlinerPass());
 	}
+
+	// In "mlir" source mode the dumped-and-inlined MLIR is itself the
+	// "source".  LocationSnapshot writes the current IR to a file and
+	// rewrites every op's location to a FileLineColLoc pointing into that
+	// file, giving GDB a real file:line mapping to step through.
+	if (debugEnabled && debugInfo.sourceMode == "mlir") {
+		mlir::LocationSnapshotOptions snapshotOpts;
+		snapshotOpts.fileName = debugInfo.sourceFile;
+		passManager.addPass(mlir::createLocationSnapshot(snapshotOpts));
+	}
+
 	// Apply lowering passes.
 	passManager.addPass(mlir::createConvertMathToLLVMPass());
 	passManager.addPass(mlir::createConvertFuncToLLVMPass());
 	passManager.addPass(mlir::createConvertControlFlowToLLVMPass());
 	passManager.addPass(mlir::createArithToLLVMConversionPass());
 	passManager.addPass(mlir::createReconcileUnrealizedCastsPass());
+
+	// Materialize a DISubprogram on every llvm.func.  Required so that
+	// the FileLineColLocs attached above translate into valid DWARF line
+	// tables.  For "nautilus-ir" mode MLIRLoweringProvider may already
+	// have attached a DISubprogramAttr; this pass is a no-op on functions
+	// that already have one.
+	if (debugEnabled) {
+		// Request Full emission (not the default LineTablesOnly) so
+		// the DWARF emitter keeps DILocalVariables / dbg.value
+		// records that EmitDbgValuePass is about to insert.  With
+		// LineTablesOnly, GDB sees line info but `info scope` / `p $N`
+		// report nothing.
+		mlir::LLVM::DIScopeForLLVMFuncOpPassOptions scopeOpts;
+		scopeOpts.emissionKind = mlir::LLVM::DIEmissionKind::Full;
+		passManager.addPass(mlir::LLVM::createDIScopeForLLVMFuncOpPass(scopeOpts));
+		// Emit llvm.intr.dbg.value intrinsics for each Nautilus SSA
+		// value so GDB/LLDB can resolve `p $N` at a breakpoint.  Must
+		// run after the subprogram pass because dbg.value's
+		// DILocalVariable requires a DISubprogram scope.
+		passManager.addPass(createEmitDbgValuePass());
+	}
+
 	// Run passes.
 	if (mlir::failed(passManager.run(*module))) {
 		llvm::errs() << "MLIRPassManager::lowerAndOptimizeMLIRModule: Failed to "

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRPassManager.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRPassManager.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp"
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/Pass.h>
 #include <vector>
@@ -10,7 +11,14 @@ namespace nautilus::compiler::mlir {
 class MLIRPassManager {
 public:
 	enum class OptimizationPass : uint8_t { Inline };
+
+	// Run the lowering/optimization pipeline on `module`.  When
+	// `debugInfo.enable` is true, inserts the
+	// Nautilus debug-info passes (location snapshot for mlir source
+	// mode, DIScopeForLLVMFuncOp to materialize a DISubprogram on every
+	// llvm.func).  Returns non-zero on pass-pipeline failure.
 	static int lowerAndOptimizeMLIRModule(::mlir::OwningOpRef<::mlir::ModuleOp>& module,
-	                                      const std::vector<OptimizationPass>& optimizationPasses);
+	                                      const std::vector<OptimizationPass>& optimizationPasses,
+	                                      const DebugInfoOptions& debugInfo = {});
 };
 } // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_source_files(nautilus
+        DebugInfoOptions.cpp
+        EmitDbgValuePass.cpp
+        IRSourceMap.cpp
+)
+
+# EmitDbgValuePass subclasses mlir::PassWrapper, which derives from
+# mlir::Pass.  MLIR itself is built with -fno-rtti, so its libraries do
+# not export typeinfo for mlir::Pass.  Match the flag for this one TU
+# so our subclass's vtable does not reference the missing typeinfo.
+# The nautilus target's sources are aggregated globally via add_source_files
+# and compiled from nautilus/CMakeLists.txt, so the DIRECTORY scope must
+# be the one that owns the target.  Compute that path relative to this
+# file so the property also resolves when the example sub-project is
+# the top-level CMake project (in which case CMAKE_SOURCE_DIR is
+# example/, not the nautilus repo root).
+get_filename_component(_nautilus_target_dir
+        "${CMAKE_CURRENT_LIST_DIR}/../../../../../.."
+        ABSOLUTE)
+set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/EmitDbgValuePass.cpp
+        DIRECTORY ${_nautilus_target_dir}
+        PROPERTIES COMPILE_OPTIONS -fno-rtti
+)

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/DebugInfoOptions.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/DebugInfoOptions.cpp
@@ -1,0 +1,55 @@
+
+#include "nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp"
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace nautilus::compiler::mlir {
+
+namespace {
+
+// Returns $TMPDIR, $TEMP, or "/tmp" if neither is set. The debug
+// source file is written under this directory.
+std::string tempDir() {
+	if (const char* t = std::getenv("TMPDIR")) {
+		return t;
+	}
+	if (const char* t = std::getenv("TEMP")) {
+		return t;
+	}
+	return "/tmp";
+}
+
+// Generate a path like
+// `$TMPDIR/nautilus_debug_<pid>_<counter>.<ext>` that is unique
+// across parallel compilations within the same process.
+std::string synthesizeSourcePath(const std::string& extension) {
+	static std::atomic<uint64_t> counter {0};
+	std::filesystem::path dir = tempDir();
+	auto name =
+	    "nautilus_debug_" + std::to_string(::getpid()) + "_" + std::to_string(counter.fetch_add(1)) + "." + extension;
+	return (dir / name).string();
+}
+
+} // namespace
+
+DebugInfoOptions debugInfoOptionsFromEngineOptions(const engine::Options& options) {
+	DebugInfoOptions opts;
+	opts.enable = options.getOptionOrDefault("mlir.debug.enable", false);
+	opts.sourceMode = options.getOptionOrDefault<std::string>("mlir.debug.source_mode", "mlir");
+	opts.sourceFile = options.getOptionOrDefault<std::string>("mlir.debug.source_file", "");
+	opts.producer = options.getOptionOrDefault<std::string>("mlir.debug.producer", "Nautilus JIT");
+	opts.dwarfVersion = options.getOptionOrDefault("mlir.debug.dwarf_version", 4);
+	opts.autoRegisterGdbListener = options.getOptionOrDefault("mlir.debug.auto_register_gdb", true);
+
+	if (opts.enable && opts.sourceFile.empty()) {
+		const std::string ext = (opts.sourceMode == "nautilus-ir") ? "ir" : "mlir";
+		opts.sourceFile = synthesizeSourcePath(ext);
+	}
+	return opts;
+}
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "nautilus/options.hpp"
+#include <string>
+
+namespace nautilus::compiler::mlir {
+
+// Configuration for emitting DWARF debug information during MLIR compilation.
+// Populated from the public engine::Options by fromEngineOptions() so the rest
+// of the backend does not depend on the string-keyed Options header.
+struct DebugInfoOptions {
+	// When false, all debug-related plumbing is a no-op and the backend
+	// behaves identically to a build with no debug support.
+	bool enable = false;
+
+	// "mlir" snapshots the post-inline MLIR to disk and uses its line numbers
+	// as "source" locations.  "nautilus-ir" dumps the Nautilus IR to disk
+	// instead and lets MLIRLoweringProvider tag every emitted MLIR op with a
+	// FileLineColLoc pointing into that dump.
+	std::string sourceMode = "mlir";
+
+	// Absolute path where the "source" file is written.  When empty, a
+	// unique path under $TMPDIR is synthesized per compilation.
+	std::string sourceFile;
+
+	// DW_AT_producer string that shows up in DWARF (e.g. `gdb` calls this
+	// "produced by" on `info source`).
+	std::string producer = "Nautilus JIT";
+
+	// DWARF version emitted as an LLVM module flag.  4 is most compatible
+	// with older GDBs; LLVM's modern default is 5.
+	int dwarfVersion = 4;
+
+	// When true, the backend automatically attaches
+	// llvm::JITEventListener::createGDBRegistrationListener() to the OrcJIT.
+	// Turn off if you want to manage the listener list yourself via
+	// engine::Options::addMLIRJitEventListener().
+	bool autoRegisterGdbListener = true;
+};
+
+// Build a DebugInfoOptions from the string-keyed engine::Options.
+DebugInfoOptions debugInfoOptionsFromEngineOptions(const engine::Options& options);
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/EmitDbgValuePass.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/EmitDbgValuePass.cpp
@@ -1,0 +1,230 @@
+
+#include "nautilus/compiler/backends/mlir/debug/EmitDbgValuePass.hpp"
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SetVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/BinaryFormat/Dwarf.h>
+#include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/LLVMIR/LLVMTypes.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/Location.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/Value.h>
+#include <mlir/Pass/Pass.h>
+#include <string>
+#include <unordered_map>
+
+namespace nautilus::compiler::mlir {
+
+namespace {
+
+// Parse `$<digits>` and return the digits, or empty if the string is not
+// a Nautilus-identifier-form NameLoc name.
+llvm::StringRef nautilusIdFromName(llvm::StringRef s) {
+	if (s.size() < 2 || s.front() != '$') {
+		return {};
+	}
+	llvm::StringRef rest = s.drop_front();
+	for (char c : rest) {
+		if (c < '0' || c > '9') {
+			return {};
+		}
+	}
+	return rest;
+}
+
+// Walk the Location tree and return the first NameLoc whose name is a
+// `$N` identifier, or a null NameLoc if none exists.
+::mlir::NameLoc findDollarNameLoc(::mlir::Location loc) {
+	::mlir::NameLoc result;
+	loc->walk([&](::mlir::Location inner) {
+		if (auto name = llvm::dyn_cast<::mlir::NameLoc>(inner)) {
+			if (!nautilusIdFromName(name.getName().strref()).empty()) {
+				result = name;
+				return ::mlir::WalkResult::interrupt();
+			}
+		}
+		return ::mlir::WalkResult::advance();
+	});
+	return result;
+}
+
+// Walk the Location tree looking for a FusedLoc whose metadata is a
+// DISubprogramAttr.  Returns the attribute or a null attr if absent.
+::mlir::LLVM::DISubprogramAttr findSubprogram(::mlir::Location loc) {
+	::mlir::LLVM::DISubprogramAttr result;
+	loc->walk([&](::mlir::Location inner) {
+		if (auto fused = llvm::dyn_cast<::mlir::FusedLoc>(inner)) {
+			if (auto sp = llvm::dyn_cast_or_null<::mlir::LLVM::DISubprogramAttr>(fused.getMetadata())) {
+				result = sp;
+				return ::mlir::WalkResult::interrupt();
+			}
+		}
+		return ::mlir::WalkResult::advance();
+	});
+	return result;
+}
+
+// Derive a DIBasicTypeAttr for the given LLVM-dialect / builtin type.
+// Keeps the mapping intentionally simple: integer widths map to signed
+// DW_ATE_signed, floating widths to DW_ATE_float, pointers to an
+// address-typed basic type.  Returns null if the type is not supported
+// (void, composite, etc.); callers skip emission in that case.
+::mlir::LLVM::DITypeAttr basicTypeFor(::mlir::Type type, ::mlir::MLIRContext* ctx) {
+	using ::mlir::LLVM::DIBasicTypeAttr;
+	auto basic = [&](const char* name, uint64_t bits, unsigned encoding) -> ::mlir::LLVM::DITypeAttr {
+		return DIBasicTypeAttr::get(ctx, llvm::dwarf::DW_TAG_base_type, name, bits, encoding);
+	};
+	if (auto intTy = llvm::dyn_cast<::mlir::IntegerType>(type)) {
+		const unsigned bits = intTy.getWidth();
+		const char* name = bits == 1 ? "bool" : bits == 8 ? "i8" : bits == 16 ? "i16" : bits == 32 ? "i32" : "i64";
+		const unsigned enc = bits == 1 ? llvm::dwarf::DW_ATE_boolean : llvm::dwarf::DW_ATE_signed;
+		return basic(name, bits, enc);
+	}
+	if (llvm::isa<::mlir::Float32Type>(type)) {
+		return basic("f32", 32, llvm::dwarf::DW_ATE_float);
+	}
+	if (llvm::isa<::mlir::Float64Type>(type)) {
+		return basic("f64", 64, llvm::dwarf::DW_ATE_float);
+	}
+	if (llvm::isa<::mlir::LLVM::LLVMPointerType>(type)) {
+		return basic("ptr", 64, llvm::dwarf::DW_ATE_address);
+	}
+	return {};
+}
+
+struct EmitDbgValuePass : public ::mlir::PassWrapper<EmitDbgValuePass, ::mlir::OperationPass<::mlir::ModuleOp>> {
+	MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(EmitDbgValuePass)
+
+	llvm::StringRef getArgument() const final {
+		return "nautilus-emit-dbg-value";
+	}
+	llvm::StringRef getDescription() const final {
+		return "Scope Nautilus $N shadow allocas per basic block and attach llvm.intr.dbg.declare";
+	}
+
+	void getDependentDialects(::mlir::DialectRegistry& registry) const override {
+		registry.insert<::mlir::LLVM::LLVMDialect>();
+	}
+
+	void runOnOperation() override {
+		::mlir::ModuleOp module = getOperation();
+		::mlir::MLIRContext* ctx = module.getContext();
+
+		// Shadow allocas pair with a dbg.declare whose DIExpression
+		// simply states "the variable lives at this address" — no
+		// stack-value rewriting needed since every $N has a real
+		// memory slot.
+		auto emptyExpr = ::mlir::LLVM::DIExpressionAttr::get(ctx, {});
+
+		module.walk([&](::mlir::LLVM::LLVMFuncOp funcOp) {
+			auto subprogram = findSubprogram(funcOp->getLoc());
+			if (!subprogram || funcOp.empty()) {
+				return;
+			}
+			auto file = subprogram.getFile();
+			::mlir::OpBuilder builder(ctx);
+
+			// Walk allocas BEFORE any location rewriting so the `$N`
+			// NameLoc is still directly reachable from each alloca's
+			// location root.
+			std::unordered_map<std::string, ::mlir::LLVM::AllocaOp> allocaForId;
+			funcOp.walk([&](::mlir::LLVM::AllocaOp alloca) {
+				if (auto nameLoc = findDollarNameLoc(alloca->getLoc())) {
+					allocaForId.try_emplace(nameLoc.getName().str(), alloca);
+				}
+			});
+
+			// One DILexicalBlock per MLIR basic block.  Wrapping every
+			// op's location in a FusedLoc tagged with the block scope
+			// tells MLIR's debug translator to emit !DILocation with
+			// that scope, which in turn defines the DILexicalBlock's
+			// PC range in the emitted DWARF.  Variables scoped to the
+			// block then only appear in GDB when execution is inside
+			// it.
+			auto firstLineIn = [](::mlir::Block& block) -> unsigned {
+				for (auto& op : block) {
+					if (auto fl = op.getLoc()->findInstanceOf<::mlir::FileLineColLoc>()) {
+						if (fl.getLine() != 0) {
+							return fl.getLine();
+						}
+					}
+				}
+				return 0;
+			};
+			llvm::DenseMap<::mlir::Block*, ::mlir::LLVM::DILexicalBlockAttr> blockScopes;
+			for (auto& block : funcOp.getBody()) {
+				blockScopes[&block] =
+				    ::mlir::LLVM::DILexicalBlockAttr::get(ctx, subprogram, file, firstLineIn(block), /*column=*/1);
+			}
+			for (auto& block : funcOp.getBody()) {
+				auto scope = blockScopes[&block];
+				for (auto& op : block) {
+					op.setLoc(::mlir::FusedLoc::get({op.getLoc()}, scope, ctx));
+				}
+			}
+
+			// Discover which blocks store into each alloca.  Every
+			// store is a definition/refresh of $N in that block — we
+			// use the set to emit one dbg.declare per (block, $N).
+			llvm::DenseMap<::mlir::Operation*, llvm::SetVector<::mlir::Block*>> blocksStoringAlloca;
+			for (auto& kv : allocaForId) {
+				blocksStoringAlloca[kv.second.getOperation()];
+			}
+			funcOp.walk([&](::mlir::LLVM::StoreOp store) {
+				if (auto* defOp = store.getAddr().getDefiningOp()) {
+					if (auto it = blocksStoringAlloca.find(defOp); it != blocksStoringAlloca.end()) {
+						it->second.insert(store->getBlock());
+					}
+				}
+			});
+
+			for (const auto& kv : allocaForId) {
+				auto alloca = kv.second;
+				auto diType = basicTypeFor(alloca.getElemType(), ctx);
+				if (!diType) {
+					continue;
+				}
+				// DILocalVariable names drop the leading `$` for a
+				// `v` prefix — GDB's value-history syntax reserves
+				// `$<digits>` and would confuse DAP clients otherwise.
+				auto rawName = findDollarNameLoc(alloca->getLoc()).getName().strref();
+				std::string displayName = "v";
+				displayName.append((!rawName.empty() && rawName.front() == '$') ? rawName.drop_front(1) : rawName);
+
+				unsigned declLine = 0;
+				if (auto attr = alloca->getAttrOfType<::mlir::IntegerAttr>("nautilus.debug.decl_line")) {
+					declLine = static_cast<unsigned>(attr.getInt());
+				}
+
+				for (auto* block : blocksStoringAlloca[alloca.getOperation()]) {
+					auto blockScope = blockScopes[block];
+					auto localVar = ::mlir::LLVM::DILocalVariableAttr::get(
+					    ctx, blockScope, ::mlir::StringAttr::get(ctx, displayName), file, declLine,
+					    /*arg=*/0, /*alignInBits=*/0, diType, ::mlir::LLVM::DIFlags::Zero);
+					auto declLoc = ::mlir::FusedLoc::get(
+					    {::mlir::FileLineColLoc::get(file.getName(), firstLineIn(*block), 1)}, blockScope, ctx);
+					// In the entry block the dbg.declare must come
+					// after its alloca to preserve dominance; elsewhere
+					// anywhere inside the block will do.
+					if (block == &funcOp.getBody().front()) {
+						builder.setInsertionPointAfter(alloca);
+					} else {
+						builder.setInsertionPointToStart(block);
+					}
+					builder.create<::mlir::LLVM::DbgDeclareOp>(declLoc, alloca.getResult(), localVar, emptyExpr);
+				}
+			}
+		});
+	}
+};
+
+} // namespace
+
+std::unique_ptr<::mlir::Pass> createEmitDbgValuePass() {
+	return std::make_unique<EmitDbgValuePass>();
+}
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/EmitDbgValuePass.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/EmitDbgValuePass.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+#include <mlir/Pass/Pass.h>
+
+namespace nautilus::compiler::mlir {
+
+// Post-conversion MLIR pass that emits `llvm.intr.dbg.value` intrinsics
+// for each SSA value that carries a Nautilus `$N` NameLoc.
+//
+// Must run after `convert-func-to-llvm` (so everything is in the LLVM
+// dialect and `LLVMFuncOp`s exist) and after `DIScopeForLLVMFuncOpPass`
+// (so each LLVMFuncOp already has a distinct DISubprogram attached via
+// its fused location).  For every operation whose location contains a
+// NameLoc of the form `$N` and whose result is an LLVM-typed SSA value,
+// the pass inserts a `llvm.intr.dbg.value` after the op that tags the
+// value as the variable named `$N` in GDB/LLDB.  When the same `$N`
+// appears on multiple emitted ops (some Nautilus ops lower to several
+// MLIR ops), only the last op in program order gets the intrinsic — it
+// is the one whose result is bound to the Nautilus identifier.
+//
+// Uses the `DW_OP_LLVM_arg 0, DW_OP_stack_value` expression so the
+// debugger interprets the intrinsic operand as the variable's live
+// value (not its address), which works without spilling to memory.
+std::unique_ptr<::mlir::Pass> createEmitDbgValuePass();
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/IRSourceMap.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/IRSourceMap.cpp
@@ -1,0 +1,180 @@
+
+#include "nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp"
+#include "nautilus/compiler/ir/IRGraph.hpp"
+#include <cctype>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+
+namespace nautilus::compiler::mlir {
+
+namespace {
+
+// Sentinel returned by parseDollarId when the view does not start with
+// `$<digits>`.  Using a sentinel instead of std::optional sidesteps a
+// GCC-12 false positive -Wmaybe-uninitialized when the optional is
+// inlined into its caller.
+static constexpr uint32_t kNoId = std::numeric_limits<uint32_t>::max();
+
+// Parse a leading `$N` token and return N, or kNoId if the view does
+// not start with `$<digits>`.
+uint32_t parseDollarId(std::string_view s) {
+	if (s.empty() || s[0] != '$') {
+		return kNoId;
+	}
+	uint32_t id = 0;
+	bool any = false;
+	for (size_t i = 1; i < s.size(); ++i) {
+		if (std::isdigit(static_cast<unsigned char>(s[i]))) {
+			id = id * 10 + static_cast<uint32_t>(s[i] - '0');
+			any = true;
+		} else {
+			break;
+		}
+	}
+	return any ? id : kNoId;
+}
+
+std::string_view trimLeadingWhitespace(std::string_view s) {
+	size_t i = 0;
+	while (i < s.size() && (s[i] == ' ' || s[i] == '\t')) {
+		++i;
+	}
+	return s.substr(i);
+}
+
+// Scan a `(...)` argument list for `$N:type` entries and record each
+// discovered identifier as defined on `line` (unless a prior definition
+// has already been recorded, which takes precedence).
+void recordBlockArgs(std::string_view args, uint32_t line, std::unordered_map<uint32_t, uint32_t>& operationLines) {
+	size_t pos = 0;
+	while (pos < args.size()) {
+		auto dollar = args.find('$', pos);
+		if (dollar == std::string_view::npos) {
+			break;
+		}
+		const uint32_t id = parseDollarId(args.substr(dollar));
+		if (id != kNoId) {
+			operationLines.try_emplace(id, line);
+		}
+		pos = dollar + 1;
+	}
+}
+
+} // namespace
+
+IRSourceMap dumpIRWithSourceMap(const ir::IRGraph& graph) {
+	IRSourceMap result;
+	result.text = graph.toString();
+
+	std::string_view remaining = result.text;
+	uint32_t lineNo = 0;
+
+	// Nautilus IR restarts `$N` ids and `Block_N` indices at 0 for
+	// every function.  Track which function each line belongs to so
+	// we can partition the tables; a `name(...) {` line starts a new
+	// function scope and a top-level `}` ends it.
+	IRSourceMap::FunctionLines* currentFunction = nullptr;
+	// The block whose body we are currently scanning — used to append
+	// body-op lines (including terminators) to that block's sequence
+	// so the lowering provider can map ops to lines by position.
+	uint32_t currentBlockId = 0;
+	bool insideBlock = false;
+
+	while (!remaining.empty()) {
+		++lineNo;
+		auto nl = remaining.find('\n');
+		std::string_view line = (nl == std::string_view::npos) ? remaining : remaining.substr(0, nl);
+
+		std::string_view trimmed = trimLeadingWhitespace(line);
+		// A function scope ends at a `}` that is the first character
+		// on its line (top-level close brace; nested block-body
+		// terminators are indented).
+		if (!line.empty() && line[0] == '}') {
+			currentFunction = nullptr;
+			insideBlock = false;
+		}
+		// A blank line separates two blocks in the dump — close out
+		// the current block so terminator lookups use the right id.
+		if (trimmed.empty()) {
+			insideBlock = false;
+		}
+
+		if (trimmed.empty()) {
+			// fall through to advance
+		} else if (trimmed.starts_with("Block_")) {
+			if (currentFunction == nullptr) {
+				// Stray block header outside a function — should not
+				// happen for well-formed IR.  Skip to stay robust.
+			} else {
+				// Format: `Block_K($1:i32, $2:i32):`
+				auto open = trimmed.find('(');
+				auto close = (open == std::string_view::npos) ? std::string_view::npos : trimmed.find(')', open);
+				if (open != std::string_view::npos && close != std::string_view::npos) {
+					recordBlockArgs(trimmed.substr(open + 1, close - open - 1), lineNo,
+					                currentFunction->operationLines);
+				}
+				// Parse the numeric suffix after `Block_` so the
+				// lowering provider can map block-arg store !dbg to
+				// the block header line.
+				constexpr std::string_view prefix = "Block_";
+				auto suffix = trimmed.substr(prefix.size());
+				uint32_t blockId = 0;
+				bool any = false;
+				for (char c : suffix) {
+					if (std::isdigit(static_cast<unsigned char>(c))) {
+						blockId = blockId * 10 + static_cast<uint32_t>(c - '0');
+						any = true;
+					} else {
+						break;
+					}
+				}
+				if (any) {
+					currentFunction->blockHeaderLines[blockId] = lineNo;
+					currentBlockId = blockId;
+					insideBlock = true;
+				}
+			}
+		} else if (trimmed[0] == '$') {
+			// Format: `$N = ...` — an operation definition.
+			if (currentFunction != nullptr) {
+				const uint32_t id = parseDollarId(trimmed);
+				if (id != kNoId) {
+					currentFunction->operationLines.try_emplace(id, lineNo);
+					if (insideBlock) {
+						currentFunction->blockOpLines[currentBlockId].push_back(lineNo);
+					}
+				}
+			}
+		} else if (std::isalpha(static_cast<unsigned char>(trimmed[0])) || trimmed[0] == '_') {
+			// Format: `name(args) {` for function headers.  We
+			// recognise this by the presence of `(` before the next
+			// whitespace and an eventual `{` on the same line.
+			auto paren = trimmed.find('(');
+			auto brace = trimmed.find('{');
+			if (paren != std::string_view::npos && brace != std::string_view::npos && brace > paren) {
+				std::string name(trimmed.substr(0, paren));
+				result.functionLines[name] = lineNo;
+				currentFunction = &result.functions[name];
+				insideBlock = false;
+			} else if (insideBlock && currentFunction != nullptr) {
+				// Indented line inside a block body that does not
+				// start with `$` — a terminator like `if ... ? ... :
+				// ...`, `br Block_K(...)`, or `return (...)`.  Record
+				// its line so the lowering provider can give the
+				// corresponding MLIR op a !dbg that lets GDB stop on
+				// the terminator line.
+				currentFunction->blockOpLines[currentBlockId].push_back(lineNo);
+			}
+		}
+
+		if (nl == std::string_view::npos) {
+			break;
+		}
+		remaining = remaining.substr(nl + 1);
+	}
+
+	return result;
+}
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/src/nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace nautilus::compiler::ir {
+class IRGraph;
+} // namespace nautilus::compiler::ir
+
+namespace nautilus::compiler::mlir {
+
+// A text dump of a Nautilus IRGraph paired with lookup tables that map
+// each SSA operation identifier ($N) and basic-block id to the 1-based
+// line number where it appears in the dump.  Produced by
+// dumpIRWithSourceMap() and consumed by MLIRLoweringProvider to tag
+// emitted MLIR ops with FileLineColLocs pointing into `text`.
+//
+// Nautilus IR restarts `$N` identifiers and `Block_N` indices at 0 for
+// every function, so the line tables must be scoped per-function —
+// looking `$1` up without saying which function it belongs to would
+// collide across callers and callees in the same module.
+struct IRSourceMap {
+	// Per-function line tables.  Populated once per Nautilus
+	// FunctionOperation by dumpIRWithSourceMap().
+	struct FunctionLines {
+		// Maps OperationIdentifier id to the 1-based line in `text`
+		// where the operation is defined in this function.  For
+		// operations that produce a result this is the `$N = ...`
+		// line; for block arguments it is the enclosing block
+		// header.  First occurrence wins so function parameters keep
+		// their Block_0 header line even when a later block re-uses
+		// the same id as a block arg.
+		std::unordered_map<uint32_t, uint32_t> operationLines;
+
+		// Maps BasicBlock id (the integer after `Block_`) to its
+		// header line.  Used for the !dbg on block-arg stores so
+		// that entering a block advances GDB to the block's header
+		// rather than back to where the same $N was first
+		// introduced.
+		std::unordered_map<uint32_t, uint32_t> blockHeaderLines;
+
+		// For each BasicBlock id, the 1-based dump line of each op
+		// in that block, in the order IRGraph::toString() prints
+		// them.  The lowering provider consults this by position so
+		// terminators (`br`, `if`, `return`) — which have no `$N`
+		// identifier in the dump — still get a non-zero !dbg and
+		// stay steppable in GDB.
+		std::unordered_map<uint32_t, std::vector<uint32_t>> blockOpLines;
+	};
+
+	// The full text of the IR dump (identical to IRGraph::toString()).
+	std::string text;
+
+	// Maps function name to the 1-based line of its header (`name(...) {`).
+	std::unordered_map<std::string, uint32_t> functionLines;
+
+	// Per-function line tables indexed by function name.
+	std::unordered_map<std::string, FunctionLines> functions;
+};
+
+// Dumps `graph` via IRGraph::toString() and parses the result to build
+// the SSA-id to line-number map.  Relies on the stable format emitted by
+// the fmt formatters in IRGraph.cpp (`\t$N = ...` for definitions,
+// `Block_K($N:type, ...):` for block arguments, `name(args) {` for
+// function headers).  If the dump format is ever changed, update the
+// parser here in lockstep.
+IRSourceMap dumpIRWithSourceMap(const ir::IRGraph& graph);
+
+} // namespace nautilus::compiler::mlir

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -18,7 +18,8 @@ set(NAUTILUS_EXECUTION_TEST_SOURCES
 if (ENABLE_MLIR_BACKEND)
     list(APPEND NAUTILUS_EXECUTION_TEST_SOURCES
             MLIRJitEventListenerTest.cpp
-            MLIRJitEventListenerTestFixture.cpp)
+            MLIRJitEventListenerTestFixture.cpp
+            DebugInfoExecutionTest.cpp)
 endif ()
 
 add_executable(nautilus-execution-tests ${NAUTILUS_EXECUTION_TEST_SOURCES})

--- a/nautilus/test/execution-tests/DebugInfoExecutionTest.cpp
+++ b/nautilus/test/execution-tests/DebugInfoExecutionTest.cpp
@@ -1,0 +1,1087 @@
+#include "nautilus/config.hpp"
+
+#if defined(ENABLE_TRACING) && defined(ENABLE_MLIR_BACKEND)
+
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/nautilus_function.hpp"
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <cctype>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <unistd.h>
+
+namespace nautilus::engine {
+
+namespace {
+
+val<int32_t> debugAddOne(val<int32_t> x) {
+	return x + 1;
+}
+
+val<int32_t> debugSumThree(val<int32_t> a, val<int32_t> b, val<int32_t> c) {
+	auto t = a + b;
+	return t + c;
+}
+
+val<int32_t> debugSumLoop(val<int32_t> upperLimit) {
+	val<int32_t> agg = val<int32_t>(0);
+	for (val<int32_t> i = 0; i < upperLimit; i = i + 1) {
+		agg = agg + i;
+	}
+	return agg;
+}
+
+// A small bundle of functions registered together in a CompiledModule,
+// used to exercise debug info for compilation units that contain more
+// than one Nautilus function.
+val<int32_t> debugModAdd(val<int32_t> x) {
+	return x + 1;
+}
+
+val<int32_t> debugModMul(val<int32_t> x, val<int32_t> y) {
+	auto t = x * y;
+	return t + 1;
+}
+
+val<int32_t> debugModLoop(val<int32_t> n) {
+	val<int32_t> agg = 0;
+	for (val<int32_t> i = 0; i < n; i = i + 1) {
+		agg = agg + i;
+	}
+	return agg;
+}
+
+// A helper traced as a separate Nautilus function.  Wrapping it in a
+// NautilusFunction makes the call from `debugCaller` emit a
+// ProxyCallOperation — the caller and callee lower to two distinct
+// `func.func`s in the same MLIR module and exercise debug info across
+// function boundaries.
+val<int32_t> debugHelperImpl(val<int32_t> x, val<int32_t> y) {
+	auto prod = x * y;
+	return prod + 1;
+}
+
+static auto debugHelper = NautilusFunction {"debug_helper", debugHelperImpl};
+
+val<int32_t> debugCaller(val<int32_t> a, val<int32_t> b) {
+	val<int32_t> acc = 0;
+	for (val<int32_t> i = 0; i < b; i = i + 1) {
+		acc = acc + debugHelper(a, i);
+	}
+	return acc;
+}
+
+val<int32_t> debugNestedControlFlow(val<int32_t> limit) {
+	val<int32_t> even = 0;
+	val<int32_t> odd = 0;
+	for (val<int32_t> i = 0; i < limit; i = i + 1) {
+		if (i % 2 == 0) {
+			if (i > 4) {
+				even = even + i;
+			}
+		} else {
+			odd = odd + 1;
+		}
+	}
+	return even + odd;
+}
+
+std::string readFile(const std::string& path) {
+	std::ifstream in(path);
+	std::stringstream ss;
+	ss << in.rdbuf();
+	return ss.str();
+}
+
+} // namespace
+
+TEST_CASE("Debug info: disabled by default produces identical results") {
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugAddOne);
+	REQUIRE(fn(41) == 42);
+}
+
+TEST_CASE("Debug info: MLIR source mode writes a snapshot file and compiles") {
+	const auto sourcePath =
+	    (std::filesystem::temp_directory_path() / ("nautilus_debug_mlir_test_" + std::to_string(::getpid()) + ".mlir"))
+	        .string();
+	std::filesystem::remove(sourcePath);
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("mlir"));
+	options.setOption("mlir.debug.source_file", sourcePath);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugAddOne);
+	REQUIRE(fn(41) == 42);
+
+	// LocationSnapshot should have written the post-inline MLIR to the
+	// configured path.  The file must be non-empty and contain the func
+	// symbol so gdb/lldb can resolve breakpoints against its lines.
+	REQUIRE(std::filesystem::exists(sourcePath));
+	const auto contents = readFile(sourcePath);
+	REQUIRE_FALSE(contents.empty());
+	REQUIRE(contents.find("func.func") != std::string::npos);
+
+	std::filesystem::remove(sourcePath);
+}
+
+TEST_CASE("Debug info: Nautilus IR source mode emits the IR dump as the source file") {
+	const auto sourcePath =
+	    (std::filesystem::temp_directory_path() / ("nautilus_debug_ir_test_" + std::to_string(::getpid()) + ".ir"))
+	        .string();
+	std::filesystem::remove(sourcePath);
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("mlir.debug.source_file", sourcePath);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugSumThree);
+	REQUIRE(fn(1, 2, 3) == 6);
+
+	// The IR source file should be the Nautilus IR dump, recognizable by
+	// the outer `nautilus { ... } //nautilus` bracket pattern produced by
+	// IRGraph::toString().
+	REQUIRE(std::filesystem::exists(sourcePath));
+	const auto contents = readFile(sourcePath);
+	REQUIRE(contents.find("nautilus {") != std::string::npos);
+	REQUIRE(contents.find("//nautilus") != std::string::npos);
+
+	std::filesystem::remove(sourcePath);
+}
+
+TEST_CASE("Debug info: default source path is synthesized when none provided") {
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugAddOne);
+	REQUIRE(fn(10) == 11);
+}
+
+TEST_CASE("Debug info: nautilus-ir mode emits alloca + dbg.declare for each $N DILocalVariable") {
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("dump.before_llvm_optimization", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugSumThree);
+	REQUIRE(fn(1, 2, 3) == 6);
+
+	// Each `$N` is now a shadow alloca with a dbg.declare pointing at
+	// it (see EmitDbgValuePass).  Verify both the DILocalVariable
+	// metadata and the dbg.declare debug record survive MLIR→LLVM
+	// translation.  Accept either the legacy `call void
+	// @llvm.dbg.declare` syntax or LLVM 21's `#dbg_declare` record form.
+	bool foundDILocalVar = false;
+	bool foundDbgDeclare = false;
+	bool foundAlloca = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().filename() == "before_llvm_optimization.ll") {
+					auto contents = readFile(entry.path().string());
+					// DILocalVariable names use a `v<N>` prefix rather
+					// than `$<N>` to avoid GDB's value-history syntax.
+					if (contents.find("!DILocalVariable(name: \"v") != std::string::npos) {
+						foundDILocalVar = true;
+					}
+					if (contents.find("#dbg_declare") != std::string::npos ||
+					    contents.find("@llvm.dbg.declare") != std::string::npos) {
+						foundDbgDeclare = true;
+					}
+					if (contents.find("= alloca i32") != std::string::npos) {
+						foundAlloca = true;
+					}
+				}
+			}
+		}
+	}
+	REQUIRE(foundDILocalVar);
+	REQUIRE(foundDbgDeclare);
+	REQUIRE(foundAlloca);
+}
+
+TEST_CASE("Debug info: generated LLVM IR contains DICompileUnit") {
+	// DumpHandler writes under $TMPDIR/dump/<compilation-unit-id>/ — no way
+	// to override, so snapshot the state, run, then search newly-created
+	// subdirs for the after_llvm_generation.ll dump.
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("mlir"));
+	options.setOption("dump.after_llvm_generation", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugAddOne);
+	REQUIRE(fn(5) == 6);
+
+	// Find new subdir(s) and look for the expected LLVM IR dump.
+	bool foundDICompileUnit = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().extension() == ".ll") {
+					auto contents = readFile(entry.path().string());
+					if (contents.find("DICompileUnit") != std::string::npos) {
+						foundDICompileUnit = true;
+						break;
+					}
+				}
+			}
+			if (foundDICompileUnit) {
+				break;
+			}
+		}
+	}
+	REQUIRE(foundDICompileUnit);
+}
+
+TEST_CASE("Debug info: nautilus-ir mode emits DISubprogram with non-zero line") {
+	// Regression: DIScopeForLLVMFuncOpPass used to synthesize DISubprograms
+	// with `line: 0` because MLIRLoweringProvider tagged the FuncOp with a
+	// NameLoc whose nested FileLineColLoc had line 0.  DWARF treats line 0
+	// as "no location", so GDB's `step` could not land inside the function.
+	// The lowering now looks the function's header line up in
+	// IRSourceMap::functionLines, which must surface as a non-zero `line:`
+	// attribute on every emitted DISubprogram.
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("dump.after_llvm_generation", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugSumThree);
+	REQUIRE(fn(1, 2, 3) == 6);
+
+	bool foundDISubprogram = false;
+	bool foundLineZero = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().filename() == "after_llvm_generation.ll") {
+					auto contents = readFile(entry.path().string());
+					std::string::size_type pos = 0;
+					while ((pos = contents.find("!DISubprogram(", pos)) != std::string::npos) {
+						const auto end = contents.find(')', pos);
+						if (end == std::string::npos) {
+							break;
+						}
+						const auto record = contents.substr(pos, end - pos);
+						foundDISubprogram = true;
+						if (record.find("line: 0") != std::string::npos) {
+							foundLineZero = true;
+						}
+						pos = end;
+					}
+				}
+			}
+		}
+	}
+	REQUIRE(foundDISubprogram);
+	REQUIRE_FALSE(foundLineZero);
+}
+
+TEST_CASE("Debug info: loop body produces a multi-block IR with N lines for every op") {
+	// Sanity-check that a looping function — which lowers to several MLIR
+	// basic blocks and carries SSA block arguments across iterations —
+	// still produces a valid IR source dump where every `$N = ...`
+	// definition and every block-argument appears on its own line, and
+	// every emitted DISubprogram gets a real `line:` attribute.
+	const auto sourcePath =
+	    (std::filesystem::temp_directory_path() / ("nautilus_debug_loop_test_" + std::to_string(::getpid()) + ".ir"))
+	        .string();
+	std::filesystem::remove(sourcePath);
+
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("mlir.debug.source_file", sourcePath);
+	options.setOption("dump.after_llvm_generation", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugSumLoop);
+	// sum of 0..4 inclusive
+	REQUIRE(fn(5) == 10);
+
+	// IR dump should contain at least one `Block_` header (the loop
+	// body/header) and the final `return` — i.e. the function is in fact
+	// multi-block.
+	REQUIRE(std::filesystem::exists(sourcePath));
+	const auto ir = readFile(sourcePath);
+	REQUIRE(ir.find("Block_") != std::string::npos);
+	REQUIRE(ir.find("return") != std::string::npos);
+	REQUIRE(std::count(ir.begin(), ir.end(), '\n') > 5);
+
+	// DISubprogram must still carry a non-zero `line:` for the main
+	// function even when the body is multi-block.
+	bool foundDISubprogram = false;
+	bool foundLineZero = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().filename() == "after_llvm_generation.ll") {
+					auto contents = readFile(entry.path().string());
+					std::string::size_type pos = 0;
+					while ((pos = contents.find("!DISubprogram(", pos)) != std::string::npos) {
+						const auto end = contents.find(')', pos);
+						if (end == std::string::npos) {
+							break;
+						}
+						const auto record = contents.substr(pos, end - pos);
+						foundDISubprogram = true;
+						if (record.find("line: 0") != std::string::npos) {
+							foundLineZero = true;
+						}
+						pos = end;
+					}
+				}
+			}
+		}
+	}
+	REQUIRE(foundDISubprogram);
+	REQUIRE_FALSE(foundLineZero);
+
+	std::filesystem::remove(sourcePath);
+}
+
+TEST_CASE("Debug info: nested control flow preserves $N DILocalVariables across blocks") {
+	// Nested if/else inside a loop produces branching control flow where
+	// block-arg SSA ids bridge iterations.  Verify that every Nautilus
+	// `$N` in the IR dump has a matching DILocalVariable in the lowered
+	// LLVM IR so GDB can resolve each intermediate across all branches.
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	const auto sourcePath =
+	    (std::filesystem::temp_directory_path() / ("nautilus_debug_cf_test_" + std::to_string(::getpid()) + ".ir"))
+	        .string();
+	std::filesystem::remove(sourcePath);
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("mlir.debug.source_file", sourcePath);
+	options.setOption("dump.before_llvm_optimization", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugNestedControlFlow);
+	// limit = 10 → odd count {1,3,5,7,9}=5; even>4 sum {6,8}=14; total=19.
+	REQUIRE(fn(10) == 19);
+
+	REQUIRE(std::filesystem::exists(sourcePath));
+	const auto ir = readFile(sourcePath);
+
+	// Count distinct `$N` definitions in the IR dump — block arg
+	// declarations (`$N:type` inside a block header) and `$N = ...`
+	// lines.  Every one must surface as a `!DILocalVariable(name: "vN"…)`
+	// in the lowered LLVM IR, otherwise GDB cannot resolve it across a
+	// branch.  (DILocalVariable uses the `v` prefix instead of `$` so
+	// GDB doesn't interpret the name as value-history syntax.)
+	std::set<int> irIds;
+	for (std::string::size_type p = 0; (p = ir.find('$', p)) != std::string::npos; ++p) {
+		std::string::size_type q = p + 1;
+		int id = 0;
+		bool any = false;
+		while (q < ir.size() && std::isdigit(static_cast<unsigned char>(ir[q]))) {
+			id = id * 10 + (ir[q] - '0');
+			any = true;
+			++q;
+		}
+		if (any) {
+			irIds.insert(id);
+		}
+	}
+	REQUIRE(irIds.size() > 5);
+
+	std::set<int> llIds;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().filename() == "before_llvm_optimization.ll") {
+					auto contents = readFile(entry.path().string());
+					const std::string marker = "!DILocalVariable(name: \"v";
+					std::string::size_type pos = 0;
+					while ((pos = contents.find(marker, pos)) != std::string::npos) {
+						auto idStart = pos + marker.size();
+						int id = 0;
+						bool any = false;
+						while (idStart < contents.size() &&
+						       std::isdigit(static_cast<unsigned char>(contents[idStart]))) {
+							id = id * 10 + (contents[idStart] - '0');
+							any = true;
+							++idStart;
+						}
+						if (any) {
+							llIds.insert(id);
+						}
+						pos = idStart;
+					}
+				}
+			}
+		}
+	}
+
+	REQUIRE_FALSE(llIds.empty());
+	for (int id : irIds) {
+		INFO("IR defines $" << id << " but no matching DILocalVariable was emitted in LLVM IR");
+		REQUIRE(llIds.count(id) == 1);
+	}
+
+	std::filesystem::remove(sourcePath);
+}
+
+TEST_CASE("Debug info: per-block DILexicalBlock scoping narrows variable visibility") {
+	// EmitDbgValuePass builds one DILexicalBlock per Nautilus basic
+	// block and scopes each DILocalVariable to the block that stores
+	// into its shadow alloca.  This test asserts:
+	//   * more than one DILexicalBlock is emitted for a multi-block
+	//     function (otherwise every variable would share the function
+	//     scope).
+	//   * each DILexicalBlock's parent is the function's DISubprogram.
+	//   * at least one DILocalVariable is scoped to a DILexicalBlock
+	//     rather than directly to the DISubprogram — proving that
+	//     scoping has actually been narrowed from function scope.
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("dump.before_llvm_optimization", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugSumLoop);
+	REQUIRE(fn(5) == 10);
+
+	int lexicalBlockCount = 0;
+	int varsScopedToLexBlock = 0;
+	bool foundLexBlock = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().filename() == "before_llvm_optimization.ll") {
+					auto contents = readFile(entry.path().string());
+
+					// Iterate line-by-line so parser state machines
+					// do not risk looping on the same position.
+					std::set<std::string> lexBlockIds;
+					{
+						std::istringstream iss(contents);
+						std::string line;
+						while (std::getline(iss, line)) {
+							const auto marker = line.find("= distinct !DILexicalBlock(");
+							if (marker == std::string::npos) {
+								continue;
+							}
+							// Line shape: `!<N> = distinct !DILexicalBlock(...)`
+							auto bang = line.find('!');
+							if (bang == std::string::npos) {
+								continue;
+							}
+							auto idEnd = line.find(' ', bang);
+							if (idEnd == std::string::npos) {
+								continue;
+							}
+							lexBlockIds.insert(line.substr(bang + 1, idEnd - bang - 1));
+							foundLexBlock = true;
+						}
+					}
+					lexicalBlockCount = static_cast<int>(lexBlockIds.size());
+
+					{
+						std::istringstream iss(contents);
+						std::string line;
+						while (std::getline(iss, line)) {
+							if (line.find("= !DILocalVariable(") == std::string::npos) {
+								continue;
+							}
+							const auto scopeKey = line.find("scope: !");
+							if (scopeKey == std::string::npos) {
+								continue;
+							}
+							auto scopeStart = scopeKey + std::string("scope: !").size();
+							auto scopeEnd = scopeStart;
+							while (scopeEnd < line.size() &&
+							       std::isdigit(static_cast<unsigned char>(line[scopeEnd]))) {
+								++scopeEnd;
+							}
+							auto scopeId = line.substr(scopeStart, scopeEnd - scopeStart);
+							if (lexBlockIds.count(scopeId)) {
+								++varsScopedToLexBlock;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	REQUIRE(foundLexBlock);
+	REQUIRE(lexicalBlockCount >= 2);
+	REQUIRE(varsScopedToLexBlock >= 1);
+}
+
+TEST_CASE("Debug info: multi-function module emits a DISubprogram + scopes per function") {
+	// A CompiledModule built from several Nautilus functions lowers to a
+	// single MLIR module containing one `func.func` per registration.
+	// Each must surface as its own DWARF DISubprogram (with a non-zero
+	// `line:`), carry its own DILexicalBlocks, and isolate its `vN`
+	// DILocalVariables so names don't leak across functions.
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("dump.before_llvm_optimization", true);
+
+	NautilusEngine engine(options);
+	auto module = engine.createModule();
+	module.registerFunction("mod_add", debugModAdd);
+	module.registerFunction("mod_mul", debugModMul);
+	module.registerFunction("mod_loop", debugModLoop);
+	auto compiled = module.compile();
+
+	auto addFn = compiled.getFunction<int32_t(int32_t)>("mod_add");
+	auto mulFn = compiled.getFunction<int32_t(int32_t, int32_t)>("mod_mul");
+	auto loopFn = compiled.getFunction<int32_t(int32_t)>("mod_loop");
+	REQUIRE(addFn(41) == 42);
+	REQUIRE(mulFn(3, 4) == 13);
+	REQUIRE(loopFn(5) == 10);
+
+	// Harvest (subprogramId → name) and (lexBlockId → subprogramId)
+	// tables from the pre-optimization dump, then check that:
+	//   * one DISubprogram is emitted per user function (plus the
+	//     MLIR-generated `_mlir_ciface_*` wrappers that ride along);
+	//   * every DISubprogram has line != 0;
+	//   * each DILexicalBlock's `scope:` is one of the DISubprograms;
+	//   * DILocalVariables scoped to a lexical block never cross
+	//     function boundaries (a given scope → exactly one function).
+	std::map<std::string, std::string> subprogramName; // id → name
+	std::map<std::string, std::string> lexBlockOwner;  // id → subprogram id
+	std::map<std::string, std::string> subprogramLine; // id → line string
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (!entry.is_regular_file() || entry.path().filename() != "before_llvm_optimization.ll") {
+					continue;
+				}
+				auto contents = readFile(entry.path().string());
+				std::istringstream iss(contents);
+				std::string line;
+				while (std::getline(iss, line)) {
+					const auto bang = line.find('!');
+					if (bang == std::string::npos) {
+						continue;
+					}
+					const auto idEnd = line.find(' ', bang);
+					if (idEnd == std::string::npos || line.find('=', idEnd) == std::string::npos) {
+						continue;
+					}
+					const auto metaId = line.substr(bang + 1, idEnd - bang - 1);
+
+					if (line.find("!DISubprogram(") != std::string::npos) {
+						auto nameKey = line.find("name: \"");
+						auto lineKey = line.find("line: ");
+						if (nameKey == std::string::npos || lineKey == std::string::npos) {
+							continue;
+						}
+						auto nameStart = nameKey + std::string("name: \"").size();
+						auto nameEnd = line.find('"', nameStart);
+						auto lineStart = lineKey + std::string("line: ").size();
+						auto lineEnd = lineStart;
+						while (lineEnd < line.size() && std::isdigit(static_cast<unsigned char>(line[lineEnd]))) {
+							++lineEnd;
+						}
+						subprogramName[metaId] = line.substr(nameStart, nameEnd - nameStart);
+						subprogramLine[metaId] = line.substr(lineStart, lineEnd - lineStart);
+					} else if (line.find("!DILexicalBlock(") != std::string::npos) {
+						auto scopeKey = line.find("scope: !");
+						if (scopeKey == std::string::npos) {
+							continue;
+						}
+						auto scopeStart = scopeKey + std::string("scope: !").size();
+						auto scopeEnd = scopeStart;
+						while (scopeEnd < line.size() && std::isdigit(static_cast<unsigned char>(line[scopeEnd]))) {
+							++scopeEnd;
+						}
+						lexBlockOwner[metaId] = line.substr(scopeStart, scopeEnd - scopeStart);
+					}
+				}
+				break; // one dump is enough
+			}
+			if (!subprogramName.empty()) {
+				break;
+			}
+		}
+	}
+
+	// Collect distinct user-level function names — ignore the
+	// `_mlir_ciface_*` / `_mlir_*` wrappers that convert-func-to-llvm
+	// synthesizes alongside each emitted function.
+	std::set<std::string> userFunctions;
+	for (const auto& kv : subprogramName) {
+		if (kv.second.rfind("_mlir_", 0) == 0) {
+			continue;
+		}
+		userFunctions.insert(kv.second);
+	}
+	REQUIRE(userFunctions.count("mod_add") == 1);
+	REQUIRE(userFunctions.count("mod_mul") == 1);
+	REQUIRE(userFunctions.count("mod_loop") == 1);
+
+	// Every DISubprogram — including the C-interface wrappers — must
+	// have a non-zero `line:` attribute, otherwise GDB cannot land
+	// inside the function on `step`.
+	for (const auto& kv : subprogramLine) {
+		INFO("DISubprogram !" << kv.first << " has line: " << kv.second);
+		REQUIRE(kv.second != "0");
+	}
+
+	// Per-function lexical-block isolation: each DILexicalBlock's
+	// parent scope must resolve to a DISubprogram we captured.
+	REQUIRE_FALSE(lexBlockOwner.empty());
+	for (const auto& kv : lexBlockOwner) {
+		INFO("DILexicalBlock !" << kv.first << " owner !" << kv.second);
+		REQUIRE(subprogramName.count(kv.second) == 1);
+	}
+
+	// Count lexical blocks per owning DISubprogram.  The multi-block
+	// `mod_loop` function must contribute more than one lexical block
+	// (entry + loop header + body + exit), proving that per-block
+	// scoping works independently across module functions.
+	std::map<std::string, int> blocksPerSubprogram;
+	for (const auto& kv : lexBlockOwner) {
+		blocksPerSubprogram[kv.second]++;
+	}
+	int multiBlockFunctions = 0;
+	for (const auto& kv : blocksPerSubprogram) {
+		if (kv.second >= 2) {
+			++multiBlockFunctions;
+		}
+	}
+	REQUIRE(multiBlockFunctions >= 1);
+}
+
+TEST_CASE("Debug info: one Nautilus function calling another gets per-function debug info") {
+	// `debugCaller` invokes `debug_helper` via a NautilusFunction
+	// wrapper, which ends up as a ProxyCallOperation — so both
+	// functions are compiled into the same MLIR module and the caller
+	// site lowers to a `func.call` inside `debugCaller`'s body.
+	// Verify that:
+	//   * Both functions appear as distinct DISubprograms with
+	//     non-zero `line:` attributes.
+	//   * The emitted LLVM IR contains an actual `call i32 @debug_helper`
+	//     from within `debugCaller`.
+	//   * The call instruction carries a `!dbg` whose scope resolves
+	//     to the CALLER's DILexicalBlock — proving we preserve scope
+	//     across the call site.
+	const auto sourcePath =
+	    (std::filesystem::temp_directory_path() / ("nautilus_debug_call_" + std::to_string(::getpid()) + ".ir"))
+	        .string();
+	std::filesystem::remove(sourcePath);
+
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("mlir.debug.source_file", sourcePath);
+	options.setOption("dump.before_llvm_optimization", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugCaller);
+	// sum_{i=0..3} ((5*i)+1) = 1 + 6 + 11 + 16 = 34
+	REQUIRE(fn(5, 4) == 34);
+
+	// IR dump should list two function headers so the user can step
+	// into both caller and callee.
+	REQUIRE(std::filesystem::exists(sourcePath));
+	const auto ir = readFile(sourcePath);
+	REQUIRE(ir.find("debug_helper(") != std::string::npos);
+	const bool hasOuterFn =
+	    ir.find("execute(") != std::string::npos || ir.find("debugCaller(") != std::string::npos;
+	REQUIRE(hasOuterFn);
+
+	// Parse the pre-optimization LLVM IR to map subprograms to their
+	// metadata ids, check the call lowered correctly, and confirm the
+	// call's !dbg scope belongs to the caller.  We must capture the
+	// call that appears in the OUTER `@execute` function — the module
+	// also contains `@debug_helper` and its `_mlir_ciface_*` wrapper,
+	// each of which emits its own `call i32 @debug_helper` forwarder.
+	std::map<std::string, std::string> subprogramName;
+	std::map<std::string, std::string> subprogramLine;
+	std::map<std::string, std::string> lexBlockOwner;   // !N -> !M (lexBlock -> scope)
+	std::map<std::string, std::string> dilocationScope; // !N -> !M (DILocation -> scope)
+	std::string callDbgScope;
+	bool sawHelperCall = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (!entry.is_regular_file() || entry.path().filename() != "before_llvm_optimization.ll") {
+					continue;
+				}
+				auto contents = readFile(entry.path().string());
+				std::istringstream iss(contents);
+				std::string line;
+				std::string currentFunction;
+				while (std::getline(iss, line)) {
+					// Track which user-level function we're scanning
+					// through.  `define ... @<name>(...)` marks the
+					// start, `^}` the end.
+					if (line.rfind("define ", 0) == 0) {
+						auto at = line.find('@');
+						auto open = (at == std::string::npos) ? std::string::npos : line.find('(', at);
+						currentFunction = (at != std::string::npos && open != std::string::npos)
+						                      ? line.substr(at + 1, open - at - 1)
+						                      : std::string {};
+					} else if (line == "}") {
+						currentFunction.clear();
+					}
+
+					// Only capture the call from the CALLER — ignore
+					// the `_mlir_ciface_debug_helper` forwarder and any
+					// un-debugged `_mlir_*` wrapper.
+					if (currentFunction == "execute" && line.find("call i32 @debug_helper") != std::string::npos) {
+						sawHelperCall = true;
+						const auto dbgKey = line.find("!dbg !");
+						if (dbgKey != std::string::npos) {
+							auto idStart = dbgKey + std::string("!dbg !").size();
+							auto idEnd = idStart;
+							while (idEnd < line.size() &&
+							       std::isdigit(static_cast<unsigned char>(line[idEnd]))) {
+								++idEnd;
+							}
+							callDbgScope = line.substr(idStart, idEnd - idStart);
+						}
+						continue;
+					}
+					const auto bang = line.find('!');
+					if (bang == std::string::npos) {
+						continue;
+					}
+					const auto idEnd = line.find(' ', bang);
+					if (idEnd == std::string::npos) {
+						continue;
+					}
+					const auto metaId = line.substr(bang + 1, idEnd - bang - 1);
+					auto scopeIdAt = [&](std::string::size_type key) {
+						auto start = key + std::string("scope: !").size();
+						auto end = start;
+						while (end < line.size() && std::isdigit(static_cast<unsigned char>(line[end]))) {
+							++end;
+						}
+						return line.substr(start, end - start);
+					};
+					if (line.find("!DISubprogram(") != std::string::npos) {
+						auto nameKey = line.find("name: \"");
+						auto lineKey = line.find("line: ");
+						if (nameKey == std::string::npos || lineKey == std::string::npos) {
+							continue;
+						}
+						auto nameStart = nameKey + std::string("name: \"").size();
+						auto nameEnd = line.find('"', nameStart);
+						auto lineStart = lineKey + std::string("line: ").size();
+						auto lineNumEnd = lineStart;
+						while (lineNumEnd < line.size() &&
+						       std::isdigit(static_cast<unsigned char>(line[lineNumEnd]))) {
+							++lineNumEnd;
+						}
+						subprogramName[metaId] = line.substr(nameStart, nameEnd - nameStart);
+						subprogramLine[metaId] = line.substr(lineStart, lineNumEnd - lineStart);
+					} else if (line.find("!DILexicalBlock(") != std::string::npos) {
+						auto scopeKey = line.find("scope: !");
+						if (scopeKey == std::string::npos) {
+							continue;
+						}
+						lexBlockOwner[metaId] = scopeIdAt(scopeKey);
+					} else if (line.find("!DILocation(") != std::string::npos) {
+						auto scopeKey = line.find("scope: !");
+						if (scopeKey == std::string::npos) {
+							continue;
+						}
+						dilocationScope[metaId] = scopeIdAt(scopeKey);
+					}
+				}
+				break;
+			}
+			if (sawHelperCall) {
+				break;
+			}
+		}
+	}
+	REQUIRE(sawHelperCall);
+
+	// Both the helper and the outer function must have their own
+	// DISubprogram with a real line number.
+	std::set<std::string> userFuncs;
+	for (const auto& kv : subprogramName) {
+		if (kv.second.rfind("_mlir_", 0) != 0) {
+			userFuncs.insert(kv.second);
+		}
+	}
+	REQUIRE(userFuncs.count("debug_helper") == 1);
+	// The outer fn is registered via engine.registerFunction(debugCaller)
+	// without an explicit name, so Nautilus assigns the standard
+	// "execute" symbol for single-registerFunction engines.
+	REQUIRE(userFuncs.count("execute") == 1);
+	for (const auto& kv : subprogramLine) {
+		INFO("DISubprogram !" << kv.first << " (" << subprogramName[kv.first] << ") line: " << kv.second);
+		REQUIRE(kv.second != "0");
+	}
+
+	// The `call @debug_helper` instruction's `!dbg` must live under a
+	// scope whose chain terminates at the CALLER's DISubprogram — not
+	// the callee's.  The chain is
+	//     DILocation -> (DILexicalBlock*) -> DISubprogram.
+	REQUIRE_FALSE(callDbgScope.empty());
+	std::string walkId = callDbgScope;
+	for (int steps = 0; steps < 16 && !walkId.empty(); ++steps) {
+		if (subprogramName.count(walkId)) {
+			break;
+		}
+		if (auto it = dilocationScope.find(walkId); it != dilocationScope.end()) {
+			walkId = it->second;
+			continue;
+		}
+		if (auto it = lexBlockOwner.find(walkId); it != lexBlockOwner.end()) {
+			walkId = it->second;
+			continue;
+		}
+		walkId.clear();
+		break;
+	}
+	REQUIRE(subprogramName.count(walkId) == 1);
+	REQUIRE(subprogramName[walkId] != "debug_helper");
+
+	std::filesystem::remove(sourcePath);
+}
+
+TEST_CASE("Debug info: block terminators carry non-zero !dbg lines") {
+	// Terminators (`br`, `cond_br`, `return`) don't have a `$N = ...`
+	// line in the Nautilus IR dump, so prior to positional
+	// `blockOpLines` tracking they inherited line 0 — which DWARF
+	// treats as "no location" and GDB's `step` silently skips.  This
+	// test lowers a function with both forms of branch plus a return,
+	// then scans the LLVM IR for those terminators and requires every
+	// one of their `!dbg` lines to be > 0.
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("mlir.debug.enable", true);
+	options.setOption("mlir.debug.source_mode", std::string("nautilus-ir"));
+	options.setOption("dump.before_llvm_optimization", true);
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(debugNestedControlFlow);
+	REQUIRE(fn(10) == 19);
+
+	int terminatorsChecked = 0;
+	bool sawLineZero = false;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path())) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (!entry.is_regular_file() || entry.path().filename() != "before_llvm_optimization.ll") {
+					continue;
+				}
+				auto contents = readFile(entry.path().string());
+
+				// Map each DILocation metadata id to its `line:` value.
+				std::map<std::string, std::string> dilocationLine;
+				{
+					std::istringstream iss(contents);
+					std::string line;
+					while (std::getline(iss, line)) {
+						if (line.find("!DILocation(") == std::string::npos) {
+							continue;
+						}
+						const auto bang = line.find('!');
+						const auto idEnd = line.find(' ', bang);
+						if (bang == std::string::npos || idEnd == std::string::npos) {
+							continue;
+						}
+						auto metaId = line.substr(bang + 1, idEnd - bang - 1);
+						const auto key = line.find("line: ");
+						if (key == std::string::npos) {
+							continue;
+						}
+						auto start = key + std::string("line: ").size();
+						auto end = start;
+						while (end < line.size() && std::isdigit(static_cast<unsigned char>(line[end]))) {
+							++end;
+						}
+						dilocationLine[metaId] = line.substr(start, end - start);
+					}
+				}
+
+				// Scan instruction lines for branches and returns and
+				// assert every associated !dbg resolves to a non-zero
+				// line.  Skip the `_mlir_*` ABI wrappers — those are
+				// synthesized by MLIR and correctly carry line 0.
+				std::istringstream iss(contents);
+				std::string line;
+				std::string currentFunction;
+				while (std::getline(iss, line)) {
+					if (line.rfind("define ", 0) == 0) {
+						auto at = line.find('@');
+						auto open = (at == std::string::npos) ? std::string::npos : line.find('(', at);
+						currentFunction = (at != std::string::npos && open != std::string::npos)
+						                      ? line.substr(at + 1, open - at - 1)
+						                      : std::string {};
+					} else if (line == "}") {
+						currentFunction.clear();
+					}
+					if (currentFunction.empty() || currentFunction.rfind("_mlir_", 0) == 0) {
+						continue;
+					}
+					const bool isBr = line.find("  br label ") != std::string::npos ||
+					                  line.find("  br i1 ") != std::string::npos ||
+					                  line.find("  ret ") != std::string::npos;
+					if (!isBr) {
+						continue;
+					}
+					const auto dbgKey = line.find("!dbg !");
+					if (dbgKey == std::string::npos) {
+						continue;
+					}
+					auto start = dbgKey + std::string("!dbg !").size();
+					auto end = start;
+					while (end < line.size() && std::isdigit(static_cast<unsigned char>(line[end]))) {
+						++end;
+					}
+					auto id = line.substr(start, end - start);
+					const auto it = dilocationLine.find(id);
+					REQUIRE(it != dilocationLine.end());
+					++terminatorsChecked;
+					if (it->second == "0") {
+						INFO("terminator in @" << currentFunction << " has !dbg !" << id << " line: 0 — "
+						                       << line);
+						sawLineZero = true;
+					}
+				}
+				break;
+			}
+			if (terminatorsChecked > 0) {
+				break;
+			}
+		}
+	}
+	REQUIRE(terminatorsChecked > 0);
+	REQUIRE_FALSE(sawLineZero);
+}
+
+} // namespace nautilus::engine
+
+#endif // ENABLE_TRACING && ENABLE_MLIR_BACKEND

--- a/tools/vscode-nautilus-ir/package-lock.json
+++ b/tools/vscode-nautilus-ir/package-lock.json
@@ -8,13 +8,11 @@
 			"name": "nautilus-ir",
 			"version": "0.1.0",
 			"license": "MIT",
-			"dependencies": {
-				"@vscode/debugadapter": "^1.65.0",
-				"@vscode/debugprotocol": "^1.65.0"
-			},
 			"devDependencies": {
 				"@types/node": "^20.10.0",
 				"@types/vscode": "^1.80.0",
+				"@vscode/debugadapter": "^1.65.0",
+				"@vscode/debugprotocol": "^1.65.0",
 				"dompurify": "^3.1.6",
 				"esbuild": "^0.28.0",
 				"mermaid": "^10.9.0",
@@ -561,6 +559,7 @@
 			"version": "1.68.0",
 			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
 			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/debugprotocol": "1.68.0"
@@ -573,6 +572,7 @@
 			"version": "1.68.0",
 			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
 			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/character-entities": {
@@ -612,6 +612,7 @@
 			"integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -1016,6 +1017,7 @@
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}


### PR DESCRIPTION
Enables line-level debugging of Nautilus JIT'd code in GDB/LLDB. Two
source modes let the user choose which level of IR is the "source file"
they step through:
- mlir: the post-inline MLIR dumped via LocationSnapshotPass
- nautilus-ir: the Nautilus IR dumped via IRGraph::toString()

In either mode, FileLineColLocs flow through lowering, MLIR's built-in
DIScopeForLLVMFuncOpPass materializes a DISubprogram per llvm.func, and
LLVM module flags emit DWARF sections. When mlir.debug.auto_register_gdb
is set (default), the compilation backend attaches LLVM's
GDBRegistrationListener to the OrcJIT so debuggers can discover the
JIT'd object on load.

Follow-up: per-SSA-value llvm.dbg.value intrinsics for `p $N` variable
inspection. Requires a post-conversion pass to build DILocalVariables
scoped by the DISubprograms that DIScopeForLLVMFuncOpPass creates.

New options (string-keyed, all off by default):
  mlir.debug.enable
  mlir.debug.source_mode            "mlir" | "nautilus-ir"
  mlir.debug.source_file            synthesized under $TMPDIR if empty
  mlir.debug.producer               DW_AT_producer
  mlir.debug.dwarf_version          module flag value
  mlir.debug.auto_register_gdb      default true when enable is true