### PR TITLE
Print function args and return type in IR dumps

### DIFF
--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -342,10 +342,32 @@ struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::str
 	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}(", func.getName());
-		for (const auto& arg : func.getInputArgNames()) {
-			fmt::format_to(out, "{} ", arg);
+		// The trace-to-IR conversion leaves `inputArgs`/`inputArgNames` empty;
+		// the parameters live on the entry block. Fall back to those.
+		const auto& argTypes = func.getInputArgs();
+		const auto& argNames = func.getInputArgNames();
+		const auto* entry = func.getEntryBlock();
+		if (entry != nullptr && argTypes.empty() && argNames.empty()) {
+			const auto& blockArgs = entry->getArguments();
+			for (size_t i = 0; i < blockArgs.size(); ++i) {
+				if (i > 0) {
+					fmt::format_to(out, ", ");
+				}
+				fmt::format_to(out, "{}:{}", blockArgs[i]->getIdentifier(), toString(blockArgs[i]->getStamp()));
+			}
+		} else {
+			for (size_t i = 0; i < argTypes.size(); ++i) {
+				if (i > 0) {
+					fmt::format_to(out, ", ");
+				}
+				if (i < argNames.size()) {
+					fmt::format_to(out, "{}:{}", argNames[i], toString(argTypes[i]));
+				} else {
+					fmt::format_to(out, "{}", toString(argTypes[i]));
+				}
+			}
 		}
-		fmt::format_to(out, ") {{");
+		fmt::format_to(out, ") :{} {{", toString(func.getOutputArg()));
 		for (const auto* block : func.getBasicBlocks()) {
 			fmt::format_to(out, "{}", *block);
 		}

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolAnd.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 and $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolAssignment.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	return ($1) :bool
 }

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolAssignmentOr.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolAssignmentOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$4 = $1 or $2 :bool
 	return ($4) :bool

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolConst.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = true :bool
 	$3 = $1 and $2 :bool

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolEquals.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 == $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolIfElse.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolIfElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 and $2 :bool
 	if $3 ? Block_1() : Block_2() :void

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolNestedFunction.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolNestedFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$5 = $1 == $2 :bool
 	if $5 ? Block_1() : Block_2() :void

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolNot.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolNot.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = !$1 :bool
 	return ($2) :bool

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolNotEquals.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolNotEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1  $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_constant_folding/boolOr.nautilus
+++ b/nautilus/test/data/bool-tests/after_constant_folding/boolOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 or $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolAnd.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 and $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolAssignment.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	return ($1) :bool
 }

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolAssignmentOr.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolAssignmentOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$4 = $1 or $2 :bool
 	return ($4) :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolConst.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = true :bool
 	$3 = $1 and $2 :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolEquals.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 == $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolIfElse.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolIfElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 and $2 :bool
 	if $3 ? Block_1() : Block_2() :void

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolNestedFunction.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolNestedFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$5 = $1 == $2 :bool
 	if $5 ? Block_1() : Block_2() :void

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolNot.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolNot.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = !$1 :bool
 	return ($2) :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolNotEquals.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolNotEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1  $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/after_empty_block_elim/boolOr.nautilus
+++ b/nautilus/test/data/bool-tests/after_empty_block_elim/boolOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 or $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/ir/boolAnd.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 and $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/ir/boolAssignment.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	return ($1) :bool
 }

--- a/nautilus/test/data/bool-tests/ir/boolAssignmentOr.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolAssignmentOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$4 = $1 or $2 :bool
 	return ($4) :bool

--- a/nautilus/test/data/bool-tests/ir/boolConst.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = true :bool
 	$3 = $1 and $2 :bool

--- a/nautilus/test/data/bool-tests/ir/boolEquals.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 == $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/ir/boolIfElse.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolIfElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 and $2 :bool
 	if $3 ? Block_1() : Block_2() :void

--- a/nautilus/test/data/bool-tests/ir/boolNestedFunction.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolNestedFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$5 = $1 == $2 :bool
 	if $5 ? Block_1() : Block_2() :void

--- a/nautilus/test/data/bool-tests/ir/boolNot.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolNot.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = !$1 :bool
 	return ($2) :bool

--- a/nautilus/test/data/bool-tests/ir/boolNotEquals.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolNotEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1  $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/bool-tests/ir/boolOr.nautilus
+++ b/nautilus/test/data/bool-tests/ir/boolOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool) :bool {
 Block_0($1:bool, $2:bool):
 	$3 = $1 or $2 :bool
 	return ($3) :bool

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i16 {
 Block_0($1:f64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i32 {
 Block_0($1:f64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i64 {
 Block_0($1:f64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i8 {
 Block_0($1:f64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui16 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui32 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui64 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_d_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui8 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i16 {
 Block_0($1:f32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i32 {
 Block_0($1:f32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i64 {
 Block_0($1:f32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i8 {
 Block_0($1:f32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui16 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui32 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui64 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_f_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui8 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	return ($1) :i16
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i32 {
 Block_0($1:i16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i64 {
 Block_0($1:i16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i8 {
 Block_0($1:i16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui16 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui32 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui64 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui8 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i16 {
 Block_0($1:i32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i8 {
 Block_0($1:i32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui16 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui32 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui64 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui8 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i16 {
 Block_0($1:i64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i32 {
 Block_0($1:i64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	return ($1) :i64
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i8 {
 Block_0($1:i64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui16 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui32 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui64 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui8 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i16 {
 Block_0($1:i8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i32 {
 Block_0($1:i8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	return ($1) :i8
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui16 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui32 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui64 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_i8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui8 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i16 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui16 {
 Block_0($1:ui16):
 	return ($1) :ui16
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	return ($1) :ui32
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i64 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui64 {
 Block_0($1:ui64):
 	return ($1) :ui64
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i8 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/implicitCast_ui8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui8 {
 Block_0($1:ui8):
 	return ($1) :ui8
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i16 {
 Block_0($1:f64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i32 {
 Block_0($1:f64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i64 {
 Block_0($1:f64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i8 {
 Block_0($1:f64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui16 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui32 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui64 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_d_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui8 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i16 {
 Block_0($1:f32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i32 {
 Block_0($1:f32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i64 {
 Block_0($1:f32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i8 {
 Block_0($1:f32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui16 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui32 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui64 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_f_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui8 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	return ($1) :i16
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i32 {
 Block_0($1:i16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i64 {
 Block_0($1:i16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i8 {
 Block_0($1:i16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui16 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui32 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui64 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui8 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i16 {
 Block_0($1:i32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i8 {
 Block_0($1:i32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui16 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui32 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui64 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui8 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i16 {
 Block_0($1:i64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i32 {
 Block_0($1:i64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	return ($1) :i64
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i8 {
 Block_0($1:i64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui16 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui32 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui64 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui8 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i16 {
 Block_0($1:i8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i32 {
 Block_0($1:i8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	return ($1) :i8
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui16 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui32 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui64 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_i8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui8 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i16 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui16 {
 Block_0($1:ui16):
 	return ($1) :ui16
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	return ($1) :ui32
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i64 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui64 {
 Block_0($1:ui64):
 	return ($1) :ui64
 }

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i8 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_constant_folding/staticCast_ui8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui8 {
 Block_0($1:ui8):
 	return ($1) :ui8
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i16 {
 Block_0($1:f64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i32 {
 Block_0($1:f64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i64 {
 Block_0($1:f64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i8 {
 Block_0($1:f64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui16 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui32 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui64 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_d_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui8 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i16 {
 Block_0($1:f32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i32 {
 Block_0($1:f32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i64 {
 Block_0($1:f32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i8 {
 Block_0($1:f32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui16 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui32 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui64 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_f_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui8 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	return ($1) :i16
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i32 {
 Block_0($1:i16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i64 {
 Block_0($1:i16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i8 {
 Block_0($1:i16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui16 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui32 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui64 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui8 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i16 {
 Block_0($1:i32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i8 {
 Block_0($1:i32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui16 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui32 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui64 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui8 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i16 {
 Block_0($1:i64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i32 {
 Block_0($1:i64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	return ($1) :i64
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i8 {
 Block_0($1:i64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui16 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui32 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui64 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui8 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i16 {
 Block_0($1:i8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i32 {
 Block_0($1:i8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	return ($1) :i8
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui16 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui32 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui64 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_i8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui8 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i16 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui16 {
 Block_0($1:ui16):
 	return ($1) :ui16
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	return ($1) :ui32
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i64 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui64 {
 Block_0($1:ui64):
 	return ($1) :ui64
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i8 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/implicitCast_ui8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui8 {
 Block_0($1:ui8):
 	return ($1) :ui8
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i16 {
 Block_0($1:f64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i32 {
 Block_0($1:f64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i64 {
 Block_0($1:f64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i8 {
 Block_0($1:f64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui16 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui32 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui64 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_d_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui8 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i16 {
 Block_0($1:f32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i32 {
 Block_0($1:f32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i64 {
 Block_0($1:f32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i8 {
 Block_0($1:f32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui16 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui32 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui64 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_f_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui8 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	return ($1) :i16
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i32 {
 Block_0($1:i16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i64 {
 Block_0($1:i16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i8 {
 Block_0($1:i16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui16 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui32 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui64 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui8 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i16 {
 Block_0($1:i32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i8 {
 Block_0($1:i32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui16 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui32 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui64 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui8 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i16 {
 Block_0($1:i64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i32 {
 Block_0($1:i64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	return ($1) :i64
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i8 {
 Block_0($1:i64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui16 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui32 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui64 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui8 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i16 {
 Block_0($1:i8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i32 {
 Block_0($1:i8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	return ($1) :i8
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui16 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui32 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui64 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_i8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui8 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i16 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui16 {
 Block_0($1:ui16):
 	return ($1) :ui16
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	return ($1) :ui32
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i64 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui64 {
 Block_0($1:ui64):
 	return ($1) :ui64
 }

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i8 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/after_empty_block_elim/staticCast_ui8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui8 {
 Block_0($1:ui8):
 	return ($1) :ui8
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i16 {
 Block_0($1:f64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i32 {
 Block_0($1:f64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i64 {
 Block_0($1:f64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i8 {
 Block_0($1:f64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui16 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui32 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui64 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_d_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_d_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui8 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i16 {
 Block_0($1:f32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i32 {
 Block_0($1:f32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i64 {
 Block_0($1:f32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i8 {
 Block_0($1:f32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui16 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui32 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui64 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_f_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_f_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui8 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	return ($1) :i16
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i32 {
 Block_0($1:i16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i64 {
 Block_0($1:i16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i8 {
 Block_0($1:i16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui16 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui32 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui64 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui8 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i16 {
 Block_0($1:i32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i8 {
 Block_0($1:i32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui16 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui32 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui64 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui8 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i16 {
 Block_0($1:i64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i32 {
 Block_0($1:i64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	return ($1) :i64
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i8 {
 Block_0($1:i64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui16 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui32 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui64 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui8 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i16 {
 Block_0($1:i8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i32 {
 Block_0($1:i8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	return ($1) :i8
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui16 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui32 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui64 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_i8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui8 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i16 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui16 {
 Block_0($1:ui16):
 	return ($1) :ui16
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	return ($1) :ui32
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i64 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui64 {
 Block_0($1:ui64):
 	return ($1) :ui64
 }

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i8 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/implicitCast_ui8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui8 {
 Block_0($1:ui8):
 	return ($1) :ui8
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i16 {
 Block_0($1:f64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i32 {
 Block_0($1:f64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i64 {
 Block_0($1:f64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :i8 {
 Block_0($1:f64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui16 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui32 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui64 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_d_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_d_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :ui8 {
 Block_0($1:f64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i16 {
 Block_0($1:f32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i32 {
 Block_0($1:f32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i64 {
 Block_0($1:f32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :i8 {
 Block_0($1:f32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui16 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui32 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui64 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_f_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_f_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :ui8 {
 Block_0($1:f32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	return ($1) :i16
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i32 {
 Block_0($1:i16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i64 {
 Block_0($1:i16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i8 {
 Block_0($1:i16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui16 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui32 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui64 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :ui8 {
 Block_0($1:i16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i16 {
 Block_0($1:i32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i8 {
 Block_0($1:i32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui16 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui32 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui64 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :ui8 {
 Block_0($1:i32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i16 {
 Block_0($1:i64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i32 {
 Block_0($1:i64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	return ($1) :i64
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i8 {
 Block_0($1:i64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui16 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui32 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui64 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :ui8 {
 Block_0($1:i64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i16 {
 Block_0($1:i8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i32 {
 Block_0($1:i8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	return ($1) :i8
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui16 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui32 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui64 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_i8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_i8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :ui8 {
 Block_0($1:i8):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i16 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :i8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui16 {
 Block_0($1:ui16):
 	return ($1) :ui16
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui32 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui64 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui16_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui16) :ui8 {
 Block_0($1:ui16):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui16 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	return ($1) :ui32
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui64 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui32_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui8 {
 Block_0($1:ui32):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i64 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :i8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui16 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui32 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui64 {
 Block_0($1:ui64):
 	return ($1) :ui64
 }

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui64_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui64) :ui8 {
 Block_0($1:ui64):
 	$2 = $1 cast_to ui8 :ui8
 	return ($2) :ui8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_i16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i16 :i16
 	return ($2) :i16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_i32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i32 :i32
 	return ($2) :i32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_i64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i64 :i64
 	return ($2) :i64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_i8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i8 {
 Block_0($1:ui8):
 	$2 = $1 cast_to i8 :i8
 	return ($2) :i8

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui16.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui16 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui16 :ui16
 	return ($2) :ui16

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui32.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui32 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui32 :ui32
 	return ($2) :ui32

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui64.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui64 {
 Block_0($1:ui8):
 	$2 = $1 cast_to ui64 :ui64
 	return ($2) :ui64

--- a/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui8.nautilus
+++ b/nautilus/test/data/cast-tests/ir/staticCast_ui8_ui8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :ui8 {
 Block_0($1:ui8):
 	return ($1) :ui8
 }

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/andCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/andCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 1 :i32
 	$4 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/andFunction.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/andFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :bool {
 Block_0($1:i32):
 	$2 = true :bool
 	$3 = 42 :i64

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/chainedIf10.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/chainedIf10.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/chainedIf100.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/chainedIf100.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/chainedIf500.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/chainedIf500.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/complexLogicalExpressions.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/complexLogicalExpressions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/compoundAssignment.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/compoundAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/compoundStatements.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/compoundStatements.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/constructComplexReturnObject.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/constructComplexReturnObject.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$5 = $1 > $2 :bool
 	if $5 ? Block_1($2, $1) : Block_2() :void

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/constructComplexReturnObject2.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/constructComplexReturnObject2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$8 = $1 > $2 :bool

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/deeplyNestedIfElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/deeplyNestedIfElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 5 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/deeplyNestedIfElseIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/deeplyNestedIfElseIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 5 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/doubleIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/doubleIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifElseIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifElseIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifElseIfElse.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifElseIfElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifElseIfOnly.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifElseIfOnly.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifNotEqual.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifNotEqual.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifThenCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifThenCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 42 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifThenElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifThenElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 42 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifWithFunctionCall.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifWithFunctionCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$4 = 2 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/ifWithTernary.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/ifWithTernary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/logicalAnd.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/logicalAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/logicalOr.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/logicalOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/logicalXOR.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/logicalXOR.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/multipleConditions.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/multipleConditions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/multipleElse.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/multipleElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/multipleVoidReturnsFunction.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/multipleVoidReturnsFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$4 = load($1) :i32
 	$5 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIf.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIf.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 20 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIf10.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIf10.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIf100.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIf100.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIfElseDifferentLevels.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIfElseDifferentLevels.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIfNoElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIfNoElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	$4 = $1 == $3 :bool

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIfThenElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/nestedIfThenElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	$4 = $1 == $3 :bool

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/orCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/orCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/shortCircuitEvaluation.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/shortCircuitEvaluation.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_constant_folding/varyingComplexity.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_constant_folding/varyingComplexity.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/andCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/andCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 1 :i32
 	$4 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/andFunction.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/andFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :bool {
 Block_0($1:i32):
 	$2 = true :bool
 	$3 = 42 :i64

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/chainedIf10.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/chainedIf10.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/chainedIf100.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/chainedIf100.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/chainedIf500.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/chainedIf500.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/complexLogicalExpressions.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/complexLogicalExpressions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/compoundAssignment.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/compoundAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/compoundStatements.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/compoundStatements.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/constructComplexReturnObject.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/constructComplexReturnObject.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$5 = $1 > $2 :bool
 	if $5 ? Block_1($2, $1) : Block_2() :void

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/constructComplexReturnObject2.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/constructComplexReturnObject2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$8 = $1 > $2 :bool

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/deeplyNestedIfElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/deeplyNestedIfElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 5 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/deeplyNestedIfElseIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/deeplyNestedIfElseIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 5 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/doubleIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/doubleIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifElseIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifElseIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifElseIfElse.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifElseIfElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifElseIfOnly.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifElseIfOnly.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifNotEqual.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifNotEqual.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifThenCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifThenCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 42 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifThenElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifThenElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 42 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifWithFunctionCall.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifWithFunctionCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$4 = 2 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifWithTernary.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/ifWithTernary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/logicalAnd.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/logicalAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/logicalOr.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/logicalOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/logicalXOR.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/logicalXOR.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/multipleConditions.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/multipleConditions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/multipleElse.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/multipleElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/multipleVoidReturnsFunction.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/multipleVoidReturnsFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$4 = load($1) :i32
 	$5 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIf.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIf.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 20 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIf10.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIf10.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIf100.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIf100.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIfElseDifferentLevels.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIfElseDifferentLevels.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIfNoElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIfNoElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	$4 = $1 == $3 :bool

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIfThenElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/nestedIfThenElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	$4 = $1 == $3 :bool

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/orCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/orCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/shortCircuitEvaluation.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/shortCircuitEvaluation.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/after_empty_block_elim/varyingComplexity.nautilus
+++ b/nautilus/test/data/control-flow-tests/after_empty_block_elim/varyingComplexity.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/andCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/andCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 1 :i32
 	$4 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/ir/andFunction.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/andFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :bool {
 Block_0($1:i32):
 	$2 = true :bool
 	$3 = 42 :i64

--- a/nautilus/test/data/control-flow-tests/ir/chainedIf10.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/chainedIf10.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/chainedIf100.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/chainedIf100.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/chainedIf500.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/chainedIf500.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/complexLogicalExpressions.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/complexLogicalExpressions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/compoundAssignment.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/compoundAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/compoundStatements.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/compoundStatements.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/constructComplexReturnObject.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/constructComplexReturnObject.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$5 = $1 > $2 :bool
 	if $5 ? Block_1($2, $1) : Block_2() :void

--- a/nautilus/test/data/control-flow-tests/ir/constructComplexReturnObject2.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/constructComplexReturnObject2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$8 = $1 > $2 :bool

--- a/nautilus/test/data/control-flow-tests/ir/deeplyNestedIfElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/deeplyNestedIfElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 5 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/ir/deeplyNestedIfElseIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/deeplyNestedIfElseIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 5 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/ir/doubleIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/doubleIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifElseIfCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifElseIfCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifElseIfElse.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifElseIfElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifElseIfOnly.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifElseIfOnly.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifNotEqual.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifNotEqual.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifThenCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifThenCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 42 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifThenElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifThenElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 42 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifWithFunctionCall.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifWithFunctionCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$4 = 2 :i32

--- a/nautilus/test/data/control-flow-tests/ir/ifWithTernary.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/ifWithTernary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/control-flow-tests/ir/logicalAnd.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/logicalAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/control-flow-tests/ir/logicalOr.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/logicalOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/ir/logicalXOR.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/logicalXOR.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/ir/multipleConditions.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/multipleConditions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/multipleElse.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/multipleElse.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/ir/multipleVoidReturnsFunction.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/multipleVoidReturnsFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$4 = load($1) :i32
 	$5 = 10 :i32

--- a/nautilus/test/data/control-flow-tests/ir/nestedIf.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/nestedIf.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 20 :i32

--- a/nautilus/test/data/control-flow-tests/ir/nestedIf10.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/nestedIf10.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/nestedIf100.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/nestedIf100.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/nestedIfElseDifferentLevels.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/nestedIfElseDifferentLevels.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/nestedIfNoElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/nestedIfNoElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	$4 = $1 == $3 :bool

--- a/nautilus/test/data/control-flow-tests/ir/nestedIfThenElseCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/nestedIfThenElseCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	$4 = $1 == $3 :bool

--- a/nautilus/test/data/control-flow-tests/ir/orCondition.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/orCondition.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 8 :i32

--- a/nautilus/test/data/control-flow-tests/ir/shortCircuitEvaluation.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/shortCircuitEvaluation.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/control-flow-tests/ir/varyingComplexity.nautilus
+++ b/nautilus/test/data/control-flow-tests/ir/varyingComplexity.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/enum-tests/after_constant_folding/callEnumClassFunction.nautilus
+++ b/nautilus/test/data/enum-tests/after_constant_folding/callEnumClassFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/enum-tests/after_constant_folding/callEnumFunction.nautilus
+++ b/nautilus/test/data/enum-tests/after_constant_folding/callEnumFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/enum-tests/after_constant_folding/getEnum.nautilus
+++ b/nautilus/test/data/enum-tests/after_constant_folding/getEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :ui32 {
 Block_0():
 	$1 = 0 :ui32
 	return ($1) :ui32

--- a/nautilus/test/data/enum-tests/after_constant_folding/handleEnum.nautilus
+++ b/nautilus/test/data/enum-tests/after_constant_folding/handleEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :bool {
 Block_0($1:ui32):
 	$2 = 0 :ui32
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/after_constant_folding/handleEnumLogLevel.nautilus
+++ b/nautilus/test/data/enum-tests/after_constant_folding/handleEnumLogLevel.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :bool {
 Block_0($1:ui8):
 	$2 = 6 :ui8
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/after_constant_folding/isEnum.nautilus
+++ b/nautilus/test/data/enum-tests/after_constant_folding/isEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = 0 :ui32
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/after_empty_block_elim/callEnumClassFunction.nautilus
+++ b/nautilus/test/data/enum-tests/after_empty_block_elim/callEnumClassFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/enum-tests/after_empty_block_elim/callEnumFunction.nautilus
+++ b/nautilus/test/data/enum-tests/after_empty_block_elim/callEnumFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/enum-tests/after_empty_block_elim/getEnum.nautilus
+++ b/nautilus/test/data/enum-tests/after_empty_block_elim/getEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :ui32 {
 Block_0():
 	$1 = 0 :ui32
 	return ($1) :ui32

--- a/nautilus/test/data/enum-tests/after_empty_block_elim/handleEnum.nautilus
+++ b/nautilus/test/data/enum-tests/after_empty_block_elim/handleEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :bool {
 Block_0($1:ui32):
 	$2 = 0 :ui32
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/after_empty_block_elim/handleEnumLogLevel.nautilus
+++ b/nautilus/test/data/enum-tests/after_empty_block_elim/handleEnumLogLevel.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :bool {
 Block_0($1:ui8):
 	$2 = 6 :ui8
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/after_empty_block_elim/isEnum.nautilus
+++ b/nautilus/test/data/enum-tests/after_empty_block_elim/isEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = 0 :ui32
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/ir/callEnumClassFunction.nautilus
+++ b/nautilus/test/data/enum-tests/ir/callEnumClassFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :i32 {
 Block_0($1:ui8):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/enum-tests/ir/callEnumFunction.nautilus
+++ b/nautilus/test/data/enum-tests/ir/callEnumFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/enum-tests/ir/getEnum.nautilus
+++ b/nautilus/test/data/enum-tests/ir/getEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :ui32 {
 Block_0():
 	$1 = 0 :ui32
 	return ($1) :ui32

--- a/nautilus/test/data/enum-tests/ir/handleEnum.nautilus
+++ b/nautilus/test/data/enum-tests/ir/handleEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :bool {
 Block_0($1:ui32):
 	$2 = 0 :ui32
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/ir/handleEnumLogLevel.nautilus
+++ b/nautilus/test/data/enum-tests/ir/handleEnumLogLevel.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui8) :bool {
 Block_0($1:ui8):
 	$2 = 6 :ui8
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/enum-tests/ir/isEnum.nautilus
+++ b/nautilus/test/data/enum-tests/ir/isEnum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :i32 {
 Block_0($1:ui32):
 	$2 = 0 :ui32
 	$3 = $1 == $2 :bool

--- a/nautilus/test/data/expression-tests/after_constant_folding/addInt8AndInt32.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/addInt8AndInt32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i32) :i32 {
 Block_0($1:i8, $2:i32):
 	$3 = $1 cast_to i32 :i32
 	$4 = $3 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignAdd.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignAnd.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 & $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignDiv.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignDiv.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 / $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignMod.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignMod.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 % $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignMul.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignMul.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 * $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignOr.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 | $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignShl.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignShl.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 << $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignShr.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignShr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 >> $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignSub.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignSub.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignXor.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignXor.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 ^ $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignment1.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignment1.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignment2.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignment2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignment3.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignment3.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignment4.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignment4.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 42 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/assignment5.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/assignment5.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 42 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/castFloatToDoubleAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/castFloatToDoubleAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :f64 {
 Block_0($1:f32):
 	$2 = 7 :f64
 	$3 = $1 cast_to f64 :f64

--- a/nautilus/test/data/expression-tests/after_constant_folding/castInt8ToInt64AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/castInt8ToInt64AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = 7 :i64
 	$3 = $1 cast_to i64 :i64

--- a/nautilus/test/data/expression-tests/after_constant_folding/castInt8ToInt64AddExpression2.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/castInt8ToInt64AddExpression2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = 42 :i64
 	$3 = $1 cast_to i64 :i64

--- a/nautilus/test/data/expression-tests/after_constant_folding/decrementPost.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/decrementPost.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 - $3 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/decrementPre.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/decrementPre.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/doubleAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/doubleAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :f64 {
 Block_0($1:f64):
 	$2 = 7 :f64
 	$3 = $1 + $2 :f64

--- a/nautilus/test/data/expression-tests/after_constant_folding/floatAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/floatAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :f32 {
 Block_0($1:f32):
 	$2 = 7 :f32
 	$3 = $1 + $2 :f32

--- a/nautilus/test/data/expression-tests/after_constant_folding/incrementPost.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/incrementPost.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/incrementPre.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/incrementPre.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/int16AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/int16AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	$2 = 5 :i16
 	$3 = $1 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/int32AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/int32AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/int64AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/int64AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$2 = 7 :i64
 	$3 = $1 + $2 :i64

--- a/nautilus/test/data/expression-tests/after_constant_folding/int8AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/int8AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	$2 = 2 :i8
 	$3 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/logicalNot_bool.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/logicalNot_bool.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = !$1 :bool
 	return ($2) :bool

--- a/nautilus/test/data/expression-tests/after_constant_folding/mulInt64AndNotDefinedI64.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/mulInt64AndNotDefinedI64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$2 = 0 :i64
 	$3 = $1 * $2 :i64

--- a/nautilus/test/data/expression-tests/after_constant_folding/negate_i8.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/negate_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	$3 = ~$1 :i8
 	return ($3) :i8

--- a/nautilus/test/data/expression-tests/after_constant_folding/nestedSelect.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/nestedSelect.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectBasedOnComparison.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectBasedOnComparison.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 > $2 :bool
 	$6 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectBool.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectBool.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool, $3:bool) :bool {
 Block_0($1:bool, $2:bool, $3:bool):
 	$7 :bool
 	return ($7) :bool

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectDouble.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectDouble.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:f64, $3:f64) :f64 {
 Block_0($1:bool, $2:f64, $3:f64):
 	$7 :f64
 	return ($7) :f64

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectFloat.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectFloat.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:f32, $3:f32) :f32 {
 Block_0($1:bool, $2:f32, $3:f32):
 	$7 :f32
 	return ($7) :f32

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectInLoop.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectInt16.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectInt16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i16, $3:i16) :i16 {
 Block_0($1:bool, $2:i16, $3:i16):
 	$7 :i16
 	return ($7) :i16

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectInt32True.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectInt32True.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i32, $3:i32) :i32 {
 Block_0($1:bool, $2:i32, $3:i32):
 	$7 :i32
 	return ($7) :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectInt64True.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectInt64True.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i64, $3:i64) :i64 {
 Block_0($1:bool, $2:i64, $3:i64):
 	$7 :i64
 	return ($7) :i64

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectInt8.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectInt8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i8, $3:i8) :i8 {
 Block_0($1:bool, $2:i8, $3:i8):
 	$7 :i8
 	return ($7) :i8

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectPointer.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectPointer.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ptr, $3:ptr) :ptr {
 Block_0($1:bool, $2:ptr, $3:ptr):
 	$7 :ptr
 	return ($7) :ptr

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectPointerAndDeref.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectPointerAndDeref.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ptr, $3:ptr) :i32 {
 Block_0($1:bool, $2:ptr, $3:ptr):
 	$7 :ptr
 	$10 = load($7) :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectUInt32.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectUInt32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ui32, $3:ui32) :ui32 {
 Block_0($1:bool, $2:ui32, $3:ui32):
 	$7 :ui32
 	return ($7) :ui32

--- a/nautilus/test/data/expression-tests/after_constant_folding/selectUInt64.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/selectUInt64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ui64, $3:ui64) :ui64 {
 Block_0($1:bool, $2:ui64, $3:ui64):
 	$7 :ui64
 	return ($7) :ui64

--- a/nautilus/test/data/expression-tests/after_constant_folding/shiftLeft_i8.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/shiftLeft_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i8 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/shiftRight_i8.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/shiftRight_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i8 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_constant_folding/subInt8AndInt8.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/subInt8AndInt8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i32 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/addInt8AndInt32.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/addInt8AndInt32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i32) :i32 {
 Block_0($1:i8, $2:i32):
 	$3 = $1 cast_to i32 :i32
 	$4 = $3 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignAdd.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignAnd.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 & $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignDiv.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignDiv.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 / $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignMod.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignMod.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 % $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignMul.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignMul.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 * $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignOr.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 | $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignShl.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignShl.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 << $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignShr.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignShr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 >> $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignSub.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignSub.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignXor.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignXor.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 ^ $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignment1.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignment1.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignment2.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignment2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignment3.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignment3.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignment4.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignment4.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 42 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/assignment5.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/assignment5.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 42 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/castFloatToDoubleAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/castFloatToDoubleAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :f64 {
 Block_0($1:f32):
 	$2 = 7 :f64
 	$3 = $1 cast_to f64 :f64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/castInt8ToInt64AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/castInt8ToInt64AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = 7 :i64
 	$3 = $1 cast_to i64 :i64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/castInt8ToInt64AddExpression2.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/castInt8ToInt64AddExpression2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = 42 :i64
 	$3 = $1 cast_to i64 :i64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/decrementPost.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/decrementPost.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 - $3 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/decrementPre.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/decrementPre.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/doubleAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/doubleAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :f64 {
 Block_0($1:f64):
 	$2 = 7 :f64
 	$3 = $1 + $2 :f64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/floatAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/floatAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :f32 {
 Block_0($1:f32):
 	$2 = 7 :f32
 	$3 = $1 + $2 :f32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/incrementPost.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/incrementPost.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/incrementPre.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/incrementPre.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/int16AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/int16AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	$2 = 5 :i16
 	$3 = $1 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/int32AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/int32AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/int64AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/int64AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$2 = 7 :i64
 	$3 = $1 + $2 :i64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/int8AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/int8AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	$2 = 2 :i8
 	$3 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/logicalNot_bool.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/logicalNot_bool.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = !$1 :bool
 	return ($2) :bool

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/mulInt64AndNotDefinedI64.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/mulInt64AndNotDefinedI64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$2 = 0 :i64
 	$3 = $1 * $2 :i64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/negate_i8.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/negate_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	$3 = ~$1 :i8
 	return ($3) :i8

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/nestedSelect.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/nestedSelect.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectBasedOnComparison.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectBasedOnComparison.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 > $2 :bool
 	$6 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectBool.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectBool.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool, $3:bool) :bool {
 Block_0($1:bool, $2:bool, $3:bool):
 	$7 :bool
 	return ($7) :bool

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectDouble.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectDouble.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:f64, $3:f64) :f64 {
 Block_0($1:bool, $2:f64, $3:f64):
 	$7 :f64
 	return ($7) :f64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectFloat.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectFloat.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:f32, $3:f32) :f32 {
 Block_0($1:bool, $2:f32, $3:f32):
 	$7 :f32
 	return ($7) :f32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectInLoop.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt16.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i16, $3:i16) :i16 {
 Block_0($1:bool, $2:i16, $3:i16):
 	$7 :i16
 	return ($7) :i16

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt32True.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt32True.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i32, $3:i32) :i32 {
 Block_0($1:bool, $2:i32, $3:i32):
 	$7 :i32
 	return ($7) :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt64True.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt64True.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i64, $3:i64) :i64 {
 Block_0($1:bool, $2:i64, $3:i64):
 	$7 :i64
 	return ($7) :i64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt8.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectInt8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i8, $3:i8) :i8 {
 Block_0($1:bool, $2:i8, $3:i8):
 	$7 :i8
 	return ($7) :i8

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectPointer.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectPointer.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ptr, $3:ptr) :ptr {
 Block_0($1:bool, $2:ptr, $3:ptr):
 	$7 :ptr
 	return ($7) :ptr

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectPointerAndDeref.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectPointerAndDeref.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ptr, $3:ptr) :i32 {
 Block_0($1:bool, $2:ptr, $3:ptr):
 	$7 :ptr
 	$10 = load($7) :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectUInt32.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectUInt32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ui32, $3:ui32) :ui32 {
 Block_0($1:bool, $2:ui32, $3:ui32):
 	$7 :ui32
 	return ($7) :ui32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/selectUInt64.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/selectUInt64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ui64, $3:ui64) :ui64 {
 Block_0($1:bool, $2:ui64, $3:ui64):
 	$7 :ui64
 	return ($7) :ui64

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/shiftLeft_i8.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/shiftLeft_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i8 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/shiftRight_i8.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/shiftRight_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i8 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/subInt8AndInt8.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/subInt8AndInt8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i32 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/ir/addInt8AndInt32.nautilus
+++ b/nautilus/test/data/expression-tests/ir/addInt8AndInt32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i32) :i32 {
 Block_0($1:i8, $2:i32):
 	$3 = $1 cast_to i32 :i32
 	$4 = $3 + $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignAdd.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignAnd.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignAnd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 & $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignDiv.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignDiv.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 / $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignMod.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignMod.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 % $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignMul.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignMul.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 * $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignOr.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignOr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 | $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignShl.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignShl.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 << $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignShr.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignShr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 >> $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignSub.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignSub.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignXor.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignXor.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 ^ $2 :i32

--- a/nautilus/test/data/expression-tests/ir/assignment1.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignment1.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/expression-tests/ir/assignment2.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignment2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/ir/assignment3.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignment3.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/ir/assignment4.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignment4.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 42 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/expression-tests/ir/assignment5.nautilus
+++ b/nautilus/test/data/expression-tests/ir/assignment5.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 42 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/expression-tests/ir/castFloatToDoubleAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/castFloatToDoubleAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :f64 {
 Block_0($1:f32):
 	$2 = 7 :f64
 	$3 = $1 cast_to f64 :f64

--- a/nautilus/test/data/expression-tests/ir/castInt8ToInt64AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/castInt8ToInt64AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = 7 :i64
 	$3 = $1 cast_to i64 :i64

--- a/nautilus/test/data/expression-tests/ir/castInt8ToInt64AddExpression2.nautilus
+++ b/nautilus/test/data/expression-tests/ir/castInt8ToInt64AddExpression2.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i64 {
 Block_0($1:i8):
 	$2 = 42 :i64
 	$3 = $1 cast_to i64 :i64

--- a/nautilus/test/data/expression-tests/ir/decrementPost.nautilus
+++ b/nautilus/test/data/expression-tests/ir/decrementPost.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 - $3 :i32

--- a/nautilus/test/data/expression-tests/ir/decrementPre.nautilus
+++ b/nautilus/test/data/expression-tests/ir/decrementPre.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/expression-tests/ir/doubleAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/doubleAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64) :f64 {
 Block_0($1:f64):
 	$2 = 7 :f64
 	$3 = $1 + $2 :f64

--- a/nautilus/test/data/expression-tests/ir/floatAddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/floatAddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f32) :f32 {
 Block_0($1:f32):
 	$2 = 7 :f32
 	$3 = $1 + $2 :f32

--- a/nautilus/test/data/expression-tests/ir/incrementPost.nautilus
+++ b/nautilus/test/data/expression-tests/ir/incrementPost.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/expression-tests/ir/incrementPre.nautilus
+++ b/nautilus/test/data/expression-tests/ir/incrementPre.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/ir/int16AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/int16AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i16) :i16 {
 Block_0($1:i16):
 	$2 = 5 :i16
 	$3 = $1 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/ir/int32AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/int32AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/expression-tests/ir/int64AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/int64AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$2 = 7 :i64
 	$3 = $1 + $2 :i64

--- a/nautilus/test/data/expression-tests/ir/int8AddExpression.nautilus
+++ b/nautilus/test/data/expression-tests/ir/int8AddExpression.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	$2 = 2 :i8
 	$3 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/ir/logicalNot_bool.nautilus
+++ b/nautilus/test/data/expression-tests/ir/logicalNot_bool.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool) :bool {
 Block_0($1:bool):
 	$2 = !$1 :bool
 	return ($2) :bool

--- a/nautilus/test/data/expression-tests/ir/mulInt64AndNotDefinedI64.nautilus
+++ b/nautilus/test/data/expression-tests/ir/mulInt64AndNotDefinedI64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$2 = 0 :i64
 	$3 = $1 * $2 :i64

--- a/nautilus/test/data/expression-tests/ir/negate_i8.nautilus
+++ b/nautilus/test/data/expression-tests/ir/negate_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8) :i8 {
 Block_0($1:i8):
 	$3 = ~$1 :i8
 	return ($3) :i8

--- a/nautilus/test/data/expression-tests/ir/nestedSelect.nautilus
+++ b/nautilus/test/data/expression-tests/ir/nestedSelect.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/expression-tests/ir/selectBasedOnComparison.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectBasedOnComparison.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 > $2 :bool
 	$6 :i32

--- a/nautilus/test/data/expression-tests/ir/selectBool.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectBool.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:bool, $3:bool) :bool {
 Block_0($1:bool, $2:bool, $3:bool):
 	$7 :bool
 	return ($7) :bool

--- a/nautilus/test/data/expression-tests/ir/selectDouble.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectDouble.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:f64, $3:f64) :f64 {
 Block_0($1:bool, $2:f64, $3:f64):
 	$7 :f64
 	return ($7) :f64

--- a/nautilus/test/data/expression-tests/ir/selectFloat.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectFloat.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:f32, $3:f32) :f32 {
 Block_0($1:bool, $2:f32, $3:f32):
 	$7 :f32
 	return ($7) :f32

--- a/nautilus/test/data/expression-tests/ir/selectInLoop.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/expression-tests/ir/selectInt16.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectInt16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i16, $3:i16) :i16 {
 Block_0($1:bool, $2:i16, $3:i16):
 	$7 :i16
 	return ($7) :i16

--- a/nautilus/test/data/expression-tests/ir/selectInt32True.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectInt32True.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i32, $3:i32) :i32 {
 Block_0($1:bool, $2:i32, $3:i32):
 	$7 :i32
 	return ($7) :i32

--- a/nautilus/test/data/expression-tests/ir/selectInt64True.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectInt64True.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i64, $3:i64) :i64 {
 Block_0($1:bool, $2:i64, $3:i64):
 	$7 :i64
 	return ($7) :i64

--- a/nautilus/test/data/expression-tests/ir/selectInt8.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectInt8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i8, $3:i8) :i8 {
 Block_0($1:bool, $2:i8, $3:i8):
 	$7 :i8
 	return ($7) :i8

--- a/nautilus/test/data/expression-tests/ir/selectPointer.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectPointer.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ptr, $3:ptr) :ptr {
 Block_0($1:bool, $2:ptr, $3:ptr):
 	$7 :ptr
 	return ($7) :ptr

--- a/nautilus/test/data/expression-tests/ir/selectPointerAndDeref.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectPointerAndDeref.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ptr, $3:ptr) :i32 {
 Block_0($1:bool, $2:ptr, $3:ptr):
 	$7 :ptr
 	$10 = load($7) :i32

--- a/nautilus/test/data/expression-tests/ir/selectUInt32.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectUInt32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ui32, $3:ui32) :ui32 {
 Block_0($1:bool, $2:ui32, $3:ui32):
 	$7 :ui32
 	return ($7) :ui32

--- a/nautilus/test/data/expression-tests/ir/selectUInt64.nautilus
+++ b/nautilus/test/data/expression-tests/ir/selectUInt64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:ui64, $3:ui64) :ui64 {
 Block_0($1:bool, $2:ui64, $3:ui64):
 	$7 :ui64
 	return ($7) :ui64

--- a/nautilus/test/data/expression-tests/ir/shiftLeft_i8.nautilus
+++ b/nautilus/test/data/expression-tests/ir/shiftLeft_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i8 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/ir/shiftRight_i8.nautilus
+++ b/nautilus/test/data/expression-tests/ir/shiftRight_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i8 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/expression-tests/ir/subInt8AndInt8.nautilus
+++ b/nautilus/test/data/expression-tests/ir/subInt8AndInt8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i8) :i32 {
 Block_0($1:i8, $2:i8):
 	$3 = $1 cast_to i32 :i32
 	$4 = $2 cast_to i32 :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/callThroughFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/callThroughFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 :i32
 	return ($4) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/callVoidFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/callVoidFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 :void
 	return ($2) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrAsTypedArg.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrAsTypedArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 = func_*($1,$2,$3) :i32
 	return ($4) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrAssignAndCall.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrAssignAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:i32, $4:i32) :i32 {
 Block_0($1:ptr, $2:ptr, $3:i32, $4:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrCopyAndCall.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrCopyAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrEquals.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 == $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrFromLambda.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrFromLambda.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = * :ptr
 	$3 :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrInLoop.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 = 0 :i32
 	$5 = 0 :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrInlineConst.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrInlineConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = * :ptr
 	$4 :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrInlineConstUnary.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrInlineConstUnary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = * :ptr
 	$3 :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrIsNull.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrIsNull.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1 == $3 :bool

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrNotEquals.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrNotEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1  $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrNotNull.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrNotNull.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1  $3 :bool

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrNullBranch.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrNullBranch.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 = * :ptr
 	$8 = $1 == $5 :bool

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrRoundtripVoidPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrRoundtripVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrToVoidPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/fnPtrToVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	func_*($1) :void
 	return ($2) :i32

--- a/nautilus/test/data/function-ptr-tests/after_constant_folding/selectFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_constant_folding/selectFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i32, $3:i32) :i32 {
 Block_0($1:bool, $2:i32, $3:i32):
 	$4 = * :ptr
 	if $1 ? Block_1($2, $3) : Block_2($2, $3) :void

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/callThroughFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/callThroughFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 :i32
 	return ($4) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/callVoidFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/callVoidFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 :void
 	return ($2) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrAsTypedArg.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrAsTypedArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 = func_*($1,$2,$3) :i32
 	return ($4) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrAssignAndCall.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrAssignAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:i32, $4:i32) :i32 {
 Block_0($1:ptr, $2:ptr, $3:i32, $4:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrCopyAndCall.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrCopyAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrEquals.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 == $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrFromLambda.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrFromLambda.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = * :ptr
 	$3 :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrInLoop.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 = 0 :i32
 	$5 = 0 :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrInlineConst.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrInlineConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = * :ptr
 	$4 :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrInlineConstUnary.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrInlineConstUnary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = * :ptr
 	$3 :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrIsNull.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrIsNull.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1 == $3 :bool

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrNotEquals.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrNotEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1  $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrNotNull.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrNotNull.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1  $3 :bool

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrNullBranch.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrNullBranch.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 = * :ptr
 	$8 = $1 == $5 :bool

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrRoundtripVoidPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrRoundtripVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrToVoidPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/fnPtrToVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	func_*($1) :void
 	return ($2) :i32

--- a/nautilus/test/data/function-ptr-tests/after_empty_block_elim/selectFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/after_empty_block_elim/selectFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i32, $3:i32) :i32 {
 Block_0($1:bool, $2:i32, $3:i32):
 	$4 = * :ptr
 	if $1 ? Block_1($2, $3) : Block_2($2, $3) :void

--- a/nautilus/test/data/function-ptr-tests/ir/callThroughFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/callThroughFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 :i32
 	return ($4) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/callVoidFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/callVoidFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 :void
 	return ($2) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrAsTypedArg.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrAsTypedArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 = func_*($1,$2,$3) :i32
 	return ($4) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrAssignAndCall.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrAssignAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:i32, $4:i32) :i32 {
 Block_0($1:ptr, $2:ptr, $3:i32, $4:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrCopyAndCall.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrCopyAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrEquals.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 == $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrFromLambda.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrFromLambda.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = * :ptr
 	$3 :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrInLoop.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$4 = 0 :i32
 	$5 = 0 :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrInlineConst.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrInlineConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = * :ptr
 	$4 :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrInlineConstUnary.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrInlineConstUnary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = * :ptr
 	$3 :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrIsNull.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrIsNull.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1 == $3 :bool

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrNotEquals.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrNotEquals.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1  $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrNotNull.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrNotNull.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1  $3 :bool

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrNullBranch.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrNullBranch.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 = * :ptr
 	$8 = $1 == $5 :bool

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrRoundtripVoidPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrRoundtripVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32, $3:i32) :i32 {
 Block_0($1:ptr, $2:i32, $3:i32):
 	$5 :i32
 	return ($5) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/fnPtrToVoidPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/fnPtrToVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	func_*($1) :void
 	return ($2) :i32

--- a/nautilus/test/data/function-ptr-tests/ir/selectFnPtr.nautilus
+++ b/nautilus/test/data/function-ptr-tests/ir/selectFnPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:bool, $2:i32, $3:i32) :i32 {
 Block_0($1:bool, $2:i32, $3:i32):
 	$4 = * :ptr
 	if $1 ? Block_1($2, $3) : Block_2($2, $3) :void

--- a/nautilus/test/data/loop-tests/after_constant_folding/collatz.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/collatz.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/countDigits.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/countDigits.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/decimalToBinary.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/decimalToBinary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/digitSum.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/digitSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/elseOnlySumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/elseOnlySumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/factorial.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/factorial.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/fibonacci.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/fibonacci.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/forBreak.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/forBreak.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/gcd.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/gcd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	br Block_3($1, $2, $3) :void

--- a/nautilus/test/data/loop-tests/after_constant_folding/ifElseSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/ifElseSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/ifInsideLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/ifInsideLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/ifSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/ifSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/isPrime.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/isPrime.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :bool {
 Block_0($1:i32):
 	$2 = false :bool
 	$3 = true :bool

--- a/nautilus/test/data/loop-tests/after_constant_folding/nestedElseOnlySumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/nestedElseOnlySumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/nestedIfElseSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/nestedIfElseSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/nestedIfSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/nestedIfSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/nestedSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/nestedSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/reverseNumber.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/reverseNumber.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/sumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/sumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/sumOfNumbers.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/sumOfNumbers.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/sumOfSquares.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/sumOfSquares.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/whileBreak.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/whileBreak.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 100 :i32

--- a/nautilus/test/data/loop-tests/after_constant_folding/whileContinue.nautilus
+++ b/nautilus/test/data/loop-tests/after_constant_folding/whileContinue.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/collatz.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/collatz.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/countDigits.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/countDigits.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/decimalToBinary.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/decimalToBinary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/digitSum.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/digitSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/elseOnlySumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/elseOnlySumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/factorial.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/factorial.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/fibonacci.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/fibonacci.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/forBreak.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/forBreak.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/gcd.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/gcd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	br Block_3($1, $2, $3) :void

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/ifElseSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/ifElseSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/ifInsideLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/ifInsideLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/ifSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/ifSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/isPrime.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/isPrime.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :bool {
 Block_0($1:i32):
 	$2 = false :bool
 	$3 = true :bool

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/nestedElseOnlySumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/nestedElseOnlySumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/nestedIfElseSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/nestedIfElseSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/nestedIfSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/nestedIfSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/nestedSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/nestedSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/reverseNumber.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/reverseNumber.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/sumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/sumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/sumOfNumbers.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/sumOfNumbers.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/sumOfSquares.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/sumOfSquares.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/whileBreak.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/whileBreak.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 100 :i32

--- a/nautilus/test/data/loop-tests/after_empty_block_elim/whileContinue.nautilus
+++ b/nautilus/test/data/loop-tests/after_empty_block_elim/whileContinue.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/collatz.nautilus
+++ b/nautilus/test/data/loop-tests/ir/collatz.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/ir/countDigits.nautilus
+++ b/nautilus/test/data/loop-tests/ir/countDigits.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/decimalToBinary.nautilus
+++ b/nautilus/test/data/loop-tests/ir/decimalToBinary.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/ir/digitSum.nautilus
+++ b/nautilus/test/data/loop-tests/ir/digitSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/loop-tests/ir/elseOnlySumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/elseOnlySumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/factorial.nautilus
+++ b/nautilus/test/data/loop-tests/ir/factorial.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/ir/fibonacci.nautilus
+++ b/nautilus/test/data/loop-tests/ir/fibonacci.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/ir/forBreak.nautilus
+++ b/nautilus/test/data/loop-tests/ir/forBreak.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/gcd.nautilus
+++ b/nautilus/test/data/loop-tests/ir/gcd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	br Block_3($1, $2, $3) :void

--- a/nautilus/test/data/loop-tests/ir/ifElseSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/ifElseSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/ifInsideLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/ifInsideLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/ifSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/ifSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/isPrime.nautilus
+++ b/nautilus/test/data/loop-tests/ir/isPrime.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :bool {
 Block_0($1:i32):
 	$2 = false :bool
 	$3 = true :bool

--- a/nautilus/test/data/loop-tests/ir/nestedElseOnlySumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/nestedElseOnlySumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/nestedIfElseSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/nestedIfElseSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/nestedIfSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/nestedIfSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/nestedSumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/nestedSumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/reverseNumber.nautilus
+++ b/nautilus/test/data/loop-tests/ir/reverseNumber.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/loop-tests/ir/sumLoop.nautilus
+++ b/nautilus/test/data/loop-tests/ir/sumLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/loop-tests/ir/sumOfNumbers.nautilus
+++ b/nautilus/test/data/loop-tests/ir/sumOfNumbers.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/ir/sumOfSquares.nautilus
+++ b/nautilus/test/data/loop-tests/ir/sumOfSquares.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/loop-tests/ir/whileBreak.nautilus
+++ b/nautilus/test/data/loop-tests/ir/whileBreak.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 100 :i32

--- a/nautilus/test/data/loop-tests/ir/whileContinue.nautilus
+++ b/nautilus/test/data/loop-tests/ir/whileContinue.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunction.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunction.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunction2.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunction2.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($3,$2) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionComplex.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionComplex.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-complexComputation() {
+complexComputation($1:i32, $2:i32, $3:i32) :i32 {
 Block_0($1:i32, $2:i32, $3:i32):
 	$4 = $1 * $2 :i32
 	$5 = $2 + $3 :i32
@@ -8,7 +8,7 @@ Block_0($1:i32, $2:i32, $3:i32):
 	$8 = $6 * $7 :i32
 	return ($8) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 5 :i32
 	$4 = func_*($1,$2,$3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionConditional.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionConditional.nautilus
@@ -1,11 +1,11 @@
 nautilus {
-conditionalHelper() {
+conditionalHelper($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 100 :i32
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionGetFuncPtr.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionGetFuncPtr.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 :ptr
 	$4 = func_*($3,$1,$2) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInline.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInline.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineAdd() {
+inlineAdd($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInlineLambda.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInlineLambda.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineMul() {
+inlineMul($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInlineMember.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInlineMember.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineSub() {
+inlineSub($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 - $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionLoop.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32
@@ -18,7 +18,7 @@ Block_1($1:i32, $3:i32, $2:i32):
 Block_2($2:i32):
 	return ($2) :i32
 }
-loopHelper() {
+loopHelper($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionMultiple.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionMultiple.nautilus
@@ -1,24 +1,24 @@
 nautilus {
-add10() {
+add10($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = func_*($2) :i32
 	$4 = func_*($3) :i32
 	return ($4) :i32
 }
-multiply2() {
+multiply2($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 2 :i32
 	$3 = $1 * $2 :i32
 	return ($3) :i32
 }
-subtract5() {
+subtract5($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionMultipleInline.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionMultipleInline.nautilus
@@ -1,17 +1,17 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($1,$2) :i32
 	$5 = $3 + $4 :i32
 	return ($5) :i32
 }
-inlineAdd2() {
+inlineAdd2($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-inlineMul2() {
+inlineMul2($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionMultipleResults.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionMultipleResults.nautilus
@@ -1,12 +1,12 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32, $3:i32) :i32 {
 Block_0($1:i32, $2:i32, $3:i32):
 	$4 = func_*($1,$2) :i32
 	$5 = func_*($2,$3) :i32
 	$6 = func_*($4,$5) :i32
 	return ($6) :i32
 }
-multiply() {
+multiply($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionNested.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionNested.nautilus
@@ -1,16 +1,16 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	return ($2) :i32
 }
-inner() {
+inner($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 2 :i32
 	$3 = $1 * $2 :i32
 	return ($3) :i32
 }
-outer() {
+outer($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionRecursiveStyle.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionRecursiveStyle.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 3 :i32
 	$4 = func_*($1,$3) :i32
@@ -9,7 +9,7 @@ Block_0($1:i32):
 	$8 = func_*($6,$7) :i32
 	return ($8) :i32
 }
-recursiveHelper() {
+recursiveHelper($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$4 = $2 <= $3 :bool

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionVoid.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionVoid.nautilus
@@ -1,11 +1,11 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	func_*($1) :void
 	$5 = load($1) :i32
 	return ($5) :i32
 }
-voidHelper() {
+voidHelper($1:ptr) :void {
 Block_0($1:ptr):
 	$4 = 10 :i32
 	$5 = load($1) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunction.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunction.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunction2.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunction2.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($3,$2) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionComplex.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionComplex.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-complexComputation() {
+complexComputation($1:i32, $2:i32, $3:i32) :i32 {
 Block_0($1:i32, $2:i32, $3:i32):
 	$4 = $1 * $2 :i32
 	$5 = $2 + $3 :i32
@@ -8,7 +8,7 @@ Block_0($1:i32, $2:i32, $3:i32):
 	$8 = $6 * $7 :i32
 	return ($8) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 5 :i32
 	$4 = func_*($1,$2,$3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionConditional.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionConditional.nautilus
@@ -1,11 +1,11 @@
 nautilus {
-conditionalHelper() {
+conditionalHelper($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 100 :i32
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionGetFuncPtr.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionGetFuncPtr.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 :ptr
 	$4 = func_*($3,$1,$2) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInline.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInline.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineAdd() {
+inlineAdd($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInlineLambda.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInlineLambda.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineMul() {
+inlineMul($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInlineMember.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInlineMember.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineSub() {
+inlineSub($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 - $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionLoop.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32
@@ -18,7 +18,7 @@ Block_1($1:i32, $3:i32, $2:i32):
 Block_2($2:i32):
 	return ($2) :i32
 }
-loopHelper() {
+loopHelper($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionMultiple.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionMultiple.nautilus
@@ -1,24 +1,24 @@
 nautilus {
-add10() {
+add10($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = func_*($2) :i32
 	$4 = func_*($3) :i32
 	return ($4) :i32
 }
-multiply2() {
+multiply2($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 2 :i32
 	$3 = $1 * $2 :i32
 	return ($3) :i32
 }
-subtract5() {
+subtract5($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionMultipleInline.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionMultipleInline.nautilus
@@ -1,17 +1,17 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($1,$2) :i32
 	$5 = $3 + $4 :i32
 	return ($5) :i32
 }
-inlineAdd2() {
+inlineAdd2($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-inlineMul2() {
+inlineMul2($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionMultipleResults.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionMultipleResults.nautilus
@@ -1,12 +1,12 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32, $3:i32) :i32 {
 Block_0($1:i32, $2:i32, $3:i32):
 	$4 = func_*($1,$2) :i32
 	$5 = func_*($2,$3) :i32
 	$6 = func_*($4,$5) :i32
 	return ($6) :i32
 }
-multiply() {
+multiply($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionNested.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionNested.nautilus
@@ -1,16 +1,16 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	return ($2) :i32
 }
-inner() {
+inner($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 2 :i32
 	$3 = $1 * $2 :i32
 	return ($3) :i32
 }
-outer() {
+outer($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionRecursiveStyle.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionRecursiveStyle.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 3 :i32
 	$4 = func_*($1,$3) :i32
@@ -9,7 +9,7 @@ Block_0($1:i32):
 	$8 = func_*($6,$7) :i32
 	return ($8) :i32
 }
-recursiveHelper() {
+recursiveHelper($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$4 = $2 <= $3 :bool

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionVoid.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionVoid.nautilus
@@ -1,11 +1,11 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	func_*($1) :void
 	$5 = load($1) :i32
 	return ($5) :i32
 }
-voidHelper() {
+voidHelper($1:ptr) :void {
 Block_0($1:ptr):
 	$4 = 10 :i32
 	$5 = load($1) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunction.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunction.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunction2.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunction2.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($3,$2) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionComplex.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionComplex.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-complexComputation() {
+complexComputation($1:i32, $2:i32, $3:i32) :i32 {
 Block_0($1:i32, $2:i32, $3:i32):
 	$4 = $1 * $2 :i32
 	$5 = $2 + $3 :i32
@@ -8,7 +8,7 @@ Block_0($1:i32, $2:i32, $3:i32):
 	$8 = $6 * $7 :i32
 	return ($8) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 5 :i32
 	$4 = func_*($1,$2,$3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionConditional.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionConditional.nautilus
@@ -1,11 +1,11 @@
 nautilus {
-conditionalHelper() {
+conditionalHelper($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 100 :i32
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 > $2 :bool

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionGetFuncPtr.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionGetFuncPtr.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-add() {
+add($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 :ptr
 	$4 = func_*($3,$1,$2) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInline.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInline.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineAdd() {
+inlineAdd($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInlineLambda.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInlineLambda.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineMul() {
+inlineMul($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInlineMember.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInlineMember.nautilus
@@ -1,10 +1,10 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32
 }
-inlineSub() {
+inlineSub($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 - $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionLoop.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32
@@ -18,7 +18,7 @@ Block_1($1:i32, $3:i32, $2:i32):
 Block_2($2:i32):
 	return ($2) :i32
 }
-loopHelper() {
+loopHelper($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 1 :i32
 	$3 = $1 + $2 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionMultiple.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionMultiple.nautilus
@@ -1,24 +1,24 @@
 nautilus {
-add10() {
+add10($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 10 :i32
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = func_*($2) :i32
 	$4 = func_*($3) :i32
 	return ($4) :i32
 }
-multiply2() {
+multiply2($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 2 :i32
 	$3 = $1 * $2 :i32
 	return ($3) :i32
 }
-subtract5() {
+subtract5($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 5 :i32
 	$3 = $1 - $2 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionMultipleInline.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionMultipleInline.nautilus
@@ -1,17 +1,17 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($1,$2) :i32
 	$5 = $3 + $4 :i32
 	return ($5) :i32
 }
-inlineAdd2() {
+inlineAdd2($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 + $2 :i32
 	return ($3) :i32
 }
-inlineMul2() {
+inlineMul2($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionMultipleResults.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionMultipleResults.nautilus
@@ -1,12 +1,12 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32, $3:i32) :i32 {
 Block_0($1:i32, $2:i32, $3:i32):
 	$4 = func_*($1,$2) :i32
 	$5 = func_*($2,$3) :i32
 	$6 = func_*($4,$5) :i32
 	return ($6) :i32
 }
-multiply() {
+multiply($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = $1 * $2 :i32
 	return ($3) :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionNested.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionNested.nautilus
@@ -1,16 +1,16 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	return ($2) :i32
 }
-inner() {
+inner($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 2 :i32
 	$3 = $1 * $2 :i32
 	return ($3) :i32
 }
-outer() {
+outer($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = 5 :i32

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionRecursiveStyle.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionRecursiveStyle.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 3 :i32
 	$4 = func_*($1,$3) :i32
@@ -9,7 +9,7 @@ Block_0($1:i32):
 	$8 = func_*($6,$7) :i32
 	return ($8) :i32
 }
-recursiveHelper() {
+recursiveHelper($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$4 = $2 <= $3 :bool

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionVoid.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionVoid.nautilus
@@ -1,11 +1,11 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	func_*($1) :void
 	$5 = load($1) :i32
 	return ($5) :i32
 }
-voidHelper() {
+voidHelper($1:ptr) :void {
 Block_0($1:ptr):
 	$4 = 10 :i32
 	$5 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/addArray_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/addArray_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:i8) :void {
 Block_0($1:ptr, $2:ptr, $3:i8):
 	$4 = 0 :i8
 	br Block_3($4, $3, $1, $2) :void

--- a/nautilus/test/data/pointer-tests/after_constant_folding/callMemcpy.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/callMemcpy.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :void {
 Block_0($1:ptr, $2:ptr):
 	$3 = 0 :ui64
 	$4 = func_*($2,$1,$3) :ptr

--- a/nautilus/test/data/pointer-tests/after_constant_folding/castCustomClass.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/castCustomClass.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/castPtrAndGetValue_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/castPtrAndGetValue_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$2 = 0 :i32
 	$6 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/castVoidPtr.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/castVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = 0 :i32
 	$6 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/customPointerAdd.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/customPointerAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :ptr {
 Block_0($1:ptr, $2:i32):
 	$6 = 12 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/getField.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/getField.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/isNullptr_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/isNullptr_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1 == $3 :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/load.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/load.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/loadConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/loadConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = * :ptr
 	$4 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/passCustomClass.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/passCustomClass.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAddConst_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i16_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i16 {
 Block_0($1:ptr, $2:i32):
 	$6 = 2 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i16) :i32 {
 Block_0($1:ptr, $2:i16):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_ui32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ui32) :i32 {
 Block_0($1:ptr, $2:ui32):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_ui64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ui64) :i32 {
 Block_0($1:ptr, $2:ui64):
 	$6 = 4 :ui64
 	$7 = $2 * $6 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$6 = 8 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerAdd_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$6 = 1 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i32_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$5 = 0 :i32
 	$6 = $5 cast_to i64 :i64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$5 = 0 :i32
 	$6 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerMinusAssign_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i32_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$7 = 8 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPlusAssign_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$7 = 1 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPreIncrement_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPreIncrement_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPreIncrement_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPreIncrement_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerPreIncrement_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerPreIncrement_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSubConst_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i16_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i16 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i32_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i16) :i32 {
 Block_0($1:ptr, $2:i16):
 	$4 = 0 :i32
 	$5 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$4 = 0 :i32
 	$5 = $4 cast_to i64 :i64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$4 = 0 :i32
 	$5 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/pointerSub_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrAssignment.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :i32 {
 Block_0($1:ptr, $2:ptr):
 	$6 = load($2) :i32
 	$9 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 == $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrGreaterThanEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrGreaterThanEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 >= $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrGreaterThan_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrGreaterThan_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 > $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrLessThanEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrLessThanEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 <= $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrLessThan_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrLessThan_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 < $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/ptrNotEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/ptrNotEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1  $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_constant_folding/setFieldConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/setFieldConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/setFieldIndirect.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/setFieldIndirect.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :ui64
 	$7 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_constant_folding/specializeType.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/specializeType.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/sumArray.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/sumArray.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$3 = 0 :i32
 	$4 = 0 :i32

--- a/nautilus/test/data/pointer-tests/after_constant_folding/useWrapper.nautilus
+++ b/nautilus/test/data/pointer-tests/after_constant_folding/useWrapper.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :i32 {
 Block_0($1:ptr, $2:ptr):
 	$3 = func_*($1) :i32
 	$4 = func_*($2) :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/addArray_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/addArray_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:i8) :void {
 Block_0($1:ptr, $2:ptr, $3:i8):
 	$4 = 0 :i8
 	br Block_3($4, $3, $1, $2) :void

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/callMemcpy.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/callMemcpy.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :void {
 Block_0($1:ptr, $2:ptr):
 	$3 = 0 :ui64
 	$4 = func_*($2,$1,$3) :ptr

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/castCustomClass.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/castCustomClass.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/castPtrAndGetValue_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/castPtrAndGetValue_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$2 = 0 :i32
 	$6 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/castVoidPtr.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/castVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = 0 :i32
 	$6 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/customPointerAdd.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/customPointerAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :ptr {
 Block_0($1:ptr, $2:i32):
 	$6 = 12 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/getField.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/getField.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/isNullptr_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/isNullptr_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1 == $3 :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/load.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/load.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/loadConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/loadConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = * :ptr
 	$4 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/passCustomClass.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/passCustomClass.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAddConst_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i16_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i16 {
 Block_0($1:ptr, $2:i32):
 	$6 = 2 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i16) :i32 {
 Block_0($1:ptr, $2:i16):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_ui32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ui32) :i32 {
 Block_0($1:ptr, $2:ui32):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_ui64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ui64) :i32 {
 Block_0($1:ptr, $2:ui64):
 	$6 = 4 :ui64
 	$7 = $2 * $6 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$6 = 8 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerAdd_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$6 = 1 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i32_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$5 = 0 :i32
 	$6 = $5 cast_to i64 :i64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$5 = 0 :i32
 	$6 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerMinusAssign_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i32_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$7 = 8 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPlusAssign_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$7 = 1 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPreIncrement_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPreIncrement_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPreIncrement_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPreIncrement_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPreIncrement_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerPreIncrement_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSubConst_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i16_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i16 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i32_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i16) :i32 {
 Block_0($1:ptr, $2:i16):
 	$4 = 0 :i32
 	$5 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$4 = 0 :i32
 	$5 = $4 cast_to i64 :i64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$4 = 0 :i32
 	$5 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/pointerSub_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrAssignment.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :i32 {
 Block_0($1:ptr, $2:ptr):
 	$6 = load($2) :i32
 	$9 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 == $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrGreaterThanEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrGreaterThanEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 >= $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrGreaterThan_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrGreaterThan_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 > $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrLessThanEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrLessThanEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 <= $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrLessThan_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrLessThan_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 < $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrNotEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/ptrNotEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1  $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/setFieldConst.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/setFieldConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/setFieldIndirect.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/setFieldIndirect.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :ui64
 	$7 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/specializeType.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/specializeType.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/sumArray.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/sumArray.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$3 = 0 :i32
 	$4 = 0 :i32

--- a/nautilus/test/data/pointer-tests/after_empty_block_elim/useWrapper.nautilus
+++ b/nautilus/test/data/pointer-tests/after_empty_block_elim/useWrapper.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :i32 {
 Block_0($1:ptr, $2:ptr):
 	$3 = func_*($1) :i32
 	$4 = func_*($2) :i32

--- a/nautilus/test/data/pointer-tests/ir/addArray_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/addArray_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:i8) :void {
 Block_0($1:ptr, $2:ptr, $3:i8):
 	$4 = 0 :i8
 	br Block_3($4, $3, $1, $2) :void

--- a/nautilus/test/data/pointer-tests/ir/callMemcpy.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/callMemcpy.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :void {
 Block_0($1:ptr, $2:ptr):
 	$3 = 0 :ui64
 	$4 = func_*($2,$1,$3) :ptr

--- a/nautilus/test/data/pointer-tests/ir/castCustomClass.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/castCustomClass.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/ir/castPtrAndGetValue_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/castPtrAndGetValue_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$2 = 0 :i32
 	$6 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/ir/castVoidPtr.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/castVoidPtr.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = 0 :i32
 	$6 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/ir/customPointerAdd.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/customPointerAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :ptr {
 Block_0($1:ptr, $2:i32):
 	$6 = 12 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/getField.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/getField.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/ir/isNullptr_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/isNullptr_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :bool {
 Block_0($1:ptr):
 	$3 = * :ptr
 	$6 = $1 == $3 :bool

--- a/nautilus/test/data/pointer-tests/ir/load.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/load.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/loadConst.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/loadConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = * :ptr
 	$4 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/ir/passCustomClass.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/passCustomClass.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAddConst.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAddConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAddConst_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAddConst_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAddConst_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAddConst_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAddConst_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAddConst_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = 2 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i16_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i16 {
 Block_0($1:ptr, $2:i32):
 	$6 = 2 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i16) :i32 {
 Block_0($1:ptr, $2:i16):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_ui32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_ui32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ui32) :i32 {
 Block_0($1:ptr, $2:ui32):
 	$6 = 4 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_ui64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i32_ui64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ui64) :i32 {
 Block_0($1:ptr, $2:ui64):
 	$6 = 4 :ui64
 	$7 = $2 * $6 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$6 = 8 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerAdd_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerAdd_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$6 = 1 :ui64
 	$7 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i32_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$5 = 0 :i32
 	$6 = $5 cast_to i64 :i64

--- a/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$5 = 0 :i32
 	$6 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerMinusAssign_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :i32
 	$6 = $5 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i32_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i32_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$7 = 4 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$7 = 8 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPlusAssign_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$7 = 1 :ui64
 	$8 = $2 cast_to ui64 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPreIncrement_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPreIncrement_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPreIncrement_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPreIncrement_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerPreIncrement_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerPreIncrement_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = 1 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerSub.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerSubConst.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSubConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 4 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerSubConst_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSubConst_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i16 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 2 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerSubConst_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSubConst_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i64 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 8 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerSubConst_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSubConst_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i8 {
 Block_0($1:ptr):
 	$3 = -2 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/ir/pointerSub_i16_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub_i16_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i16 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerSub_i32_i16.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub_i32_i16.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i16) :i32 {
 Block_0($1:ptr, $2:i16):
 	$4 = 0 :i32
 	$5 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerSub_i32_i64.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub_i32_i64.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i64) :i32 {
 Block_0($1:ptr, $2:i64):
 	$4 = 0 :i32
 	$5 = $4 cast_to i64 :i64

--- a/nautilus/test/data/pointer-tests/ir/pointerSub_i32_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub_i32_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i8) :i32 {
 Block_0($1:ptr, $2:i8):
 	$4 = 0 :i32
 	$5 = $2 cast_to i32 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerSub_i64_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub_i64_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i64 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/pointerSub_i8_i32.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/pointerSub_i8_i32.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i8 {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :i32
 	$5 = $4 - $2 :i32

--- a/nautilus/test/data/pointer-tests/ir/ptrAssignment.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrAssignment.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :i32 {
 Block_0($1:ptr, $2:ptr):
 	$6 = load($2) :i32
 	$9 = load($1) :i32

--- a/nautilus/test/data/pointer-tests/ir/ptrEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 == $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/ir/ptrGreaterThanEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrGreaterThanEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 >= $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/ir/ptrGreaterThan_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrGreaterThan_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 > $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/ir/ptrLessThanEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrLessThanEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 <= $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/ir/ptrLessThan_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrLessThan_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1 < $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/ir/ptrNotEquals_i8.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/ptrNotEquals_i8.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :bool {
 Block_0($1:ptr, $2:ptr):
 	$5 = $1  $2 :bool
 	return ($5) :bool

--- a/nautilus/test/data/pointer-tests/ir/setFieldConst.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/setFieldConst.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/ir/setFieldIndirect.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/setFieldIndirect.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$5 = 0 :ui64
 	$7 = 1 :ui64

--- a/nautilus/test/data/pointer-tests/ir/specializeType.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/specializeType.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :i32 {
 Block_0($1:ptr):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/pointer-tests/ir/sumArray.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/sumArray.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:i32) :i32 {
 Block_0($1:ptr, $2:i32):
 	$3 = 0 :i32
 	$4 = 0 :i32

--- a/nautilus/test/data/pointer-tests/ir/useWrapper.nautilus
+++ b/nautilus/test/data/pointer-tests/ir/useWrapper.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr) :i32 {
 Block_0($1:ptr, $2:ptr):
 	$3 = func_*($1) :i32
 	$4 = func_*($2) :i32

--- a/nautilus/test/data/regressions/after_constant_folding/store_mising_downcast-gh_#90.nautilus
+++ b/nautilus/test/data/regressions/after_constant_folding/store_mising_downcast-gh_#90.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$2 = -1 :i64
 	$5 = $2 cast_to ui32 :ui32

--- a/nautilus/test/data/regressions/after_empty_block_elim/store_mising_downcast-gh_#90.nautilus
+++ b/nautilus/test/data/regressions/after_empty_block_elim/store_mising_downcast-gh_#90.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$2 = -1 :i64
 	$5 = $2 cast_to ui32 :ui32

--- a/nautilus/test/data/regressions/ir/store_mising_downcast-gh_#90.nautilus
+++ b/nautilus/test/data/regressions/ir/store_mising_downcast-gh_#90.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr) :void {
 Block_0($1:ptr):
 	$2 = -1 :i64
 	$5 = $2 cast_to ui32 :ui32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/callSameFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/callSameFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1,$1) :i32
 	$3 = func_*($2,$2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/callTwoFunctions.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/callTwoFunctions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($1,$2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/lambdaRuntimeFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/lambdaRuntimeFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/loopDirectCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/loopDirectCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$4 = 0 :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/nestedLambdaRuntimeFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/nestedLambdaRuntimeFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = func_*($2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/simpleDirectCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/simpleDirectCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/useFirstArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/useFirstArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/useNoArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/useNoArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	return ($3) :i32

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/useSecondArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/useSecondArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	return ($2) :i32
 }

--- a/nautilus/test/data/runtime-call-tests/after_constant_folding/voidFuncCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_constant_folding/voidFuncCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	func_*($1,$2) :void
 	return ($1) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/callSameFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/callSameFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1,$1) :i32
 	$3 = func_*($2,$2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/callTwoFunctions.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/callTwoFunctions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($1,$2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/lambdaRuntimeFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/lambdaRuntimeFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/loopDirectCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/loopDirectCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$4 = 0 :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/nestedLambdaRuntimeFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/nestedLambdaRuntimeFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = func_*($2) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/simpleDirectCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/simpleDirectCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/useFirstArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/useFirstArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/useNoArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/useNoArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	return ($3) :i32

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/useSecondArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/useSecondArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	return ($2) :i32
 }

--- a/nautilus/test/data/runtime-call-tests/after_empty_block_elim/voidFuncCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/after_empty_block_elim/voidFuncCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	func_*($1,$2) :void
 	return ($1) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/callSameFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/callSameFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1,$1) :i32
 	$3 = func_*($2,$2) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/callTwoFunctions.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/callTwoFunctions.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	$4 = func_*($1,$2) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/lambdaRuntimeFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/lambdaRuntimeFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	return ($2) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/loopDirectCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/loopDirectCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 0 :i32
 	$4 = 0 :i32

--- a/nautilus/test/data/runtime-call-tests/ir/nestedLambdaRuntimeFunction.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/nestedLambdaRuntimeFunction.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = func_*($1) :i32
 	$3 = func_*($2) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/simpleDirectCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/simpleDirectCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = func_*($1,$2) :i32
 	return ($3) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/useFirstArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/useFirstArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	return ($1) :i32
 }

--- a/nautilus/test/data/runtime-call-tests/ir/useNoArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/useNoArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = 42 :i32
 	return ($3) :i32

--- a/nautilus/test/data/runtime-call-tests/ir/useSecondArg.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/useSecondArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	return ($2) :i32
 }

--- a/nautilus/test/data/runtime-call-tests/ir/voidFuncCall.nautilus
+++ b/nautilus/test/data/runtime-call-tests/ir/voidFuncCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	func_*($1,$2) :void
 	return ($1) :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticConstIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticConstIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticCountdown.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticCountdown.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 5 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticEnumerateSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticEnumerateSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticEnumerateWeightedSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticEnumerateWeightedSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticIteratorSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticIteratorSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopAccumulateCounter.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopAccumulateCounter.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopMultipleAccumulators.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopMultipleAccumulators.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopSingleIteration.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopSingleIteration.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 42 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithArg.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoopNotEqual.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoopNotEqual.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoopPostIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoopPostIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoopPreIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticLoopWithDynamicLoopPreIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticNestedLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticNestedLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticPreDecrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticPreDecrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticPreIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticPreIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticRawArrayIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticRawArrayIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 2 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticSequentialLoops.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticSequentialLoops.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticStdArrayIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticStdArrayIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 3 :i32

--- a/nautilus/test/data/static-loop-tests/after_constant_folding/staticWhileLoopDecrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_constant_folding/staticWhileLoopDecrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticConstIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticConstIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticCountdown.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticCountdown.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 5 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticEnumerateSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticEnumerateSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticEnumerateWeightedSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticEnumerateWeightedSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticIteratorSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticIteratorSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopAccumulateCounter.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopAccumulateCounter.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopMultipleAccumulators.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopMultipleAccumulators.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopSingleIteration.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopSingleIteration.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 42 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithArg.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoopNotEqual.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoopNotEqual.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoopPostIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoopPostIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoopPreIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticLoopWithDynamicLoopPreIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticNestedLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticNestedLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticPreDecrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticPreDecrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticPreIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticPreIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticRawArrayIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticRawArrayIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 2 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticSequentialLoops.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticSequentialLoops.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticStdArrayIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticStdArrayIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 3 :i32

--- a/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticWhileLoopDecrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/after_empty_block_elim/staticWhileLoopDecrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticConstIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticConstIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticCountdown.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticCountdown.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 5 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticEnumerateSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticEnumerateSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticEnumerateWeightedSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticEnumerateWeightedSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticIteratorSum.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticIteratorSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopAccumulateCounter.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopAccumulateCounter.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopMultipleAccumulators.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopMultipleAccumulators.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopSingleIteration.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopSingleIteration.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 42 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopWithArg.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopWithArg.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$3 = 1 :i32
 	$4 = $1 + $3 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoopNotEqual.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoopNotEqual.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoopPostIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoopPostIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoopPreIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticLoopWithDynamicLoopPreIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 0 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticNestedLoop.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticNestedLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 1 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticPreDecrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticPreDecrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticPreIncrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticPreIncrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticRawArrayIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticRawArrayIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 2 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticSequentialLoops.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticSequentialLoops.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 0 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticStdArrayIterator.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticStdArrayIterator.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = 0 :i32
 	$3 = 3 :i32

--- a/nautilus/test/data/static-loop-tests/ir/staticWhileLoopDecrement.nautilus
+++ b/nautilus/test/data/static-loop-tests/ir/staticWhileLoopDecrement.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = 1 :i32
 	$2 = 10 :i32

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/allocaMergeBug.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/allocaMergeBug.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i64 {
 Block_0():
 	$2 = alloca 8b :ptr
 	$14 = alloca 64b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/allocaMergeInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/allocaMergeInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$7 = alloca 8b :ptr
 	$19 = alloca 64b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/constructAndAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/constructAndAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$3 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/constructAndCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/constructAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	func_*($2,$1,$1) :void

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/constructNonTrivialDefault.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/constructNonTrivialDefault.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	func_*($1) :void

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/constructSetBothFields.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/constructSetBothFields.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$3 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/constructStructInLoopWithNestedCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/constructStructInLoopWithNestedCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$6 = alloca 8b :ptr
 	$2 = 0 :i32
@@ -25,7 +25,7 @@ Block_1($1:i32, $3:i32, $2:i32, $6:ptr):
 Block_2($2:i32):
 	return ($2) :i32
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/constructWithArgs.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/constructWithArgs.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = alloca 8b :ptr
 	func_*($3,$1,$2) :void

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/copyAssign.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/copyAssign.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$14 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/copyConstruct.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/copyConstruct.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$26 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/copyConstructNonTrivial.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/copyConstructNonTrivial.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 4b :ptr
 	$15 = alloca 4b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/copyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/copyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$19 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/doubleAndByteAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/doubleAndByteAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64, $2:i8) :f64 {
 Block_0($1:f64, $2:i8):
 	$3 = alloca 16b :ptr
 	$7 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$6 = alloca 16b :ptr
 	$2 = 0 :i32

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignModifyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignModifyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = alloca 16b :ptr
 	$3 = 0 :i8

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignNoClobber.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignNoClobber.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i64 {
 Block_0():
 	$1 = alloca 16b :ptr
 	$2 = 1000 :i64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignSetAll.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/mixedAlignSetAll.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i32, $3:i64) :i64 {
 Block_0($1:i8, $2:i32, $3:i64):
 	$4 = alloca 16b :ptr
 	$8 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/modifyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/modifyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/modifyStructInLoopWithNestedCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/modifyStructInLoopWithNestedCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64
@@ -26,7 +26,7 @@ Block_2($2:ptr):
 	$25 = func_*($2) :i32
 	return ($25) :i32
 }
-incrementFieldA() {
+incrementFieldA($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :ui64
 	$6 = 1 :ui64
@@ -41,7 +41,7 @@ Block_0($1:ptr, $2:i32):
 	store($13, $19) :void
 	return :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/multiStructConditionalLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/multiStructConditionalLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i64) :i64 {
 Block_0($1:i32, $2:i64):
 	$11 = alloca 16b :ptr
 	$25 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/multiStructMultiLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/multiStructMultiLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$6 = alloca 16b :ptr
 	$62 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/multipleNestedCallsInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/multipleNestedCallsInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64
@@ -32,7 +32,7 @@ Block_2($2:ptr):
 	$38 = func_*($2) :i32
 	return ($38) :i32
 }
-incrementFieldA() {
+incrementFieldA($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :ui64
 	$6 = 1 :ui64
@@ -47,7 +47,7 @@ Block_0($1:ptr, $2:i32):
 	store($13, $19) :void
 	return :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64
@@ -56,7 +56,7 @@ Block_0($1:ptr):
 	$10 = load($7) :i32
 	return ($10) :i32
 }
-sumFields() {
+sumFields($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/nonTrivialDestructor.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/nonTrivialDestructor.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 4b :ptr
 	func_*($1) :void

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/outerAndInnerStructLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/outerAndInnerStructLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = alloca 16b :ptr
 	$19 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/reversePaddingAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/reversePaddingAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64, $2:i8, $3:i16) :i64 {
 Block_0($1:i64, $2:i8, $3:i16):
 	$4 = alloca 16b :ptr
 	$8 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/structInBothBranches.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/structInBothBranches.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$29 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/structInConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/structInConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$2 = 0 :i32

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/structInNestedConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/structInNestedConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$2 = 0 :i32
@@ -22,7 +22,7 @@ Block_2():
 	$22 = 0 :i32
 	br Block_3($22) :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_constant_folding/twoStructsSameLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_constant_folding/twoStructsSameLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$6 = alloca 16b :ptr
 	$20 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/allocaMergeBug.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/allocaMergeBug.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i64 {
 Block_0():
 	$2 = alloca 8b :ptr
 	$14 = alloca 64b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/allocaMergeInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/allocaMergeInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$7 = alloca 8b :ptr
 	$19 = alloca 64b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructAndAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructAndAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$3 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructAndCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	func_*($2,$1,$1) :void

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructNonTrivialDefault.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructNonTrivialDefault.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	func_*($1) :void

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructSetBothFields.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructSetBothFields.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$3 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructStructInLoopWithNestedCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructStructInLoopWithNestedCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$6 = alloca 8b :ptr
 	$2 = 0 :i32
@@ -25,7 +25,7 @@ Block_1($1:i32, $3:i32, $2:i32, $6:ptr):
 Block_2($2:i32):
 	return ($2) :i32
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructWithArgs.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/constructWithArgs.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = alloca 8b :ptr
 	func_*($3,$1,$2) :void

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyAssign.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyAssign.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$14 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyConstruct.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyConstruct.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$26 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyConstructNonTrivial.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyConstructNonTrivial.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 4b :ptr
 	$15 = alloca 4b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/copyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$19 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/doubleAndByteAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/doubleAndByteAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64, $2:i8) :f64 {
 Block_0($1:f64, $2:i8):
 	$3 = alloca 16b :ptr
 	$7 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$6 = alloca 16b :ptr
 	$2 = 0 :i32

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignModifyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignModifyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = alloca 16b :ptr
 	$3 = 0 :i8

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignNoClobber.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignNoClobber.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i64 {
 Block_0():
 	$1 = alloca 16b :ptr
 	$2 = 1000 :i64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignSetAll.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/mixedAlignSetAll.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i32, $3:i64) :i64 {
 Block_0($1:i8, $2:i32, $3:i64):
 	$4 = alloca 16b :ptr
 	$8 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/modifyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/modifyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/modifyStructInLoopWithNestedCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/modifyStructInLoopWithNestedCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64
@@ -26,7 +26,7 @@ Block_2($2:ptr):
 	$25 = func_*($2) :i32
 	return ($25) :i32
 }
-incrementFieldA() {
+incrementFieldA($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :ui64
 	$6 = 1 :ui64
@@ -41,7 +41,7 @@ Block_0($1:ptr, $2:i32):
 	store($13, $19) :void
 	return :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/multiStructConditionalLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/multiStructConditionalLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i64) :i64 {
 Block_0($1:i32, $2:i64):
 	$11 = alloca 16b :ptr
 	$25 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/multiStructMultiLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/multiStructMultiLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$6 = alloca 16b :ptr
 	$62 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/multipleNestedCallsInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/multipleNestedCallsInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64
@@ -32,7 +32,7 @@ Block_2($2:ptr):
 	$38 = func_*($2) :i32
 	return ($38) :i32
 }
-incrementFieldA() {
+incrementFieldA($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :ui64
 	$6 = 1 :ui64
@@ -47,7 +47,7 @@ Block_0($1:ptr, $2:i32):
 	store($13, $19) :void
 	return :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64
@@ -56,7 +56,7 @@ Block_0($1:ptr):
 	$10 = load($7) :i32
 	return ($10) :i32
 }
-sumFields() {
+sumFields($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/nonTrivialDestructor.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/nonTrivialDestructor.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 4b :ptr
 	func_*($1) :void

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/outerAndInnerStructLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/outerAndInnerStructLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = alloca 16b :ptr
 	$19 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/reversePaddingAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/reversePaddingAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64, $2:i8, $3:i16) :i64 {
 Block_0($1:i64, $2:i8, $3:i16):
 	$4 = alloca 16b :ptr
 	$8 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/structInBothBranches.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/structInBothBranches.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$29 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/structInConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/structInConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$2 = 0 :i32

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/structInNestedConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/structInNestedConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$2 = 0 :i32
@@ -22,7 +22,7 @@ Block_2():
 	$22 = 0 :i32
 	br Block_3($22) :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/after_empty_block_elim/twoStructsSameLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/after_empty_block_elim/twoStructsSameLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$6 = alloca 16b :ptr
 	$20 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/allocaMergeBug.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/allocaMergeBug.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i64 {
 Block_0():
 	$2 = alloca 8b :ptr
 	$14 = alloca 64b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/allocaMergeInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/allocaMergeInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$7 = alloca 8b :ptr
 	$19 = alloca 64b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/constructAndAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/constructAndAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$3 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/constructAndCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/constructAndCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	func_*($2,$1,$1) :void

--- a/nautilus/test/data/value-tracing-tests/ir/constructNonTrivialDefault.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/constructNonTrivialDefault.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	func_*($1) :void

--- a/nautilus/test/data/value-tracing-tests/ir/constructSetBothFields.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/constructSetBothFields.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$3 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/constructStructInLoopWithNestedCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/constructStructInLoopWithNestedCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$6 = alloca 8b :ptr
 	$2 = 0 :i32
@@ -25,7 +25,7 @@ Block_1($1:i32, $3:i32, $2:i32, $6:ptr):
 Block_2($2:i32):
 	return ($2) :i32
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/constructWithArgs.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/constructWithArgs.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i32) :i32 {
 Block_0($1:i32, $2:i32):
 	$3 = alloca 8b :ptr
 	func_*($3,$1,$2) :void

--- a/nautilus/test/data/value-tracing-tests/ir/copyAssign.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/copyAssign.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$14 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/copyConstruct.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/copyConstruct.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 8b :ptr
 	$26 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/copyConstructNonTrivial.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/copyConstructNonTrivial.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 4b :ptr
 	$15 = alloca 4b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/copyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/copyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$19 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/doubleAndByteAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/doubleAndByteAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:f64, $2:i8) :f64 {
 Block_0($1:f64, $2:i8):
 	$3 = alloca 16b :ptr
 	$7 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/mixedAlignConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/mixedAlignConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64) :i64 {
 Block_0($1:i64):
 	$6 = alloca 16b :ptr
 	$2 = 0 :i32

--- a/nautilus/test/data/value-tracing-tests/ir/mixedAlignModifyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/mixedAlignModifyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = alloca 16b :ptr
 	$3 = 0 :i8

--- a/nautilus/test/data/value-tracing-tests/ir/mixedAlignNoClobber.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/mixedAlignNoClobber.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i64 {
 Block_0():
 	$1 = alloca 16b :ptr
 	$2 = 1000 :i64

--- a/nautilus/test/data/value-tracing-tests/ir/mixedAlignSetAll.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/mixedAlignSetAll.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i8, $2:i32, $3:i64) :i64 {
 Block_0($1:i8, $2:i32, $3:i64):
 	$4 = alloca 16b :ptr
 	$8 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/modifyInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/modifyInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/modifyStructInLoopWithNestedCall.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/modifyStructInLoopWithNestedCall.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64
@@ -26,7 +26,7 @@ Block_2($2:ptr):
 	$25 = func_*($2) :i32
 	return ($25) :i32
 }
-incrementFieldA() {
+incrementFieldA($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :ui64
 	$6 = 1 :ui64
@@ -41,7 +41,7 @@ Block_0($1:ptr, $2:i32):
 	store($13, $19) :void
 	return :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/multiStructConditionalLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/multiStructConditionalLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32, $2:i64) :i64 {
 Block_0($1:i32, $2:i64):
 	$11 = alloca 16b :ptr
 	$25 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/multiStructMultiLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/multiStructMultiLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$6 = alloca 16b :ptr
 	$62 = alloca 16b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/multipleNestedCallsInLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/multipleNestedCallsInLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$2 = alloca 8b :ptr
 	$4 = 0 :ui64
@@ -32,7 +32,7 @@ Block_2($2:ptr):
 	$38 = func_*($2) :i32
 	return ($38) :i32
 }
-incrementFieldA() {
+incrementFieldA($1:ptr, $2:i32) :void {
 Block_0($1:ptr, $2:i32):
 	$4 = 0 :ui64
 	$6 = 1 :ui64
@@ -47,7 +47,7 @@ Block_0($1:ptr, $2:i32):
 	store($13, $19) :void
 	return :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64
@@ -56,7 +56,7 @@ Block_0($1:ptr):
 	$10 = load($7) :i32
 	return ($10) :i32
 }
-sumFields() {
+sumFields($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/nonTrivialDestructor.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/nonTrivialDestructor.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :i32 {
 Block_0():
 	$1 = alloca 4b :ptr
 	func_*($1) :void

--- a/nautilus/test/data/value-tracing-tests/ir/outerAndInnerStructLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/outerAndInnerStructLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$2 = alloca 16b :ptr
 	$19 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/reversePaddingAccess.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/reversePaddingAccess.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i64, $2:i8, $3:i16) :i64 {
 Block_0($1:i64, $2:i8, $3:i16):
 	$4 = alloca 16b :ptr
 	$8 = 0 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/structInBothBranches.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/structInBothBranches.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$29 = alloca 8b :ptr

--- a/nautilus/test/data/value-tracing-tests/ir/structInConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/structInConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$2 = 0 :i32

--- a/nautilus/test/data/value-tracing-tests/ir/structInNestedConditionalReturn.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/structInNestedConditionalReturn.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i32 {
 Block_0($1:i32):
 	$5 = alloca 8b :ptr
 	$2 = 0 :i32
@@ -22,7 +22,7 @@ Block_2():
 	$22 = 0 :i32
 	br Block_3($22) :void
 }
-readFieldA() {
+readFieldA($1:ptr) :i32 {
 Block_0($1:ptr):
 	$3 = 0 :ui64
 	$5 = 1 :ui64

--- a/nautilus/test/data/value-tracing-tests/ir/twoStructsSameLoop.nautilus
+++ b/nautilus/test/data/value-tracing-tests/ir/twoStructsSameLoop.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:i32) :i64 {
 Block_0($1:i32):
 	$6 = alloca 16b :ptr
 	$20 = alloca 16b :ptr

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuBlockDimX.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuBlockDimX.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	$2 = func_*() :ui32
 	$3 = $2 + $1 :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuBlockIdxX.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuBlockIdxX.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	$2 = func_*() :ui32
 	$3 = $2 + $1 :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuBoundedIndex.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuBoundedIndex.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	$2 = func_*() :ui32
 	$3 = func_*() :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuGlobalThreadIdx.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuGlobalThreadIdx.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :ui32 {
 Block_0():
 	$1 = func_*() :ui32
 	$2 = func_*() :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuGridDimX.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuGridDimX.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	$2 = func_*() :ui32
 	$3 = $2 + $1 :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchClassify.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchClassify.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-classify() {
+classify($1:ptr, $2:ptr, $3:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ui32):
 	$6 = func_*() :ui32
 	$7 = func_*() :ui32
@@ -88,7 +88,7 @@ Block_8($5:ptr, $10:ui32):
 Block_2():
 	br Block_9() :void
 }
-execute() {
+execute($1:ptr, $2:ptr, $3:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ui32):
 	$4 = 1 :ui32
 	$6 = 1 :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchPrefixSum.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchPrefixSum.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ui32):
 	$4 = 1 :ui32
 	$6 = 1 :ui32
@@ -12,7 +12,7 @@ Block_0($1:ptr, $2:ptr, $3:ui32):
 	func_*($1,$2,$3) :void
 	return :void
 }
-prefixSum() {
+prefixSum($1:ptr, $2:ptr, $3:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ui32):
 	$6 = func_*() :ui32
 	$7 = func_*() :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchSaxpy.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchSaxpy.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:f32) :void {
 Block_0($1:ptr, $2:ptr, $3:f32):
 	$4 = 1 :ui32
 	$6 = 1 :ui32
@@ -12,7 +12,7 @@ Block_0($1:ptr, $2:ptr, $3:f32):
 	func_*($1,$2,$3) :void
 	return :void
 }
-saxpy() {
+saxpy($1:ptr, $2:ptr, $3:f32) :void {
 Block_0($1:ptr, $2:ptr, $3:f32):
 	$6 = func_*() :ui32
 	$7 = func_*() :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecAdd.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:ptr) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr):
 	$4 = 1 :ui32
 	$6 = 1 :ui32
@@ -12,7 +12,7 @@ Block_0($1:ptr, $2:ptr, $3:ptr):
 	func_*($1,$2,$3) :void
 	return :void
 }
-vecAdd() {
+vecAdd($1:ptr, $2:ptr, $3:ptr) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr):
 	$7 = func_*() :ui32
 	$8 = $7 cast_to i32 :i32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecAddBounded.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecAddBounded.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:ptr, $4:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr, $4:ui32):
 	$5 = 255 :ui32
 	$6 = $4 + $5 :ui32
@@ -15,7 +15,7 @@ Block_0($1:ptr, $2:ptr, $3:ptr, $4:ui32):
 	func_*($1,$2,$3,$4) :void
 	return :void
 }
-vecAddBounded() {
+vecAddBounded($1:ptr, $2:ptr, $3:ptr, $4:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr, $4:ui32):
 	$8 = func_*() :ui32
 	$9 = func_*() :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecAddDynamic.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecAddDynamic.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:ptr, $4:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr, $4:ui32):
 	$5 = 255 :ui32
 	$6 = $4 + $5 :ui32
@@ -15,7 +15,7 @@ Block_0($1:ptr, $2:ptr, $3:ptr, $4:ui32):
 	func_*($1,$2,$3) :void
 	return :void
 }
-vecAdd() {
+vecAdd($1:ptr, $2:ptr, $3:ptr) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr):
 	$7 = func_*() :ui32
 	$8 = $7 cast_to i32 :i32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecScale.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuLaunchVecScale.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ui32):
 	$4 = 1 :ui32
 	$6 = 1 :ui32
@@ -12,7 +12,7 @@ Block_0($1:ptr, $2:ptr, $3:ui32):
 	func_*($1,$2,$3) :void
 	return :void
 }
-vecScale() {
+vecScale($1:ptr, $2:ptr, $3:ui32) :void {
 Block_0($1:ptr, $2:ptr, $3:ui32):
 	$6 = func_*() :ui32
 	$7 = $6 cast_to i32 :i32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuSyncThreadsOnly.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuSyncThreadsOnly.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :void {
 Block_0():
 	func_*() :void
 	return :void

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuThreadIdx3D.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuThreadIdx3D.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute() :ui32 {
 Block_0():
 	$1 = func_*() :ui32
 	$2 = func_*() :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuThreadIdxX.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuThreadIdxX.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ui32) :ui32 {
 Block_0($1:ui32):
 	$2 = func_*() :ui32
 	$3 = $2 + $1 :ui32

--- a/plugins/gpu/test/data/gpu-tests/ir/gpuVectorAdd.nautilus
+++ b/plugins/gpu/test/data/gpu-tests/ir/gpuVectorAdd.nautilus
@@ -1,5 +1,5 @@
 nautilus {
-execute() {
+execute($1:ptr, $2:ptr, $3:ptr) :void {
 Block_0($1:ptr, $2:ptr, $3:ptr):
 	$4 = func_*() :ui32
 	$5 = $4 cast_to i32 :i32


### PR DESCRIPTION
The FunctionOperation formatter previously emitted only `name() {` because
`inputArgs`/`inputArgNames` are not populated by the trace-to-IR conversion;
the parameters live as BasicBlockArguments on the entry block. The signature
now shows `name($1:type, $2:type) :ret {` by falling back to the entry
block's arguments when the function-level vectors are empty, while still
honoring them when populated.

Reference dumps under nautilus/test/data and plugins/gpu/test/data have been
regenerated to match the new format.