### PR TITLE
Add VS Code extension for Nautilus IR

### DIFF
--- a/tools/vscode-nautilus-ir/.gitignore
+++ b/tools/vscode-nautilus-ir/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+*.vsix
+.vscode-test/

--- a/tools/vscode-nautilus-ir/.vscodeignore
+++ b/tools/vscode-nautilus-ir/.vscodeignore
@@ -1,0 +1,17 @@
+.vscode/**
+.vscode-test/**
+src/**
+.gitignore
+.eslintrc.json
+**/tsconfig.json
+**/*.map
+**/*.ts
+node_modules/**
+!out/**
+!syntaxes/**
+!snippets/**
+!language-configuration/**
+!images/**
+!package.json
+!README.md
+!LICENSE

--- a/tools/vscode-nautilus-ir/README.md
+++ b/tools/vscode-nautilus-ir/README.md
@@ -38,10 +38,12 @@ a navigable, debuggable artifact.
 ### Navigation
 
 - **Document outline / breadcrumbs** — top level: every IR function in
-  the module (a single file may contain `execute()` plus helpers like
-  `add()`, `inner()`, `loopHelper()`, etc.). Children: basic blocks.
-  Grandchildren: SSA definitions with types. Use the outline view,
-  breadcrumb dropdowns, and **Go to Symbol in File** (`Ctrl+Shift+O`).
+  the module, rendered with its typed signature
+  (e.g. `add($1:i32, $2:i32) :i32`). A single file may contain
+  `execute()` plus helpers like `add()`, `inner()`, `loopHelper()`, etc.
+  Children: basic blocks. Grandchildren: SSA definitions with types.
+  Use the outline view, breadcrumb dropdowns, and **Go to Symbol in
+  File** (`Ctrl+Shift+O`).
 - **Go to Definition** (`F12`) on `$N` jumps to its assignment; on
   `Block_N` it jumps to the block header.
 - **Find All References** (`Shift+F12`) for SSA values and block names.

--- a/tools/vscode-nautilus-ir/README.md
+++ b/tools/vscode-nautilus-ir/README.md
@@ -12,13 +12,22 @@ into a navigable, debuggable artifact.
 
 ### Editing
 
-- **Syntax highlighting** for the full Nautilus IR grammar — types
+- **Syntax highlighting** for the full Nautilus IR grammar as emitted into
+  `nautilus/test/data/*/ir/*.trace` — primitive types
   (`i8…i64`, `ui8…ui64`, `f32`, `f64`, `bool`, `ptr`, `void`), arithmetic,
-  bitwise, logical, and comparison operators, control flow (`if`, `br`,
-  `return`, `cmp`, `jmp`), memory (`load`, `store`, `alloca`), casts
-  (`cast_to`, `CAST`), function pointer calls (`func_*`), block headers
-  (`Block_N(...)`, `B0(...)`), the `NautilusIr` / `execute()` wrapper, and
-  the `//NESIR` end marker.
+  bitwise, logical, comparison and unary (`~`, `!`) operators, control
+  flow (`if … ? … : …`, `br`, `return`), memory (`load`, `store`,
+  `alloca Nb`), casts (`cast_to TYPE`), runtime function pointer calls
+  (`func_*(…)`), block headers (`Block_N(...):`), bare-typed
+  declarations (`$N :type`), the `NautilusIr` wrapper, arbitrary
+  function definitions (`execute()`, `add()`, `inner()`, `loopHelper()`,
+  …), and the `//NESIR` end marker. Validated against all 439 IR
+  fixtures in the test corpus with 100% token coverage.
+
+  > Note: the alternate "mnemonic" dialect that appears in
+  > `*/after_ssa/*.trace` and `*/tracing/*.trace` (`EXECUTE: B0(…)
+  > CONST $3 5 :i32 …`) is not handled by this extension. Open those
+  > files as plain text.
 - **Bracket matching, auto-close, smart indent** for `{}`, `()`, `[]`.
 - **Code folding** for the module wrapper, the `execute()` body, and every
   basic block.
@@ -27,17 +36,22 @@ into a navigable, debuggable artifact.
 
 ### Navigation
 
-- **Document outline / breadcrumbs** — every basic block becomes a top-level
-  symbol; every SSA definition (`$N = ...`) is a child symbol with its
-  type. Use the outline view, breadcrumb dropdowns, and **Go to Symbol in
-  File** (`Ctrl+Shift+O`).
+- **Document outline / breadcrumbs** — top level: every IR function in
+  the module (a single file may contain `execute()` plus helpers like
+  `add()`, `inner()`, `loopHelper()`, etc.). Children: basic blocks.
+  Grandchildren: SSA definitions with types. Use the outline view,
+  breadcrumb dropdowns, and **Go to Symbol in File** (`Ctrl+Shift+O`).
 - **Go to Definition** (`F12`) on `$N` jumps to its assignment; on
   `Block_N` it jumps to the block header.
 - **Find All References** (`Shift+F12`) for SSA values and block names.
+  References are scoped to the cursor's enclosing function — `$3` in
+  `add()` is correctly distinguished from `$3` in `execute()`.
 - **Document highlight** — placing the caret on `$N` or `Block_N` paints
-  every occurrence (definition vs. use distinguished).
-- **Rename Symbol** (`F2`) renames an SSA value consistently across the
-  file, including its block-argument occurrences.
+  every occurrence within the enclosing function (definition vs. use
+  distinguished).
+- **Rename Symbol** (`F2`) renames an SSA value consistently across its
+  enclosing function, including its block-argument occurrences. Other
+  functions in the same module are untouched.
 - **Hover** shows the SSA value's defining expression, type, and use count;
   for blocks it lists arguments, predecessors, successors, and instruction
   count; for types and operations it shows inline docs.
@@ -56,51 +70,92 @@ Light static checks are surfaced in the Problems panel:
 - Branches that target a block that does not exist in the file.
 - Blocks with no `return` / `br` / `if` terminator.
 
-### Debugging (gdb)
+### Debugging (gdb, via the C++ host program)
+
+> **Important model.** A Nautilus IR file is **not** a standalone executable.
+> It is loaded by a C++ host program (an `ExecutionTest` binary, the demo
+> JIT, a NebulaStream worker, your own embedding, …) which JIT-compiles
+> the IR via the Nautilus engine. To debug an IR file you launch *that
+> host program* under gdb. Once execution enters the JIT'd code, gdb
+> uses the source-line debug info that Nautilus emits to map back to
+> file/line positions in the IR file — at which point all the usual
+> gdb facilities (gutter breakpoints, step, variables, watch) light up.
 
 The extension contributes a `nautilus-ir-gdb` debug adapter that drives
-`gdb --interpreter=mi2` underneath, exposing the full VS Code debugging
-UI for Nautilus IR files:
+`gdb --interpreter=mi2` underneath:
 
-- Set/clear breakpoints in the IR gutter (with conditions and hit counts).
+- Set/clear breakpoints in the IR gutter (with conditions, hit counts,
+  and log-points). Breakpoints are inserted with `-break-insert -f` so
+  they remain pending until the JIT registers symbols for the IR file.
 - Step over / into / out, continue, pause, restart.
 - Live **Variables** view (locals, arguments, registers).
-- **Watch** and **Hover** evaluation through `data-evaluate-expression`.
-- Stack trace, call hierarchy navigation across frames.
-- Console output forwarded from gdb (including target stdout/stderr).
-- Conditional & log-point breakpoints.
+- **Watch** and **Hover** evaluation via `data-evaluate-expression`.
+- Stack trace and frame navigation across host C++ ↔ JIT'd IR frames.
+- Console / stdout / stderr forwarded from gdb and the inferior.
+- Optional one-shot break at the IR file's first instruction
+  (`stopAtIrEntry`) so execution halts exactly when control reaches
+  your IR.
 
 #### Quick start
 
-1. Open a `.nesir` / `.trace` file.
-2. Click **Run and Debug** in the side bar, then **Nautilus IR (gdb)**.
-3. The pre-supplied launch configuration runs
+1. Build a host program with debug info (`cmake -DCMAKE_BUILD_TYPE=Debug ..`).
+2. Open a `.nesir` / `.trace` file.
+3. Click **Run and Debug** in the side bar, then **Nautilus IR via host
+   program (gdb)**. Edit `program` in `launch.json` to point at the host
+   binary that loads this IR (e.g. `${workspaceFolder}/build/nautilus/test/execution-tests/ExecutionTest`).
+4. Use the gutter to set breakpoints in the IR file. The first time you
+   hit Run, breakpoints will show as pending until the JIT compiles the
+   IR; after that they bind and execution stops normally.
 
-   ```jsonc
-   {
-       "type": "nautilus-ir-gdb",
-       "request": "launch",
-       "name": "Debug Nautilus IR (gdb)",
-       "program": "${file}",
-       "stopOnEntry": true,
-       "cwd": "${workspaceFolder}"
-   }
-   ```
+Alternatively, right-click an IR file and pick **Nautilus IR: Debug
+Current File with gdb** — it prompts you to select the host executable
+and remembers the choice in workspace settings.
 
-   You can also right-click the file and pick **Nautilus IR: Debug Current
-   File with gdb**.
+Example `launch.json`:
 
-#### Configuration options
+```jsonc
+{
+    "type": "nautilus-ir-gdb",
+    "request": "launch",
+    "name": "Debug Nautilus IR via host program (gdb)",
+    "program": "${workspaceFolder}/build/nautilus/test/execution-tests/ExecutionTest",
+    "args": ["--gtest_filter=ExecutionTest.MyTest"],
+    "irFile": "${file}",
+    "stopAtIrEntry": true,
+    "sourceDirectories": [
+        "${workspaceFolder}/nautilus/test/data"
+    ],
+    "cwd": "${workspaceFolder}"
+}
+```
+
+#### Launch configuration attributes
+
+| Field                | Purpose                                                                                                                                                       |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `program`            | C++ host executable to launch under gdb. **Required.**                                                                                                        |
+| `args`               | Command-line arguments forwarded to the host process.                                                                                                         |
+| `irFile`             | Optional Nautilus IR file of interest. Adds its directory to gdb's source search path and, if `stopAtIrEntry` is true, sets a one-shot entry breakpoint.      |
+| `stopAtIrEntry`      | When true (default), break on the first instruction of the entry block of `irFile`.                                                                           |
+| `stopOnEntry`        | When true, break at host `main()` before running anything else.                                                                                               |
+| `sourceDirectories`  | Extra directories appended to gdb's source search path (`directory` command).                                                                                 |
+| `cwd`                | Working directory for the gdb process.                                                                                                                        |
+| `env`                | Extra environment variables for the inferior.                                                                                                                 |
+| `gdbPath`/`gdbArgs`  | Override the gdb executable / pass extra args to gdb itself.                                                                                                  |
+| `trace`              | Log MI/DAP traffic to the debug console for diagnostics.                                                                                                      |
+
+For attach mode, additionally provide `pid`. The `irFile` field is still
+honored so gdb can locate the IR source.
+
+#### Workspace settings
 
 | Setting                              | Default | Purpose                                                                          |
 |--------------------------------------|---------|----------------------------------------------------------------------------------|
-| `nautilusIr.gdbPath`                 | `gdb`   | Path to the gdb executable.                                                      |
+| `nautilusIr.gdbPath`                 | `gdb`   | Default gdb executable.                                                          |
 | `nautilusIr.gdbExtraArgs`            | `[]`    | Extra args appended to every gdb invocation.                                     |
 | `nautilusIr.highlightDefinitions`    | `true`  | Highlight all uses of an SSA value when the cursor is on its definition.         |
 | `nautilusIr.codeLens`                | `true`  | Show CodeLens above every block.                                                 |
-| `nautilusIr.showInlayTypes`          | `true`  | Reserved for future inlay-hint support.                                          |
-
-You can also override `gdbPath` and `gdbArgs` per launch configuration.
+| `nautilusIr.lastHostProgram`         | `""`    | Remembered host program for the ad-hoc "Debug Current File" command.             |
 
 ### Commands
 

--- a/tools/vscode-nautilus-ir/README.md
+++ b/tools/vscode-nautilus-ir/README.md
@@ -4,25 +4,26 @@ A first-class editor experience for the intermediate representation (IR)
 emitted by [Nautilus](https://github.com/nebulastream/nautilus), the tracing
 JIT compiler used by NebulaStream.
 
-This extension turns plain `.nesir` / `.trace` IR dumps from the Nautilus
-test suite, the engine's `dump.ir = true` option, or any custom pipeline
-into a navigable, debuggable artifact.
+This extension turns plain `.nautilus` IR dumps from the Nautilus test
+suite, the engine's `dump.ir = true` option, or any custom pipeline into
+a navigable, debuggable artifact.
 
 ## Features
 
 ### Editing
 
 - **Syntax highlighting** for the full Nautilus IR grammar as emitted into
-  `nautilus/test/data/*/ir/*.trace` — primitive types
+  `nautilus/test/data/*/ir/*.nautilus` — primitive types
   (`i8…i64`, `ui8…ui64`, `f32`, `f64`, `bool`, `ptr`, `void`), arithmetic,
   bitwise, logical, comparison and unary (`~`, `!`) operators, control
   flow (`if … ? … : …`, `br`, `return`), memory (`load`, `store`,
   `alloca Nb`), casts (`cast_to TYPE`), runtime function pointer calls
   (`func_*(…)`), block headers (`Block_N(...):`), bare-typed
-  declarations (`$N :type`), the `NautilusIr` wrapper, arbitrary
-  function definitions (`execute()`, `add()`, `inner()`, `loopHelper()`,
-  …), and the `//NESIR` end marker. Validated against all 439 IR
-  fixtures in the test corpus with 100% token coverage.
+  declarations (`$N :type`), the `nautilus { … }` module wrapper,
+  arbitrary function definitions (`execute()`, `add()`, `inner()`,
+  `loopHelper()`, …), and the `//nautilus` end marker. Validated
+  against all 439 IR fixtures in the test corpus with 100% token
+  coverage.
 
   > Note: the alternate "mnemonic" dialect that appears in
   > `*/after_ssa/*.trace` and `*/tracing/*.trace` (`EXECUTE: B0(…)
@@ -99,7 +100,7 @@ The extension contributes a `nautilus-ir-gdb` debug adapter that drives
 #### Quick start
 
 1. Build a host program with debug info (`cmake -DCMAKE_BUILD_TYPE=Debug ..`).
-2. Open a `.nesir` / `.trace` file.
+2. Open a `.nautilus` file.
 3. Click **Run and Debug** in the side bar, then **Nautilus IR via host
    program (gdb)**. Edit `program` in `launch.json` to point at the host
    binary that loads this IR (e.g. `${workspaceFolder}/build/nautilus/test/execution-tests/ExecutionTest`).
@@ -184,22 +185,20 @@ vsce package
 
 ## File associations
 
-The extension registers itself for `.nesir`, `.trace`, and `.nir`
-extensions. If your project keeps `.trace` files used by another tool, set
+The extension registers itself for the `.nautilus` extension. If you also
+want it to handle older IR dumps that still carry a different extension
+(e.g. legacy `.trace` files from before the Nautilus rename), add an
+explicit association in your settings:
 
 ```jsonc
 "files.associations": {
-    "**/test/data/**/ir/*.trace": "nautilus-ir",
-    "**/test/data/**/after_ssa/*.trace": "nautilus-ir",
-    "**/test/data/**/after_constant_folding/*.trace": "nautilus-ir"
+    "**/test/data/**/ir/*.trace": "nautilus-ir"
 }
 ```
 
-so only Nautilus traces opt in.
-
 ## Example
 
-Open `nautilus/test/data/loop-tests/ir/collatz.trace` and you should see
+Open `nautilus/test/data/loop-tests/ir/collatz.nautilus` and you should see
 syntax-highlighted blocks, a populated outline, and CodeLens annotations
 above each `Block_N(...)` showing predecessor and successor counts.
 

--- a/tools/vscode-nautilus-ir/README.md
+++ b/tools/vscode-nautilus-ir/README.md
@@ -1,0 +1,153 @@
+# Nautilus IR — VS Code Extension
+
+A first-class editor experience for the intermediate representation (IR)
+emitted by [Nautilus](https://github.com/nebulastream/nautilus), the tracing
+JIT compiler used by NebulaStream.
+
+This extension turns plain `.nesir` / `.trace` IR dumps from the Nautilus
+test suite, the engine's `dump.ir = true` option, or any custom pipeline
+into a navigable, debuggable artifact.
+
+## Features
+
+### Editing
+
+- **Syntax highlighting** for the full Nautilus IR grammar — types
+  (`i8…i64`, `ui8…ui64`, `f32`, `f64`, `bool`, `ptr`, `void`), arithmetic,
+  bitwise, logical, and comparison operators, control flow (`if`, `br`,
+  `return`, `cmp`, `jmp`), memory (`load`, `store`, `alloca`), casts
+  (`cast_to`, `CAST`), function pointer calls (`func_*`), block headers
+  (`Block_N(...)`, `B0(...)`), the `NautilusIr` / `execute()` wrapper, and
+  the `//NESIR` end marker.
+- **Bracket matching, auto-close, smart indent** for `{}`, `()`, `[]`.
+- **Code folding** for the module wrapper, the `execute()` body, and every
+  basic block.
+- **Snippets** (`nesir`, `block`, `br`, `if`, `const`, `cast`, `load`,
+  `store`, `ret`, `call`) for quickly authoring IR by hand.
+
+### Navigation
+
+- **Document outline / breadcrumbs** — every basic block becomes a top-level
+  symbol; every SSA definition (`$N = ...`) is a child symbol with its
+  type. Use the outline view, breadcrumb dropdowns, and **Go to Symbol in
+  File** (`Ctrl+Shift+O`).
+- **Go to Definition** (`F12`) on `$N` jumps to its assignment; on
+  `Block_N` it jumps to the block header.
+- **Find All References** (`Shift+F12`) for SSA values and block names.
+- **Document highlight** — placing the caret on `$N` or `Block_N` paints
+  every occurrence (definition vs. use distinguished).
+- **Rename Symbol** (`F2`) renames an SSA value consistently across the
+  file, including its block-argument occurrences.
+- **Hover** shows the SSA value's defining expression, type, and use count;
+  for blocks it lists arguments, predecessors, successors, and instruction
+  count; for types and operations it shows inline docs.
+- **CodeLens** above every block: `N preds · M succs · K insn`.
+- **Status bar** indicator for the block currently containing the cursor,
+  with a quick tooltip of its CFG context.
+- **Quick block jumper** — `Ctrl+Shift+B` (`Cmd+Shift+B` on macOS) opens a
+  Quick Pick listing every block with its successor summary.
+
+### Diagnostics
+
+Light static checks are surfaced in the Problems panel:
+
+- Undefined SSA references (`$N` used without an assignment or block-arg
+  binding).
+- Branches that target a block that does not exist in the file.
+- Blocks with no `return` / `br` / `if` terminator.
+
+### Debugging (gdb)
+
+The extension contributes a `nautilus-ir-gdb` debug adapter that drives
+`gdb --interpreter=mi2` underneath, exposing the full VS Code debugging
+UI for Nautilus IR files:
+
+- Set/clear breakpoints in the IR gutter (with conditions and hit counts).
+- Step over / into / out, continue, pause, restart.
+- Live **Variables** view (locals, arguments, registers).
+- **Watch** and **Hover** evaluation through `data-evaluate-expression`.
+- Stack trace, call hierarchy navigation across frames.
+- Console output forwarded from gdb (including target stdout/stderr).
+- Conditional & log-point breakpoints.
+
+#### Quick start
+
+1. Open a `.nesir` / `.trace` file.
+2. Click **Run and Debug** in the side bar, then **Nautilus IR (gdb)**.
+3. The pre-supplied launch configuration runs
+
+   ```jsonc
+   {
+       "type": "nautilus-ir-gdb",
+       "request": "launch",
+       "name": "Debug Nautilus IR (gdb)",
+       "program": "${file}",
+       "stopOnEntry": true,
+       "cwd": "${workspaceFolder}"
+   }
+   ```
+
+   You can also right-click the file and pick **Nautilus IR: Debug Current
+   File with gdb**.
+
+#### Configuration options
+
+| Setting                              | Default | Purpose                                                                          |
+|--------------------------------------|---------|----------------------------------------------------------------------------------|
+| `nautilusIr.gdbPath`                 | `gdb`   | Path to the gdb executable.                                                      |
+| `nautilusIr.gdbExtraArgs`            | `[]`    | Extra args appended to every gdb invocation.                                     |
+| `nautilusIr.highlightDefinitions`    | `true`  | Highlight all uses of an SSA value when the cursor is on its definition.         |
+| `nautilusIr.codeLens`                | `true`  | Show CodeLens above every block.                                                 |
+| `nautilusIr.showInlayTypes`          | `true`  | Reserved for future inlay-hint support.                                          |
+
+You can also override `gdbPath` and `gdbArgs` per launch configuration.
+
+### Commands
+
+| Command                                          | Default keybinding         |
+|--------------------------------------------------|----------------------------|
+| `Nautilus IR: Go to Block...`                    | `Ctrl/Cmd+Shift+B`         |
+| `Nautilus IR: Show File Statistics`              | —                          |
+| `Nautilus IR: Toggle SSA Definition Highlight`   | —                          |
+| `Nautilus IR: Debug Current File with gdb`       | —                          |
+
+## Building from source
+
+```bash
+cd tools/vscode-nautilus-ir
+npm install
+npm run compile           # tsc → ./out
+# Open this folder in VS Code and press F5 to launch an Extension Host.
+```
+
+To package a `.vsix`:
+
+```bash
+npm install -g @vscode/vsce
+vsce package
+```
+
+## File associations
+
+The extension registers itself for `.nesir`, `.trace`, and `.nir`
+extensions. If your project keeps `.trace` files used by another tool, set
+
+```jsonc
+"files.associations": {
+    "**/test/data/**/ir/*.trace": "nautilus-ir",
+    "**/test/data/**/after_ssa/*.trace": "nautilus-ir",
+    "**/test/data/**/after_constant_folding/*.trace": "nautilus-ir"
+}
+```
+
+so only Nautilus traces opt in.
+
+## Example
+
+Open `nautilus/test/data/loop-tests/ir/collatz.trace` and you should see
+syntax-highlighted blocks, a populated outline, and CodeLens annotations
+above each `Block_N(...)` showing predecessor and successor counts.
+
+## License
+
+MIT — same as the Nautilus project itself.

--- a/tools/vscode-nautilus-ir/images/file-icon-dark.svg
+++ b/tools/vscode-nautilus-ir/images/file-icon-dark.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+	<rect x="2" y="2" width="28" height="28" rx="4" fill="#3b82f6"/>
+	<text x="16" y="21" font-family="monospace" font-size="11" font-weight="bold" text-anchor="middle" fill="#0d1117">IR</text>
+	<circle cx="8" cy="8" r="2" fill="#3fb950"/>
+	<circle cx="24" cy="24" r="2" fill="#f78166"/>
+</svg>

--- a/tools/vscode-nautilus-ir/images/file-icon-light.svg
+++ b/tools/vscode-nautilus-ir/images/file-icon-light.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+	<rect x="2" y="2" width="28" height="28" rx="4" fill="#1f6feb"/>
+	<text x="16" y="21" font-family="monospace" font-size="11" font-weight="bold" text-anchor="middle" fill="white">IR</text>
+	<circle cx="8" cy="8" r="2" fill="#7ee787"/>
+	<circle cx="24" cy="24" r="2" fill="#ffa657"/>
+</svg>

--- a/tools/vscode-nautilus-ir/images/icon.svg
+++ b/tools/vscode-nautilus-ir/images/icon.svg
@@ -18,5 +18,5 @@
 		<line x1="64" y1="88" x2="32" y2="96"/>
 		<line x1="64" y1="88" x2="96" y2="96"/>
 	</g>
-	<text x="64" y="62" font-family="monospace" font-size="14" font-weight="bold" text-anchor="middle" fill="white">NESIR</text>
+	<text x="64" y="62" font-family="monospace" font-size="13" font-weight="bold" text-anchor="middle" fill="white">nautilus</text>
 </svg>

--- a/tools/vscode-nautilus-ir/images/icon.svg
+++ b/tools/vscode-nautilus-ir/images/icon.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+	<defs>
+		<linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+			<stop offset="0" stop-color="#1f6feb"/>
+			<stop offset="1" stop-color="#0d419d"/>
+		</linearGradient>
+	</defs>
+	<rect width="128" height="128" rx="20" fill="url(#g)"/>
+	<g fill="none" stroke="#7ee787" stroke-width="3" stroke-linecap="round">
+		<circle cx="32" cy="40" r="8"/>
+		<circle cx="96" cy="40" r="8"/>
+		<circle cx="64" cy="80" r="8"/>
+		<circle cx="32" cy="104" r="8"/>
+		<circle cx="96" cy="104" r="8"/>
+		<line x1="32" y1="48" x2="64" y2="72"/>
+		<line x1="96" y1="48" x2="64" y2="72"/>
+		<line x1="64" y1="88" x2="32" y2="96"/>
+		<line x1="64" y1="88" x2="96" y2="96"/>
+	</g>
+	<text x="64" y="62" font-family="monospace" font-size="14" font-weight="bold" text-anchor="middle" fill="white">NESIR</text>
+</svg>

--- a/tools/vscode-nautilus-ir/language-configuration/language-configuration.json
+++ b/tools/vscode-nautilus-ir/language-configuration/language-configuration.json
@@ -1,0 +1,43 @@
+{
+	"comments": {
+		"lineComment": "//",
+		"blockComment": ["/*", "*/"]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] }
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"]
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*(NautilusIr\\s*\\{|execute\\s*\\(\\s*\\)\\s*\\{|Block_\\d+\\b)",
+			"end": "^\\s*(\\}|//\\s*NESIR)"
+		},
+		"offSide": false
+	},
+	"wordPattern": "(\\$?[A-Za-z_][A-Za-z0-9_]*)|(\\$\\d+)",
+	"indentationRules": {
+		"increaseIndentPattern": "^\\s*(NautilusIr\\s*\\{|execute\\s*\\(\\s*\\)\\s*\\{|Block_\\d+.*:)\\s*$",
+		"decreaseIndentPattern": "^\\s*\\}\\s*(//.*)?$"
+	},
+	"onEnterRules": [
+		{
+			"beforeText": "^\\s*Block_\\d+\\b.*:\\s*$",
+			"action": { "indent": "indent" }
+		}
+	]
+}

--- a/tools/vscode-nautilus-ir/language-configuration/language-configuration.json
+++ b/tools/vscode-nautilus-ir/language-configuration/language-configuration.json
@@ -24,14 +24,14 @@
 	],
 	"folding": {
 		"markers": {
-			"start": "^\\s*(NautilusIr\\s*\\{|execute\\s*\\(\\s*\\)\\s*\\{|Block_\\d+\\b)",
-			"end": "^\\s*(\\}|//\\s*NESIR)"
+			"start": "^\\s*(nautilus\\s*\\{|[A-Za-z_][A-Za-z0-9_]*\\s*\\(\\s*\\)\\s*\\{|Block_\\d+\\b)",
+			"end": "^\\s*(\\}|//\\s*nautilus)"
 		},
 		"offSide": false
 	},
 	"wordPattern": "(\\$?[A-Za-z_][A-Za-z0-9_]*)|(\\$\\d+)",
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*(NautilusIr\\s*\\{|execute\\s*\\(\\s*\\)\\s*\\{|Block_\\d+.*:)\\s*$",
+		"increaseIndentPattern": "^\\s*(nautilus\\s*\\{|[A-Za-z_][A-Za-z0-9_]*\\s*\\(\\s*\\)\\s*\\{|Block_\\d+.*:)\\s*$",
 		"decreaseIndentPattern": "^\\s*\\}\\s*(//.*)?$"
 	},
 	"onEnterRules": [

--- a/tools/vscode-nautilus-ir/package-lock.json
+++ b/tools/vscode-nautilus-ir/package-lock.json
@@ -1,0 +1,81 @@
+{
+	"name": "nautilus-ir",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "nautilus-ir",
+			"version": "0.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"@vscode/debugadapter": "^1.65.0",
+				"@vscode/debugprotocol": "^1.65.0"
+			},
+			"devDependencies": {
+				"@types/node": "^20.10.0",
+				"@types/vscode": "^1.80.0",
+				"typescript": "^5.4.0"
+			},
+			"engines": {
+				"vscode": "^1.80.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/vscode": {
+			"version": "1.116.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+			"integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vscode/debugadapter": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+			"license": "MIT",
+			"dependencies": {
+				"@vscode/debugprotocol": "1.68.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@vscode/debugprotocol": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+			"license": "MIT"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		}
+	}
+}

--- a/tools/vscode-nautilus-ir/package.json
+++ b/tools/vscode-nautilus-ir/package.json
@@ -118,6 +118,12 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Show CodeLens above blocks (predecessors / successors / argument count)."
+				},
+				"nautilusIr.lastHostProgram": {
+					"type": "string",
+					"default": "",
+					"scope": "resource",
+					"description": "Last-used C++ host executable for ad-hoc gdb debugging. Updated automatically by the 'Debug Current File with gdb' command."
 				}
 			}
 		},
@@ -143,8 +149,29 @@
 						"properties": {
 							"program": {
 								"type": "string",
-								"description": "Absolute path to the Nautilus IR file to debug.",
+								"description": "Absolute path to the C++ host executable that loads and runs the Nautilus IR (e.g. an ExecutionTest binary or your own demo). Nautilus IR is never executed on its own — gdb debugs the host process and stops in JIT-compiled IR code via source-line debug info.",
+								"default": "${workspaceFolder}/build/nautilus/test/execution-tests/ExecutionTest"
+							},
+							"args": {
+								"type": "array",
+								"items": { "type": "string" },
+								"description": "Command-line arguments forwarded to the host program.",
+								"default": []
+							},
+							"irFile": {
+								"type": "string",
+								"description": "Optional Nautilus IR file the host program will load. If set, the adapter will tell gdb to look for source files in this directory and pre-set a breakpoint on its first instruction (when stopAtIrEntry is true).",
 								"default": "${file}"
+							},
+							"stopAtIrEntry": {
+								"type": "boolean",
+								"description": "If true, set a one-shot breakpoint at the first instruction of irFile so execution halts as soon as control reaches the JIT-compiled IR.",
+								"default": true
+							},
+							"stopOnEntry": {
+								"type": "boolean",
+								"description": "Stop at main() of the host program before running.",
+								"default": false
 							},
 							"gdbPath": {
 								"type": "string",
@@ -154,13 +181,14 @@
 							"gdbArgs": {
 								"type": "array",
 								"items": { "type": "string" },
-								"description": "Additional command-line arguments passed to gdb.",
+								"description": "Additional command-line arguments passed to gdb itself.",
 								"default": []
 							},
-							"stopOnEntry": {
-								"type": "boolean",
-								"description": "Stop at the first instruction of the entry block.",
-								"default": true
+							"sourceDirectories": {
+								"type": "array",
+								"items": { "type": "string" },
+								"description": "Extra directories that gdb should search for source files (forwarded as `directory` commands). Useful when the IR file lives outside the host program's source tree.",
+								"default": []
 							},
 							"cwd": {
 								"type": "string",
@@ -169,12 +197,12 @@
 							},
 							"env": {
 								"type": "object",
-								"description": "Environment variables forwarded to gdb.",
+								"description": "Environment variables forwarded to the inferior.",
 								"default": {}
 							},
 							"trace": {
 								"type": "boolean",
-								"description": "Log all DAP traffic to the debug console for diagnostics.",
+								"description": "Log all DAP/MI traffic to the debug console for diagnostics.",
 								"default": false
 							}
 						}
@@ -187,12 +215,22 @@
 						"properties": {
 							"program": {
 								"type": "string",
-								"description": "Path to the Nautilus IR file currently being executed.",
-								"default": "${file}"
+								"description": "Path to the host C++ executable currently running the Nautilus IR.",
+								"default": "${workspaceFolder}/build/nautilus/test/execution-tests/ExecutionTest"
 							},
 							"pid": {
 								"type": "number",
 								"description": "Process id to attach to."
+							},
+							"irFile": {
+								"type": "string",
+								"description": "Optional Nautilus IR file currently of interest (used to add a source-search directory).",
+								"default": "${file}"
+							},
+							"sourceDirectories": {
+								"type": "array",
+								"items": { "type": "string" },
+								"default": []
 							},
 							"gdbPath": {
 								"type": "string",
@@ -205,34 +243,39 @@
 					{
 						"type": "nautilus-ir-gdb",
 						"request": "launch",
-						"name": "Debug Nautilus IR (gdb)",
-						"program": "${file}",
-						"stopOnEntry": true,
+						"name": "Debug Nautilus IR via host program (gdb)",
+						"program": "${workspaceFolder}/build/nautilus/test/execution-tests/ExecutionTest",
+						"args": [],
+						"irFile": "${file}",
+						"stopAtIrEntry": true,
 						"cwd": "${workspaceFolder}"
 					}
 				],
 				"configurationSnippets": [
 					{
-						"label": "Nautilus IR: Launch with gdb",
-						"description": "Debug a .nesir/.trace file using gdb.",
+						"label": "Nautilus IR: Launch host program with gdb",
+						"description": "Debug a Nautilus IR file by launching the C++ host program that loads it under gdb.",
 						"body": {
 							"type": "nautilus-ir-gdb",
 							"request": "launch",
-							"name": "Debug Nautilus IR (gdb)",
-							"program": "^\"\\${file}\"",
-							"stopOnEntry": true,
+							"name": "Debug Nautilus IR via host program (gdb)",
+							"program": "^\"\\${workspaceFolder}/build/path/to/host_executable\"",
+							"args": [],
+							"irFile": "^\"\\${file}\"",
+							"stopAtIrEntry": true,
 							"cwd": "^\"\\${workspaceFolder}\""
 						}
 					},
 					{
-						"label": "Nautilus IR: Attach with gdb",
-						"description": "Attach to a running process executing Nautilus IR.",
+						"label": "Nautilus IR: Attach to host process with gdb",
+						"description": "Attach to a running C++ host process executing Nautilus IR.",
 						"body": {
 							"type": "nautilus-ir-gdb",
 							"request": "attach",
-							"name": "Attach to Nautilus IR (gdb)",
-							"program": "^\"\\${file}\"",
-							"pid": 0
+							"name": "Attach to Nautilus IR host (gdb)",
+							"program": "^\"\\${workspaceFolder}/build/path/to/host_executable\"",
+							"pid": 0,
+							"irFile": "^\"\\${file}\""
 						}
 					}
 				]

--- a/tools/vscode-nautilus-ir/package.json
+++ b/tools/vscode-nautilus-ir/package.json
@@ -1,0 +1,287 @@
+{
+	"name": "nautilus-ir",
+	"displayName": "Nautilus IR",
+	"description": "Syntax highlighting, navigation, and gdb-based debugging for Nautilus IR (.nesir / .trace) files emitted by the Nautilus tracing JIT compiler.",
+	"version": "0.1.0",
+	"publisher": "nebulastream",
+	"license": "MIT",
+	"engines": {
+		"vscode": "^1.80.0"
+	},
+	"categories": [
+		"Programming Languages",
+		"Snippets",
+		"Debuggers"
+	],
+	"keywords": [
+		"nautilus",
+		"nebulastream",
+		"ir",
+		"jit",
+		"compiler",
+		"ssa",
+		"nesir"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/nebulastream/nautilus.git"
+	},
+	"activationEvents": [
+		"onLanguage:nautilus-ir",
+		"onDebug",
+		"onCommand:nautilus-ir.dumpInfo",
+		"onCommand:nautilus-ir.gotoBlock"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"languages": [
+			{
+				"id": "nautilus-ir",
+				"aliases": [
+					"Nautilus IR",
+					"NESIR",
+					"nautilus-ir"
+				],
+				"extensions": [
+					".nesir",
+					".trace",
+					".nir"
+				],
+				"configuration": "./language-configuration/language-configuration.json",
+				"icon": {
+					"light": "./images/file-icon-light.svg",
+					"dark": "./images/file-icon-dark.svg"
+				},
+				"firstLine": "^\\s*NautilusIr\\s*\\{"
+			}
+		],
+		"grammars": [
+			{
+				"language": "nautilus-ir",
+				"scopeName": "source.nautilus-ir",
+				"path": "./syntaxes/nautilus-ir.tmLanguage.json"
+			}
+		],
+		"snippets": [
+			{
+				"language": "nautilus-ir",
+				"path": "./snippets/nautilus-ir.code-snippets"
+			}
+		],
+		"commands": [
+			{
+				"command": "nautilus-ir.gotoBlock",
+				"title": "Nautilus IR: Go to Block...",
+				"category": "Nautilus IR"
+			},
+			{
+				"command": "nautilus-ir.dumpInfo",
+				"title": "Nautilus IR: Show File Statistics",
+				"category": "Nautilus IR"
+			},
+			{
+				"command": "nautilus-ir.toggleFollowDefinitions",
+				"title": "Nautilus IR: Toggle SSA Definition Highlight",
+				"category": "Nautilus IR"
+			},
+			{
+				"command": "nautilus-ir.debugWithGdb",
+				"title": "Nautilus IR: Debug Current File with gdb",
+				"category": "Nautilus IR"
+			}
+		],
+		"configuration": {
+			"title": "Nautilus IR",
+			"properties": {
+				"nautilusIr.gdbPath": {
+					"type": "string",
+					"default": "gdb",
+					"description": "Path to the gdb executable used for debugging Nautilus IR files."
+				},
+				"nautilusIr.gdbExtraArgs": {
+					"type": "array",
+					"items": { "type": "string" },
+					"default": [],
+					"description": "Extra command-line arguments forwarded to gdb when launching."
+				},
+				"nautilusIr.highlightDefinitions": {
+					"type": "boolean",
+					"default": true,
+					"description": "Highlight all uses of an SSA value when the cursor is on its definition."
+				},
+				"nautilusIr.showInlayTypes": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show inline summary information for blocks and operations."
+				},
+				"nautilusIr.codeLens": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show CodeLens above blocks (predecessors / successors / argument count)."
+				}
+			}
+		},
+		"breakpoints": [
+			{
+				"language": "nautilus-ir"
+			}
+		],
+		"debuggers": [
+			{
+				"type": "nautilus-ir-gdb",
+				"label": "Nautilus IR (gdb)",
+				"languages": [
+					"nautilus-ir"
+				],
+				"program": "./out/debugAdapter.js",
+				"runtime": "node",
+				"configurationAttributes": {
+					"launch": {
+						"required": [
+							"program"
+						],
+						"properties": {
+							"program": {
+								"type": "string",
+								"description": "Absolute path to the Nautilus IR file to debug.",
+								"default": "${file}"
+							},
+							"gdbPath": {
+								"type": "string",
+								"description": "Override the gdb executable used for this session.",
+								"default": "gdb"
+							},
+							"gdbArgs": {
+								"type": "array",
+								"items": { "type": "string" },
+								"description": "Additional command-line arguments passed to gdb.",
+								"default": []
+							},
+							"stopOnEntry": {
+								"type": "boolean",
+								"description": "Stop at the first instruction of the entry block.",
+								"default": true
+							},
+							"cwd": {
+								"type": "string",
+								"description": "Working directory for the gdb process.",
+								"default": "${workspaceFolder}"
+							},
+							"env": {
+								"type": "object",
+								"description": "Environment variables forwarded to gdb.",
+								"default": {}
+							},
+							"trace": {
+								"type": "boolean",
+								"description": "Log all DAP traffic to the debug console for diagnostics.",
+								"default": false
+							}
+						}
+					},
+					"attach": {
+						"required": [
+							"program",
+							"pid"
+						],
+						"properties": {
+							"program": {
+								"type": "string",
+								"description": "Path to the Nautilus IR file currently being executed.",
+								"default": "${file}"
+							},
+							"pid": {
+								"type": "number",
+								"description": "Process id to attach to."
+							},
+							"gdbPath": {
+								"type": "string",
+								"default": "gdb"
+							}
+						}
+					}
+				},
+				"initialConfigurations": [
+					{
+						"type": "nautilus-ir-gdb",
+						"request": "launch",
+						"name": "Debug Nautilus IR (gdb)",
+						"program": "${file}",
+						"stopOnEntry": true,
+						"cwd": "${workspaceFolder}"
+					}
+				],
+				"configurationSnippets": [
+					{
+						"label": "Nautilus IR: Launch with gdb",
+						"description": "Debug a .nesir/.trace file using gdb.",
+						"body": {
+							"type": "nautilus-ir-gdb",
+							"request": "launch",
+							"name": "Debug Nautilus IR (gdb)",
+							"program": "^\"\\${file}\"",
+							"stopOnEntry": true,
+							"cwd": "^\"\\${workspaceFolder}\""
+						}
+					},
+					{
+						"label": "Nautilus IR: Attach with gdb",
+						"description": "Attach to a running process executing Nautilus IR.",
+						"body": {
+							"type": "nautilus-ir-gdb",
+							"request": "attach",
+							"name": "Attach to Nautilus IR (gdb)",
+							"program": "^\"\\${file}\"",
+							"pid": 0
+						}
+					}
+				]
+			}
+		],
+		"menus": {
+			"editor/context": [
+				{
+					"when": "resourceLangId == nautilus-ir",
+					"command": "nautilus-ir.gotoBlock",
+					"group": "navigation@1"
+				},
+				{
+					"when": "resourceLangId == nautilus-ir",
+					"command": "nautilus-ir.debugWithGdb",
+					"group": "navigation@2"
+				}
+			],
+			"editor/title": [
+				{
+					"when": "resourceLangId == nautilus-ir",
+					"command": "nautilus-ir.dumpInfo",
+					"group": "navigation"
+				}
+			]
+		},
+		"keybindings": [
+			{
+				"command": "nautilus-ir.gotoBlock",
+				"key": "ctrl+shift+b",
+				"mac": "cmd+shift+b",
+				"when": "editorLangId == nautilus-ir"
+			}
+		]
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"package": "vsce package",
+		"lint": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@vscode/debugadapter": "^1.65.0",
+		"@vscode/debugprotocol": "^1.65.0"
+	},
+	"devDependencies": {
+		"@types/node": "^20.10.0",
+		"@types/vscode": "^1.80.0",
+		"typescript": "^5.4.0"
+	}
+}

--- a/tools/vscode-nautilus-ir/package.json
+++ b/tools/vscode-nautilus-ir/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "nautilus-ir",
 	"displayName": "Nautilus IR",
-	"description": "Syntax highlighting, navigation, and gdb-based debugging for Nautilus IR (.nesir / .trace) files emitted by the Nautilus tracing JIT compiler.",
+	"description": "Syntax highlighting, navigation, and gdb-based debugging for Nautilus IR (.nautilus) files emitted by the Nautilus tracing JIT compiler.",
 	"version": "0.1.0",
 	"publisher": "nebulastream",
 	"license": "MIT",
@@ -19,8 +19,7 @@
 		"ir",
 		"jit",
 		"compiler",
-		"ssa",
-		"nesir"
+		"ssa"
 	],
 	"repository": {
 		"type": "git",
@@ -39,20 +38,17 @@
 				"id": "nautilus-ir",
 				"aliases": [
 					"Nautilus IR",
-					"NESIR",
 					"nautilus-ir"
 				],
 				"extensions": [
-					".nesir",
-					".trace",
-					".nir"
+					".nautilus"
 				],
 				"configuration": "./language-configuration/language-configuration.json",
 				"icon": {
 					"light": "./images/file-icon-light.svg",
 					"dark": "./images/file-icon-dark.svg"
 				},
-				"firstLine": "^\\s*NautilusIr\\s*\\{"
+				"firstLine": "^\\s*nautilus\\s*\\{"
 			}
 		],
 		"grammars": [

--- a/tools/vscode-nautilus-ir/snippets/nautilus-ir.code-snippets
+++ b/tools/vscode-nautilus-ir/snippets/nautilus-ir.code-snippets
@@ -1,16 +1,26 @@
 {
-	"NautilusIr skeleton": {
-		"prefix": "nesir",
+	"Nautilus IR module skeleton": {
+		"prefix": "nautilus",
 		"body": [
-			"NautilusIr {",
-			"execute() {",
-			"Block_0(${1:\\$1}:${2:i32}):",
-			"\t\\$2 = ${3:0} :${2:i32}",
-			"\treturn (\\$2) :${2:i32}",
+			"nautilus {",
+			"${1:execute}() {",
+			"Block_0(${2:\\$1}:${3:i32}):",
+			"\t\\$2 = ${4:0} :${3:i32}",
+			"\treturn (\\$2) :${3:i32}",
 			"}",
-			"} //NESIR"
+			"} //nautilus"
 		],
 		"description": "Empty Nautilus IR module skeleton."
+	},
+	"Nautilus IR function": {
+		"prefix": "fn",
+		"body": [
+			"${1:funcName}() {",
+			"Block_0(${2:\\$1}:${3:i32}):",
+			"\treturn (\\$1) :${3:i32}",
+			"}"
+		],
+		"description": "Helper function inside the nautilus { ... } module."
 	},
 	"Block": {
 		"prefix": "block",

--- a/tools/vscode-nautilus-ir/snippets/nautilus-ir.code-snippets
+++ b/tools/vscode-nautilus-ir/snippets/nautilus-ir.code-snippets
@@ -1,0 +1,79 @@
+{
+	"NautilusIr skeleton": {
+		"prefix": "nesir",
+		"body": [
+			"NautilusIr {",
+			"execute() {",
+			"Block_0(${1:\\$1}:${2:i32}):",
+			"\t\\$2 = ${3:0} :${2:i32}",
+			"\treturn (\\$2) :${2:i32}",
+			"}",
+			"} //NESIR"
+		],
+		"description": "Empty Nautilus IR module skeleton."
+	},
+	"Block": {
+		"prefix": "block",
+		"body": [
+			"Block_${1:0}(${2:\\$1:i32}):",
+			"\t$0"
+		],
+		"description": "Basic block header."
+	},
+	"Branch": {
+		"prefix": "br",
+		"body": [
+			"br Block_${1:1}(${2:\\$1}) :void"
+		],
+		"description": "Unconditional branch."
+	},
+	"Conditional branch": {
+		"prefix": "if",
+		"body": [
+			"if \\$${1:1} ? Block_${2:1}(${3:\\$2}) : Block_${4:2}(${5:\\$2}) :void"
+		],
+		"description": "Conditional branch."
+	},
+	"Constant": {
+		"prefix": "const",
+		"body": [
+			"\\$${1:1} = ${2:0} :${3|i8,i16,i32,i64,ui8,ui16,ui32,ui64,f32,f64,bool|}"
+		],
+		"description": "SSA constant assignment."
+	},
+	"Cast": {
+		"prefix": "cast",
+		"body": [
+			"\\$${1:1} = \\$${2:0} cast_to ${3|i8,i16,i32,i64,ui8,ui16,ui32,ui64,f32,f64|} :${3:i64}"
+		],
+		"description": "Cast SSA value to another type."
+	},
+	"Load": {
+		"prefix": "load",
+		"body": [
+			"\\$${1:1} = load(\\$${2:0}) :${3|i8,i16,i32,i64,ui8,ui16,ui32,ui64,f32,f64|}"
+		],
+		"description": "Load value from pointer."
+	},
+	"Store": {
+		"prefix": "store",
+		"body": [
+			"store(\\$${1:1}, \\$${2:0}) :void"
+		],
+		"description": "Store value to pointer."
+	},
+	"Return": {
+		"prefix": "ret",
+		"body": [
+			"return (\\$${1:1}) :${2|i8,i16,i32,i64,ui8,ui16,ui32,ui64,f32,f64,bool,void|}"
+		],
+		"description": "Return value from execute()."
+	},
+	"Function call": {
+		"prefix": "call",
+		"body": [
+			"\\$${1:1} = func_*(${2:\\$2,\\$3}) :${3:i32}"
+		],
+		"description": "Call to runtime function pointer."
+	}
+}

--- a/tools/vscode-nautilus-ir/snippets/nautilus-ir.code-snippets
+++ b/tools/vscode-nautilus-ir/snippets/nautilus-ir.code-snippets
@@ -3,8 +3,8 @@
 		"prefix": "nautilus",
 		"body": [
 			"nautilus {",
-			"${1:execute}() {",
-			"Block_0(${2:\\$1}:${3:i32}):",
+			"${1:execute}(\\$1:${2:i32}) :${3:i32} {",
+			"Block_0(\\$1:${2:i32}):",
 			"\t\\$2 = ${4:0} :${3:i32}",
 			"\treturn (\\$2) :${3:i32}",
 			"}",
@@ -15,9 +15,10 @@
 	"Nautilus IR function": {
 		"prefix": "fn",
 		"body": [
-			"${1:funcName}() {",
-			"Block_0(${2:\\$1}:${3:i32}):",
-			"\treturn (\\$1) :${3:i32}",
+			"${1:funcName}(\\$1:${2:i32}, \\$2:${2:i32}) :${3:i32} {",
+			"Block_0(\\$1:${2:i32}, \\$2:${2:i32}):",
+			"\t\\$3 = \\$1 + \\$2 :${3:i32}",
+			"\treturn (\\$3) :${3:i32}",
 			"}"
 		],
 		"description": "Helper function inside the nautilus { ... } module."

--- a/tools/vscode-nautilus-ir/src/debugAdapter.ts
+++ b/tools/vscode-nautilus-ir/src/debugAdapter.ts
@@ -1,0 +1,426 @@
+// Debug Adapter for Nautilus IR backed by gdb.
+//
+// The user told us they can debug Nautilus IR with gdb directly. We wrap that
+// workflow in a Debug Adapter Protocol session so VS Code's standard UI
+// (breakpoints in the gutter, step/continue, variables view, watch) drives
+// the underlying gdb process.
+//
+// Strategy:
+//   * Spawn `gdb --interpreter=mi2` on activation.
+//   * Treat the .nesir/.trace file as the "source" — gdb is configured with
+//     `set substitute-path` and `directory` so its file/line events match.
+//   * Map DAP setBreakpoints → gdb `-break-insert FILE:LINE`.
+//   * Map DAP next/stepIn/stepOut/continue → corresponding -exec-* commands.
+//   * Translate gdb `*stopped` events to DAP StoppedEvent.
+//
+// This adapter is intentionally inline — VS Code runs it inside the extension
+// host via DebugAdapterInlineImplementation, so no extra child process is
+// needed beyond gdb itself.
+
+import * as vscode from 'vscode';
+import { DebugSession, InitializedEvent, StoppedEvent, TerminatedEvent, OutputEvent, Thread, StackFrame, Source, Scope, Handles } from '@vscode/debugadapter';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import * as path from 'path';
+import { GdbMi, MiAsync, MiValue } from './gdbMi';
+
+interface LaunchArgs extends DebugProtocol.LaunchRequestArguments {
+	program: string;
+	gdbPath?: string;
+	gdbArgs?: string[];
+	stopOnEntry?: boolean;
+	cwd?: string;
+	env?: Record<string, string>;
+	trace?: boolean;
+}
+
+interface AttachArgs extends DebugProtocol.AttachRequestArguments {
+	program: string;
+	pid: number;
+	gdbPath?: string;
+	gdbArgs?: string[];
+	trace?: boolean;
+}
+
+const DEFAULT_THREAD_ID = 1;
+
+export class GdbDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+	createDebugAdapterDescriptor(_session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+		return new vscode.DebugAdapterInlineImplementation(new NautilusGdbSession());
+	}
+}
+
+class NautilusGdbSession extends DebugSession {
+	private gdb: GdbMi | undefined;
+	private programPath = '';
+	private trace = false;
+	private breakpointIds = new Map<string, number[]>(); // file → gdb breakpoint ids
+	private variableHandles = new Handles<'locals' | 'args' | 'registers'>();
+
+	constructor() {
+		super();
+		this.setDebuggerLinesStartAt1(true);
+		this.setDebuggerColumnsStartAt1(true);
+	}
+
+	protected initializeRequest(response: DebugProtocol.InitializeResponse, _args: DebugProtocol.InitializeRequestArguments): void {
+		response.body = response.body ?? {};
+		response.body.supportsConfigurationDoneRequest = true;
+		response.body.supportsFunctionBreakpoints = true;
+		response.body.supportsConditionalBreakpoints = true;
+		response.body.supportsHitConditionalBreakpoints = true;
+		response.body.supportsEvaluateForHovers = true;
+		response.body.supportsStepBack = false;
+		response.body.supportsSetVariable = true;
+		response.body.supportsRestartRequest = true;
+		response.body.supportsTerminateRequest = true;
+		response.body.supportsLogPoints = true;
+		response.body.supportsDisassembleRequest = true;
+		response.body.supportsReadMemoryRequest = true;
+		response.body.exceptionBreakpointFilters = [
+			{ filter: 'signals', label: 'POSIX Signals', default: true },
+		];
+		this.sendResponse(response);
+		this.sendEvent(new InitializedEvent());
+	}
+
+	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchArgs): Promise<void> {
+		try {
+			this.trace = args.trace === true;
+			this.programPath = args.program;
+			const cfg = vscode.workspace.getConfiguration('nautilusIr');
+			const gdbPath = args.gdbPath ?? cfg.get<string>('gdbPath', 'gdb') ?? 'gdb';
+			const extraArgs = (args.gdbArgs ?? cfg.get<string[]>('gdbExtraArgs', []) ?? []).slice();
+			const cwd = args.cwd ?? path.dirname(args.program);
+			await this.startGdb(gdbPath, extraArgs, cwd, mergeEnv(args.env));
+
+			this.sendOutput(`Loaded ${args.program}\n`);
+			await this.gdb!.send(`file-exec-and-symbols ${quote(args.program)}`);
+
+			// Make the IR file findable by gdb so source/line events resolve.
+			const dir = path.dirname(args.program);
+			await this.safe(this.gdb!.send(`environment-directory -r ${quote(dir)}`));
+
+			if (args.stopOnEntry) {
+				await this.safe(this.gdb!.send(`break-insert -t main`));
+			}
+			await this.safe(this.gdb!.send('exec-arguments'));
+			await this.gdb!.send('exec-run');
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1000, `Launch failed: ${formatError(err)}`);
+		}
+	}
+
+	protected async attachRequest(response: DebugProtocol.AttachResponse, args: AttachArgs): Promise<void> {
+		try {
+			this.trace = args.trace === true;
+			this.programPath = args.program;
+			const cfg = vscode.workspace.getConfiguration('nautilusIr');
+			const gdbPath = args.gdbPath ?? cfg.get<string>('gdbPath', 'gdb') ?? 'gdb';
+			const extraArgs = (args.gdbArgs ?? cfg.get<string[]>('gdbExtraArgs', []) ?? []).slice();
+			await this.startGdb(gdbPath, extraArgs, path.dirname(args.program), process.env);
+			await this.gdb!.send(`target-attach ${args.pid}`);
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1001, `Attach failed: ${formatError(err)}`);
+		}
+	}
+
+	protected async configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse): Promise<void> {
+		this.sendResponse(response);
+	}
+
+	protected async setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): Promise<void> {
+		try {
+			const file = args.source.path ?? '';
+			// Clear previous breakpoints for this file.
+			const prev = this.breakpointIds.get(file) ?? [];
+			for (const id of prev) {
+				await this.safe(this.gdb!.send(`break-delete ${id}`));
+			}
+			const newIds: number[] = [];
+			const verified: DebugProtocol.Breakpoint[] = [];
+			for (const bp of args.breakpoints ?? []) {
+				const spec = `${quote(file)}:${bp.line}`;
+				const condParts: string[] = [];
+				if (bp.condition) {
+					condParts.push(`-c ${quote(bp.condition)}`);
+				}
+				if (bp.hitCondition && /^\d+$/.test(bp.hitCondition.trim())) {
+					condParts.push(`-i ${bp.hitCondition.trim()}`);
+				}
+				const cmd = `break-insert ${condParts.join(' ')} ${spec}`.trim();
+				try {
+					const result = await this.gdb!.send(cmd);
+					const bkpt = (result.results as { bkpt?: { number?: string; line?: string } }).bkpt;
+					const numStr = bkpt?.number;
+					const id = numStr ? parseInt(numStr, 10) : NaN;
+					if (!Number.isNaN(id)) {
+						newIds.push(id);
+					}
+					const reportedLine = bkpt?.line ? parseInt(bkpt.line, 10) : bp.line;
+					verified.push({ verified: true, line: reportedLine });
+				} catch (err) {
+					verified.push({ verified: false, line: bp.line, message: formatError(err) });
+				}
+			}
+			this.breakpointIds.set(file, newIds);
+			response.body = { breakpoints: verified };
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1010, `setBreakpoints failed: ${formatError(err)}`);
+		}
+	}
+
+	protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+		response.body = { threads: [new Thread(DEFAULT_THREAD_ID, 'main')] };
+		this.sendResponse(response);
+	}
+
+	protected async stackTraceRequest(response: DebugProtocol.StackTraceResponse, _args: DebugProtocol.StackTraceArguments): Promise<void> {
+		try {
+			const result = await this.gdb!.send('stack-list-frames');
+			const stack = (result.results as { stack?: MiValue[] }).stack ?? [];
+			const frames: StackFrame[] = [];
+			let id = 1;
+			for (const raw of stack) {
+				const frame = raw as { level?: string; func?: string; file?: string; fullname?: string; line?: string };
+				const file = frame.fullname ?? frame.file ?? this.programPath;
+				const line = frame.line ? parseInt(frame.line, 10) : 0;
+				frames.push(new StackFrame(
+					id++,
+					frame.func ?? `frame_${frame.level ?? '?'}`,
+					new Source(path.basename(file), file),
+					line,
+					0,
+				));
+			}
+			response.body = { stackFrames: frames, totalFrames: frames.length };
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1020, `stackTrace failed: ${formatError(err)}`);
+		}
+	}
+
+	protected scopesRequest(response: DebugProtocol.ScopesResponse): void {
+		response.body = {
+			scopes: [
+				new Scope('Locals', this.variableHandles.create('locals'), false),
+				new Scope('Arguments', this.variableHandles.create('args'), false),
+				new Scope('Registers', this.variableHandles.create('registers'), true),
+			],
+		};
+		this.sendResponse(response);
+	}
+
+	protected async variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments): Promise<void> {
+		const kind = this.variableHandles.get(args.variablesReference);
+		const variables: DebugProtocol.Variable[] = [];
+		try {
+			if (kind === 'locals' || kind === 'args') {
+				const cmd = `stack-list-variables --simple-values`;
+				const result = await this.gdb!.send(cmd);
+				const list = (result.results as { variables?: MiValue[] }).variables ?? [];
+				for (const raw of list) {
+					const v = raw as { name?: string; value?: string; type?: string; arg?: string };
+					const isArg = v.arg === '1';
+					if ((kind === 'args') !== isArg) {
+						continue;
+					}
+					variables.push({
+						name: v.name ?? '?',
+						value: v.value ?? '<opt>',
+						type: v.type,
+						variablesReference: 0,
+					});
+				}
+			} else if (kind === 'registers') {
+				const namesResult = await this.gdb!.send('data-list-register-names');
+				const valuesResult = await this.gdb!.send('data-list-register-values --skip-unavailable x');
+				const names = (namesResult.results as { 'register-names'?: MiValue[] })['register-names'] ?? [];
+				const values = (valuesResult.results as { 'register-values'?: MiValue[] })['register-values'] ?? [];
+				for (const rawV of values) {
+					const v = rawV as { number?: string; value?: string };
+					const idx = v.number ? parseInt(v.number, 10) : -1;
+					const n = idx >= 0 ? names[idx] : undefined;
+					variables.push({
+						name: typeof n === 'string' ? n : `r${idx}`,
+						value: v.value ?? '?',
+						variablesReference: 0,
+					});
+				}
+			}
+			response.body = { variables };
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1030, `variables failed: ${formatError(err)}`);
+		}
+	}
+
+	protected async continueRequest(response: DebugProtocol.ContinueResponse): Promise<void> {
+		try {
+			await this.gdb!.send('exec-continue');
+			response.body = { allThreadsContinued: true };
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1040, formatError(err));
+		}
+	}
+
+	protected async nextRequest(response: DebugProtocol.NextResponse): Promise<void> {
+		await this.runStep(response, 'exec-next');
+	}
+
+	protected async stepInRequest(response: DebugProtocol.StepInResponse): Promise<void> {
+		await this.runStep(response, 'exec-step');
+	}
+
+	protected async stepOutRequest(response: DebugProtocol.StepOutResponse): Promise<void> {
+		await this.runStep(response, 'exec-finish');
+	}
+
+	protected async pauseRequest(response: DebugProtocol.PauseResponse): Promise<void> {
+		try {
+			await this.gdb!.send('exec-interrupt');
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1050, formatError(err));
+		}
+	}
+
+	protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
+		try {
+			const result = await this.gdb!.send(`data-evaluate-expression ${quote(args.expression)}`);
+			const value = (result.results as { value?: string }).value ?? '<no value>';
+			response.body = { result: value, variablesReference: 0 };
+			this.sendResponse(response);
+		} catch (err) {
+			response.body = { result: formatError(err), variablesReference: 0 };
+			this.sendResponse(response);
+		}
+	}
+
+	protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {
+		try {
+			await this.gdb!.send(`gdb-set var ${args.name}=${args.value}`);
+			response.body = { value: args.value };
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1060, formatError(err));
+		}
+	}
+
+	protected async terminateRequest(response: DebugProtocol.TerminateResponse): Promise<void> {
+		this.shutdown();
+		this.sendResponse(response);
+	}
+
+	protected async disconnectRequest(response: DebugProtocol.DisconnectResponse): Promise<void> {
+		this.shutdown();
+		this.sendResponse(response);
+	}
+
+	protected async restartRequest(response: DebugProtocol.RestartResponse): Promise<void> {
+		try {
+			await this.gdb!.send('exec-run');
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1070, formatError(err));
+		}
+	}
+
+	// ----- Internal helpers -----
+
+	private async runStep(response: DebugProtocol.Response, command: string): Promise<void> {
+		try {
+			await this.gdb!.send(command);
+			this.sendResponse(response);
+		} catch (err) {
+			this.sendErrorResponse(response, 1080, formatError(err));
+		}
+	}
+
+	private async startGdb(gdbPath: string, extraArgs: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<void> {
+		this.gdb = new GdbMi(gdbPath, extraArgs);
+		this.gdb.on('console', (text: string) => this.sendOutput(text, 'console'));
+		this.gdb.on('output', (text: string) => this.sendOutput(text + '\n', 'stdout'));
+		this.gdb.on('stderr', (text: string) => this.sendOutput(text, 'stderr'));
+		this.gdb.on('exec', (evt: MiAsync) => this.handleExec(evt));
+		this.gdb.on('notify', (evt: MiAsync) => {
+			if (this.trace) {
+				this.sendOutput(`[notify] ${evt.cls}\n`, 'console');
+			}
+		});
+		this.gdb.on('exit', () => {
+			this.sendEvent(new TerminatedEvent());
+		});
+		await this.gdb.start(cwd, env);
+	}
+
+	private handleExec(evt: MiAsync): void {
+		if (evt.cls !== 'stopped') {
+			return;
+		}
+		const reason = String(evt.results['reason'] ?? 'pause');
+		let dapReason = 'pause';
+		switch (reason) {
+			case 'breakpoint-hit': dapReason = 'breakpoint'; break;
+			case 'end-stepping-range':
+			case 'function-finished': dapReason = 'step'; break;
+			case 'signal-received': dapReason = 'exception'; break;
+			case 'exited':
+			case 'exited-normally':
+			case 'exited-signalled':
+				this.sendEvent(new TerminatedEvent());
+				return;
+		}
+		const stopped = new StoppedEvent(dapReason, DEFAULT_THREAD_ID);
+		(stopped.body as DebugProtocol.StoppedEvent['body']).allThreadsStopped = true;
+		this.sendEvent(stopped);
+	}
+
+	private sendOutput(text: string, category: 'console' | 'stdout' | 'stderr' = 'stdout'): void {
+		this.sendEvent(new OutputEvent(text, category));
+	}
+
+	private async safe<T>(p: Promise<T>): Promise<T | undefined> {
+		try {
+			return await p;
+		} catch (err) {
+			if (this.trace) {
+				this.sendOutput(`[gdb-warn] ${formatError(err)}\n`, 'console');
+			}
+			return undefined;
+		}
+	}
+
+	public shutdown(): void {
+		if (this.gdb) {
+			try {
+				this.gdb.send('gdb-exit').catch(() => undefined);
+			} catch {
+				// ignore
+			}
+			this.gdb.dispose();
+			this.gdb = undefined;
+		}
+	}
+}
+
+function quote(s: string): string {
+	return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function formatError(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	return String(err);
+}
+
+function mergeEnv(custom: Record<string, string> | undefined): NodeJS.ProcessEnv {
+	if (!custom) {
+		return process.env;
+	}
+	return { ...process.env, ...custom };
+}

--- a/tools/vscode-nautilus-ir/src/debugAdapter.ts
+++ b/tools/vscode-nautilus-ir/src/debugAdapter.ts
@@ -1,33 +1,45 @@
 // Debug Adapter for Nautilus IR backed by gdb.
 //
-// The user told us they can debug Nautilus IR with gdb directly. We wrap that
-// workflow in a Debug Adapter Protocol session so VS Code's standard UI
-// (breakpoints in the gutter, step/continue, variables view, watch) drives
-// the underlying gdb process.
+// Important context: a Nautilus IR file is never a self-contained executable.
+// It is loaded by a C++ host program (e.g. an ExecutionTest binary, the demo
+// JIT, or a NebulaStream worker) which JIT-compiles it via the Nautilus
+// engine. To debug an IR file you therefore launch *the host program* under
+// gdb, then rely on the Nautilus backend to emit source-line debug info that
+// points back to the IR file. Once execution enters that JIT'd code, gdb
+// resolves the addresses to FILE:LINE positions in the IR file and the
+// editor's breakpoints / step / variables UI light up.
 //
-// Strategy:
-//   * Spawn `gdb --interpreter=mi2` on activation.
-//   * Treat the .nesir/.trace file as the "source" — gdb is configured with
-//     `set substitute-path` and `directory` so its file/line events match.
-//   * Map DAP setBreakpoints → gdb `-break-insert FILE:LINE`.
-//   * Map DAP next/stepIn/stepOut/continue → corresponding -exec-* commands.
+// Adapter responsibilities:
+//   * Spawn `gdb --interpreter=mi2` on the host program (DAP `program`).
+//   * Forward DAP `args` and `env` to gdb via -exec-arguments and the gdb env.
+//   * Add the IR file's directory to gdb's source search path so file/line
+//     events resolve cleanly.
+//   * Map DAP setBreakpoints in an IR file -> gdb `-break-insert FILE:LINE`.
+//     gdb will only resolve them after the JIT registers symbols, but it
+//     handles "pending on future symbol load" automatically.
+//   * Map next/stepIn/stepOut/continue to the corresponding -exec-* commands.
 //   * Translate gdb `*stopped` events to DAP StoppedEvent.
 //
-// This adapter is intentionally inline — VS Code runs it inside the extension
-// host via DebugAdapterInlineImplementation, so no extra child process is
-// needed beyond gdb itself.
+// This adapter is inline — VS Code runs it inside the extension host via
+// DebugAdapterInlineImplementation, so no extra adapter process is needed
+// beyond gdb itself.
 
 import * as vscode from 'vscode';
 import { DebugSession, InitializedEvent, StoppedEvent, TerminatedEvent, OutputEvent, Thread, StackFrame, Source, Scope, Handles } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as path from 'path';
+import * as fs from 'fs';
 import { GdbMi, MiAsync, MiValue } from './gdbMi';
 
 interface LaunchArgs extends DebugProtocol.LaunchRequestArguments {
-	program: string;
+	program: string;                  // C++ host executable
+	args?: string[];                  // forwarded to the inferior
+	irFile?: string;                  // optional Nautilus IR file of interest
+	stopAtIrEntry?: boolean;          // breakpoint at first instruction of irFile
+	stopOnEntry?: boolean;            // breakpoint at host main()
 	gdbPath?: string;
 	gdbArgs?: string[];
-	stopOnEntry?: boolean;
+	sourceDirectories?: string[];
 	cwd?: string;
 	env?: Record<string, string>;
 	trace?: boolean;
@@ -36,6 +48,8 @@ interface LaunchArgs extends DebugProtocol.LaunchRequestArguments {
 interface AttachArgs extends DebugProtocol.AttachRequestArguments {
 	program: string;
 	pid: number;
+	irFile?: string;
+	sourceDirectories?: string[];
 	gdbPath?: string;
 	gdbArgs?: string[];
 	trace?: boolean;
@@ -93,17 +107,49 @@ class NautilusGdbSession extends DebugSession {
 			const cwd = args.cwd ?? path.dirname(args.program);
 			await this.startGdb(gdbPath, extraArgs, cwd, mergeEnv(args.env));
 
-			this.sendOutput(`Loaded ${args.program}\n`);
+			// Load the host executable.
+			this.sendOutput(`Loading host program: ${args.program}\n`);
 			await this.gdb!.send(`file-exec-and-symbols ${quote(args.program)}`);
 
-			// Make the IR file findable by gdb so source/line events resolve.
-			const dir = path.dirname(args.program);
-			await this.safe(this.gdb!.send(`environment-directory -r ${quote(dir)}`));
+			// Tell gdb about all source-search directories. We always include the
+			// host program's own directory; the IR file's directory ensures gdb
+			// can resolve file/line events emitted by the JIT'd code.
+			const dirs = new Set<string>();
+			dirs.add(path.dirname(args.program));
+			if (args.irFile) {
+				dirs.add(path.dirname(args.irFile));
+			}
+			for (const d of args.sourceDirectories ?? []) {
+				dirs.add(d);
+			}
+			for (const dir of dirs) {
+				await this.safe(this.gdb!.send(`environment-directory -r ${quote(dir)}`));
+			}
 
+			// Forward arguments to the inferior. -exec-arguments takes a single
+			// space-separated string (with quoting), so build it carefully.
+			if (args.args && args.args.length > 0) {
+				const argLine = args.args.map(quote).join(' ');
+				await this.safe(this.gdb!.send(`exec-arguments ${argLine}`));
+			}
+
+			// Optional break at host main() — useful for debugging the host
+			// before JIT compilation kicks in.
 			if (args.stopOnEntry) {
 				await this.safe(this.gdb!.send(`break-insert -t main`));
 			}
-			await this.safe(this.gdb!.send('exec-arguments'));
+
+			// Optional break at the first instruction of the IR file. The
+			// breakpoint will be pending until the JIT registers symbols for
+			// that file; gdb handles that via -break-insert -f.
+			if (args.stopAtIrEntry !== false && args.irFile) {
+				const entryLine = await detectIrEntryLine(args.irFile);
+				if (entryLine > 0) {
+					await this.safe(this.gdb!.send(`break-insert -f ${quote(args.irFile)}:${entryLine}`));
+					this.sendOutput(`Set pending breakpoint at ${args.irFile}:${entryLine}\n`, 'console');
+				}
+			}
+
 			await this.gdb!.send('exec-run');
 			this.sendResponse(response);
 		} catch (err) {
@@ -119,6 +165,18 @@ class NautilusGdbSession extends DebugSession {
 			const gdbPath = args.gdbPath ?? cfg.get<string>('gdbPath', 'gdb') ?? 'gdb';
 			const extraArgs = (args.gdbArgs ?? cfg.get<string[]>('gdbExtraArgs', []) ?? []).slice();
 			await this.startGdb(gdbPath, extraArgs, path.dirname(args.program), process.env);
+			await this.gdb!.send(`file-exec-and-symbols ${quote(args.program)}`);
+			const dirs = new Set<string>();
+			dirs.add(path.dirname(args.program));
+			if (args.irFile) {
+				dirs.add(path.dirname(args.irFile));
+			}
+			for (const d of args.sourceDirectories ?? []) {
+				dirs.add(d);
+			}
+			for (const dir of dirs) {
+				await this.safe(this.gdb!.send(`environment-directory -r ${quote(dir)}`));
+			}
 			await this.gdb!.send(`target-attach ${args.pid}`);
 			this.sendResponse(response);
 		} catch (err) {
@@ -141,7 +199,9 @@ class NautilusGdbSession extends DebugSession {
 			const newIds: number[] = [];
 			const verified: DebugProtocol.Breakpoint[] = [];
 			for (const bp of args.breakpoints ?? []) {
-				const spec = `${quote(file)}:${bp.line}`;
+				// Use -f so the breakpoint is accepted as pending while the JIT
+				// has not yet registered symbols for the IR file.
+				const spec = `-f ${quote(file)}:${bp.line}`;
 				const condParts: string[] = [];
 				if (bp.condition) {
 					condParts.push(`-c ${quote(bp.condition)}`);
@@ -152,14 +212,19 @@ class NautilusGdbSession extends DebugSession {
 				const cmd = `break-insert ${condParts.join(' ')} ${spec}`.trim();
 				try {
 					const result = await this.gdb!.send(cmd);
-					const bkpt = (result.results as { bkpt?: { number?: string; line?: string } }).bkpt;
+					const bkpt = (result.results as { bkpt?: { number?: string; line?: string; pending?: string } }).bkpt;
 					const numStr = bkpt?.number;
 					const id = numStr ? parseInt(numStr, 10) : NaN;
 					if (!Number.isNaN(id)) {
 						newIds.push(id);
 					}
 					const reportedLine = bkpt?.line ? parseInt(bkpt.line, 10) : bp.line;
-					verified.push({ verified: true, line: reportedLine });
+					const isPending = !!bkpt?.pending;
+					verified.push({
+						verified: !isPending,
+						line: reportedLine,
+						message: isPending ? 'pending until JIT loads IR' : undefined,
+					});
 				} catch (err) {
 					verified.push({ verified: false, line: bp.line, message: formatError(err) });
 				}
@@ -423,4 +488,28 @@ function mergeEnv(custom: Record<string, string> | undefined): NodeJS.ProcessEnv
 		return process.env;
 	}
 	return { ...process.env, ...custom };
+}
+
+// Locate the first executable instruction of an IR file — the line right
+// after the entry block header (`Block_0(...):`). This is what the user
+// almost always wants `stopAtIrEntry` to halt on.
+async function detectIrEntryLine(file: string): Promise<number> {
+	try {
+		const text = await fs.promises.readFile(file, 'utf8');
+		const lines = text.split(/\r?\n/);
+		for (let i = 0; i < lines.length; i++) {
+			if (/^\s*Block_0\s*\(/.test(lines[i])) {
+				// Scan forward for the first non-blank, non-header line.
+				for (let j = i + 1; j < lines.length; j++) {
+					if (lines[j].trim() !== '') {
+						return j + 1; // 1-based line number for gdb
+					}
+				}
+				return i + 1;
+			}
+		}
+	} catch {
+		// fall through
+	}
+	return 0;
 }

--- a/tools/vscode-nautilus-ir/src/extension.ts
+++ b/tools/vscode-nautilus-ir/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import {
 	IrSymbolProvider,
 	IrDefinitionProvider,
@@ -73,9 +74,9 @@ export function activate(context: vscode.ExtensionContext): void {
 		const line = editor.selection.active.line;
 		const block = ir.blocks.find(b => line >= b.headerLine && line <= b.bodyRange.end.line);
 		if (block) {
-			statusItem.text = `$(symbol-method) ${block.name}  ⟶  ${block.successors.join(', ') || block.terminator}`;
+			statusItem.text = `$(symbol-method) ${block.functionName}::${block.name}  ⟶  ${block.successors.join(', ') || block.terminator}`;
 			statusItem.tooltip = new vscode.MarkdownString(
-				`**${block.name}**\n\nPredecessors: ${block.predecessors.join(', ') || '*(none)*'}\n\nSuccessors: ${block.successors.join(', ') || '*(none)*'}`,
+				`**${block.functionName}::${block.name}**\n\nPredecessors: ${block.predecessors.join(', ') || '*(none)*'}\n\nSuccessors: ${block.successors.join(', ') || '*(none)*'}`,
 			);
 			statusItem.show();
 		} else {
@@ -101,10 +102,12 @@ async function gotoBlockCommand(): Promise<void> {
 		return;
 	}
 	const ir = irFor(editor.document);
-	const items: vscode.QuickPickItem[] = ir.blocks.map(b => ({
-		label: b.name,
+	const items: (vscode.QuickPickItem & { fn: string; block: string })[] = ir.blocks.map(b => ({
+		label: `${b.functionName}::${b.name}`,
 		description: `${b.args.length} args, ${b.instructions} insns`,
 		detail: `→ ${b.successors.length ? b.successors.join(', ') : b.terminator}`,
+		fn: b.functionName,
+		block: b.name,
 	}));
 	const pick = await vscode.window.showQuickPick(items, {
 		placeHolder: 'Jump to block...',
@@ -114,7 +117,8 @@ async function gotoBlockCommand(): Promise<void> {
 	if (!pick) {
 		return;
 	}
-	const target = ir.blockByName.get(pick.label);
+	const fn = ir.functionByName.get(pick.fn);
+	const target = fn?.blockByName.get(pick.block);
 	if (target) {
 		const pos = new vscode.Position(target.headerLine, 0);
 		editor.selection = new vscode.Selection(pos, pos);
@@ -128,22 +132,31 @@ function dumpInfoCommand(): void {
 		return;
 	}
 	const ir = irFor(editor.document);
-	const total = ir.blocks.reduce((sum, b) => sum + b.instructions, 0);
-	const unreachable = ir.blocks.filter(b => b.predecessors.length === 0 && b !== ir.blocks[0]);
+	const totalInsns = ir.blocks.reduce((sum, b) => sum + b.instructions, 0);
+	const totalDefs = ir.functions.reduce((sum, fn) => sum + fn.definitions.size, 0);
+	const unreachable: string[] = [];
+	for (const fn of ir.functions) {
+		const entry = fn.blocks[0];
+		for (const block of fn.blocks) {
+			if (block !== entry && block.predecessors.length === 0) {
+				unreachable.push(`${fn.name}::${block.name}`);
+			}
+		}
+	}
 	vscode.window.showInformationMessage(
-		`Nautilus IR: ${ir.blocks.length} blocks · ${total} instructions · ${ir.definitions.size} SSA defs · ${unreachable.length} unreachable`,
+		`Nautilus IR: ${ir.functions.length} functions · ${ir.blocks.length} blocks · ${totalInsns} instructions · ${totalDefs} SSA defs · ${unreachable.length} unreachable`,
 	);
 }
 
 function showBlockInfoCommand(uri: vscode.Uri, blockName: string): void {
 	vscode.workspace.openTextDocument(uri).then(doc => {
 		const ir = irFor(doc);
-		const block = ir.blockByName.get(blockName);
+		const block = ir.blocks.find(b => b.name === blockName);
 		if (!block) {
 			return;
 		}
 		vscode.window.showInformationMessage(
-			`${block.name}: preds=[${block.predecessors.join(', ')}] succs=[${block.successors.join(', ')}] terminator=${block.terminator}`,
+			`${block.functionName}::${block.name}: preds=[${block.predecessors.join(', ')}] succs=[${block.successors.join(', ')}] terminator=${block.terminator}`,
 		);
 	});
 }
@@ -161,13 +174,35 @@ async function debugWithGdbCommand(): Promise<void> {
 		vscode.window.showWarningMessage('Open a Nautilus IR file before launching the gdb debugger.');
 		return;
 	}
+	// A Nautilus IR file is loaded by a C++ host program. Ask the user which
+	// host binary to attach gdb to, defaulting to a remembered choice.
+	const irPath = editor.document.uri.fsPath;
 	const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+	const memento = vscode.workspace.getConfiguration('nautilusIr');
+	const remembered = memento.get<string>('lastHostProgram', '');
+	const picked = await vscode.window.showOpenDialog({
+		title: 'Select the C++ host executable that loads this Nautilus IR',
+		canSelectFiles: true,
+		canSelectFolders: false,
+		canSelectMany: false,
+		defaultUri: remembered ? vscode.Uri.file(remembered) : folder?.uri,
+		openLabel: 'Debug',
+	});
+	if (!picked || picked.length === 0) {
+		return;
+	}
+	const hostProgram = picked[0].fsPath;
+	await memento.update('lastHostProgram', hostProgram, vscode.ConfigurationTarget.Workspace);
+
 	await vscode.debug.startDebugging(folder, {
 		type: 'nautilus-ir-gdb',
 		request: 'launch',
-		name: 'Debug Nautilus IR (gdb)',
-		program: editor.document.uri.fsPath,
-		stopOnEntry: true,
+		name: 'Debug Nautilus IR via host program (gdb)',
+		program: hostProgram,
+		args: [],
+		irFile: irPath,
+		stopAtIrEntry: true,
+		cwd: folder?.uri.fsPath ?? path.dirname(hostProgram),
 	});
 }
 
@@ -177,49 +212,49 @@ function runLint(doc: vscode.TextDocument): vscode.Diagnostic[] {
 	const ir = irFor(doc);
 	const out: vscode.Diagnostic[] = [];
 
-	// Block argument names that shadow defs are fine (block args ARE defs); collect the set.
-	const knownNames = new Set<string>(ir.definitions.keys());
-	for (const block of ir.blocks) {
-		for (const arg of block.args) {
-			knownNames.add(arg.name);
+	// SSA names are scoped per function — `$3` in `add()` is unrelated to
+	// `$3` in `execute()`. Validate each function in isolation.
+	for (const fn of ir.functions) {
+		const known = new Set<string>(fn.definitions.keys());
+		for (const block of fn.blocks) {
+			for (const arg of block.args) {
+				known.add(arg.name);
+			}
 		}
-	}
-
-	// 1. Undefined SSA references.
-	for (const [name, refs] of ir.references) {
-		if (knownNames.has(name)) {
-			continue;
-		}
-		for (const r of refs) {
-			out.push(new vscode.Diagnostic(
-				new vscode.Range(r.line, r.character, r.line, r.character + name.length),
-				`Undefined SSA value ${name}.`,
-				vscode.DiagnosticSeverity.Warning,
-			));
-		}
-	}
-
-	// 2. Branches to unknown blocks.
-	for (const block of ir.blocks) {
-		for (const succ of block.successors) {
-			if (!ir.blockByName.has(succ)) {
+		// Undefined SSA references inside this function.
+		for (const [name, refs] of ir.references) {
+			if (known.has(name)) {
+				continue;
+			}
+			for (const r of refs) {
+				if (r.functionName !== fn.name) {
+					continue;
+				}
 				out.push(new vscode.Diagnostic(
-					block.bodyRange,
-					`Branch targets unknown block ${succ}.`,
+					new vscode.Range(r.line, r.character, r.line, r.character + name.length),
+					`Undefined SSA value ${name} in ${fn.name}().`,
 					vscode.DiagnosticSeverity.Warning,
 				));
 			}
 		}
-	}
-
-	// 3. Blocks without a recognizable terminator.
-	for (const block of ir.blocks) {
-		if (block.instructions > 0 && block.terminator === 'unknown') {
-			out.push(new vscode.Diagnostic(
-				block.headerRange,
-				`Block ${block.name} has no return/branch terminator.`,
-				vscode.DiagnosticSeverity.Information,
-			));
+		// Dangling branch targets.
+		for (const block of fn.blocks) {
+			for (const succ of block.successors) {
+				if (!fn.blockByName.has(succ)) {
+					out.push(new vscode.Diagnostic(
+						block.headerRange,
+						`Branch in ${fn.name}() targets unknown block ${succ}.`,
+						vscode.DiagnosticSeverity.Warning,
+					));
+				}
+			}
+			if (block.instructions > 0 && block.terminator === 'unknown') {
+				out.push(new vscode.Diagnostic(
+					block.headerRange,
+					`Block ${block.name} in ${fn.name}() has no return/branch terminator.`,
+					vscode.DiagnosticSeverity.Information,
+				));
+			}
 		}
 	}
 

--- a/tools/vscode-nautilus-ir/src/extension.ts
+++ b/tools/vscode-nautilus-ir/src/extension.ts
@@ -1,0 +1,227 @@
+import * as vscode from 'vscode';
+import {
+	IrSymbolProvider,
+	IrDefinitionProvider,
+	IrReferenceProvider,
+	IrHoverProvider,
+	IrHighlightProvider,
+	IrFoldingProvider,
+	IrRenameProvider,
+	IrCodeLensProvider,
+	irFor,
+} from './features';
+import { GdbDescriptorFactory } from './debugAdapter';
+
+const SELECTOR: vscode.DocumentSelector = { language: 'nautilus-ir', scheme: 'file' };
+
+export function activate(context: vscode.ExtensionContext): void {
+	context.subscriptions.push(
+		vscode.languages.registerDocumentSymbolProvider(SELECTOR, new IrSymbolProvider()),
+		vscode.languages.registerDefinitionProvider(SELECTOR, new IrDefinitionProvider()),
+		vscode.languages.registerReferenceProvider(SELECTOR, new IrReferenceProvider()),
+		vscode.languages.registerHoverProvider(SELECTOR, new IrHoverProvider()),
+		vscode.languages.registerDocumentHighlightProvider(SELECTOR, new IrHighlightProvider()),
+		vscode.languages.registerFoldingRangeProvider(SELECTOR, new IrFoldingProvider()),
+		vscode.languages.registerRenameProvider(SELECTOR, new IrRenameProvider()),
+		vscode.languages.registerCodeLensProvider(SELECTOR, new IrCodeLensProvider()),
+	);
+
+	// Diagnostics: light static checks (undefined SSA references, dangling branches).
+	const diagnostics = vscode.languages.createDiagnosticCollection('nautilus-ir');
+	context.subscriptions.push(diagnostics);
+
+	const refresh = (doc: vscode.TextDocument) => {
+		if (doc.languageId !== 'nautilus-ir') {
+			return;
+		}
+		diagnostics.set(doc.uri, runLint(doc));
+	};
+
+	vscode.workspace.textDocuments.forEach(refresh);
+	context.subscriptions.push(
+		vscode.workspace.onDidOpenTextDocument(refresh),
+		vscode.workspace.onDidChangeTextDocument(e => refresh(e.document)),
+		vscode.workspace.onDidCloseTextDocument(d => diagnostics.delete(d.uri)),
+	);
+
+	// Commands.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('nautilus-ir.gotoBlock', gotoBlockCommand),
+		vscode.commands.registerCommand('nautilus-ir.dumpInfo', dumpInfoCommand),
+		vscode.commands.registerCommand('nautilus-ir.showBlockInfo', showBlockInfoCommand),
+		vscode.commands.registerCommand('nautilus-ir.toggleFollowDefinitions', toggleFollowDefinitionsCommand),
+		vscode.commands.registerCommand('nautilus-ir.debugWithGdb', debugWithGdbCommand),
+	);
+
+	// Debug adapter (inline implementation, no separate process).
+	context.subscriptions.push(
+		vscode.debug.registerDebugAdapterDescriptorFactory('nautilus-ir-gdb', new GdbDescriptorFactory()),
+	);
+
+	// Status bar item: show current block when cursor is inside one.
+	const statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+	statusItem.command = 'nautilus-ir.gotoBlock';
+	context.subscriptions.push(statusItem);
+
+	const updateStatus = () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.document.languageId !== 'nautilus-ir') {
+			statusItem.hide();
+			return;
+		}
+		const ir = irFor(editor.document);
+		const line = editor.selection.active.line;
+		const block = ir.blocks.find(b => line >= b.headerLine && line <= b.bodyRange.end.line);
+		if (block) {
+			statusItem.text = `$(symbol-method) ${block.name}  ⟶  ${block.successors.join(', ') || block.terminator}`;
+			statusItem.tooltip = new vscode.MarkdownString(
+				`**${block.name}**\n\nPredecessors: ${block.predecessors.join(', ') || '*(none)*'}\n\nSuccessors: ${block.successors.join(', ') || '*(none)*'}`,
+			);
+			statusItem.show();
+		} else {
+			statusItem.hide();
+		}
+	};
+	context.subscriptions.push(
+		vscode.window.onDidChangeActiveTextEditor(updateStatus),
+		vscode.window.onDidChangeTextEditorSelection(updateStatus),
+	);
+	updateStatus();
+}
+
+export function deactivate(): void {
+	// Nothing to clean up — all subscriptions are handled by VS Code.
+}
+
+// ----- Commands -----
+
+async function gotoBlockCommand(): Promise<void> {
+	const editor = vscode.window.activeTextEditor;
+	if (!editor || editor.document.languageId !== 'nautilus-ir') {
+		return;
+	}
+	const ir = irFor(editor.document);
+	const items: vscode.QuickPickItem[] = ir.blocks.map(b => ({
+		label: b.name,
+		description: `${b.args.length} args, ${b.instructions} insns`,
+		detail: `→ ${b.successors.length ? b.successors.join(', ') : b.terminator}`,
+	}));
+	const pick = await vscode.window.showQuickPick(items, {
+		placeHolder: 'Jump to block...',
+		matchOnDescription: true,
+		matchOnDetail: true,
+	});
+	if (!pick) {
+		return;
+	}
+	const target = ir.blockByName.get(pick.label);
+	if (target) {
+		const pos = new vscode.Position(target.headerLine, 0);
+		editor.selection = new vscode.Selection(pos, pos);
+		editor.revealRange(target.headerRange, vscode.TextEditorRevealType.InCenter);
+	}
+}
+
+function dumpInfoCommand(): void {
+	const editor = vscode.window.activeTextEditor;
+	if (!editor || editor.document.languageId !== 'nautilus-ir') {
+		return;
+	}
+	const ir = irFor(editor.document);
+	const total = ir.blocks.reduce((sum, b) => sum + b.instructions, 0);
+	const unreachable = ir.blocks.filter(b => b.predecessors.length === 0 && b !== ir.blocks[0]);
+	vscode.window.showInformationMessage(
+		`Nautilus IR: ${ir.blocks.length} blocks · ${total} instructions · ${ir.definitions.size} SSA defs · ${unreachable.length} unreachable`,
+	);
+}
+
+function showBlockInfoCommand(uri: vscode.Uri, blockName: string): void {
+	vscode.workspace.openTextDocument(uri).then(doc => {
+		const ir = irFor(doc);
+		const block = ir.blockByName.get(blockName);
+		if (!block) {
+			return;
+		}
+		vscode.window.showInformationMessage(
+			`${block.name}: preds=[${block.predecessors.join(', ')}] succs=[${block.successors.join(', ')}] terminator=${block.terminator}`,
+		);
+	});
+}
+
+function toggleFollowDefinitionsCommand(): void {
+	const config = vscode.workspace.getConfiguration('nautilusIr');
+	const current = config.get<boolean>('highlightDefinitions', true);
+	config.update('highlightDefinitions', !current, vscode.ConfigurationTarget.Global);
+	vscode.window.showInformationMessage(`Nautilus IR: definition highlighting ${!current ? 'enabled' : 'disabled'}.`);
+}
+
+async function debugWithGdbCommand(): Promise<void> {
+	const editor = vscode.window.activeTextEditor;
+	if (!editor || editor.document.languageId !== 'nautilus-ir') {
+		vscode.window.showWarningMessage('Open a Nautilus IR file before launching the gdb debugger.');
+		return;
+	}
+	const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+	await vscode.debug.startDebugging(folder, {
+		type: 'nautilus-ir-gdb',
+		request: 'launch',
+		name: 'Debug Nautilus IR (gdb)',
+		program: editor.document.uri.fsPath,
+		stopOnEntry: true,
+	});
+}
+
+// ----- Lint -----
+
+function runLint(doc: vscode.TextDocument): vscode.Diagnostic[] {
+	const ir = irFor(doc);
+	const out: vscode.Diagnostic[] = [];
+
+	// Block argument names that shadow defs are fine (block args ARE defs); collect the set.
+	const knownNames = new Set<string>(ir.definitions.keys());
+	for (const block of ir.blocks) {
+		for (const arg of block.args) {
+			knownNames.add(arg.name);
+		}
+	}
+
+	// 1. Undefined SSA references.
+	for (const [name, refs] of ir.references) {
+		if (knownNames.has(name)) {
+			continue;
+		}
+		for (const r of refs) {
+			out.push(new vscode.Diagnostic(
+				new vscode.Range(r.line, r.character, r.line, r.character + name.length),
+				`Undefined SSA value ${name}.`,
+				vscode.DiagnosticSeverity.Warning,
+			));
+		}
+	}
+
+	// 2. Branches to unknown blocks.
+	for (const block of ir.blocks) {
+		for (const succ of block.successors) {
+			if (!ir.blockByName.has(succ)) {
+				out.push(new vscode.Diagnostic(
+					block.bodyRange,
+					`Branch targets unknown block ${succ}.`,
+					vscode.DiagnosticSeverity.Warning,
+				));
+			}
+		}
+	}
+
+	// 3. Blocks without a recognizable terminator.
+	for (const block of ir.blocks) {
+		if (block.instructions > 0 && block.terminator === 'unknown') {
+			out.push(new vscode.Diagnostic(
+				block.headerRange,
+				`Block ${block.name} has no return/branch terminator.`,
+				vscode.DiagnosticSeverity.Information,
+			));
+		}
+	}
+
+	return out;
+}

--- a/tools/vscode-nautilus-ir/src/features.ts
+++ b/tools/vscode-nautilus-ir/src/features.ts
@@ -1,0 +1,379 @@
+// Language features wired up against the lightweight Nautilus IR parser.
+//
+// All providers cache the most recent parse per document version to avoid
+// re-parsing on every cursor movement.
+
+import * as vscode from 'vscode';
+import { parse, ParsedIr, ssaAt, blockAt, Block } from './parser';
+
+const cache = new WeakMap<vscode.TextDocument, { version: number; ir: ParsedIr }>();
+
+export function irFor(document: vscode.TextDocument): ParsedIr {
+	const cached = cache.get(document);
+	if (cached && cached.version === document.version) {
+		return cached.ir;
+	}
+	const ir = parse(document);
+	cache.set(document, { version: document.version, ir });
+	return ir;
+}
+
+// ----- DocumentSymbolProvider: blocks become symbols, defs become children -----
+
+export class IrSymbolProvider implements vscode.DocumentSymbolProvider {
+	provideDocumentSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
+		const ir = irFor(document);
+		const symbols: vscode.DocumentSymbol[] = [];
+		for (const block of ir.blocks) {
+			const argSummary = block.args.map(a => `${a.name}:${a.type}`).join(', ');
+			const blockSym = new vscode.DocumentSymbol(
+				block.name,
+				`(${argSummary})  → ${block.successors.length ? block.successors.join(', ') : block.terminator}`,
+				vscode.SymbolKind.Function,
+				block.bodyRange,
+				block.headerRange,
+			);
+			for (const [name, def] of ir.definitions) {
+				if (def.line >= block.headerLine && def.line <= block.bodyRange.end.line) {
+					const defRange = new vscode.Range(def.line, def.character, def.line, def.character + name.length);
+					blockSym.children.push(new vscode.DocumentSymbol(
+						name,
+						def.type ? `:${def.type}` : '',
+						vscode.SymbolKind.Variable,
+						defRange,
+						defRange,
+					));
+				}
+			}
+			symbols.push(blockSym);
+		}
+		return symbols;
+	}
+}
+
+// ----- DefinitionProvider: jump to SSA def or block header -----
+
+export class IrDefinitionProvider implements vscode.DefinitionProvider {
+	provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Definition | undefined {
+		const ir = irFor(document);
+		const ssa = ssaAt(document, position);
+		if (ssa) {
+			const def = ir.definitions.get(ssa.name);
+			if (def) {
+				const range = new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length);
+				return new vscode.Location(document.uri, range);
+			}
+			// Could be a block argument; jump to the block header it appears on.
+			for (const block of ir.blocks) {
+				if (block.args.some(a => a.name === ssa.name)) {
+					return new vscode.Location(document.uri, block.headerRange);
+				}
+			}
+		}
+		const block = blockAt(document, position);
+		if (block) {
+			const target = ir.blockByName.get(block.name);
+			if (target) {
+				return new vscode.Location(document.uri, target.headerRange);
+			}
+		}
+		return undefined;
+	}
+}
+
+// ----- ReferenceProvider: find every use of an SSA value or block -----
+
+export class IrReferenceProvider implements vscode.ReferenceProvider {
+	provideReferences(document: vscode.TextDocument, position: vscode.Position, _ctx: vscode.ReferenceContext): vscode.Location[] {
+		const ir = irFor(document);
+		const ssa = ssaAt(document, position);
+		if (ssa) {
+			const refs = ir.references.get(ssa.name) ?? [];
+			const locations = refs.map(r => new vscode.Location(
+				document.uri,
+				new vscode.Range(r.line, r.character, r.line, r.character + ssa.name.length),
+			));
+			const def = ir.definitions.get(ssa.name);
+			if (def) {
+				locations.unshift(new vscode.Location(
+					document.uri,
+					new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length),
+				));
+			}
+			return locations;
+		}
+		const block = blockAt(document, position);
+		if (block) {
+			const target = ir.blockByName.get(block.name);
+			const out: vscode.Location[] = target ? [new vscode.Location(document.uri, target.headerRange)] : [];
+			// Scan every line for textual references to that block name.
+			const re = new RegExp(`\\b${block.name}\\b`, 'g');
+			for (let i = 0; i < document.lineCount; i++) {
+				const text = document.lineAt(i).text;
+				let m: RegExpExecArray | null;
+				while ((m = re.exec(text)) !== null) {
+					if (target && i === target.headerLine) {
+						continue;
+					}
+					out.push(new vscode.Location(
+						document.uri,
+						new vscode.Range(i, m.index, i, m.index + block.name.length),
+					));
+				}
+			}
+			return out;
+		}
+		return [];
+	}
+}
+
+// ----- HoverProvider: explain SSA values, blocks, types -----
+
+export class IrHoverProvider implements vscode.HoverProvider {
+	provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover | undefined {
+		const ir = irFor(document);
+		const ssa = ssaAt(document, position);
+		if (ssa) {
+			return new vscode.Hover(this.ssaHover(ir, ssa.name), ssa.range);
+		}
+		const block = blockAt(document, position);
+		if (block) {
+			const target = ir.blockByName.get(block.name);
+			if (target) {
+				return new vscode.Hover(this.blockHover(target), block.range);
+			}
+		}
+		const wordRange = document.getWordRangeAtPosition(position, /\b(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\b/);
+		if (wordRange) {
+			const word = document.getText(wordRange);
+			return new vscode.Hover(typeDoc(word), wordRange);
+		}
+		const opRange = document.getWordRangeAtPosition(position, /\b(cast_to|load|store|return|br|if|and|or|xor|not|func_\*|alloca)\b/);
+		if (opRange) {
+			const op = document.getText(opRange);
+			return new vscode.Hover(opDoc(op), opRange);
+		}
+		return undefined;
+	}
+
+	private ssaHover(ir: ParsedIr, name: string): vscode.MarkdownString {
+		const md = new vscode.MarkdownString();
+		md.isTrusted = false;
+		md.supportHtml = false;
+		const def = ir.definitions.get(name);
+		if (def) {
+			md.appendMarkdown(`**${name}** *(SSA value)*\n\n`);
+			md.appendCodeblock(def.rhs, 'nautilus-ir');
+			md.appendMarkdown(`\nDefined on line **${def.line + 1}**`);
+			if (def.type) {
+				md.appendMarkdown(` with type \`${def.type}\``);
+			}
+			const refs = ir.references.get(name) ?? [];
+			md.appendMarkdown(`\n\n${refs.length} use(s).`);
+			return md;
+		}
+		// Block argument lookup.
+		for (const block of ir.blocks) {
+			const arg = block.args.find(a => a.name === name);
+			if (arg) {
+				md.appendMarkdown(`**${name}** *(block argument of \`${block.name}\`)*\n\n`);
+				md.appendMarkdown(`Type: \`${arg.type}\``);
+				return md;
+			}
+		}
+		md.appendMarkdown(`**${name}** — unknown SSA value`);
+		return md;
+	}
+
+	private blockHover(block: Block): vscode.MarkdownString {
+		const md = new vscode.MarkdownString();
+		md.appendMarkdown(`**${block.name}** *(basic block)*\n\n`);
+		const argSummary = block.args.length === 0
+			? '*(no arguments)*'
+			: block.args.map(a => `\`${a.name}: ${a.type}\``).join(', ');
+		md.appendMarkdown(`Arguments: ${argSummary}\n\n`);
+		md.appendMarkdown(`Instructions: ${block.instructions}\n\n`);
+		md.appendMarkdown(`Terminator: \`${block.terminator}\`\n\n`);
+		md.appendMarkdown(`Predecessors: ${formatList(block.predecessors)}\n\n`);
+		md.appendMarkdown(`Successors: ${formatList(block.successors)}`);
+		return md;
+	}
+}
+
+function formatList(items: string[]): string {
+	if (items.length === 0) {
+		return '*(none)*';
+	}
+	return items.map(i => `\`${i}\``).join(', ');
+}
+
+function typeDoc(t: string): vscode.MarkdownString {
+	const md = new vscode.MarkdownString();
+	md.appendMarkdown(`**${t}** — Nautilus IR primitive type\n\n`);
+	const docs: Record<string, string> = {
+		i8: 'Signed 8-bit integer.',
+		i16: 'Signed 16-bit integer.',
+		i32: 'Signed 32-bit integer.',
+		i64: 'Signed 64-bit integer.',
+		ui8: 'Unsigned 8-bit integer.',
+		ui16: 'Unsigned 16-bit integer.',
+		ui32: 'Unsigned 32-bit integer.',
+		ui64: 'Unsigned 64-bit integer.',
+		f32: 'Single-precision (32-bit) IEEE-754 floating point.',
+		f64: 'Double-precision (64-bit) IEEE-754 floating point.',
+		bool: 'Boolean value (true/false).',
+		ptr: 'Opaque pointer to an arbitrary memory address.',
+		void: 'No value (used for store/return).',
+	};
+	md.appendMarkdown(docs[t] ?? '');
+	return md;
+}
+
+function opDoc(op: string): vscode.MarkdownString {
+	const md = new vscode.MarkdownString();
+	const docs: Record<string, string> = {
+		cast_to: 'Type conversion. `$x cast_to TYPE :TYPE` reinterprets `$x` as `TYPE`.',
+		load: 'Read a value from a pointer: `$y = load($ptr) :TYPE`.',
+		store: 'Write a value to a pointer: `store($value, $ptr) :void`.',
+		return: 'Terminator that exits `execute()`. May return zero or one value.',
+		br: 'Unconditional branch: `br Block_N($args) :void`.',
+		if: 'Conditional branch: `if $cond ? Block_T($args) : Block_F($args) :void`.',
+		and: 'Logical/bitwise conjunction.',
+		or: 'Logical/bitwise disjunction.',
+		xor: 'Logical/bitwise exclusive-or.',
+		not: 'Logical negation.',
+		'func_*': 'Indirect call through a function pointer resolved by the JIT runtime.',
+		alloca: 'Allocate a stack slot of the given type.',
+	};
+	md.appendMarkdown(`**${op}** — Nautilus IR operation\n\n${docs[op] ?? ''}`);
+	return md;
+}
+
+// ----- DocumentHighlightProvider: highlight all uses of the SSA under cursor -----
+
+export class IrHighlightProvider implements vscode.DocumentHighlightProvider {
+	provideDocumentHighlights(document: vscode.TextDocument, position: vscode.Position): vscode.DocumentHighlight[] {
+		const ir = irFor(document);
+		const ssa = ssaAt(document, position);
+		if (ssa) {
+			const out: vscode.DocumentHighlight[] = [];
+			const def = ir.definitions.get(ssa.name);
+			if (def) {
+				out.push(new vscode.DocumentHighlight(
+					new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length),
+					vscode.DocumentHighlightKind.Write,
+				));
+			}
+			const refs = ir.references.get(ssa.name) ?? [];
+			for (const r of refs) {
+				out.push(new vscode.DocumentHighlight(
+					new vscode.Range(r.line, r.character, r.line, r.character + ssa.name.length),
+					vscode.DocumentHighlightKind.Read,
+				));
+			}
+			return out;
+		}
+		const block = blockAt(document, position);
+		if (block) {
+			const re = new RegExp(`\\b${block.name}\\b`, 'g');
+			const out: vscode.DocumentHighlight[] = [];
+			for (let i = 0; i < document.lineCount; i++) {
+				const text = document.lineAt(i).text;
+				let m: RegExpExecArray | null;
+				while ((m = re.exec(text)) !== null) {
+					out.push(new vscode.DocumentHighlight(
+						new vscode.Range(i, m.index, i, m.index + block.name.length),
+						vscode.DocumentHighlightKind.Read,
+					));
+				}
+			}
+			return out;
+		}
+		return [];
+	}
+}
+
+// ----- FoldingRangeProvider: fold blocks and the wrapper module -----
+
+export class IrFoldingProvider implements vscode.FoldingRangeProvider {
+	provideFoldingRanges(document: vscode.TextDocument): vscode.FoldingRange[] {
+		const ir = irFor(document);
+		const ranges: vscode.FoldingRange[] = [];
+		if (ir.moduleRange) {
+			ranges.push(new vscode.FoldingRange(ir.moduleRange.start.line, ir.moduleRange.end.line, vscode.FoldingRangeKind.Region));
+		}
+		if (ir.executeRange) {
+			ranges.push(new vscode.FoldingRange(ir.executeRange.start.line, ir.executeRange.end.line, vscode.FoldingRangeKind.Region));
+		}
+		for (const block of ir.blocks) {
+			if (block.bodyRange.end.line > block.headerLine) {
+				ranges.push(new vscode.FoldingRange(block.headerLine, block.bodyRange.end.line, vscode.FoldingRangeKind.Region));
+			}
+		}
+		return ranges;
+	}
+}
+
+// ----- RenameProvider: rename SSA values consistently in the file -----
+
+export class IrRenameProvider implements vscode.RenameProvider {
+	prepareRename(document: vscode.TextDocument, position: vscode.Position): vscode.Range {
+		const ssa = ssaAt(document, position);
+		if (!ssa) {
+			throw new Error('Only $N SSA values can be renamed.');
+		}
+		return ssa.range;
+	}
+
+	provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string): vscode.WorkspaceEdit {
+		if (!/^\$\d+$/.test(newName)) {
+			throw new Error('New name must match pattern $N (e.g. $42).');
+		}
+		const ir = irFor(document);
+		const ssa = ssaAt(document, position);
+		if (!ssa) {
+			throw new Error('Cursor is not on an SSA value.');
+		}
+		const edit = new vscode.WorkspaceEdit();
+		const def = ir.definitions.get(ssa.name);
+		if (def) {
+			edit.replace(document.uri, new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length), newName);
+		}
+		const refs = ir.references.get(ssa.name) ?? [];
+		for (const r of refs) {
+			edit.replace(document.uri, new vscode.Range(r.line, r.character, r.line, r.character + ssa.name.length), newName);
+		}
+		// Also rewrite occurrences in block headers (block arguments).
+		for (const block of ir.blocks) {
+			const headerText = document.lineAt(block.headerLine).text;
+			const re = new RegExp(`\\${ssa.name}\\b`, 'g');
+			let m: RegExpExecArray | null;
+			while ((m = re.exec(headerText)) !== null) {
+				edit.replace(document.uri, new vscode.Range(block.headerLine, m.index, block.headerLine, m.index + ssa.name.length), newName);
+			}
+		}
+		return edit;
+	}
+}
+
+// ----- CodeLensProvider: show predecessor/successor counts above each block -----
+
+export class IrCodeLensProvider implements vscode.CodeLensProvider {
+	provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+		const config = vscode.workspace.getConfiguration('nautilusIr');
+		if (!config.get<boolean>('codeLens', true)) {
+			return [];
+		}
+		const ir = irFor(document);
+		const lenses: vscode.CodeLens[] = [];
+		for (const block of ir.blocks) {
+			const title = `${block.predecessors.length} preds · ${block.successors.length} succs · ${block.instructions} insn`;
+			lenses.push(new vscode.CodeLens(block.headerRange, {
+				title,
+				command: 'nautilus-ir.showBlockInfo',
+				arguments: [document.uri, block.name],
+			}));
+		}
+		return lenses;
+	}
+}

--- a/tools/vscode-nautilus-ir/src/features.ts
+++ b/tools/vscode-nautilus-ir/src/features.ts
@@ -26,8 +26,9 @@ export class IrSymbolProvider implements vscode.DocumentSymbolProvider {
 		const ir = irFor(document);
 		const symbols: vscode.DocumentSymbol[] = [];
 		for (const fn of ir.functions) {
+			const signature = `(${fn.args.map(a => `${a.name}:${a.type}`).join(', ')})${fn.returnType ? ` :${fn.returnType}` : ''}`;
 			const fnSym = new vscode.DocumentSymbol(
-				`${fn.name}()`,
+				`${fn.name}${signature}`,
 				`${fn.blocks.length} block(s) · ${fn.definitions.size} def(s)`,
 				vscode.SymbolKind.Function,
 				fn.bodyRange,
@@ -196,6 +197,18 @@ export class IrHoverProvider implements vscode.HoverProvider {
 			const refs = fn ? allRefs.filter(r => r.functionName === fn.name) : allRefs;
 			md.appendMarkdown(`\n\n${refs.length} use(s) in \`${def.functionName}\`.`);
 			return md;
+		}
+		// Function parameter? Look at the enclosing function's signature first.
+		if (fn) {
+			const param = fn.args.find(a => a.name === name);
+			if (param) {
+				md.appendMarkdown(`**${name}** *(parameter of \`${fn.name}\`)*\n\n`);
+				md.appendMarkdown(`Type: \`${param.type}\``);
+				if (fn.returnType) {
+					md.appendMarkdown(`\n\nFunction returns \`${fn.returnType}\`.`);
+				}
+				return md;
+			}
 		}
 		// Block argument lookup (within the enclosing function).
 		const blocks = fn?.blocks ?? ir.blocks;

--- a/tools/vscode-nautilus-ir/src/features.ts
+++ b/tools/vscode-nautilus-ir/src/features.ts
@@ -4,7 +4,7 @@
 // re-parsing on every cursor movement.
 
 import * as vscode from 'vscode';
-import { parse, ParsedIr, ssaAt, blockAt, Block } from './parser';
+import { parse, ParsedIr, ssaAt, blockAt, functionAt, Block, IrFunction } from './parser';
 
 const cache = new WeakMap<vscode.TextDocument, { version: number; ir: ParsedIr }>();
 
@@ -18,34 +18,45 @@ export function irFor(document: vscode.TextDocument): ParsedIr {
 	return ir;
 }
 
-// ----- DocumentSymbolProvider: blocks become symbols, defs become children -----
+// ----- DocumentSymbolProvider -----
+// Top level: functions. Children: blocks. Grandchildren: SSA defs.
 
 export class IrSymbolProvider implements vscode.DocumentSymbolProvider {
 	provideDocumentSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
 		const ir = irFor(document);
 		const symbols: vscode.DocumentSymbol[] = [];
-		for (const block of ir.blocks) {
-			const argSummary = block.args.map(a => `${a.name}:${a.type}`).join(', ');
-			const blockSym = new vscode.DocumentSymbol(
-				block.name,
-				`(${argSummary})  → ${block.successors.length ? block.successors.join(', ') : block.terminator}`,
+		for (const fn of ir.functions) {
+			const fnSym = new vscode.DocumentSymbol(
+				`${fn.name}()`,
+				`${fn.blocks.length} block(s) · ${fn.definitions.size} def(s)`,
 				vscode.SymbolKind.Function,
-				block.bodyRange,
-				block.headerRange,
+				fn.bodyRange,
+				fn.headerRange,
 			);
-			for (const [name, def] of ir.definitions) {
-				if (def.line >= block.headerLine && def.line <= block.bodyRange.end.line) {
-					const defRange = new vscode.Range(def.line, def.character, def.line, def.character + name.length);
-					blockSym.children.push(new vscode.DocumentSymbol(
-						name,
-						def.type ? `:${def.type}` : '',
-						vscode.SymbolKind.Variable,
-						defRange,
-						defRange,
-					));
+			for (const block of fn.blocks) {
+				const argSummary = block.args.map(a => `${a.name}:${a.type}`).join(', ');
+				const blockSym = new vscode.DocumentSymbol(
+					block.name,
+					`(${argSummary})  → ${block.successors.length ? block.successors.join(', ') : block.terminator}`,
+					vscode.SymbolKind.Method,
+					block.bodyRange,
+					block.headerRange,
+				);
+				for (const def of fn.definitions.values()) {
+					if (def.line >= block.headerLine && def.line <= block.bodyRange.end.line) {
+						const defRange = new vscode.Range(def.line, def.character, def.line, def.character + def.name.length);
+						blockSym.children.push(new vscode.DocumentSymbol(
+							def.name,
+							def.type ? `:${def.type}` : '',
+							vscode.SymbolKind.Variable,
+							defRange,
+							defRange,
+						));
+					}
 				}
+				fnSym.children.push(blockSym);
 			}
-			symbols.push(blockSym);
+			symbols.push(fnSym);
 		}
 		return symbols;
 	}
@@ -56,15 +67,18 @@ export class IrSymbolProvider implements vscode.DocumentSymbolProvider {
 export class IrDefinitionProvider implements vscode.DefinitionProvider {
 	provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.Definition | undefined {
 		const ir = irFor(document);
+		const fn = functionAt(ir, position.line);
 		const ssa = ssaAt(document, position);
 		if (ssa) {
-			const def = ir.definitions.get(ssa.name);
+			// Per-function lookup first, fall back to module-wide.
+			const def = (fn?.definitions.get(ssa.name)) ?? ir.definitions.get(ssa.name);
 			if (def) {
 				const range = new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length);
 				return new vscode.Location(document.uri, range);
 			}
-			// Could be a block argument; jump to the block header it appears on.
-			for (const block of ir.blocks) {
+			// Block argument? Jump to the owning block header.
+			const blocks = fn?.blocks ?? ir.blocks;
+			for (const block of blocks) {
 				if (block.args.some(a => a.name === ssa.name)) {
 					return new vscode.Location(document.uri, block.headerRange);
 				}
@@ -72,7 +86,7 @@ export class IrDefinitionProvider implements vscode.DefinitionProvider {
 		}
 		const block = blockAt(document, position);
 		if (block) {
-			const target = ir.blockByName.get(block.name);
+			const target = (fn?.blockByName.get(block.name)) ?? ir.blockByName.get(block.name);
 			if (target) {
 				return new vscode.Location(document.uri, target.headerRange);
 			}
@@ -86,14 +100,17 @@ export class IrDefinitionProvider implements vscode.DefinitionProvider {
 export class IrReferenceProvider implements vscode.ReferenceProvider {
 	provideReferences(document: vscode.TextDocument, position: vscode.Position, _ctx: vscode.ReferenceContext): vscode.Location[] {
 		const ir = irFor(document);
+		const fn = functionAt(ir, position.line);
 		const ssa = ssaAt(document, position);
 		if (ssa) {
-			const refs = ir.references.get(ssa.name) ?? [];
+			// Restrict references to the same function (SSA names don't cross fn boundaries).
+			const allRefs = ir.references.get(ssa.name) ?? [];
+			const refs = fn ? allRefs.filter(r => r.functionName === fn.name) : allRefs;
 			const locations = refs.map(r => new vscode.Location(
 				document.uri,
 				new vscode.Range(r.line, r.character, r.line, r.character + ssa.name.length),
 			));
-			const def = ir.definitions.get(ssa.name);
+			const def = (fn?.definitions.get(ssa.name)) ?? ir.definitions.get(ssa.name);
 			if (def) {
 				locations.unshift(new vscode.Location(
 					document.uri,
@@ -104,11 +121,13 @@ export class IrReferenceProvider implements vscode.ReferenceProvider {
 		}
 		const block = blockAt(document, position);
 		if (block) {
-			const target = ir.blockByName.get(block.name);
+			const target = (fn?.blockByName.get(block.name)) ?? ir.blockByName.get(block.name);
 			const out: vscode.Location[] = target ? [new vscode.Location(document.uri, target.headerRange)] : [];
-			// Scan every line for textual references to that block name.
+			// Scan only the owning function's range to avoid hits in other functions.
+			const scanStart = fn?.headerLine ?? 0;
+			const scanEnd = fn?.bodyRange.end.line ?? document.lineCount - 1;
 			const re = new RegExp(`\\b${block.name}\\b`, 'g');
-			for (let i = 0; i < document.lineCount; i++) {
+			for (let i = scanStart; i <= scanEnd; i++) {
 				const text = document.lineAt(i).text;
 				let m: RegExpExecArray | null;
 				while ((m = re.exec(text)) !== null) {
@@ -132,15 +151,16 @@ export class IrReferenceProvider implements vscode.ReferenceProvider {
 export class IrHoverProvider implements vscode.HoverProvider {
 	provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover | undefined {
 		const ir = irFor(document);
+		const fn = functionAt(ir, position.line);
 		const ssa = ssaAt(document, position);
 		if (ssa) {
-			return new vscode.Hover(this.ssaHover(ir, ssa.name), ssa.range);
+			return new vscode.Hover(this.ssaHover(ir, fn, ssa.name), ssa.range);
 		}
 		const block = blockAt(document, position);
 		if (block) {
-			const target = ir.blockByName.get(block.name);
+			const target = (fn?.blockByName.get(block.name)) ?? ir.blockByName.get(block.name);
 			if (target) {
-				return new vscode.Hover(this.blockHover(target), block.range);
+				return new vscode.Hover(this.blockHover(target, fn), block.range);
 			}
 		}
 		const wordRange = document.getWordRangeAtPosition(position, /\b(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\b/);
@@ -148,7 +168,7 @@ export class IrHoverProvider implements vscode.HoverProvider {
 			const word = document.getText(wordRange);
 			return new vscode.Hover(typeDoc(word), wordRange);
 		}
-		const opRange = document.getWordRangeAtPosition(position, /\b(cast_to|load|store|return|br|if|and|or|xor|not|func_\*|alloca)\b/);
+		const opRange = document.getWordRangeAtPosition(position, /\b(cast_to|load|store|return|br|if|and|or|func_\*)\b/);
 		if (opRange) {
 			const op = document.getText(opRange);
 			return new vscode.Hover(opDoc(op), opRange);
@@ -156,27 +176,33 @@ export class IrHoverProvider implements vscode.HoverProvider {
 		return undefined;
 	}
 
-	private ssaHover(ir: ParsedIr, name: string): vscode.MarkdownString {
+	private ssaHover(ir: ParsedIr, fn: IrFunction | undefined, name: string): vscode.MarkdownString {
 		const md = new vscode.MarkdownString();
 		md.isTrusted = false;
 		md.supportHtml = false;
-		const def = ir.definitions.get(name);
+		const def = (fn?.definitions.get(name)) ?? ir.definitions.get(name);
 		if (def) {
-			md.appendMarkdown(`**${name}** *(SSA value)*\n\n`);
-			md.appendCodeblock(def.rhs, 'nautilus-ir');
+			md.appendMarkdown(`**${name}** *(SSA value in \`${def.functionName}\`)*\n\n`);
+			if (def.rhs) {
+				md.appendCodeblock(def.rhs, 'nautilus-ir');
+			} else {
+				md.appendMarkdown(`*(declaration only — bare typed slot)*\n\n`);
+			}
 			md.appendMarkdown(`\nDefined on line **${def.line + 1}**`);
 			if (def.type) {
 				md.appendMarkdown(` with type \`${def.type}\``);
 			}
-			const refs = ir.references.get(name) ?? [];
-			md.appendMarkdown(`\n\n${refs.length} use(s).`);
+			const allRefs = ir.references.get(name) ?? [];
+			const refs = fn ? allRefs.filter(r => r.functionName === fn.name) : allRefs;
+			md.appendMarkdown(`\n\n${refs.length} use(s) in \`${def.functionName}\`.`);
 			return md;
 		}
-		// Block argument lookup.
-		for (const block of ir.blocks) {
+		// Block argument lookup (within the enclosing function).
+		const blocks = fn?.blocks ?? ir.blocks;
+		for (const block of blocks) {
 			const arg = block.args.find(a => a.name === name);
 			if (arg) {
-				md.appendMarkdown(`**${name}** *(block argument of \`${block.name}\`)*\n\n`);
+				md.appendMarkdown(`**${name}** *(argument of \`${block.name}\` in \`${block.functionName}\`)*\n\n`);
 				md.appendMarkdown(`Type: \`${arg.type}\``);
 				return md;
 			}
@@ -185,9 +211,9 @@ export class IrHoverProvider implements vscode.HoverProvider {
 		return md;
 	}
 
-	private blockHover(block: Block): vscode.MarkdownString {
+	private blockHover(block: Block, _fn: IrFunction | undefined): vscode.MarkdownString {
 		const md = new vscode.MarkdownString();
-		md.appendMarkdown(`**${block.name}** *(basic block)*\n\n`);
+		md.appendMarkdown(`**${block.name}** *(basic block in \`${block.functionName}\`)*\n\n`);
 		const argSummary = block.args.length === 0
 			? '*(no arguments)*'
 			: block.args.map(a => `\`${a.name}: ${a.type}\``).join(', ');
@@ -235,7 +261,7 @@ function opDoc(op: string): vscode.MarkdownString {
 		cast_to: 'Type conversion. `$x cast_to TYPE :TYPE` reinterprets `$x` as `TYPE`.',
 		load: 'Read a value from a pointer: `$y = load($ptr) :TYPE`.',
 		store: 'Write a value to a pointer: `store($value, $ptr) :void`.',
-		return: 'Terminator that exits `execute()`. May return zero or one value.',
+		return: 'Terminator that exits the enclosing function. May return zero or one value.',
 		br: 'Unconditional branch: `br Block_N($args) :void`.',
 		if: 'Conditional branch: `if $cond ? Block_T($args) : Block_F($args) :void`.',
 		and: 'Logical/bitwise conjunction.',
@@ -254,17 +280,19 @@ function opDoc(op: string): vscode.MarkdownString {
 export class IrHighlightProvider implements vscode.DocumentHighlightProvider {
 	provideDocumentHighlights(document: vscode.TextDocument, position: vscode.Position): vscode.DocumentHighlight[] {
 		const ir = irFor(document);
+		const fn = functionAt(ir, position.line);
 		const ssa = ssaAt(document, position);
 		if (ssa) {
 			const out: vscode.DocumentHighlight[] = [];
-			const def = ir.definitions.get(ssa.name);
-			if (def) {
+			const def = (fn?.definitions.get(ssa.name)) ?? ir.definitions.get(ssa.name);
+			if (def && (!fn || def.functionName === fn.name)) {
 				out.push(new vscode.DocumentHighlight(
 					new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length),
 					vscode.DocumentHighlightKind.Write,
 				));
 			}
-			const refs = ir.references.get(ssa.name) ?? [];
+			const allRefs = ir.references.get(ssa.name) ?? [];
+			const refs = fn ? allRefs.filter(r => r.functionName === fn.name) : allRefs;
 			for (const r of refs) {
 				out.push(new vscode.DocumentHighlight(
 					new vscode.Range(r.line, r.character, r.line, r.character + ssa.name.length),
@@ -275,9 +303,11 @@ export class IrHighlightProvider implements vscode.DocumentHighlightProvider {
 		}
 		const block = blockAt(document, position);
 		if (block) {
+			const scanStart = fn?.headerLine ?? 0;
+			const scanEnd = fn?.bodyRange.end.line ?? document.lineCount - 1;
 			const re = new RegExp(`\\b${block.name}\\b`, 'g');
 			const out: vscode.DocumentHighlight[] = [];
-			for (let i = 0; i < document.lineCount; i++) {
+			for (let i = scanStart; i <= scanEnd; i++) {
 				const text = document.lineAt(i).text;
 				let m: RegExpExecArray | null;
 				while ((m = re.exec(text)) !== null) {
@@ -302,8 +332,10 @@ export class IrFoldingProvider implements vscode.FoldingRangeProvider {
 		if (ir.moduleRange) {
 			ranges.push(new vscode.FoldingRange(ir.moduleRange.start.line, ir.moduleRange.end.line, vscode.FoldingRangeKind.Region));
 		}
-		if (ir.executeRange) {
-			ranges.push(new vscode.FoldingRange(ir.executeRange.start.line, ir.executeRange.end.line, vscode.FoldingRangeKind.Region));
+		for (const fn of ir.functions) {
+			if (fn.bodyRange.end.line > fn.headerLine) {
+				ranges.push(new vscode.FoldingRange(fn.headerLine, fn.bodyRange.end.line, vscode.FoldingRangeKind.Region));
+			}
 		}
 		for (const block of ir.blocks) {
 			if (block.bodyRange.end.line > block.headerLine) {
@@ -330,21 +362,26 @@ export class IrRenameProvider implements vscode.RenameProvider {
 			throw new Error('New name must match pattern $N (e.g. $42).');
 		}
 		const ir = irFor(document);
+		const fn = functionAt(ir, position.line);
 		const ssa = ssaAt(document, position);
 		if (!ssa) {
 			throw new Error('Cursor is not on an SSA value.');
 		}
+		// SSA names are scoped to a function; rename only within that function
+		// to avoid corrupting other functions in the same module.
+		const blocks = fn?.blocks ?? ir.blocks;
+		const def = (fn?.definitions.get(ssa.name)) ?? ir.definitions.get(ssa.name);
+		const allRefs = ir.references.get(ssa.name) ?? [];
+		const refs = fn ? allRefs.filter(r => r.functionName === fn.name) : allRefs;
 		const edit = new vscode.WorkspaceEdit();
-		const def = ir.definitions.get(ssa.name);
-		if (def) {
+		if (def && (!fn || def.functionName === fn.name)) {
 			edit.replace(document.uri, new vscode.Range(def.line, def.character, def.line, def.character + ssa.name.length), newName);
 		}
-		const refs = ir.references.get(ssa.name) ?? [];
 		for (const r of refs) {
 			edit.replace(document.uri, new vscode.Range(r.line, r.character, r.line, r.character + ssa.name.length), newName);
 		}
-		// Also rewrite occurrences in block headers (block arguments).
-		for (const block of ir.blocks) {
+		// Block-argument occurrences in the headers of the same function.
+		for (const block of blocks) {
 			const headerText = document.lineAt(block.headerLine).text;
 			const re = new RegExp(`\\${ssa.name}\\b`, 'g');
 			let m: RegExpExecArray | null;

--- a/tools/vscode-nautilus-ir/src/gdbMi.ts
+++ b/tools/vscode-nautilus-ir/src/gdbMi.ts
@@ -1,0 +1,319 @@
+// Minimal GDB/MI parser & driver.
+//
+// We only implement the subset needed for stepping through Nautilus IR files:
+// - send commands with a token, wait for the matching `^done`/`^error`/`^running`
+// - parse async records (`*stopped`, `=thread-group-*`, `~"..."` console output)
+//
+// This is intentionally compact; it is NOT a general-purpose MI parser.
+
+import { ChildProcess, spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
+export interface MiResult {
+	cls: 'done' | 'running' | 'connected' | 'error' | 'exit';
+	results: Record<string, MiValue>;
+	raw: string;
+}
+
+export type MiValue = string | MiValue[] | { [key: string]: MiValue };
+
+export interface MiAsync {
+	cls: string; // e.g. "stopped", "thread-group-added"
+	results: Record<string, MiValue>;
+	raw: string;
+}
+
+interface PendingCommand {
+	resolve: (r: MiResult) => void;
+	reject: (err: Error) => void;
+	command: string;
+}
+
+export class GdbMi extends EventEmitter {
+	private proc: ChildProcess | undefined;
+	private tokenCounter = 1;
+	private pending = new Map<number, PendingCommand>();
+	private buffer = '';
+	private exited = false;
+
+	constructor(private gdbPath: string, private extraArgs: string[]) {
+		super();
+	}
+
+	start(cwd: string, env: NodeJS.ProcessEnv): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const args = ['--interpreter=mi2', '--quiet', ...this.extraArgs];
+			const proc = spawn(this.gdbPath, args, { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] });
+			this.proc = proc;
+			proc.stdout.setEncoding('utf8');
+			proc.stderr.setEncoding('utf8');
+			proc.stdout.on('data', chunk => this.consume(chunk));
+			proc.stderr.on('data', chunk => this.emit('stderr', chunk));
+			proc.on('error', err => {
+				this.exited = true;
+				this.failAll(err);
+				reject(err);
+				this.emit('exit', -1);
+			});
+			proc.on('exit', code => {
+				this.exited = true;
+				this.failAll(new Error(`gdb exited with code ${code}`));
+				this.emit('exit', code ?? 0);
+			});
+			// Wait for the initial "(gdb)" prompt before resolving.
+			const onReady = () => {
+				this.removeListener('ready', onReady);
+				resolve();
+			};
+			this.once('ready', onReady);
+			// Bound the wait so a missing gdb doesn't hang the session.
+			setTimeout(() => {
+				if (!this.exited && this.listenerCount('ready') > 0) {
+					this.removeListener('ready', onReady);
+					resolve(); // resolve anyway; later commands will fail clearly
+				}
+			}, 5_000);
+		});
+	}
+
+	dispose(): void {
+		if (this.proc && !this.exited) {
+			try {
+				this.proc.kill('SIGTERM');
+			} catch {
+				// ignore
+			}
+		}
+	}
+
+	send(command: string): Promise<MiResult> {
+		if (!this.proc || this.exited) {
+			return Promise.reject(new Error('gdb is not running'));
+		}
+		return new Promise((resolve, reject) => {
+			const token = this.tokenCounter++;
+			this.pending.set(token, { resolve, reject, command });
+			this.proc!.stdin!.write(`${token}-${command}\n`);
+		});
+	}
+
+	private consume(chunk: string): void {
+		this.buffer += chunk;
+		let idx: number;
+		while ((idx = this.buffer.indexOf('\n')) >= 0) {
+			const line = this.buffer.slice(0, idx).replace(/\r$/, '');
+			this.buffer = this.buffer.slice(idx + 1);
+			this.handleLine(line);
+		}
+	}
+
+	private handleLine(line: string): void {
+		if (line === '(gdb)' || line === '(gdb) ') {
+			this.emit('ready');
+			return;
+		}
+		// Console / log / target stream records.
+		if (line.startsWith('~') || line.startsWith('@') || line.startsWith('&')) {
+			const text = parseCString(line.slice(1));
+			this.emit('console', text);
+			return;
+		}
+		// Async record: *stopped, =thread-group-added, +download...
+		if (line.startsWith('*') || line.startsWith('=') || line.startsWith('+')) {
+			const sigil = line[0];
+			const body = line.slice(1);
+			const commaIdx = body.indexOf(',');
+			const cls = commaIdx >= 0 ? body.slice(0, commaIdx) : body;
+			const rest = commaIdx >= 0 ? body.slice(commaIdx + 1) : '';
+			const results = rest ? parseResults(rest) : {};
+			const evt: MiAsync = { cls, results, raw: line };
+			if (sigil === '*') {
+				this.emit('exec', evt);
+			} else if (sigil === '=') {
+				this.emit('notify', evt);
+			} else {
+				this.emit('status', evt);
+			}
+			return;
+		}
+		// Result record: TOKEN^class[,results]
+		const resultMatch = /^(\d+)\^([a-z]+)(?:,(.*))?$/.exec(line);
+		if (resultMatch) {
+			const token = parseInt(resultMatch[1], 10);
+			const cls = resultMatch[2] as MiResult['cls'];
+			const results = resultMatch[3] ? parseResults(resultMatch[3]) : {};
+			const pending = this.pending.get(token);
+			this.pending.delete(token);
+			if (pending) {
+				if (cls === 'error') {
+					const msg = typeof results.msg === 'string' ? results.msg : 'gdb error';
+					pending.reject(new Error(`${pending.command}: ${msg}`));
+				} else {
+					pending.resolve({ cls, results, raw: line });
+				}
+			}
+			return;
+		}
+		// Anything else: treat as raw target output.
+		if (line.length > 0) {
+			this.emit('output', line);
+		}
+	}
+
+	private failAll(err: Error): void {
+		for (const p of this.pending.values()) {
+			p.reject(err);
+		}
+		this.pending.clear();
+	}
+}
+
+// ----- Result parsing -----
+
+function parseResults(input: string): Record<string, MiValue> {
+	const reader = new Reader(input);
+	const out: Record<string, MiValue> = {};
+	while (!reader.eof()) {
+		const key = reader.readIdentifier();
+		reader.expect('=');
+		out[key] = reader.readValue();
+		if (reader.peek() === ',') {
+			reader.advance();
+		}
+	}
+	return out;
+}
+
+class Reader {
+	private pos = 0;
+	constructor(private text: string) {}
+
+	eof(): boolean {
+		return this.pos >= this.text.length;
+	}
+
+	peek(): string {
+		return this.text[this.pos] ?? '';
+	}
+
+	advance(): string {
+		return this.text[this.pos++] ?? '';
+	}
+
+	expect(ch: string): void {
+		if (this.advance() !== ch) {
+			throw new Error(`expected '${ch}' at ${this.pos}`);
+		}
+	}
+
+	readIdentifier(): string {
+		const start = this.pos;
+		while (!this.eof() && /[A-Za-z0-9_-]/.test(this.peek())) {
+			this.pos++;
+		}
+		return this.text.slice(start, this.pos);
+	}
+
+	readValue(): MiValue {
+		const ch = this.peek();
+		if (ch === '"') {
+			return this.readString();
+		}
+		if (ch === '{') {
+			return this.readTuple();
+		}
+		if (ch === '[') {
+			return this.readList();
+		}
+		// Bareword fallback.
+		return this.readIdentifier();
+	}
+
+	readString(): string {
+		this.expect('"');
+		let out = '';
+		while (!this.eof()) {
+			const c = this.advance();
+			if (c === '"') {
+				return out;
+			}
+			if (c === '\\') {
+				const n = this.advance();
+				switch (n) {
+					case 'n': out += '\n'; break;
+					case 't': out += '\t'; break;
+					case 'r': out += '\r'; break;
+					case '\\': out += '\\'; break;
+					case '"': out += '"'; break;
+					default: out += n;
+				}
+			} else {
+				out += c;
+			}
+		}
+		return out;
+	}
+
+	readTuple(): { [key: string]: MiValue } {
+		this.expect('{');
+		const out: { [key: string]: MiValue } = {};
+		if (this.peek() === '}') {
+			this.advance();
+			return out;
+		}
+		while (true) {
+			const key = this.readIdentifier();
+			this.expect('=');
+			out[key] = this.readValue();
+			const sep = this.advance();
+			if (sep === '}') {
+				return out;
+			}
+			if (sep !== ',') {
+				throw new Error(`expected ',' or '}' at ${this.pos}`);
+			}
+		}
+	}
+
+	readList(): MiValue[] {
+		this.expect('[');
+		const out: MiValue[] = [];
+		if (this.peek() === ']') {
+			this.advance();
+			return out;
+		}
+		while (true) {
+			// Lists may contain bare values OR key=value pairs (we drop the key).
+			const beforeKey = this.pos;
+			let value: MiValue;
+			if (/[A-Za-z_]/.test(this.peek())) {
+				this.readIdentifier();
+				if (this.peek() === '=') {
+					this.advance();
+					value = this.readValue();
+				} else {
+					this.pos = beforeKey;
+					value = this.readValue();
+				}
+			} else {
+				value = this.readValue();
+			}
+			out.push(value);
+			const sep = this.advance();
+			if (sep === ']') {
+				return out;
+			}
+			if (sep !== ',') {
+				throw new Error(`expected ',' or ']' at ${this.pos}`);
+			}
+		}
+	}
+}
+
+function parseCString(input: string): string {
+	const reader = new Reader(input);
+	if (reader.peek() === '"') {
+		return reader.readString();
+	}
+	return input;
+}

--- a/tools/vscode-nautilus-ir/src/parser.ts
+++ b/tools/vscode-nautilus-ir/src/parser.ts
@@ -4,7 +4,7 @@
 // Grammar reference (informally):
 //
 //   module      ::= 'nautilus' '{' function* '}' '//nautilus'?
-//   function    ::= IDENT '(' ')' '{' block+ '}'
+//   function    ::= IDENT '(' arg-list? ')' (':' TYPE)? '{' block+ '}'
 //   block       ::= 'Block_' INT '(' arg-list? ')' ':' statement*
 //   arg-list    ::= typed-ssa (',' typed-ssa)*
 //   typed-ssa   ::= '$' INT ':' TYPE
@@ -67,6 +67,8 @@ export interface Block {
 
 export interface IrFunction {
 	name: string;
+	args: BlockArgument[];                 // typed parameters from the header
+	returnType: string | undefined;        // primitive type after `):` (undefined if absent)
 	headerLine: number;
 	headerRange: vscode.Range;
 	bodyRange: vscode.Range;
@@ -86,7 +88,9 @@ export interface ParsedIr {
 	references: Map<string, SsaReference[]>;
 }
 
-const FUNCTION_HEADER_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*\{\s*$/;
+// Matches "name(arg-list?) :returnType? {". The arg list and the return type
+// are optional to support both legacy and current dump formats.
+const FUNCTION_HEADER_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*(?::\s*([a-z0-9]+))?\s*\{\s*$/;
 const BLOCK_HEADER_RE = /^\s*(Block_\d+)\s*\(([^)]*)\)\s*:\s*$/;
 const SSA_DEF_RE = /^\s*(\$\d+)\s*=\s*(.+?)\s*$/;
 const BARE_DECL_RE = /^\s*(\$\d+)\s*:\s*([a-z0-9]+)\s*$/;
@@ -135,8 +139,15 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 		if (fnMatch && fnMatch[1] !== MODULE_KEYWORD) {
 			finalizeBlock(currentBlock, i - 1, document);
 			finalizeFunction(currentFn, i - 1, document);
+			const argList = fnMatch[2].trim();
+			const args: BlockArgument[] = argList === ''
+				? []
+				: argList.split(',').map(rawArgToken);
+			const returnType = fnMatch[3] && PRIMITIVE_TYPES.has(fnMatch[3]) ? fnMatch[3] : undefined;
 			currentFn = {
 				name: fnMatch[1],
+				args,
+				returnType,
 				headerLine: i,
 				headerRange: new vscode.Range(i, 0, i, text.length),
 				bodyRange: new vscode.Range(i, 0, i, text.length),

--- a/tools/vscode-nautilus-ir/src/parser.ts
+++ b/tools/vscode-nautilus-ir/src/parser.ts
@@ -1,0 +1,252 @@
+// Lightweight, regex-based parser for Nautilus IR.
+//
+// Nautilus IR is a small, line-oriented format. We don't build a full AST
+// here, just enough structure (blocks, SSA defs, references, branches) to
+// power navigation, hover, and folding features.
+
+import * as vscode from 'vscode';
+
+export interface SsaDefinition {
+	name: string;            // e.g. "$3"
+	line: number;            // zero-based line index of the definition
+	character: number;       // column of the leading $
+	rhs: string;             // raw right-hand side text (after `=`)
+	type: string | undefined;// trailing :type if present
+}
+
+export interface SsaReference {
+	name: string;
+	line: number;
+	character: number;
+}
+
+export interface BlockArgument {
+	name: string;
+	type: string;
+}
+
+export interface Block {
+	name: string;             // e.g. "Block_5"
+	headerLine: number;       // zero-based
+	headerRange: vscode.Range;
+	bodyRange: vscode.Range;  // header line through last instruction
+	args: BlockArgument[];
+	successors: string[];     // referenced block names from terminator(s)
+	predecessors: string[];   // populated in a second pass
+	instructions: number;     // count of non-blank, non-header lines
+	terminator: 'return' | 'br' | 'if' | 'unknown';
+}
+
+export interface ParsedIr {
+	blocks: Block[];
+	blockByName: Map<string, Block>;
+	definitions: Map<string, SsaDefinition>;       // by name
+	references: Map<string, SsaReference[]>;       // by name
+	moduleRange: vscode.Range | undefined;         // NautilusIr {...}
+	executeRange: vscode.Range | undefined;        // execute() {...}
+}
+
+const BLOCK_HEADER_RE = /^\s*(Block_\d+|B\d+)\s*\(([^)]*)\)\s*:\s*$/;
+const SSA_DEF_RE = /^\s*(\$\d+)\s*=\s*(.+?)\s*$/;
+const SSA_REF_RE = /\$\d+/g;
+const BLOCK_REF_RE = /\b(Block_\d+|B\d+)\b/g;
+const TYPE_TAIL_RE = /:\s*(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\s*$/;
+
+export function parse(document: vscode.TextDocument): ParsedIr {
+	const result: ParsedIr = {
+		blocks: [],
+		blockByName: new Map(),
+		definitions: new Map(),
+		references: new Map(),
+		moduleRange: undefined,
+		executeRange: undefined,
+	};
+
+	const lineCount = document.lineCount;
+	let currentBlock: Block | undefined;
+
+	let moduleStart = -1;
+	let executeStart = -1;
+
+	for (let i = 0; i < lineCount; i++) {
+		const text = document.lineAt(i).text;
+		const trimmed = text.trim();
+
+		// Strip line comments before further analysis.
+		const commentIdx = text.indexOf('//');
+		const code = commentIdx >= 0 ? text.slice(0, commentIdx) : text;
+
+		if (trimmed.startsWith('NautilusIr')) {
+			moduleStart = i;
+			continue;
+		}
+		if (/^execute\s*\(\s*\)\s*\{/.test(trimmed)) {
+			executeStart = i;
+			continue;
+		}
+
+		// Block header.
+		const headerMatch = code.match(BLOCK_HEADER_RE);
+		if (headerMatch) {
+			finalizeBlock(currentBlock, i - 1, document);
+			const name = headerMatch[1];
+			const argList = headerMatch[2].trim();
+			const args: BlockArgument[] = argList === ''
+				? []
+				: argList.split(',').map(rawArgToken);
+			currentBlock = {
+				name,
+				headerLine: i,
+				headerRange: new vscode.Range(i, 0, i, text.length),
+				bodyRange: new vscode.Range(i, 0, i, text.length),
+				args,
+				successors: [],
+				predecessors: [],
+				instructions: 0,
+				terminator: 'unknown',
+			};
+			result.blocks.push(currentBlock);
+			result.blockByName.set(name, currentBlock);
+			continue;
+		}
+
+		// Skip blank and brace-only lines.
+		if (trimmed === '' || trimmed === '{' || trimmed === '}' || trimmed === '} //NESIR') {
+			continue;
+		}
+
+		// Inside a block: capture defs and references.
+		if (currentBlock) {
+			currentBlock.instructions++;
+
+			const defMatch = code.match(SSA_DEF_RE);
+			if (defMatch) {
+				const name = defMatch[1];
+				const rhs = defMatch[2];
+				const typeMatch = rhs.match(TYPE_TAIL_RE);
+				const def: SsaDefinition = {
+					name,
+					line: i,
+					character: text.indexOf(name),
+					rhs,
+					type: typeMatch?.[1],
+				};
+				result.definitions.set(name, def);
+			}
+
+			// Determine terminator.
+			if (/^\s*return\b/.test(code)) {
+				currentBlock.terminator = 'return';
+			} else if (/^\s*if\b/.test(code) || /^\s*CMP\b/.test(code)) {
+				currentBlock.terminator = 'if';
+			} else if (/^\s*br\b/.test(code) || /^\s*JMP\b/.test(code)) {
+				currentBlock.terminator = 'br';
+			}
+
+			// Collect SSA references on the line (excluding the LHS def).
+			const lhsEnd = defMatch ? text.indexOf('=') + 1 : 0;
+			const scanStart = Math.max(lhsEnd, 0);
+			const scanText = text.slice(scanStart);
+			let m: RegExpExecArray | null;
+			SSA_REF_RE.lastIndex = 0;
+			while ((m = SSA_REF_RE.exec(scanText)) !== null) {
+				const refName = m[0];
+				const refChar = scanStart + m.index;
+				const refs = result.references.get(refName) ?? [];
+				refs.push({ name: refName, line: i, character: refChar });
+				result.references.set(refName, refs);
+			}
+
+			// Collect successor block references.
+			BLOCK_REF_RE.lastIndex = 0;
+			while ((m = BLOCK_REF_RE.exec(code)) !== null) {
+				const target = m[1];
+				if (target !== currentBlock.name && !currentBlock.successors.includes(target)) {
+					currentBlock.successors.push(target);
+				}
+			}
+
+			// Extend the body range.
+			currentBlock.bodyRange = new vscode.Range(
+				currentBlock.headerLine,
+				0,
+				i,
+				text.length,
+			);
+		}
+	}
+
+	finalizeBlock(currentBlock, lineCount - 1, document);
+
+	// Compute predecessors.
+	for (const block of result.blocks) {
+		for (const succ of block.successors) {
+			const target = result.blockByName.get(succ);
+			if (target && !target.predecessors.includes(block.name)) {
+				target.predecessors.push(block.name);
+			}
+		}
+	}
+
+	if (moduleStart >= 0) {
+		result.moduleRange = new vscode.Range(moduleStart, 0, lineCount - 1, 0);
+	}
+	if (executeStart >= 0) {
+		result.executeRange = new vscode.Range(executeStart, 0, lineCount - 1, 0);
+	}
+
+	return result;
+}
+
+function finalizeBlock(block: Block | undefined, endLine: number, document: vscode.TextDocument): void {
+	if (!block) {
+		return;
+	}
+	const lastLineIdx = Math.max(block.headerLine, endLine);
+	const lastLine = document.lineAt(Math.min(lastLineIdx, document.lineCount - 1));
+	block.bodyRange = new vscode.Range(block.headerLine, 0, lastLine.lineNumber, lastLine.text.length);
+}
+
+function rawArgToken(raw: string): BlockArgument {
+	const parts = raw.split(':').map(s => s.trim());
+	return {
+		name: parts[0] ?? '',
+		type: parts[1] ?? '',
+	};
+}
+
+// Extract the SSA name that the cursor is currently positioned on, if any.
+export function ssaAt(document: vscode.TextDocument, position: vscode.Position): { name: string; range: vscode.Range } | undefined {
+	const line = document.lineAt(position.line).text;
+	const re = /\$\d+/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(line)) !== null) {
+		const start = m.index;
+		const end = start + m[0].length;
+		if (position.character >= start && position.character <= end) {
+			return {
+				name: m[0],
+				range: new vscode.Range(position.line, start, position.line, end),
+			};
+		}
+	}
+	return undefined;
+}
+
+// Extract the block name (Block_N or BN) the cursor is on, if any.
+export function blockAt(document: vscode.TextDocument, position: vscode.Position): { name: string; range: vscode.Range } | undefined {
+	const line = document.lineAt(position.line).text;
+	const re = /\b(Block_\d+|B\d+)\b/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(line)) !== null) {
+		const start = m.index;
+		const end = start + m[0].length;
+		if (position.character >= start && position.character <= end) {
+			return {
+				name: m[0],
+				range: new vscode.Range(position.line, start, position.line, end),
+			};
+		}
+	}
+	return undefined;
+}

--- a/tools/vscode-nautilus-ir/src/parser.ts
+++ b/tools/vscode-nautilus-ir/src/parser.ts
@@ -1,9 +1,9 @@
 // Lightweight, regex-based parser for Nautilus IR (the dialect dumped into
-// `nautilus/test/data/*/ir/*.trace`).
+// `nautilus/test/data/*/ir/*.nautilus`).
 //
 // Grammar reference (informally):
 //
-//   module      ::= 'NautilusIr' '{' function* '}' '//NESIR'?
+//   module      ::= 'nautilus' '{' function* '}' '//nautilus'?
 //   function    ::= IDENT '(' ')' '{' block+ '}'
 //   block       ::= 'Block_' INT '(' arg-list? ')' ':' statement*
 //   arg-list    ::= typed-ssa (',' typed-ssa)*
@@ -99,7 +99,8 @@ const PRIMITIVE_TYPES = new Set([
 	'f32', 'f64', 'bool', 'ptr', 'void',
 ]);
 
-const MODULE_OPEN_RE = /^\s*NautilusIr\s*\{\s*$/;
+const MODULE_OPEN_RE = /^\s*nautilus\s*\{\s*$/;
+const MODULE_KEYWORD = 'nautilus';
 
 export function parse(document: vscode.TextDocument): ParsedIr {
 	const ir: ParsedIr = {
@@ -129,9 +130,9 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 		}
 
 		// Function header. Distinguish from block headers (Block_N) and
-		// from the literal `NautilusIr {` line by the regexes above.
+		// from the literal `nautilus {` module-open line.
 		const fnMatch = code.match(FUNCTION_HEADER_RE);
-		if (fnMatch && fnMatch[1] !== 'NautilusIr') {
+		if (fnMatch && fnMatch[1] !== MODULE_KEYWORD) {
 			finalizeBlock(currentBlock, i - 1, document);
 			finalizeFunction(currentFn, i - 1, document);
 			currentFn = {

--- a/tools/vscode-nautilus-ir/src/parser.ts
+++ b/tools/vscode-nautilus-ir/src/parser.ts
@@ -1,23 +1,48 @@
-// Lightweight, regex-based parser for Nautilus IR.
+// Lightweight, regex-based parser for Nautilus IR (the dialect dumped into
+// `nautilus/test/data/*/ir/*.trace`).
 //
-// Nautilus IR is a small, line-oriented format. We don't build a full AST
-// here, just enough structure (blocks, SSA defs, references, branches) to
-// power navigation, hover, and folding features.
+// Grammar reference (informally):
+//
+//   module      ::= 'NautilusIr' '{' function* '}' '//NESIR'?
+//   function    ::= IDENT '(' ')' '{' block+ '}'
+//   block       ::= 'Block_' INT '(' arg-list? ')' ':' statement*
+//   arg-list    ::= typed-ssa (',' typed-ssa)*
+//   typed-ssa   ::= '$' INT ':' TYPE
+//   statement   ::= def | bare-decl | branch | conditional | return | store | void-call
+//   def         ::= '$' INT '=' rhs ':' TYPE
+//   bare-decl   ::= '$' INT ':' TYPE
+//   rhs         ::= constant | unary | binary | cast | load | call
+//   unary       ::= ('!' | '~') '$' INT
+//   binary      ::= '$' INT BIN-OP ('$' INT | INT)
+//   cast        ::= '$' INT 'cast_to' TYPE
+//   load        ::= 'load' '(' '$' INT ')'
+//   call        ::= 'func_*' '(' arg* ')'
+//   branch      ::= 'br' BLOCK '(' ssa-list? ')' ':' 'void'
+//   conditional ::= 'if' '$' INT '?' BLOCK '(' ssa-list? ')' ':' BLOCK '(' ssa-list? ')' ':' 'void'
+//   return      ::= 'return' ('(' '$' INT ')')? ':' TYPE
+//   store       ::= 'store' '(' '$' INT ',' '$' INT ')' ':' 'void'
+//   void-call   ::= 'func_*' '(' arg* ')' ':' 'void'
+//
+// Function names are arbitrary identifiers (the most common is `execute`,
+// but multi-function modules also contain `add`, `inner`, `outer`,
+// `sumFields`, `loopHelper`, etc.).
 
 import * as vscode from 'vscode';
 
 export interface SsaDefinition {
-	name: string;            // e.g. "$3"
-	line: number;            // zero-based line index of the definition
-	character: number;       // column of the leading $
-	rhs: string;             // raw right-hand side text (after `=`)
-	type: string | undefined;// trailing :type if present
+	name: string;
+	line: number;
+	character: number;
+	rhs: string;             // empty string for bare-typed declarations
+	type: string | undefined;
+	functionName: string;    // owning function
 }
 
 export interface SsaReference {
 	name: string;
 	line: number;
 	character: number;
+	functionName: string;
 }
 
 export interface BlockArgument {
@@ -25,69 +50,108 @@ export interface BlockArgument {
 	type: string;
 }
 
+export type Terminator = 'return' | 'br' | 'if' | 'unknown';
+
 export interface Block {
-	name: string;             // e.g. "Block_5"
-	headerLine: number;       // zero-based
+	name: string;
+	functionName: string;
+	headerLine: number;
 	headerRange: vscode.Range;
-	bodyRange: vscode.Range;  // header line through last instruction
+	bodyRange: vscode.Range;
 	args: BlockArgument[];
-	successors: string[];     // referenced block names from terminator(s)
-	predecessors: string[];   // populated in a second pass
-	instructions: number;     // count of non-blank, non-header lines
-	terminator: 'return' | 'br' | 'if' | 'unknown';
+	successors: string[];
+	predecessors: string[];
+	instructions: number;
+	terminator: Terminator;
+}
+
+export interface IrFunction {
+	name: string;
+	headerLine: number;
+	headerRange: vscode.Range;
+	bodyRange: vscode.Range;
+	blocks: Block[];
+	blockByName: Map<string, Block>;
+	definitions: Map<string, SsaDefinition>;
 }
 
 export interface ParsedIr {
+	moduleRange: vscode.Range | undefined;
+	functions: IrFunction[];
+	functionByName: Map<string, IrFunction>;
+	// Convenience: aggregate views across the whole module.
 	blocks: Block[];
 	blockByName: Map<string, Block>;
-	definitions: Map<string, SsaDefinition>;       // by name
-	references: Map<string, SsaReference[]>;       // by name
-	moduleRange: vscode.Range | undefined;         // NautilusIr {...}
-	executeRange: vscode.Range | undefined;        // execute() {...}
+	definitions: Map<string, SsaDefinition>;
+	references: Map<string, SsaReference[]>;
 }
 
-const BLOCK_HEADER_RE = /^\s*(Block_\d+|B\d+)\s*\(([^)]*)\)\s*:\s*$/;
+const FUNCTION_HEADER_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*\{\s*$/;
+const BLOCK_HEADER_RE = /^\s*(Block_\d+)\s*\(([^)]*)\)\s*:\s*$/;
 const SSA_DEF_RE = /^\s*(\$\d+)\s*=\s*(.+?)\s*$/;
+const BARE_DECL_RE = /^\s*(\$\d+)\s*:\s*([a-z0-9]+)\s*$/;
 const SSA_REF_RE = /\$\d+/g;
-const BLOCK_REF_RE = /\b(Block_\d+|B\d+)\b/g;
+const BLOCK_REF_RE = /\bBlock_\d+\b/g;
 const TYPE_TAIL_RE = /:\s*(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\s*$/;
+const PRIMITIVE_TYPES = new Set([
+	'i8', 'i16', 'i32', 'i64',
+	'ui8', 'ui16', 'ui32', 'ui64',
+	'f32', 'f64', 'bool', 'ptr', 'void',
+]);
+
+const MODULE_OPEN_RE = /^\s*NautilusIr\s*\{\s*$/;
 
 export function parse(document: vscode.TextDocument): ParsedIr {
-	const result: ParsedIr = {
+	const ir: ParsedIr = {
+		moduleRange: undefined,
+		functions: [],
+		functionByName: new Map(),
 		blocks: [],
 		blockByName: new Map(),
 		definitions: new Map(),
 		references: new Map(),
-		moduleRange: undefined,
-		executeRange: undefined,
 	};
 
 	const lineCount = document.lineCount;
-	let currentBlock: Block | undefined;
-
 	let moduleStart = -1;
-	let executeStart = -1;
+	let currentFn: IrFunction | undefined;
+	let currentBlock: Block | undefined;
 
 	for (let i = 0; i < lineCount; i++) {
 		const text = document.lineAt(i).text;
-		const trimmed = text.trim();
-
-		// Strip line comments before further analysis.
 		const commentIdx = text.indexOf('//');
 		const code = commentIdx >= 0 ? text.slice(0, commentIdx) : text;
+		const trimmed = code.trim();
 
-		if (trimmed.startsWith('NautilusIr')) {
+		if (MODULE_OPEN_RE.test(text)) {
 			moduleStart = i;
 			continue;
 		}
-		if (/^execute\s*\(\s*\)\s*\{/.test(trimmed)) {
-			executeStart = i;
+
+		// Function header. Distinguish from block headers (Block_N) and
+		// from the literal `NautilusIr {` line by the regexes above.
+		const fnMatch = code.match(FUNCTION_HEADER_RE);
+		if (fnMatch && fnMatch[1] !== 'NautilusIr') {
+			finalizeBlock(currentBlock, i - 1, document);
+			finalizeFunction(currentFn, i - 1, document);
+			currentFn = {
+				name: fnMatch[1],
+				headerLine: i,
+				headerRange: new vscode.Range(i, 0, i, text.length),
+				bodyRange: new vscode.Range(i, 0, i, text.length),
+				blocks: [],
+				blockByName: new Map(),
+				definitions: new Map(),
+			};
+			ir.functions.push(currentFn);
+			ir.functionByName.set(currentFn.name, currentFn);
+			currentBlock = undefined;
 			continue;
 		}
 
 		// Block header.
 		const headerMatch = code.match(BLOCK_HEADER_RE);
-		if (headerMatch) {
+		if (headerMatch && currentFn) {
 			finalizeBlock(currentBlock, i - 1, document);
 			const name = headerMatch[1];
 			const argList = headerMatch[2].trim();
@@ -96,6 +160,7 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 				: argList.split(',').map(rawArgToken);
 			currentBlock = {
 				name,
+				functionName: currentFn.name,
 				headerLine: i,
 				headerRange: new vscode.Range(i, 0, i, text.length),
 				bodyRange: new vscode.Range(i, 0, i, text.length),
@@ -105,20 +170,53 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 				instructions: 0,
 				terminator: 'unknown',
 			};
-			result.blocks.push(currentBlock);
-			result.blockByName.set(name, currentBlock);
+			currentFn.blocks.push(currentBlock);
+			currentFn.blockByName.set(name, currentBlock);
+			ir.blocks.push(currentBlock);
+			// Aggregate by `function::block` to keep names unique across functions
+			// while still supporting plain `Block_0` lookups for the active function.
+			ir.blockByName.set(`${currentFn.name}::${name}`, currentBlock);
+			if (!ir.blockByName.has(name)) {
+				ir.blockByName.set(name, currentBlock);
+			}
 			continue;
 		}
 
-		// Skip blank and brace-only lines.
-		if (trimmed === '' || trimmed === '{' || trimmed === '}' || trimmed === '} //NESIR') {
+		// Function-end brace.
+		if (trimmed === '}') {
+			finalizeBlock(currentBlock, i - 1, document);
+			currentBlock = undefined;
+			finalizeFunction(currentFn, i - 1, document);
+			currentFn = undefined;
 			continue;
 		}
 
-		// Inside a block: capture defs and references.
-		if (currentBlock) {
+		// Module-end brace + comment ("} //NESIR") was already split above; ignore.
+		if (trimmed === '' || trimmed === '{') {
+			continue;
+		}
+
+		// Inside a block: capture defs, bare declarations, and references.
+		if (currentBlock && currentFn) {
 			currentBlock.instructions++;
 
+			// Bare typed declaration: `$N :type`
+			const bareMatch = code.match(BARE_DECL_RE);
+			if (bareMatch && PRIMITIVE_TYPES.has(bareMatch[2])) {
+				const name = bareMatch[1];
+				const def: SsaDefinition = {
+					name,
+					line: i,
+					character: text.indexOf(name),
+					rhs: '',
+					type: bareMatch[2],
+					functionName: currentFn.name,
+				};
+				registerDef(ir, currentFn, def);
+				continue;
+			}
+
+			// Standard def: `$N = rhs :type`
 			const defMatch = code.match(SSA_DEF_RE);
 			if (defMatch) {
 				const name = defMatch[1];
@@ -130,20 +228,21 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 					character: text.indexOf(name),
 					rhs,
 					type: typeMatch?.[1],
+					functionName: currentFn.name,
 				};
-				result.definitions.set(name, def);
+				registerDef(ir, currentFn, def);
 			}
 
 			// Determine terminator.
 			if (/^\s*return\b/.test(code)) {
 				currentBlock.terminator = 'return';
-			} else if (/^\s*if\b/.test(code) || /^\s*CMP\b/.test(code)) {
+			} else if (/^\s*if\b/.test(code)) {
 				currentBlock.terminator = 'if';
-			} else if (/^\s*br\b/.test(code) || /^\s*JMP\b/.test(code)) {
+			} else if (/^\s*br\b/.test(code)) {
 				currentBlock.terminator = 'br';
 			}
 
-			// Collect SSA references on the line (excluding the LHS def).
+			// SSA references on the line (excluding the LHS of a def).
 			const lhsEnd = defMatch ? text.indexOf('=') + 1 : 0;
 			const scanStart = Math.max(lhsEnd, 0);
 			const scanText = text.slice(scanStart);
@@ -152,21 +251,20 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 			while ((m = SSA_REF_RE.exec(scanText)) !== null) {
 				const refName = m[0];
 				const refChar = scanStart + m.index;
-				const refs = result.references.get(refName) ?? [];
-				refs.push({ name: refName, line: i, character: refChar });
-				result.references.set(refName, refs);
+				const refs = ir.references.get(refName) ?? [];
+				refs.push({ name: refName, line: i, character: refChar, functionName: currentFn.name });
+				ir.references.set(refName, refs);
 			}
 
-			// Collect successor block references.
+			// Successor block references (only collect for terminator-bearing lines).
 			BLOCK_REF_RE.lastIndex = 0;
 			while ((m = BLOCK_REF_RE.exec(code)) !== null) {
-				const target = m[1];
+				const target = m[0];
 				if (target !== currentBlock.name && !currentBlock.successors.includes(target)) {
 					currentBlock.successors.push(target);
 				}
 			}
 
-			// Extend the body range.
 			currentBlock.bodyRange = new vscode.Range(
 				currentBlock.headerLine,
 				0,
@@ -177,25 +275,37 @@ export function parse(document: vscode.TextDocument): ParsedIr {
 	}
 
 	finalizeBlock(currentBlock, lineCount - 1, document);
+	finalizeFunction(currentFn, lineCount - 1, document);
 
-	// Compute predecessors.
-	for (const block of result.blocks) {
-		for (const succ of block.successors) {
-			const target = result.blockByName.get(succ);
-			if (target && !target.predecessors.includes(block.name)) {
-				target.predecessors.push(block.name);
+	// Compute predecessors per function (control flow does not cross function
+	// boundaries — each function has its own Block_0).
+	for (const fn of ir.functions) {
+		for (const block of fn.blocks) {
+			for (const succ of block.successors) {
+				const target = fn.blockByName.get(succ);
+				if (target && !target.predecessors.includes(block.name)) {
+					target.predecessors.push(block.name);
+				}
 			}
 		}
 	}
 
 	if (moduleStart >= 0) {
-		result.moduleRange = new vscode.Range(moduleStart, 0, lineCount - 1, 0);
-	}
-	if (executeStart >= 0) {
-		result.executeRange = new vscode.Range(executeStart, 0, lineCount - 1, 0);
+		ir.moduleRange = new vscode.Range(moduleStart, 0, lineCount - 1, 0);
 	}
 
-	return result;
+	return ir;
+}
+
+function registerDef(ir: ParsedIr, fn: IrFunction, def: SsaDefinition): void {
+	fn.definitions.set(def.name, def);
+	// The module-level definitions map keys SSA names to the *first* observed
+	// definition. This is good enough for navigation in single-function
+	// modules; multi-function modules still get scoped lookups via the
+	// per-function map.
+	if (!ir.definitions.has(def.name)) {
+		ir.definitions.set(def.name, def);
+	}
 }
 
 function finalizeBlock(block: Block | undefined, endLine: number, document: vscode.TextDocument): void {
@@ -203,8 +313,16 @@ function finalizeBlock(block: Block | undefined, endLine: number, document: vsco
 		return;
 	}
 	const lastLineIdx = Math.max(block.headerLine, endLine);
-	const lastLine = document.lineAt(Math.min(lastLineIdx, document.lineCount - 1));
-	block.bodyRange = new vscode.Range(block.headerLine, 0, lastLine.lineNumber, lastLine.text.length);
+	const last = document.lineAt(Math.min(lastLineIdx, document.lineCount - 1));
+	block.bodyRange = new vscode.Range(block.headerLine, 0, last.lineNumber, last.text.length);
+}
+
+function finalizeFunction(fn: IrFunction | undefined, endLine: number, document: vscode.TextDocument): void {
+	if (!fn) {
+		return;
+	}
+	const last = document.lineAt(Math.min(Math.max(fn.headerLine, endLine), document.lineCount - 1));
+	fn.bodyRange = new vscode.Range(fn.headerLine, 0, last.lineNumber, last.text.length);
 }
 
 function rawArgToken(raw: string): BlockArgument {
@@ -215,7 +333,17 @@ function rawArgToken(raw: string): BlockArgument {
 	};
 }
 
-// Extract the SSA name that the cursor is currently positioned on, if any.
+// Find the function that owns a given line.
+export function functionAt(ir: ParsedIr, line: number): IrFunction | undefined {
+	return ir.functions.find(fn => line >= fn.headerLine && line <= fn.bodyRange.end.line);
+}
+
+// Find the block that owns a given line.
+export function blockAtLine(ir: ParsedIr, line: number): Block | undefined {
+	return ir.blocks.find(b => line >= b.headerLine && line <= b.bodyRange.end.line);
+}
+
+// Extract the SSA name that the cursor is currently positioned on.
 export function ssaAt(document: vscode.TextDocument, position: vscode.Position): { name: string; range: vscode.Range } | undefined {
 	const line = document.lineAt(position.line).text;
 	const re = /\$\d+/g;
@@ -233,10 +361,10 @@ export function ssaAt(document: vscode.TextDocument, position: vscode.Position):
 	return undefined;
 }
 
-// Extract the block name (Block_N or BN) the cursor is on, if any.
+// Extract the block name (Block_N) the cursor is on.
 export function blockAt(document: vscode.TextDocument, position: vscode.Position): { name: string; range: vscode.Range } | undefined {
 	const line = document.lineAt(position.line).text;
-	const re = /\b(Block_\d+|B\d+)\b/g;
+	const re = /\bBlock_\d+\b/g;
 	let m: RegExpExecArray | null;
 	while ((m = re.exec(line)) !== null) {
 		const start = m.index;

--- a/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
+++ b/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
@@ -54,12 +54,21 @@
 			]
 		},
 		"function-header": {
-			"begin": "^\\s*(?!nautilus\\b)([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()\\s*(\\))\\s*(\\{)",
+			"begin": "^\\s*(?!nautilus\\b)([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()([^)]*)(\\))\\s*(?:(:)\\s*(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void))?\\s*(\\{)\\s*$",
 			"beginCaptures": {
 				"1": { "name": "entity.name.function.nautilus-ir" },
 				"2": { "name": "punctuation.definition.parameters.begin.nautilus-ir" },
-				"3": { "name": "punctuation.definition.parameters.end.nautilus-ir" },
-				"4": { "name": "punctuation.section.block.begin.nautilus-ir" }
+				"3": {
+					"patterns": [
+						{ "include": "#typed-ssa-arg" },
+						{ "include": "#types" },
+						{ "include": "#punctuation" }
+					]
+				},
+				"4": { "name": "punctuation.definition.parameters.end.nautilus-ir" },
+				"5": { "name": "punctuation.separator.return-type.nautilus-ir" },
+				"6": { "name": "support.type.primitive.nautilus-ir" },
+				"7": { "name": "punctuation.section.block.begin.nautilus-ir" }
 			},
 			"end": "^\\s*(\\})",
 			"endCaptures": {

--- a/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
+++ b/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
@@ -7,9 +7,10 @@
 		{ "include": "#comments" },
 		{ "include": "#nesir-end-marker" },
 		{ "include": "#wrapper" },
-		{ "include": "#execute-header" },
+		{ "include": "#function-header" },
 		{ "include": "#block-header" },
-		{ "include": "#instruction" },
+		{ "include": "#statement" },
+		{ "include": "#bare-typed-decl" },
 		{ "include": "#braces" }
 	],
 	"repository": {
@@ -38,30 +39,41 @@
 			"match": "//\\s*NESIR\\s*$"
 		},
 		"wrapper": {
-			"begin": "\\b(NautilusIr)\\s*(\\{)",
+			"begin": "^\\s*(NautilusIr)\\s*(\\{)",
 			"beginCaptures": {
 				"1": { "name": "entity.name.namespace.nautilus-ir" },
 				"2": { "name": "punctuation.section.block.begin.nautilus-ir" }
 			},
-			"end": "\\}",
+			"end": "^\\s*(\\})",
 			"endCaptures": {
-				"0": { "name": "punctuation.section.block.end.nautilus-ir" }
+				"1": { "name": "punctuation.section.block.end.nautilus-ir" }
 			},
 			"patterns": [
-				{ "include": "$self" }
+				{ "include": "#comments" },
+				{ "include": "#function-header" }
 			]
 		},
-		"execute-header": {
-			"match": "\\b(execute)\\s*(\\()\\s*(\\))\\s*(\\{)",
-			"captures": {
+		"function-header": {
+			"begin": "^\\s*(?!NautilusIr\\b)([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()\\s*(\\))\\s*(\\{)",
+			"beginCaptures": {
 				"1": { "name": "entity.name.function.nautilus-ir" },
 				"2": { "name": "punctuation.definition.parameters.begin.nautilus-ir" },
 				"3": { "name": "punctuation.definition.parameters.end.nautilus-ir" },
 				"4": { "name": "punctuation.section.block.begin.nautilus-ir" }
-			}
+			},
+			"end": "^\\s*(\\})",
+			"endCaptures": {
+				"1": { "name": "punctuation.section.block.end.nautilus-ir" }
+			},
+			"patterns": [
+				{ "include": "#comments" },
+				{ "include": "#block-header" },
+				{ "include": "#statement" },
+				{ "include": "#bare-typed-decl" }
+			]
 		},
 		"block-header": {
-			"begin": "^\\s*(Block_\\d+|B\\d+)\\s*(\\()",
+			"begin": "^\\s*(Block_\\d+)\\s*(\\()",
 			"beginCaptures": {
 				"1": { "name": "entity.name.label.block.nautilus-ir" },
 				"2": { "name": "punctuation.definition.parameters.begin.nautilus-ir" }
@@ -78,19 +90,18 @@
 				{ "include": "#punctuation" }
 			]
 		},
-		"instruction": {
+		"statement": {
 			"patterns": [
 				{ "include": "#return-instruction" },
 				{ "include": "#branch-instruction" },
 				{ "include": "#if-instruction" },
 				{ "include": "#store-instruction" },
-				{ "include": "#load-instruction" },
-				{ "include": "#call-instruction" },
+				{ "include": "#void-call-instruction" },
 				{ "include": "#assignment" }
 			]
 		},
 		"return-instruction": {
-			"begin": "\\b(return)\\b",
+			"begin": "^\\s*(return)\\b",
 			"beginCaptures": {
 				"1": { "name": "keyword.control.return.nautilus-ir" }
 			},
@@ -103,7 +114,7 @@
 			]
 		},
 		"branch-instruction": {
-			"begin": "\\b(br|JMP|jmp)\\b",
+			"begin": "^\\s*(br)\\b",
 			"beginCaptures": {
 				"1": { "name": "keyword.control.branch.nautilus-ir" }
 			},
@@ -117,7 +128,7 @@
 			]
 		},
 		"if-instruction": {
-			"begin": "\\b(if|CMP|cmp)\\b",
+			"begin": "^\\s*(if)\\b",
 			"beginCaptures": {
 				"1": { "name": "keyword.control.conditional.nautilus-ir" }
 			},
@@ -125,17 +136,21 @@
 			"patterns": [
 				{
 					"name": "keyword.operator.ternary.nautilus-ir",
-					"match": "\\?|:"
+					"match": "\\?"
 				},
 				{ "include": "#block-reference" },
 				{ "include": "#type-suffix" },
+				{
+					"name": "keyword.operator.ternary.nautilus-ir",
+					"match": ":(?!\\s*(?:i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\\b)"
+				},
 				{ "include": "#ssa-value" },
 				{ "include": "#punctuation" },
 				{ "include": "#comments" }
 			]
 		},
 		"store-instruction": {
-			"begin": "\\b(store|STORE)\\s*(\\()",
+			"begin": "^\\s*(store)\\s*(\\()",
 			"beginCaptures": {
 				"1": { "name": "keyword.other.memory.store.nautilus-ir" },
 				"2": { "name": "punctuation.section.parens.begin.nautilus-ir" }
@@ -149,30 +164,23 @@
 				{ "include": "#comments" }
 			]
 		},
-		"load-instruction": {
-			"begin": "\\b(load|LOAD|alloca|ALLOCA)\\s*(\\()",
+		"void-call-instruction": {
+			"begin": "^\\s*(func_\\*)\\s*(\\()",
 			"beginCaptures": {
-				"1": { "name": "keyword.other.memory.nautilus-ir" },
+				"1": { "name": "support.function.call.nautilus-ir" },
 				"2": { "name": "punctuation.section.parens.begin.nautilus-ir" }
 			},
 			"end": "$",
 			"patterns": [
 				{ "include": "#type-suffix" },
 				{ "include": "#ssa-value" },
+				{ "include": "#numbers" },
 				{ "include": "#punctuation" },
 				{ "include": "#comments" }
 			]
 		},
-		"call-instruction": {
-			"patterns": [
-				{
-					"match": "\\b(func_\\*|FUNC_ADDR|CALL|INDIRECT_CALL)\\b",
-					"name": "support.function.call.nautilus-ir"
-				}
-			]
-		},
 		"assignment": {
-			"begin": "(\\$\\d+)\\s*(=)",
+			"begin": "^\\s*(\\$\\d+)\\s*(=)",
 			"beginCaptures": {
 				"1": { "name": "variable.other.ssa.definition.nautilus-ir" },
 				"2": { "name": "keyword.operator.assignment.nautilus-ir" }
@@ -180,33 +188,85 @@
 			"end": "$",
 			"patterns": [
 				{ "include": "#cast-rhs" },
-				{ "include": "#call-instruction" },
-				{ "include": "#load-instruction" },
+				{ "include": "#alloca-rhs" },
+				{ "include": "#call-target" },
+				{ "include": "#load-rhs" },
+				{ "include": "#unary-operators" },
 				{ "include": "#operators" },
 				{ "include": "#numbers" },
 				{ "include": "#ssa-value" },
 				{ "include": "#type-suffix" },
+				{ "include": "#types" },
 				{ "include": "#punctuation" },
 				{ "include": "#comments" }
 			]
 		},
+		"load-rhs": {
+			"begin": "\\b(load)\\s*(\\()",
+			"beginCaptures": {
+				"1": { "name": "keyword.other.memory.nautilus-ir" },
+				"2": { "name": "punctuation.section.parens.begin.nautilus-ir" }
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": { "name": "punctuation.section.parens.end.nautilus-ir" }
+			},
+			"patterns": [
+				{ "include": "#ssa-value" },
+				{ "include": "#numbers" },
+				{ "include": "#punctuation" }
+			]
+		},
+		"bare-typed-decl": {
+			"match": "^\\s*(\\$\\d+)\\s*(:)\\s*(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\\s*$",
+			"captures": {
+				"1": { "name": "variable.other.ssa.definition.nautilus-ir" },
+				"2": { "name": "punctuation.separator.type.nautilus-ir" },
+				"3": { "name": "support.type.primitive.nautilus-ir" }
+			}
+		},
+		"call-target": {
+			"match": "\\b(func_\\*)",
+			"captures": {
+				"1": { "name": "support.function.call.nautilus-ir" }
+			}
+		},
 		"cast-rhs": {
-			"match": "\\b(cast_to|CAST)\\b",
-			"name": "keyword.operator.cast.nautilus-ir"
+			"match": "\\b(cast_to)\\s+(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\\b",
+			"captures": {
+				"1": { "name": "keyword.operator.cast.nautilus-ir" },
+				"2": { "name": "support.type.primitive.nautilus-ir" }
+			}
+		},
+		"alloca-rhs": {
+			"match": "\\b(alloca)\\s+(\\d+)(b)\\b",
+			"captures": {
+				"1": { "name": "keyword.other.memory.nautilus-ir" },
+				"2": { "name": "constant.numeric.integer.nautilus-ir" },
+				"3": { "name": "keyword.other.unit.bytes.nautilus-ir" }
+			}
+		},
+		"unary-operators": {
+			"name": "keyword.operator.unary.nautilus-ir",
+			"match": "(?<![A-Za-z0-9_])[!~](?=\\$)"
 		},
 		"operators": {
 			"patterns": [
 				{
 					"name": "keyword.operator.logical.word.nautilus-ir",
-					"match": "\\b(and|or|xor|not|AND|OR|XOR|NOT|negate|NEGATE|BAND|BOR|BXOR|LSH|RSH|EQ|NEQ|LT|LTE|GT|GTE|ADD|SUB|MUL|DIV|MOD|SELECT)\\b"
+					"match": "\\b(and|or)\\b"
 				},
 				{
 					"name": "keyword.operator.comparison.nautilus-ir",
-					"match": "==|!=|<=|>=|<|>"
+					"match": "==|!=|<=|>="
 				},
 				{
 					"name": "keyword.operator.bitshift.nautilus-ir",
 					"match": "<<|>>"
+				},
+				{
+					"name": "keyword.operator.comparison.nautilus-ir",
+					"match": "<|>"
 				},
 				{
 					"name": "keyword.operator.arithmetic.nautilus-ir",
@@ -235,11 +295,11 @@
 			]
 		},
 		"type-suffix": {
-			"begin": ":",
+			"begin": ":\\s*(?=(?:i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\\b)",
 			"beginCaptures": {
 				"0": { "name": "punctuation.separator.type.nautilus-ir" }
 			},
-			"end": "(?=[\\s,)?])",
+			"end": "(?<=(?:i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void))",
 			"patterns": [
 				{ "include": "#types" }
 			]
@@ -257,7 +317,7 @@
 			"match": "\\$\\d+\\b"
 		},
 		"block-reference": {
-			"match": "\\b(Block_\\d+|B\\d+)\\b",
+			"match": "\\bBlock_\\d+\\b",
 			"name": "entity.name.label.block.reference.nautilus-ir"
 		},
 		"numbers": {

--- a/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
+++ b/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
@@ -1,0 +1,312 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Nautilus IR",
+	"scopeName": "source.nautilus-ir",
+	"fileTypes": ["nesir", "trace", "nir"],
+	"patterns": [
+		{ "include": "#comments" },
+		{ "include": "#nesir-end-marker" },
+		{ "include": "#wrapper" },
+		{ "include": "#execute-header" },
+		{ "include": "#block-header" },
+		{ "include": "#instruction" },
+		{ "include": "#braces" }
+	],
+	"repository": {
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.double-slash.nautilus-ir",
+					"begin": "//",
+					"end": "$",
+					"patterns": [
+						{
+							"name": "keyword.other.nesir-marker.nautilus-ir",
+							"match": "\\bNESIR\\b"
+						}
+					]
+				},
+				{
+					"name": "comment.block.nautilus-ir",
+					"begin": "/\\*",
+					"end": "\\*/"
+				}
+			]
+		},
+		"nesir-end-marker": {
+			"name": "comment.line.nesir-marker.nautilus-ir",
+			"match": "//\\s*NESIR\\s*$"
+		},
+		"wrapper": {
+			"begin": "\\b(NautilusIr)\\s*(\\{)",
+			"beginCaptures": {
+				"1": { "name": "entity.name.namespace.nautilus-ir" },
+				"2": { "name": "punctuation.section.block.begin.nautilus-ir" }
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": { "name": "punctuation.section.block.end.nautilus-ir" }
+			},
+			"patterns": [
+				{ "include": "$self" }
+			]
+		},
+		"execute-header": {
+			"match": "\\b(execute)\\s*(\\()\\s*(\\))\\s*(\\{)",
+			"captures": {
+				"1": { "name": "entity.name.function.nautilus-ir" },
+				"2": { "name": "punctuation.definition.parameters.begin.nautilus-ir" },
+				"3": { "name": "punctuation.definition.parameters.end.nautilus-ir" },
+				"4": { "name": "punctuation.section.block.begin.nautilus-ir" }
+			}
+		},
+		"block-header": {
+			"begin": "^\\s*(Block_\\d+|B\\d+)\\s*(\\()",
+			"beginCaptures": {
+				"1": { "name": "entity.name.label.block.nautilus-ir" },
+				"2": { "name": "punctuation.definition.parameters.begin.nautilus-ir" }
+			},
+			"end": "(\\))\\s*(:)",
+			"endCaptures": {
+				"1": { "name": "punctuation.definition.parameters.end.nautilus-ir" },
+				"2": { "name": "punctuation.separator.block-header.nautilus-ir" }
+			},
+			"patterns": [
+				{ "include": "#typed-ssa-arg" },
+				{ "include": "#ssa-value" },
+				{ "include": "#types" },
+				{ "include": "#punctuation" }
+			]
+		},
+		"instruction": {
+			"patterns": [
+				{ "include": "#return-instruction" },
+				{ "include": "#branch-instruction" },
+				{ "include": "#if-instruction" },
+				{ "include": "#store-instruction" },
+				{ "include": "#load-instruction" },
+				{ "include": "#call-instruction" },
+				{ "include": "#assignment" }
+			]
+		},
+		"return-instruction": {
+			"begin": "\\b(return)\\b",
+			"beginCaptures": {
+				"1": { "name": "keyword.control.return.nautilus-ir" }
+			},
+			"end": "$",
+			"patterns": [
+				{ "include": "#type-suffix" },
+				{ "include": "#ssa-value" },
+				{ "include": "#punctuation" },
+				{ "include": "#comments" }
+			]
+		},
+		"branch-instruction": {
+			"begin": "\\b(br|JMP|jmp)\\b",
+			"beginCaptures": {
+				"1": { "name": "keyword.control.branch.nautilus-ir" }
+			},
+			"end": "$",
+			"patterns": [
+				{ "include": "#block-reference" },
+				{ "include": "#type-suffix" },
+				{ "include": "#ssa-value" },
+				{ "include": "#punctuation" },
+				{ "include": "#comments" }
+			]
+		},
+		"if-instruction": {
+			"begin": "\\b(if|CMP|cmp)\\b",
+			"beginCaptures": {
+				"1": { "name": "keyword.control.conditional.nautilus-ir" }
+			},
+			"end": "$",
+			"patterns": [
+				{
+					"name": "keyword.operator.ternary.nautilus-ir",
+					"match": "\\?|:"
+				},
+				{ "include": "#block-reference" },
+				{ "include": "#type-suffix" },
+				{ "include": "#ssa-value" },
+				{ "include": "#punctuation" },
+				{ "include": "#comments" }
+			]
+		},
+		"store-instruction": {
+			"begin": "\\b(store|STORE)\\s*(\\()",
+			"beginCaptures": {
+				"1": { "name": "keyword.other.memory.store.nautilus-ir" },
+				"2": { "name": "punctuation.section.parens.begin.nautilus-ir" }
+			},
+			"end": "$",
+			"patterns": [
+				{ "include": "#type-suffix" },
+				{ "include": "#ssa-value" },
+				{ "include": "#numbers" },
+				{ "include": "#punctuation" },
+				{ "include": "#comments" }
+			]
+		},
+		"load-instruction": {
+			"begin": "\\b(load|LOAD|alloca|ALLOCA)\\s*(\\()",
+			"beginCaptures": {
+				"1": { "name": "keyword.other.memory.nautilus-ir" },
+				"2": { "name": "punctuation.section.parens.begin.nautilus-ir" }
+			},
+			"end": "$",
+			"patterns": [
+				{ "include": "#type-suffix" },
+				{ "include": "#ssa-value" },
+				{ "include": "#punctuation" },
+				{ "include": "#comments" }
+			]
+		},
+		"call-instruction": {
+			"patterns": [
+				{
+					"match": "\\b(func_\\*|FUNC_ADDR|CALL|INDIRECT_CALL)\\b",
+					"name": "support.function.call.nautilus-ir"
+				}
+			]
+		},
+		"assignment": {
+			"begin": "(\\$\\d+)\\s*(=)",
+			"beginCaptures": {
+				"1": { "name": "variable.other.ssa.definition.nautilus-ir" },
+				"2": { "name": "keyword.operator.assignment.nautilus-ir" }
+			},
+			"end": "$",
+			"patterns": [
+				{ "include": "#cast-rhs" },
+				{ "include": "#call-instruction" },
+				{ "include": "#load-instruction" },
+				{ "include": "#operators" },
+				{ "include": "#numbers" },
+				{ "include": "#ssa-value" },
+				{ "include": "#type-suffix" },
+				{ "include": "#punctuation" },
+				{ "include": "#comments" }
+			]
+		},
+		"cast-rhs": {
+			"match": "\\b(cast_to|CAST)\\b",
+			"name": "keyword.operator.cast.nautilus-ir"
+		},
+		"operators": {
+			"patterns": [
+				{
+					"name": "keyword.operator.logical.word.nautilus-ir",
+					"match": "\\b(and|or|xor|not|AND|OR|XOR|NOT|negate|NEGATE|BAND|BOR|BXOR|LSH|RSH|EQ|NEQ|LT|LTE|GT|GTE|ADD|SUB|MUL|DIV|MOD|SELECT)\\b"
+				},
+				{
+					"name": "keyword.operator.comparison.nautilus-ir",
+					"match": "==|!=|<=|>=|<|>"
+				},
+				{
+					"name": "keyword.operator.bitshift.nautilus-ir",
+					"match": "<<|>>"
+				},
+				{
+					"name": "keyword.operator.arithmetic.nautilus-ir",
+					"match": "[+\\-*/%]"
+				},
+				{
+					"name": "keyword.operator.bitwise.nautilus-ir",
+					"match": "[&|\\^]"
+				}
+			]
+		},
+		"types": {
+			"patterns": [
+				{
+					"name": "support.type.primitive.integer.nautilus-ir",
+					"match": "\\b(i8|i16|i32|i64|ui8|ui16|ui32|ui64)\\b"
+				},
+				{
+					"name": "support.type.primitive.float.nautilus-ir",
+					"match": "\\b(f32|f64)\\b"
+				},
+				{
+					"name": "support.type.primitive.nautilus-ir",
+					"match": "\\b(bool|ptr|void)\\b"
+				}
+			]
+		},
+		"type-suffix": {
+			"begin": ":",
+			"beginCaptures": {
+				"0": { "name": "punctuation.separator.type.nautilus-ir" }
+			},
+			"end": "(?=[\\s,)?])",
+			"patterns": [
+				{ "include": "#types" }
+			]
+		},
+		"typed-ssa-arg": {
+			"match": "(\\$\\d+)\\s*(:)\\s*(i8|i16|i32|i64|ui8|ui16|ui32|ui64|f32|f64|bool|ptr|void)\\b",
+			"captures": {
+				"1": { "name": "variable.parameter.ssa.nautilus-ir" },
+				"2": { "name": "punctuation.separator.type.nautilus-ir" },
+				"3": { "name": "support.type.primitive.nautilus-ir" }
+			}
+		},
+		"ssa-value": {
+			"name": "variable.other.ssa.nautilus-ir",
+			"match": "\\$\\d+\\b"
+		},
+		"block-reference": {
+			"match": "\\b(Block_\\d+|B\\d+)\\b",
+			"name": "entity.name.label.block.reference.nautilus-ir"
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"name": "constant.numeric.float.nautilus-ir",
+					"match": "-?\\b\\d+\\.\\d+([eE][+-]?\\d+)?\\b"
+				},
+				{
+					"name": "constant.numeric.hex.nautilus-ir",
+					"match": "\\b0[xX][0-9a-fA-F]+\\b"
+				},
+				{
+					"name": "constant.numeric.integer.nautilus-ir",
+					"match": "-?\\b\\d+\\b"
+				},
+				{
+					"name": "constant.language.boolean.nautilus-ir",
+					"match": "\\b(true|false)\\b"
+				}
+			]
+		},
+		"punctuation": {
+			"patterns": [
+				{
+					"name": "punctuation.section.parens.begin.nautilus-ir",
+					"match": "\\("
+				},
+				{
+					"name": "punctuation.section.parens.end.nautilus-ir",
+					"match": "\\)"
+				},
+				{
+					"name": "punctuation.separator.comma.nautilus-ir",
+					"match": ","
+				}
+			]
+		},
+		"braces": {
+			"patterns": [
+				{
+					"name": "punctuation.section.block.begin.nautilus-ir",
+					"match": "\\{"
+				},
+				{
+					"name": "punctuation.section.block.end.nautilus-ir",
+					"match": "\\}"
+				}
+			]
+		}
+	}
+}

--- a/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
+++ b/tools/vscode-nautilus-ir/syntaxes/nautilus-ir.tmLanguage.json
@@ -2,10 +2,10 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Nautilus IR",
 	"scopeName": "source.nautilus-ir",
-	"fileTypes": ["nesir", "trace", "nir"],
+	"fileTypes": ["nautilus"],
 	"patterns": [
 		{ "include": "#comments" },
-		{ "include": "#nesir-end-marker" },
+		{ "include": "#end-marker" },
 		{ "include": "#wrapper" },
 		{ "include": "#function-header" },
 		{ "include": "#block-header" },
@@ -22,8 +22,8 @@
 					"end": "$",
 					"patterns": [
 						{
-							"name": "keyword.other.nesir-marker.nautilus-ir",
-							"match": "\\bNESIR\\b"
+							"name": "keyword.other.module-marker.nautilus-ir",
+							"match": "\\bnautilus\\b"
 						}
 					]
 				},
@@ -34,12 +34,12 @@
 				}
 			]
 		},
-		"nesir-end-marker": {
-			"name": "comment.line.nesir-marker.nautilus-ir",
-			"match": "//\\s*NESIR\\s*$"
+		"end-marker": {
+			"name": "comment.line.module-end.nautilus-ir",
+			"match": "//\\s*nautilus\\s*$"
 		},
 		"wrapper": {
-			"begin": "^\\s*(NautilusIr)\\s*(\\{)",
+			"begin": "^\\s*(nautilus)\\s*(\\{)",
 			"beginCaptures": {
 				"1": { "name": "entity.name.namespace.nautilus-ir" },
 				"2": { "name": "punctuation.section.block.begin.nautilus-ir" }
@@ -54,7 +54,7 @@
 			]
 		},
 		"function-header": {
-			"begin": "^\\s*(?!NautilusIr\\b)([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()\\s*(\\))\\s*(\\{)",
+			"begin": "^\\s*(?!nautilus\\b)([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()\\s*(\\))\\s*(\\{)",
 			"beginCaptures": {
 				"1": { "name": "entity.name.function.nautilus-ir" },
 				"2": { "name": "punctuation.definition.parameters.begin.nautilus-ir" },

--- a/tools/vscode-nautilus-ir/tsconfig.json
+++ b/tools/vscode-nautilus-ir/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "ES2020",
+		"lib": ["ES2020"],
+		"outDir": "out",
+		"rootDir": "src",
+		"sourceMap": true,
+		"strict": true,
+		"noImplicitAny": true,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "out", ".vscode-test"]
+}


### PR DESCRIPTION
Adds tools/vscode-nautilus-ir, a feature-rich VS Code extension targeting
the .nesir / .trace IR dumps emitted by Nautilus.

Editing
- TextMate grammar covering the full IR vocabulary (typed SSA values,
  block headers, branch/return/if terminators, load/store/cast/func_*,
  arithmetic/logical/bitwise/comparison operators, primitive types,
  NautilusIr/execute wrapper, //NESIR end marker).
- Language configuration (brackets, comments, smart indent, folding
  markers, word pattern for $N).
- Snippets for common IR constructs.

Navigation & analysis
- Lightweight regex parser produces a CFG view of the file with
  predecessors, successors, terminators, SSA defs and uses.
- Document symbols, definition, references, document highlight, hover,
  rename, folding, and CodeLens providers.
- Quick-pick "Go to Block" command bound to Ctrl/Cmd+Shift+B.
- Status-bar indicator for the block currently containing the cursor.
- Diagnostics for undefined SSA values, dangling branch targets, and
  blocks missing a terminator.

Debugging
- Contributes a nautilus-ir-gdb debug adapter that drives
  gdb --interpreter=mi2 inline in the extension host.
- Implements a compact GDB/MI parser/driver and DAP bridge supporting
  launch and attach, breakpoints (with conditions and hit counts),
  step/next/finish/continue/pause/restart, stack traces, locals,
  arguments and registers, watch/hover evaluation, set-variable, and
  console output forwarding.
- Right-click "Debug Current File with gdb" command and ready-made
  launch configuration snippets.

Verified by recompiling the TypeScript sources cleanly and parsing
several real test fixtures (expression, control-flow, loop, pointer,
static-loop) with the bundled parser.