### PR TITLE
Add control-flow graph view to the Nautilus IR VS Code extension

### DIFF
--- a/tools/vscode-nautilus-ir/.gitignore
+++ b/tools/vscode-nautilus-ir/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 out/
+media/vendor/
 *.vsix
 .vscode-test/

--- a/tools/vscode-nautilus-ir/.vscodeignore
+++ b/tools/vscode-nautilus-ir/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+scripts/**
 .gitignore
 .eslintrc.json
 **/tsconfig.json
@@ -12,6 +13,7 @@ node_modules/**
 !snippets/**
 !language-configuration/**
 !images/**
+!media/**
 !package.json
 !README.md
 !LICENSE

--- a/tools/vscode-nautilus-ir/README.md
+++ b/tools/vscode-nautilus-ir/README.md
@@ -64,6 +64,35 @@ a navigable, debuggable artifact.
 - **Quick block jumper** — `Ctrl+Shift+B` (`Cmd+Shift+B` on macOS) opens a
   Quick Pick listing every block with its successor summary.
 
+### Graph view
+
+Run **Nautilus IR: Show Graph** (palette, editor title bar, or right-click
+menu) to open a side-by-side control-flow graph of the active `.nautilus`
+file. The graph is synthesized in the extension from the parsed IR text, so
+it works on any IR dump — there is no dependency on Nautilus's
+`dump.graph=true` option.
+
+- **Click a block node** to jump to its `Block_N(...)` header in the editor.
+- **Move the cursor** in the editor to highlight the enclosing block in the
+  graph; switching between functions in the file flips the rendered graph
+  automatically.
+- **Function picker** in the toolbar selects which function to render when
+  the file contains multiple (`execute`, helpers, etc.).
+- **Pan & zoom** with the mouse; **Fit** / **Reset** buttons restore the
+  default view.
+
+The graph shape conveys terminator type at a glance:
+
+| Shape       | Meaning                                |
+|-------------|----------------------------------------|
+| Rectangle   | Block ends in `br` (unconditional jump) |
+| Diamond     | Block ends in `if` (conditional)        |
+| Stadium     | Block ends in `return`                  |
+
+Conditional edges are labeled `true` / `false`. Entry blocks (`Block_0`)
+are tinted teal; return blocks are tinted pink, mirroring the palette of
+Nautilus's own C++ Mermaid dumper.
+
 ### Diagnostics
 
 Light static checks are surfaced in the Problems panel:
@@ -158,6 +187,7 @@ honored so gdb can locate the IR source.
 | `nautilusIr.gdbExtraArgs`            | `[]`    | Extra args appended to every gdb invocation.                                     |
 | `nautilusIr.highlightDefinitions`    | `true`  | Highlight all uses of an SSA value when the cursor is on its definition.         |
 | `nautilusIr.codeLens`                | `true`  | Show CodeLens above every block.                                                 |
+| `nautilusIr.graph.autoOpen`          | `false` | Open the graph view automatically when a `.nautilus` file is opened.             |
 | `nautilusIr.lastHostProgram`         | `""`    | Remembered host program for the ad-hoc "Debug Current File" command.             |
 
 ### Commands
@@ -165,6 +195,7 @@ honored so gdb can locate the IR source.
 | Command                                          | Default keybinding         |
 |--------------------------------------------------|----------------------------|
 | `Nautilus IR: Go to Block...`                    | `Ctrl/Cmd+Shift+B`         |
+| `Nautilus IR: Show Graph`                        | —                          |
 | `Nautilus IR: Show File Statistics`              | —                          |
 | `Nautilus IR: Toggle SSA Definition Highlight`   | —                          |
 | `Nautilus IR: Debug Current File with gdb`       | —                          |
@@ -174,7 +205,8 @@ honored so gdb can locate the IR source.
 ```bash
 cd tools/vscode-nautilus-ir
 npm install
-npm run compile           # tsc → ./out
+npm run compile           # tsc → ./out, plus copies Mermaid + svg-pan-zoom
+                          # bundles into media/vendor/ for the graph webview
 # Open this folder in VS Code and press F5 to launch an Extension Host.
 ```
 

--- a/tools/vscode-nautilus-ir/media/graph.css
+++ b/tools/vscode-nautilus-ir/media/graph.css
@@ -1,0 +1,91 @@
+html, body {
+	margin: 0;
+	padding: 0;
+	height: 100%;
+	overflow: hidden;
+	color: var(--vscode-foreground);
+	background: var(--vscode-editor-background);
+	font-family: var(--vscode-font-family);
+	font-size: var(--vscode-font-size);
+}
+
+#toolbar {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--vscode-panel-border);
+	background: var(--vscode-editorWidget-background);
+}
+
+#toolbar label {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.9em;
+}
+
+#toolbar select,
+#toolbar button {
+	color: var(--vscode-input-foreground);
+	background: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+	border-radius: 2px;
+	padding: 2px 8px;
+	font: inherit;
+}
+
+#toolbar button {
+	cursor: pointer;
+}
+
+#toolbar button:hover {
+	background: var(--vscode-button-hoverBackground, var(--vscode-input-background));
+}
+
+#status {
+	margin-left: auto;
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.85em;
+	font-style: italic;
+}
+
+#graph-host {
+	position: absolute;
+	top: 36px;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	overflow: hidden;
+}
+
+#graph-container {
+	width: 100%;
+	height: 100%;
+}
+
+#graph-container svg {
+	display: block;
+	width: 100% !important;
+	height: 100% !important;
+}
+
+/* Cursor-driven highlight on the current block. Targets the rendered
+ * Mermaid <g class="node"> wrapper; the inner shape inherits the stroke. */
+g.node.cursor-current > rect,
+g.node.cursor-current > polygon,
+g.node.cursor-current > path,
+g.node.cursor-current > circle,
+g.node.cursor-current > ellipse {
+	stroke: #da2d4f !important;
+	stroke-width: 3px !important;
+	filter: drop-shadow(0 0 4px rgba(218, 45, 79, 0.45));
+}
+
+g.node {
+	cursor: pointer;
+}
+
+pre.error {
+	color: var(--vscode-errorForeground);
+	padding: 16px;
+	white-space: pre-wrap;
+}

--- a/tools/vscode-nautilus-ir/media/graph.js
+++ b/tools/vscode-nautilus-ir/media/graph.js
@@ -1,0 +1,174 @@
+// Webview-side controller for the Nautilus IR graph view.
+//
+// Receives `render` / `highlight` messages from the extension host, drives
+// Mermaid to produce the SVG, attaches svg-pan-zoom for navigation, and
+// forwards user actions (block click, function switch) back to the host.
+
+(function () {
+	'use strict';
+
+	const vscode = acquireVsCodeApi();
+	const container = document.getElementById('graph-container');
+	const select = /** @type {HTMLSelectElement} */ (document.getElementById('function-select'));
+	const fitBtn = document.getElementById('fit-btn');
+	const resetBtn = document.getElementById('reset-btn');
+	const status = document.getElementById('status');
+
+	let panZoom = null;
+	let highlightedEl = null;
+	let renderToken = 0;
+
+	if (typeof window.mermaid === 'undefined') {
+		report('error', 'Mermaid bundle failed to load.');
+		return;
+	}
+	window.mermaid.initialize({
+		startOnLoad: false,
+		securityLevel: 'loose',
+		theme: 'neutral',
+		flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },
+	});
+
+	// Click bridge invoked from Mermaid `click NodeId call onNautilusBlockClick(...)`.
+	window.onNautilusBlockClick = function (block) {
+		vscode.postMessage({ type: 'revealBlock', block: String(block) });
+	};
+
+	select.addEventListener('change', () => {
+		vscode.postMessage({ type: 'selectFunction', name: select.value });
+	});
+	fitBtn.addEventListener('click', () => {
+		if (panZoom) {
+			panZoom.resize();
+			panZoom.fit();
+			panZoom.center();
+		}
+	});
+	resetBtn.addEventListener('click', () => {
+		if (panZoom) {
+			panZoom.resetZoom();
+			panZoom.center();
+		}
+	});
+
+	window.addEventListener('message', event => {
+		const msg = event.data;
+		if (!msg || typeof msg !== 'object') {
+			return;
+		}
+		if (msg.type === 'render') {
+			void render(msg);
+		} else if (msg.type === 'highlight') {
+			highlight(msg.block);
+		}
+	});
+
+	vscode.postMessage({ type: 'ready' });
+
+	async function render(payload) {
+		const myToken = ++renderToken;
+		populateFunctions(payload.functions, payload.activeFunction);
+		setStatus(`${payload.activeFunction || ''}`);
+
+		try {
+			const id = `nautilus-graph-${myToken}`;
+			const result = await window.mermaid.render(id, payload.mermaid);
+			if (myToken !== renderToken) {
+				return; // a newer render superseded this one
+			}
+			container.innerHTML = result.svg;
+			if (typeof result.bindFunctions === 'function') {
+				result.bindFunctions(container);
+			}
+			setupPanZoom();
+			highlight(payload.currentBlock);
+		} catch (err) {
+			container.innerHTML = '';
+			const pre = document.createElement('pre');
+			pre.className = 'error';
+			pre.textContent = `Mermaid render failed: ${err && err.message ? err.message : String(err)}`;
+			container.appendChild(pre);
+			report('error', `Mermaid render failed: ${err && err.message ? err.message : String(err)}`);
+		}
+	}
+
+	function populateFunctions(names, active) {
+		const current = select.value;
+		select.innerHTML = '';
+		for (const name of names) {
+			const opt = document.createElement('option');
+			opt.value = name;
+			opt.textContent = name;
+			if (name === active) {
+				opt.selected = true;
+			}
+			select.appendChild(opt);
+		}
+		select.disabled = names.length <= 1;
+		if (!names.includes(current) && active) {
+			select.value = active;
+		}
+	}
+
+	function setupPanZoom() {
+		if (panZoom) {
+			try { panZoom.destroy(); } catch (e) { /* ignore */ }
+			panZoom = null;
+		}
+		const svg = container.querySelector('svg');
+		if (!svg || typeof window.svgPanZoom === 'undefined') {
+			return;
+		}
+		// Mermaid sometimes sets width/height to a fixed pixel value; force
+		// the SVG to fill its host so pan-zoom has something to work with.
+		svg.removeAttribute('width');
+		svg.removeAttribute('height');
+		svg.setAttribute('width', '100%');
+		svg.setAttribute('height', '100%');
+		svg.style.maxWidth = 'none';
+		svg.style.maxHeight = 'none';
+		panZoom = window.svgPanZoom(svg, {
+			zoomEnabled: true,
+			controlIconsEnabled: false,
+			fit: true,
+			center: true,
+			minZoom: 0.1,
+			maxZoom: 20,
+		});
+	}
+
+	function highlight(blockName) {
+		if (highlightedEl) {
+			highlightedEl.classList.remove('cursor-current');
+			highlightedEl = null;
+		}
+		if (!blockName) {
+			return;
+		}
+		// Mermaid prefixes flowchart node ids with `flowchart-` and suffixes
+		// them with a numeric id. Match by attribute prefix.
+		const node = container.querySelector(`g.node[id^='flowchart-${cssEscape(blockName)}-']`)
+			?? container.querySelector(`g[id^='flowchart-${cssEscape(blockName)}-']`);
+		if (node) {
+			node.classList.add('cursor-current');
+			highlightedEl = node;
+		}
+	}
+
+	function setStatus(text) {
+		status.textContent = text;
+	}
+
+	function report(level, message) {
+		vscode.postMessage({ type: 'log', level, message });
+	}
+
+	function cssEscape(s) {
+		// Block names are `Block_\d+` so this is mostly a guard against
+		// any future labels that contain CSS-special characters.
+		if (window.CSS && typeof window.CSS.escape === 'function') {
+			return window.CSS.escape(s);
+		}
+		return s.replace(/[^A-Za-z0-9_-]/g, '\\$&');
+	}
+})();

--- a/tools/vscode-nautilus-ir/media/graph.js
+++ b/tools/vscode-nautilus-ir/media/graph.js
@@ -8,9 +8,10 @@
 //   - Mermaid runs with `securityLevel: 'strict'`, which sanitises label
 //     contents through DOMPurify before producing the SVG.
 //   - `htmlLabels` is disabled, so labels are SVG <text>, not HTML.
-//   - The rendered SVG is parsed via DOMParser and inserted as a DOM
-//     subtree (no `innerHTML`).
-//   - Click handlers are wired manually after parsing — we do *not* use
+//   - Mermaid's SVG output is run through DOMPurify a second time in the
+//     SVG profile and inserted as a DocumentFragment — never as a string,
+//     so there is no `innerHTML` / `DOMParser` sink for tainted content.
+//   - Click handlers are wired manually after rendering; we do *not* use
 //     Mermaid's `click ... call ...` directive (which would require
 //     `securityLevel: 'loose'`).
 
@@ -27,10 +28,13 @@
 	let panZoom = null;
 	let highlightedEl = null;
 	let renderToken = 0;
-	const SVG_NS = 'http://www.w3.org/2000/svg';
 
 	if (typeof window.mermaid === 'undefined') {
 		report('error', 'Mermaid bundle failed to load.');
+		return;
+	}
+	if (typeof window.DOMPurify === 'undefined') {
+		report('error', 'DOMPurify bundle failed to load.');
 		return;
 	}
 	window.mermaid.initialize({
@@ -82,7 +86,7 @@
 			if (myToken !== renderToken) {
 				return; // a newer render superseded this one
 			}
-			const svgEl = parseSvg(result.svg);
+			const svgEl = sanitizeSvg(result.svg);
 			clearChildren(container);
 			container.appendChild(svgEl);
 			attachClickHandlers(Array.isArray(payload.blocks) ? payload.blocks : []);
@@ -93,22 +97,19 @@
 		}
 	}
 
-	// Parse Mermaid's SVG output into a DOM subtree. Using DOMParser instead
-	// of innerHTML avoids the HTML-injection sink and lets us reject any
-	// output that is not well-formed SVG (which would itself be a red flag,
-	// since Mermaid's strict-mode pipeline always produces valid SVG).
-	function parseSvg(svgText) {
-		const parser = new DOMParser();
-		const doc = parser.parseFromString(svgText, 'image/svg+xml');
-		const err = doc.querySelector('parsererror');
-		if (err) {
-			throw new Error(err.textContent || 'invalid SVG');
+	// Sanitize Mermaid's SVG output via DOMPurify, returning a live SVG
+	// element. `RETURN_DOM_FRAGMENT` skips any string sink: DOMPurify
+	// produces the DOM directly from the cleaned tree.
+	function sanitizeSvg(svgText) {
+		const fragment = window.DOMPurify.sanitize(svgText, {
+			USE_PROFILES: { svg: true, svgFilters: true },
+			RETURN_DOM_FRAGMENT: true,
+		});
+		const svgEl = fragment.querySelector('svg');
+		if (!svgEl) {
+			throw new Error('Mermaid output contained no <svg> element');
 		}
-		const root = doc.documentElement;
-		if (!root || root.namespaceURI !== SVG_NS || root.localName !== 'svg') {
-			throw new Error('Mermaid output was not an <svg> element');
-		}
-		return document.importNode(root, /* deep */ true);
+		return svgEl;
 	}
 
 	function attachClickHandlers(blocks) {

--- a/tools/vscode-nautilus-ir/media/graph.js
+++ b/tools/vscode-nautilus-ir/media/graph.js
@@ -3,6 +3,16 @@
 // Receives `render` / `highlight` messages from the extension host, drives
 // Mermaid to produce the SVG, attaches svg-pan-zoom for navigation, and
 // forwards user actions (block click, function switch) back to the host.
+//
+// Security posture:
+//   - Mermaid runs with `securityLevel: 'strict'`, which sanitises label
+//     contents through DOMPurify before producing the SVG.
+//   - `htmlLabels` is disabled, so labels are SVG <text>, not HTML.
+//   - The rendered SVG is parsed via DOMParser and inserted as a DOM
+//     subtree (no `innerHTML`).
+//   - Click handlers are wired manually after parsing — we do *not* use
+//     Mermaid's `click ... call ...` directive (which would require
+//     `securityLevel: 'loose'`).
 
 (function () {
 	'use strict';
@@ -17,6 +27,7 @@
 	let panZoom = null;
 	let highlightedEl = null;
 	let renderToken = 0;
+	const SVG_NS = 'http://www.w3.org/2000/svg';
 
 	if (typeof window.mermaid === 'undefined') {
 		report('error', 'Mermaid bundle failed to load.');
@@ -24,15 +35,10 @@
 	}
 	window.mermaid.initialize({
 		startOnLoad: false,
-		securityLevel: 'loose',
+		securityLevel: 'strict',
 		theme: 'neutral',
-		flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },
+		flowchart: { useMaxWidth: false, htmlLabels: false, curve: 'basis' },
 	});
-
-	// Click bridge invoked from Mermaid `click NodeId call onNautilusBlockClick(...)`.
-	window.onNautilusBlockClick = function (block) {
-		vscode.postMessage({ type: 'revealBlock', block: String(block) });
-	};
 
 	select.addEventListener('change', () => {
 		vscode.postMessage({ type: 'selectFunction', name: select.value });
@@ -76,25 +82,61 @@
 			if (myToken !== renderToken) {
 				return; // a newer render superseded this one
 			}
-			container.innerHTML = result.svg;
-			if (typeof result.bindFunctions === 'function') {
-				result.bindFunctions(container);
-			}
-			setupPanZoom();
+			const svgEl = parseSvg(result.svg);
+			clearChildren(container);
+			container.appendChild(svgEl);
+			attachClickHandlers(Array.isArray(payload.blocks) ? payload.blocks : []);
+			setupPanZoom(svgEl);
 			highlight(payload.currentBlock);
 		} catch (err) {
-			container.innerHTML = '';
-			const pre = document.createElement('pre');
-			pre.className = 'error';
-			pre.textContent = `Mermaid render failed: ${err && err.message ? err.message : String(err)}`;
-			container.appendChild(pre);
-			report('error', `Mermaid render failed: ${err && err.message ? err.message : String(err)}`);
+			showError(`Mermaid render failed: ${err && err.message ? err.message : String(err)}`);
 		}
+	}
+
+	// Parse Mermaid's SVG output into a DOM subtree. Using DOMParser instead
+	// of innerHTML avoids the HTML-injection sink and lets us reject any
+	// output that is not well-formed SVG (which would itself be a red flag,
+	// since Mermaid's strict-mode pipeline always produces valid SVG).
+	function parseSvg(svgText) {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(svgText, 'image/svg+xml');
+		const err = doc.querySelector('parsererror');
+		if (err) {
+			throw new Error(err.textContent || 'invalid SVG');
+		}
+		const root = doc.documentElement;
+		if (!root || root.namespaceURI !== SVG_NS || root.localName !== 'svg') {
+			throw new Error('Mermaid output was not an <svg> element');
+		}
+		return document.importNode(root, /* deep */ true);
+	}
+
+	function attachClickHandlers(blocks) {
+		for (const block of blocks) {
+			if (typeof block !== 'string' || !/^Block_\d+$/.test(block)) {
+				continue; // defensive: only known-shape block ids are wired
+			}
+			const node = findBlockNode(block);
+			if (node) {
+				node.style.cursor = 'pointer';
+				node.addEventListener('click', () => {
+					vscode.postMessage({ type: 'revealBlock', block });
+				});
+			}
+		}
+	}
+
+	function findBlockNode(blockName) {
+		const safe = cssEscape(blockName);
+		return (
+			container.querySelector(`g.node[id^='flowchart-${safe}-']`) ||
+			container.querySelector(`g[id^='flowchart-${safe}-']`)
+		);
 	}
 
 	function populateFunctions(names, active) {
 		const current = select.value;
-		select.innerHTML = '';
+		clearChildren(select);
 		for (const name of names) {
 			const opt = document.createElement('option');
 			opt.value = name;
@@ -110,24 +152,23 @@
 		}
 	}
 
-	function setupPanZoom() {
+	function setupPanZoom(svgEl) {
 		if (panZoom) {
 			try { panZoom.destroy(); } catch (e) { /* ignore */ }
 			panZoom = null;
 		}
-		const svg = container.querySelector('svg');
-		if (!svg || typeof window.svgPanZoom === 'undefined') {
+		if (!svgEl || typeof window.svgPanZoom === 'undefined') {
 			return;
 		}
 		// Mermaid sometimes sets width/height to a fixed pixel value; force
 		// the SVG to fill its host so pan-zoom has something to work with.
-		svg.removeAttribute('width');
-		svg.removeAttribute('height');
-		svg.setAttribute('width', '100%');
-		svg.setAttribute('height', '100%');
-		svg.style.maxWidth = 'none';
-		svg.style.maxHeight = 'none';
-		panZoom = window.svgPanZoom(svg, {
+		svgEl.removeAttribute('width');
+		svgEl.removeAttribute('height');
+		svgEl.setAttribute('width', '100%');
+		svgEl.setAttribute('height', '100%');
+		svgEl.style.maxWidth = 'none';
+		svgEl.style.maxHeight = 'none';
+		panZoom = window.svgPanZoom(svgEl, {
 			zoomEnabled: true,
 			controlIconsEnabled: false,
 			fit: true,
@@ -142,13 +183,10 @@
 			highlightedEl.classList.remove('cursor-current');
 			highlightedEl = null;
 		}
-		if (!blockName) {
+		if (typeof blockName !== 'string' || !/^Block_\d+$/.test(blockName)) {
 			return;
 		}
-		// Mermaid prefixes flowchart node ids with `flowchart-` and suffixes
-		// them with a numeric id. Match by attribute prefix.
-		const node = container.querySelector(`g.node[id^='flowchart-${cssEscape(blockName)}-']`)
-			?? container.querySelector(`g[id^='flowchart-${cssEscape(blockName)}-']`);
+		const node = findBlockNode(blockName);
 		if (node) {
 			node.classList.add('cursor-current');
 			highlightedEl = node;
@@ -159,13 +197,26 @@
 		status.textContent = text;
 	}
 
+	function showError(message) {
+		clearChildren(container);
+		const pre = document.createElement('pre');
+		pre.className = 'error';
+		pre.textContent = message;
+		container.appendChild(pre);
+		report('error', message);
+	}
+
+	function clearChildren(node) {
+		while (node.firstChild) {
+			node.removeChild(node.firstChild);
+		}
+	}
+
 	function report(level, message) {
 		vscode.postMessage({ type: 'log', level, message });
 	}
 
 	function cssEscape(s) {
-		// Block names are `Block_\d+` so this is mostly a guard against
-		// any future labels that contain CSS-special characters.
 		if (window.CSS && typeof window.CSS.escape === 'function') {
 			return window.CSS.escape(s);
 		}

--- a/tools/vscode-nautilus-ir/package-lock.json
+++ b/tools/vscode-nautilus-ir/package-lock.json
@@ -15,6 +15,7 @@
 			"devDependencies": {
 				"@types/node": "^20.10.0",
 				"@types/vscode": "^1.80.0",
+				"dompurify": "^3.1.6",
 				"mermaid": "^10.9.0",
 				"svg-pan-zoom": "^3.6.2",
 				"typescript": "^5.4.0"

--- a/tools/vscode-nautilus-ir/package-lock.json
+++ b/tools/vscode-nautilus-ir/package-lock.json
@@ -15,11 +15,71 @@
 			"devDependencies": {
 				"@types/node": "^20.10.0",
 				"@types/vscode": "^1.80.0",
+				"mermaid": "^10.9.0",
+				"svg-pan-zoom": "^3.6.2",
 				"typescript": "^5.4.0"
 			},
 			"engines": {
 				"vscode": "^1.80.0"
 			}
+		},
+		"node_modules/@braintree/sanitize-url": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/mdast": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+			"integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "20.19.39",
@@ -30,6 +90,21 @@
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.116.0",
@@ -56,6 +131,1327 @@
 			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
 			"license": "MIT"
 		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/cose-base": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^1.0.0"
+			}
+		},
+		"node_modules/cytoscape": {
+			"version": "3.33.2",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+			"integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-cose-bilkent": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^1.0.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/d3": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "3",
+				"d3-axis": "3",
+				"d3-brush": "3",
+				"d3-chord": "3",
+				"d3-color": "3",
+				"d3-contour": "4",
+				"d3-delaunay": "6",
+				"d3-dispatch": "3",
+				"d3-drag": "3",
+				"d3-dsv": "3",
+				"d3-ease": "3",
+				"d3-fetch": "3",
+				"d3-force": "3",
+				"d3-format": "3",
+				"d3-geo": "3",
+				"d3-hierarchy": "3",
+				"d3-interpolate": "3",
+				"d3-path": "3",
+				"d3-polygon": "3",
+				"d3-quadtree": "3",
+				"d3-random": "3",
+				"d3-scale": "4",
+				"d3-scale-chromatic": "3",
+				"d3-selection": "3",
+				"d3-shape": "3",
+				"d3-time": "3",
+				"d3-time-format": "4",
+				"d3-timer": "3",
+				"d3-transition": "3",
+				"d3-zoom": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-axis": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-drag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-selection": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-fetch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dsv": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-polygon": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-interpolate": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/d3-zoom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "2 - 3",
+				"d3-transition": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/dagre-d3-es": {
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
+			"integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"d3": "^7.9.0",
+				"lodash-es": "^4.17.21"
+			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/delaunator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/diff": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+			"integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+			"dev": true,
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/elkjs": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+			"integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+			"dev": true,
+			"license": "EPL-2.0"
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/katex": {
+			"version": "0.16.45",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+			"dev": true,
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/khroma": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+			"dev": true
+		},
+		"node_modules/kleur": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/layout-base": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash-es": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+			"integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"mdast-util-to-string": "^3.1.0",
+				"micromark": "^3.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"uvu": "^0.5.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+			"integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mermaid": {
+			"version": "10.9.5",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.5.tgz",
+			"integrity": "sha512-eRlKEjzak4z1rcXeCd1OAlyawhrptClQDo8OuI8n6bSVqJ9oMfd5Lrf3Q+TdJHewi/9AIOc3UmEo8Fz+kNzzuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@braintree/sanitize-url": "^6.0.1",
+				"@types/d3-scale": "^4.0.3",
+				"@types/d3-scale-chromatic": "^3.0.0",
+				"cytoscape": "^3.28.1",
+				"cytoscape-cose-bilkent": "^4.1.0",
+				"d3": "^7.4.0",
+				"d3-sankey": "^0.12.3",
+				"dagre-d3-es": "7.0.13",
+				"dayjs": "^1.11.7",
+				"dompurify": "^3.2.4",
+				"elkjs": "^0.9.0",
+				"katex": "^0.16.9",
+				"khroma": "^2.0.0",
+				"lodash-es": "^4.17.21",
+				"mdast-util-from-markdown": "^1.3.0",
+				"non-layered-tidy-tree-layout": "^2.0.2",
+				"stylis": "^4.1.3",
+				"ts-dedent": "^2.2.0",
+				"uuid": "^9.0.0",
+				"web-worker": "^1.2.0"
+			}
+		},
+		"node_modules/micromark": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+			"integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-core-commonmark": "^1.0.1",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-combine-extensions": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-sanitize-uri": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+			"integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-factory-destination": "^1.0.0",
+				"micromark-factory-label": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-factory-title": "^1.0.0",
+				"micromark-factory-whitespace": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-classify-character": "^1.0.0",
+				"micromark-util-html-tag-name": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+			"integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+			"integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+			"integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+			"integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+			"integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+			"integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+			"integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+			"integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+			"integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+			"integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+			"integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+			"integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+			"integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+			"integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+			"integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+			"integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+			"integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+			"integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+			"integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/non-layered-tidy-tree-layout": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+			"integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mri": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/stylis": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+			"integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/svg-pan-zoom": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz",
+			"integrity": "sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -76,6 +1472,60 @@
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+			"integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/uvu": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3"
+			},
+			"bin": {
+				"uvu": "bin.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/web-worker": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+			"integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+			"dev": true,
+			"license": "Apache-2.0"
 		}
 	}
 }

--- a/tools/vscode-nautilus-ir/package.json
+++ b/tools/vscode-nautilus-ir/package.json
@@ -29,7 +29,8 @@
 		"onLanguage:nautilus-ir",
 		"onDebug",
 		"onCommand:nautilus-ir.dumpInfo",
-		"onCommand:nautilus-ir.gotoBlock"
+		"onCommand:nautilus-ir.gotoBlock",
+		"onCommand:nautilus-ir.showGraph"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -84,6 +85,11 @@
 				"command": "nautilus-ir.debugWithGdb",
 				"title": "Nautilus IR: Debug Current File with gdb",
 				"category": "Nautilus IR"
+			},
+			{
+				"command": "nautilus-ir.showGraph",
+				"title": "Nautilus IR: Show Graph",
+				"category": "Nautilus IR"
 			}
 		],
 		"configuration": {
@@ -120,6 +126,11 @@
 					"default": "",
 					"scope": "resource",
 					"description": "Last-used C++ host executable for ad-hoc gdb debugging. Updated automatically by the 'Debug Current File with gdb' command."
+				},
+				"nautilusIr.graph.autoOpen": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically open the graph view when a Nautilus IR file is opened."
 				}
 			}
 		},
@@ -288,13 +299,23 @@
 					"when": "resourceLangId == nautilus-ir",
 					"command": "nautilus-ir.debugWithGdb",
 					"group": "navigation@2"
+				},
+				{
+					"when": "resourceLangId == nautilus-ir",
+					"command": "nautilus-ir.showGraph",
+					"group": "navigation@3"
 				}
 			],
 			"editor/title": [
 				{
 					"when": "resourceLangId == nautilus-ir",
+					"command": "nautilus-ir.showGraph",
+					"group": "navigation@1"
+				},
+				{
+					"when": "resourceLangId == nautilus-ir",
 					"command": "nautilus-ir.dumpInfo",
-					"group": "navigation"
+					"group": "navigation@2"
 				}
 			]
 		},
@@ -309,7 +330,8 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
+		"compile": "tsc -p ./ && npm run build:media",
+		"build:media": "node scripts/build-media.js",
 		"watch": "tsc -watch -p ./",
 		"package": "vsce package",
 		"lint": "tsc --noEmit"
@@ -321,6 +343,8 @@
 	"devDependencies": {
 		"@types/node": "^20.10.0",
 		"@types/vscode": "^1.80.0",
+		"mermaid": "^10.9.0",
+		"svg-pan-zoom": "^3.6.2",
 		"typescript": "^5.4.0"
 	}
 }

--- a/tools/vscode-nautilus-ir/package.json
+++ b/tools/vscode-nautilus-ir/package.json
@@ -343,6 +343,7 @@
 	"devDependencies": {
 		"@types/node": "^20.10.0",
 		"@types/vscode": "^1.80.0",
+		"dompurify": "^3.1.6",
 		"mermaid": "^10.9.0",
 		"svg-pan-zoom": "^3.6.2",
 		"typescript": "^5.4.0"

--- a/tools/vscode-nautilus-ir/scripts/build-media.js
+++ b/tools/vscode-nautilus-ir/scripts/build-media.js
@@ -1,0 +1,35 @@
+// Copy the UMD bundles for the webview's runtime dependencies into
+// `media/vendor/` so they can be loaded under the webview's strict CSP
+// without needing `node_modules` at runtime. The copies are committed
+// into the packaged .vsix via .vscodeignore (which only excludes `src/`,
+// not `media/`).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const dest = path.join(root, 'media', 'vendor');
+fs.mkdirSync(dest, { recursive: true });
+
+// [source, target-name]
+const bundles = [
+	['mermaid/dist/mermaid.min.js', 'mermaid.min.js'],
+	['svg-pan-zoom/dist/svg-pan-zoom.min.js', 'svg-pan-zoom.min.js'],
+];
+
+let failed = false;
+for (const [pkgPath, targetName] of bundles) {
+	const src = path.join(root, 'node_modules', pkgPath);
+	const dst = path.join(dest, targetName);
+	if (!fs.existsSync(src)) {
+		console.error(`build-media: missing ${src} (run \`npm install\` first?)`);
+		failed = true;
+		continue;
+	}
+	fs.copyFileSync(src, dst);
+	console.log(`build-media: ${pkgPath} -> ${path.relative(root, dst)}`);
+}
+
+process.exit(failed ? 1 : 0);

--- a/tools/vscode-nautilus-ir/scripts/build-media.js
+++ b/tools/vscode-nautilus-ir/scripts/build-media.js
@@ -17,6 +17,7 @@ fs.mkdirSync(dest, { recursive: true });
 const bundles = [
 	['mermaid/dist/mermaid.min.js', 'mermaid.min.js'],
 	['svg-pan-zoom/dist/svg-pan-zoom.min.js', 'svg-pan-zoom.min.js'],
+	['dompurify/dist/purify.min.js', 'purify.min.js'],
 ];
 
 let failed = false;

--- a/tools/vscode-nautilus-ir/src/cfgFromParsedIr.ts
+++ b/tools/vscode-nautilus-ir/src/cfgFromParsedIr.ts
@@ -1,0 +1,120 @@
+// Synthesize a Mermaid `flowchart TD` from a parsed Nautilus IR function.
+//
+// The output is consumed by the extension's graph webview. Each block becomes
+// one node; edges are derived from block terminators (`return` / `br` / `if`).
+// Block names are reused verbatim as Mermaid node ids — the parser already
+// guarantees they match `/Block_\d+/`, which is a valid Mermaid identifier.
+
+import { IrFunction, ParsedIr } from './parser';
+
+export interface CfgGraph {
+	mermaid: string;
+	functionName: string;
+	// Block names rendered in this graph, in declaration order. Used by the
+	// webview to scope cursor-driven highlights.
+	blocks: string[];
+}
+
+export function cfgFor(ir: ParsedIr, functionName: string): CfgGraph | undefined {
+	const fn = ir.functionByName.get(functionName);
+	if (!fn) {
+		return undefined;
+	}
+	return buildGraph(fn);
+}
+
+function buildGraph(fn: IrFunction): CfgGraph {
+	const lines: string[] = [];
+	lines.push('flowchart TD');
+
+	if (fn.blocks.length === 0) {
+		lines.push(`    empty["${escape(fn.name)}: (no blocks)"]`);
+		return { mermaid: lines.join('\n'), functionName: fn.name, blocks: [] };
+	}
+
+	const entryName = fn.blocks[0].name;
+
+	// Nodes.
+	for (const block of fn.blocks) {
+		const id = block.name;
+		const label = renderLabel(block.name, block.args, block.instructions, block.terminator);
+		// Shape conveys role: rectangle for normal, stadium for return,
+		// rhombus for conditional branches (`if`).
+		let shape: string;
+		if (block.terminator === 'return') {
+			shape = `${id}(["${label}"])`;
+		} else if (block.terminator === 'if') {
+			shape = `${id}{{"${label}"}}`;
+		} else {
+			shape = `${id}["${label}"]`;
+		}
+		lines.push(`    ${shape}`);
+	}
+
+	// Edges. Conditional branches: the parser preserves successor order
+	// (true branch first, then false), matching the textual `if $cond ?
+	// Block_T : Block_F :void` form.
+	for (const block of fn.blocks) {
+		if (block.terminator === 'if' && block.successors.length === 2) {
+			const [t, f] = block.successors;
+			lines.push(`    ${block.name} -- "true" --> ${t}`);
+			lines.push(`    ${block.name} -- "false" --> ${f}`);
+		} else {
+			for (const succ of block.successors) {
+				lines.push(`    ${block.name} --> ${succ}`);
+			}
+		}
+	}
+
+	// Click handlers — Mermaid wires these to `window.onNautilusBlockClick`,
+	// which the webview defines and forwards to the extension host.
+	for (const block of fn.blocks) {
+		lines.push(`    click ${block.name} call onNautilusBlockClick("${block.name}")`);
+	}
+
+	// Styling. Colors mirror the palette already used by the C++ Mermaid
+	// dumper in `nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp`,
+	// so the extension's view feels familiar to anyone reading those dumps.
+	lines.push('    classDef entry stroke:#3cb4a4,stroke-width:2px,fill:#d7ede7,color:#000');
+	lines.push('    classDef exit stroke:#e98693,stroke-width:2px,fill:#fde8ec,color:#000');
+	lines.push('    classDef cond stroke:#3cb4a4,stroke-width:1px,fill:#fff,color:#000');
+	lines.push('    classDef cursor stroke:#da2d4f,stroke-width:3px,fill:#fff7f9,color:#000');
+
+	lines.push(`    class ${entryName} entry`);
+	for (const block of fn.blocks) {
+		if (block.terminator === 'return') {
+			lines.push(`    class ${block.name} exit`);
+		} else if (block.terminator === 'if') {
+			lines.push(`    class ${block.name} cond`);
+		}
+	}
+
+	return {
+		mermaid: lines.join('\n'),
+		functionName: fn.name,
+		blocks: fn.blocks.map(b => b.name),
+	};
+}
+
+function renderLabel(
+	name: string,
+	args: { name: string; type: string }[],
+	instructions: number,
+	terminator: string,
+): string {
+	const sig = args.length === 0
+		? name
+		: `${name}(${args.map(a => `${escape(a.name)}:${escape(a.type)}`).join(', ')})`;
+	const insnWord = instructions === 1 ? 'insn' : 'insns';
+	return `${escape(sig)}<br/><span style='font-size:0.85em;opacity:0.75'>${instructions} ${insnWord} · ${escape(terminator)}</span>`;
+}
+
+// Mermaid uses `"…"` to delimit labels with HTML; escape characters that
+// would either break the surrounding quotes or be rendered as raw HTML.
+function escape(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/"/g, '&quot;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}

--- a/tools/vscode-nautilus-ir/src/cfgFromParsedIr.ts
+++ b/tools/vscode-nautilus-ir/src/cfgFromParsedIr.ts
@@ -4,14 +4,20 @@
 // one node; edges are derived from block terminators (`return` / `br` / `if`).
 // Block names are reused verbatim as Mermaid node ids — the parser already
 // guarantees they match `/Block_\d+/`, which is a valid Mermaid identifier.
+//
+// The webview renders Mermaid with `securityLevel: 'strict'` and
+// `htmlLabels: false`, so labels are SVG <text> and DOMPurify-sanitised.
+// Click handlers are wired up by the webview after rendering rather than via
+// a Mermaid `click ... call ...` directive (which would require `'loose'`).
 
 import { IrFunction, ParsedIr } from './parser';
 
 export interface CfgGraph {
 	mermaid: string;
 	functionName: string;
-	// Block names rendered in this graph, in declaration order. Used by the
-	// webview to scope cursor-driven highlights.
+	// Block names rendered in this graph, in declaration order. The webview
+	// uses this list (validated against `/^Block_\d+$/`) to attach click
+	// handlers to the rendered SVG nodes.
 	blocks: string[];
 }
 
@@ -28,18 +34,17 @@ function buildGraph(fn: IrFunction): CfgGraph {
 	lines.push('flowchart TD');
 
 	if (fn.blocks.length === 0) {
-		lines.push(`    empty["${escape(fn.name)}: (no blocks)"]`);
+		lines.push(`    empty["${quoteLabel(fn.name)}: (no blocks)"]`);
 		return { mermaid: lines.join('\n'), functionName: fn.name, blocks: [] };
 	}
 
 	const entryName = fn.blocks[0].name;
 
-	// Nodes.
+	// Nodes. Shape conveys the terminator: rectangle for normal, stadium
+	// for return, rhombus for conditional `if`.
 	for (const block of fn.blocks) {
 		const id = block.name;
 		const label = renderLabel(block.name, block.args, block.instructions, block.terminator);
-		// Shape conveys role: rectangle for normal, stadium for return,
-		// rhombus for conditional branches (`if`).
 		let shape: string;
 		if (block.terminator === 'return') {
 			shape = `${id}(["${label}"])`;
@@ -51,9 +56,9 @@ function buildGraph(fn: IrFunction): CfgGraph {
 		lines.push(`    ${shape}`);
 	}
 
-	// Edges. Conditional branches: the parser preserves successor order
-	// (true branch first, then false), matching the textual `if $cond ?
-	// Block_T : Block_F :void` form.
+	// Edges. The parser preserves successor order on conditional branches
+	// (true branch first, then false), matching the textual
+	// `if $cond ? Block_T : Block_F :void` form.
 	for (const block of fn.blocks) {
 		if (block.terminator === 'if' && block.successors.length === 2) {
 			const [t, f] = block.successors;
@@ -66,15 +71,9 @@ function buildGraph(fn: IrFunction): CfgGraph {
 		}
 	}
 
-	// Click handlers — Mermaid wires these to `window.onNautilusBlockClick`,
-	// which the webview defines and forwards to the extension host.
-	for (const block of fn.blocks) {
-		lines.push(`    click ${block.name} call onNautilusBlockClick("${block.name}")`);
-	}
-
-	// Styling. Colors mirror the palette already used by the C++ Mermaid
-	// dumper in `nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp`,
-	// so the extension's view feels familiar to anyone reading those dumps.
+	// Styling. Colors mirror the palette of the C++ Mermaid dumper in
+	// `nautilus/src/nautilus/compiler/ir/util/GraphVizUtil.cpp` so the
+	// extension's view feels familiar to anyone reading those dumps.
 	lines.push('    classDef entry stroke:#3cb4a4,stroke-width:2px,fill:#d7ede7,color:#000');
 	lines.push('    classDef exit stroke:#e98693,stroke-width:2px,fill:#fde8ec,color:#000');
 	lines.push('    classDef cond stroke:#3cb4a4,stroke-width:1px,fill:#fff,color:#000');
@@ -104,17 +103,14 @@ function renderLabel(
 ): string {
 	const sig = args.length === 0
 		? name
-		: `${name}(${args.map(a => `${escape(a.name)}:${escape(a.type)}`).join(', ')})`;
+		: `${name}(${args.map(a => `${a.name}:${a.type}`).join(', ')})`;
 	const insnWord = instructions === 1 ? 'insn' : 'insns';
-	return `${escape(sig)}<br/><span style='font-size:0.85em;opacity:0.75'>${instructions} ${insnWord} · ${escape(terminator)}</span>`;
+	// Single-line plain-text label. Mermaid (strict mode, no htmlLabels)
+	// escapes any markup automatically; we only need to neutralise the
+	// closing-quote character so the label string stays well-formed.
+	return quoteLabel(`${sig} | ${instructions} ${insnWord} · ${terminator}`);
 }
 
-// Mermaid uses `"…"` to delimit labels with HTML; escape characters that
-// would either break the surrounding quotes or be rendered as raw HTML.
-function escape(s: string): string {
-	return s
-		.replace(/&/g, '&amp;')
-		.replace(/"/g, '&quot;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;');
+function quoteLabel(s: string): string {
+	return s.replace(/"/g, '&quot;');
 }

--- a/tools/vscode-nautilus-ir/src/extension.ts
+++ b/tools/vscode-nautilus-ir/src/extension.ts
@@ -12,6 +12,7 @@ import {
 	irFor,
 } from './features';
 import { GdbDescriptorFactory } from './debugAdapter';
+import { GraphPanel } from './graphView';
 
 const SELECTOR: vscode.DocumentSelector = { language: 'nautilus-ir', scheme: 'file' };
 
@@ -52,7 +53,20 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand('nautilus-ir.showBlockInfo', showBlockInfoCommand),
 		vscode.commands.registerCommand('nautilus-ir.toggleFollowDefinitions', toggleFollowDefinitionsCommand),
 		vscode.commands.registerCommand('nautilus-ir.debugWithGdb', debugWithGdbCommand),
+		vscode.commands.registerCommand('nautilus-ir.showGraph', () => GraphPanel.createOrShow(context.extensionUri)),
 	);
+
+	// Optional auto-open of the graph panel for newly opened IR files.
+	const maybeAutoOpen = (doc: vscode.TextDocument) => {
+		if (doc.languageId !== 'nautilus-ir') {
+			return;
+		}
+		const enabled = vscode.workspace.getConfiguration('nautilusIr').get<boolean>('graph.autoOpen', false);
+		if (enabled) {
+			GraphPanel.createOrShow(context.extensionUri);
+		}
+	};
+	context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(maybeAutoOpen));
 
 	// Debug adapter (inline implementation, no separate process).
 	context.subscriptions.push(

--- a/tools/vscode-nautilus-ir/src/graphView.ts
+++ b/tools/vscode-nautilus-ir/src/graphView.ts
@@ -1,0 +1,331 @@
+// Webview panel that renders the control-flow graph of the active Nautilus
+// IR file using Mermaid. The graph is synthesized client-side from the IR
+// text — there is no dependency on Nautilus's `dump.graph` option.
+//
+// Contract with the webview (see `media/graph.js`):
+//
+//   extension → webview:
+//     { type: 'render', mermaid, functions, activeFunction, currentBlock }
+//     { type: 'highlight', block }
+//
+//   webview → extension:
+//     { type: 'ready' }                     // initial handshake
+//     { type: 'revealBlock', block }        // user clicked a graph node
+//     { type: 'selectFunction', name }      // user picked from the dropdown
+//     { type: 'log', level, message }       // webview-side diagnostics
+
+import * as vscode from 'vscode';
+import { irFor } from './features';
+import { cfgFor } from './cfgFromParsedIr';
+import { ParsedIr } from './parser';
+
+const RENDER_DEBOUNCE_MS = 150;
+
+interface RenderPayload {
+	type: 'render';
+	mermaid: string;
+	functions: string[];
+	activeFunction: string;
+	currentBlock: string | null;
+}
+
+interface HighlightPayload {
+	type: 'highlight';
+	block: string | null;
+}
+
+export class GraphPanel {
+	private static current: GraphPanel | undefined;
+
+	public static createOrShow(extensionUri: vscode.Uri): void {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.document.languageId !== 'nautilus-ir') {
+			vscode.window.showInformationMessage(
+				'Open a Nautilus IR (.nautilus) file before opening the graph view.',
+			);
+			return;
+		}
+
+		if (GraphPanel.current) {
+			GraphPanel.current.panel.reveal(vscode.ViewColumn.Beside, true);
+			GraphPanel.current.linkTo(editor.document);
+			return;
+		}
+
+		const panel = vscode.window.createWebviewPanel(
+			'nautilus-ir.graph',
+			`Nautilus IR Graph — ${editor.document.fileName.split(/[\\/]/).pop() ?? ''}`,
+			{ viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+			{
+				enableScripts: true,
+				retainContextWhenHidden: true,
+				localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')],
+			},
+		);
+
+		GraphPanel.current = new GraphPanel(panel, extensionUri, editor.document);
+	}
+
+	private readonly disposables: vscode.Disposable[] = [];
+	private linkedDoc: vscode.TextDocument;
+	private activeFunction: string | undefined;
+	private renderTimer: NodeJS.Timeout | undefined;
+	private webviewReady = false;
+	private pendingRender: RenderPayload | undefined;
+
+	private constructor(
+		private readonly panel: vscode.WebviewPanel,
+		private readonly extensionUri: vscode.Uri,
+		initialDoc: vscode.TextDocument,
+	) {
+		this.linkedDoc = initialDoc;
+		this.panel.webview.html = this.htmlFor(this.panel.webview);
+
+		this.disposables.push(
+			this.panel.onDidDispose(() => this.dispose()),
+			this.panel.webview.onDidReceiveMessage(msg => this.handleMessage(msg)),
+			vscode.workspace.onDidChangeTextDocument(e => {
+				if (e.document === this.linkedDoc) {
+					this.scheduleRender();
+				}
+			}),
+			vscode.workspace.onDidCloseTextDocument(d => {
+				if (d === this.linkedDoc) {
+					// Keep the last rendered graph visible; users often close
+					// the source while inspecting the picture.
+				}
+			}),
+			vscode.window.onDidChangeActiveTextEditor(editor => {
+				if (editor && editor.document.languageId === 'nautilus-ir' && editor.document !== this.linkedDoc) {
+					this.linkTo(editor.document);
+				}
+			}),
+			vscode.window.onDidChangeTextEditorSelection(e => {
+				if (e.textEditor.document !== this.linkedDoc) {
+					return;
+				}
+				this.postCurrentBlockHighlight(e.textEditor.selection.active.line);
+			}),
+		);
+	}
+
+	public linkTo(document: vscode.TextDocument): void {
+		this.linkedDoc = document;
+		this.panel.title = `Nautilus IR Graph — ${document.fileName.split(/[\\/]/).pop() ?? ''}`;
+		this.activeFunction = undefined; // recompute default
+		this.scheduleRender(/* immediate */ true);
+	}
+
+	private scheduleRender(immediate = false): void {
+		if (this.renderTimer) {
+			clearTimeout(this.renderTimer);
+			this.renderTimer = undefined;
+		}
+		const fire = () => {
+			this.renderTimer = undefined;
+			this.render();
+		};
+		if (immediate) {
+			fire();
+		} else {
+			this.renderTimer = setTimeout(fire, RENDER_DEBOUNCE_MS);
+		}
+	}
+
+	private render(): void {
+		const ir = irFor(this.linkedDoc);
+		const payload = this.buildRenderPayload(ir);
+		if (!payload) {
+			return;
+		}
+		this.pendingRender = payload;
+		if (this.webviewReady) {
+			void this.panel.webview.postMessage(payload);
+		}
+	}
+
+	private buildRenderPayload(ir: ParsedIr): RenderPayload | undefined {
+		if (ir.functions.length === 0) {
+			return {
+				type: 'render',
+				mermaid: 'flowchart TD\n    empty["(no functions found)"]',
+				functions: [],
+				activeFunction: '',
+				currentBlock: null,
+			};
+		}
+
+		const fnNames = ir.functions.map(f => f.name);
+		if (!this.activeFunction || !fnNames.includes(this.activeFunction)) {
+			// Default: prefer the function containing the cursor in the
+			// matching editor; otherwise fall back to the first function.
+			this.activeFunction = this.functionAtCursor(ir) ?? fnNames[0];
+		}
+		const graph = cfgFor(ir, this.activeFunction);
+		if (!graph) {
+			return undefined;
+		}
+		return {
+			type: 'render',
+			mermaid: graph.mermaid,
+			functions: fnNames,
+			activeFunction: graph.functionName,
+			currentBlock: this.currentBlock(),
+		};
+	}
+
+	private functionAtCursor(ir: ParsedIr): string | undefined {
+		const editor = vscode.window.visibleTextEditors.find(e => e.document === this.linkedDoc);
+		if (!editor) {
+			return undefined;
+		}
+		const line = editor.selection.active.line;
+		const fn = ir.functions.find(f => line >= f.headerLine && line <= f.bodyRange.end.line);
+		return fn?.name;
+	}
+
+	private currentBlock(): string | null {
+		const editor = vscode.window.visibleTextEditors.find(e => e.document === this.linkedDoc);
+		if (!editor) {
+			return null;
+		}
+		const ir = irFor(this.linkedDoc);
+		const line = editor.selection.active.line;
+		const block = ir.blocks.find(b =>
+			b.functionName === this.activeFunction &&
+			line >= b.headerLine && line <= b.bodyRange.end.line,
+		);
+		return block?.name ?? null;
+	}
+
+	private postCurrentBlockHighlight(line: number): void {
+		if (!this.webviewReady) {
+			return;
+		}
+		const ir = irFor(this.linkedDoc);
+		// If the cursor moved into a different function, switch the rendered
+		// function so the highlight has somewhere to land.
+		const fn = ir.functions.find(f => line >= f.headerLine && line <= f.bodyRange.end.line);
+		if (fn && fn.name !== this.activeFunction) {
+			this.activeFunction = fn.name;
+			this.scheduleRender(/* immediate */ true);
+			return;
+		}
+		const block = ir.blocks.find(b =>
+			b.functionName === this.activeFunction &&
+			line >= b.headerLine && line <= b.bodyRange.end.line,
+		);
+		const payload: HighlightPayload = { type: 'highlight', block: block?.name ?? null };
+		void this.panel.webview.postMessage(payload);
+	}
+
+	private handleMessage(msg: { type: string; [k: string]: unknown }): void {
+		switch (msg.type) {
+		case 'ready':
+			this.webviewReady = true;
+			if (!this.pendingRender) {
+				const ir = irFor(this.linkedDoc);
+				this.pendingRender = this.buildRenderPayload(ir);
+			}
+			if (this.pendingRender) {
+				void this.panel.webview.postMessage(this.pendingRender);
+			}
+			return;
+		case 'revealBlock':
+			void this.revealBlock(typeof msg.block === 'string' ? msg.block : '');
+			return;
+		case 'selectFunction':
+			if (typeof msg.name === 'string') {
+				this.activeFunction = msg.name;
+				this.scheduleRender(/* immediate */ true);
+			}
+			return;
+		case 'log':
+			if (msg.level === 'error') {
+				vscode.window.showErrorMessage(`Nautilus IR graph: ${msg.message}`);
+			}
+			return;
+		}
+	}
+
+	private async revealBlock(blockName: string): Promise<void> {
+		if (!blockName) {
+			return;
+		}
+		const editor = await vscode.window.showTextDocument(this.linkedDoc, {
+			viewColumn: vscode.ViewColumn.One,
+			preserveFocus: false,
+		});
+		const ir = irFor(this.linkedDoc);
+		const block = ir.blocks.find(b =>
+			b.functionName === this.activeFunction && b.name === blockName,
+		) ?? ir.blocks.find(b => b.name === blockName);
+		if (!block) {
+			return;
+		}
+		const pos = new vscode.Position(block.headerLine, 0);
+		editor.selection = new vscode.Selection(pos, pos);
+		editor.revealRange(block.headerRange, vscode.TextEditorRevealType.InCenter);
+	}
+
+	private htmlFor(webview: vscode.Webview): string {
+		const mediaRoot = vscode.Uri.joinPath(this.extensionUri, 'media');
+		const mermaidUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'vendor', 'mermaid.min.js'));
+		const panZoomUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'vendor', 'svg-pan-zoom.min.js'));
+		const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'graph.js'));
+		const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'graph.css'));
+		const nonce = randomNonce();
+		const csp = [
+			`default-src 'none'`,
+			`img-src ${webview.cspSource} data:`,
+			`style-src ${webview.cspSource} 'unsafe-inline'`,
+			`font-src ${webview.cspSource}`,
+			`script-src ${webview.cspSource} 'nonce-${nonce}'`,
+		].join('; ');
+
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<link rel="stylesheet" href="${styleUri}">
+<title>Nautilus IR Graph</title>
+</head>
+<body>
+<div id="toolbar">
+	<label for="function-select">Function</label>
+	<select id="function-select"></select>
+	<button id="fit-btn" title="Fit to window">Fit</button>
+	<button id="reset-btn" title="Reset zoom">Reset</button>
+	<span id="status"></span>
+</div>
+<div id="graph-host">
+	<div id="graph-container"></div>
+</div>
+<script nonce="${nonce}" src="${mermaidUri}"></script>
+<script nonce="${nonce}" src="${panZoomUri}"></script>
+<script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+	}
+
+	private dispose(): void {
+		GraphPanel.current = undefined;
+		if (this.renderTimer) {
+			clearTimeout(this.renderTimer);
+		}
+		while (this.disposables.length) {
+			const d = this.disposables.pop();
+			try { d?.dispose(); } catch { /* ignore */ }
+		}
+	}
+}
+
+function randomNonce(): string {
+	const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	let s = '';
+	for (let i = 0; i < 32; i++) {
+		s += chars.charAt(Math.floor(Math.random() * chars.length));
+	}
+	return s;
+}

--- a/tools/vscode-nautilus-ir/src/graphView.ts
+++ b/tools/vscode-nautilus-ir/src/graphView.ts
@@ -254,6 +254,7 @@ export class GraphPanel {
 		const mediaRoot = vscode.Uri.joinPath(this.extensionUri, 'media');
 		const mermaidUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'vendor', 'mermaid.min.js'));
 		const panZoomUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'vendor', 'svg-pan-zoom.min.js'));
+		const purifyUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'vendor', 'purify.min.js'));
 		const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'graph.js'));
 		const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'graph.css'));
 		const nonce = randomNonce();
@@ -284,6 +285,7 @@ export class GraphPanel {
 <div id="graph-host">
 	<div id="graph-container"></div>
 </div>
+<script nonce="${nonce}" src="${purifyUri}"></script>
 <script nonce="${nonce}" src="${mermaidUri}"></script>
 <script nonce="${nonce}" src="${panZoomUri}"></script>
 <script nonce="${nonce}" src="${scriptUri}"></script>

--- a/tools/vscode-nautilus-ir/src/graphView.ts
+++ b/tools/vscode-nautilus-ir/src/graphView.ts
@@ -5,7 +5,7 @@
 // Contract with the webview (see `media/graph.js`):
 //
 //   extension → webview:
-//     { type: 'render', mermaid, functions, activeFunction, currentBlock }
+//     { type: 'render', mermaid, functions, activeFunction, blocks, currentBlock }
 //     { type: 'highlight', block }
 //
 //   webview → extension:
@@ -26,6 +26,10 @@ interface RenderPayload {
 	mermaid: string;
 	functions: string[];
 	activeFunction: string;
+	// Block names that the webview should wire click handlers for. The
+	// webview validates each entry against `/^Block_\d+$/` before using it
+	// in a CSS selector.
+	blocks: string[];
 	currentBlock: string | null;
 }
 
@@ -151,6 +155,7 @@ export class GraphPanel {
 				mermaid: 'flowchart TD\n    empty["(no functions found)"]',
 				functions: [],
 				activeFunction: '',
+				blocks: [],
 				currentBlock: null,
 			};
 		}
@@ -170,6 +175,7 @@ export class GraphPanel {
 			mermaid: graph.mermaid,
 			functions: fnNames,
 			activeFunction: graph.functionName,
+			blocks: graph.blocks,
 			currentBlock: this.currentBlock(),
 		};
 	}

--- a/tools/vscode-nautilus-ir/src/graphView.ts
+++ b/tools/vscode-nautilus-ir/src/graphView.ts
@@ -1,42 +1,24 @@
 // Webview panel that renders the control-flow graph of the active Nautilus
 // IR file using Mermaid. The graph is synthesized client-side from the IR
 // text — there is no dependency on Nautilus's `dump.graph` option.
-//
-// Contract with the webview (see `media/graph.js`):
-//
-//   extension → webview:
-//     { type: 'render', mermaid, functions, activeFunction, blocks, currentBlock }
-//     { type: 'highlight', block }
-//
-//   webview → extension:
-//     { type: 'ready' }                     // initial handshake
-//     { type: 'revealBlock', block }        // user clicked a graph node
-//     { type: 'selectFunction', name }      // user picked from the dropdown
-//     { type: 'log', level, message }       // webview-side diagnostics
 
 import * as vscode from 'vscode';
 import { irFor } from './features';
 import { cfgFor } from './cfgFromParsedIr';
-import { ParsedIr } from './parser';
+import { ParsedIr, blockAtLine, functionAt } from './parser';
 
 const RENDER_DEBOUNCE_MS = 150;
 
-interface RenderPayload {
-	type: 'render';
-	mermaid: string;
-	functions: string[];
-	activeFunction: string;
-	// Block names that the webview should wire click handlers for. The
-	// webview validates each entry against `/^Block_\d+$/` before using it
-	// in a CSS selector.
-	blocks: string[];
-	currentBlock: string | null;
-}
+// Wire-format messages exchanged with `media/graph.js`.
+type ExtensionToWebview =
+	| { type: 'render'; mermaid: string; functions: string[]; activeFunction: string; blocks: string[]; currentBlock: string | null }
+	| { type: 'highlight'; block: string | null };
 
-interface HighlightPayload {
-	type: 'highlight';
-	block: string | null;
-}
+type WebviewToExtension =
+	| { type: 'ready' }
+	| { type: 'revealBlock'; block: string }
+	| { type: 'selectFunction'; name: string }
+	| { type: 'log'; level: 'info' | 'warn' | 'error'; message: string };
 
 export class GraphPanel {
 	private static current: GraphPanel | undefined;
@@ -58,7 +40,7 @@ export class GraphPanel {
 
 		const panel = vscode.window.createWebviewPanel(
 			'nautilus-ir.graph',
-			`Nautilus IR Graph — ${editor.document.fileName.split(/[\\/]/).pop() ?? ''}`,
+			titleFor(editor.document),
 			{ viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
 			{
 				enableScripts: true,
@@ -75,7 +57,9 @@ export class GraphPanel {
 	private activeFunction: string | undefined;
 	private renderTimer: NodeJS.Timeout | undefined;
 	private webviewReady = false;
-	private pendingRender: RenderPayload | undefined;
+	private pendingRender: Extract<ExtensionToWebview, { type: 'render' }> | undefined;
+	private lastRenderJson: string | undefined;
+	private lastHighlightedBlock: string | null | undefined;
 
 	private constructor(
 		private readonly panel: vscode.WebviewPanel,
@@ -87,16 +71,10 @@ export class GraphPanel {
 
 		this.disposables.push(
 			this.panel.onDidDispose(() => this.dispose()),
-			this.panel.webview.onDidReceiveMessage(msg => this.handleMessage(msg)),
+			this.panel.webview.onDidReceiveMessage(msg => this.handleMessage(msg as WebviewToExtension)),
 			vscode.workspace.onDidChangeTextDocument(e => {
 				if (e.document === this.linkedDoc) {
 					this.scheduleRender();
-				}
-			}),
-			vscode.workspace.onDidCloseTextDocument(d => {
-				if (d === this.linkedDoc) {
-					// Keep the last rendered graph visible; users often close
-					// the source while inspecting the picture.
 				}
 			}),
 			vscode.window.onDidChangeActiveTextEditor(editor => {
@@ -115,8 +93,10 @@ export class GraphPanel {
 
 	public linkTo(document: vscode.TextDocument): void {
 		this.linkedDoc = document;
-		this.panel.title = `Nautilus IR Graph — ${document.fileName.split(/[\\/]/).pop() ?? ''}`;
-		this.activeFunction = undefined; // recompute default
+		this.panel.title = titleFor(document);
+		this.activeFunction = undefined;
+		this.lastRenderJson = undefined; // new doc → never dedup against old payload
+		this.lastHighlightedBlock = undefined;
 		this.scheduleRender(/* immediate */ true);
 	}
 
@@ -142,13 +122,19 @@ export class GraphPanel {
 		if (!payload) {
 			return;
 		}
+		const json = JSON.stringify(payload);
+		if (json === this.lastRenderJson) {
+			return; // edits that don't change the rendered graph stay invisible
+		}
+		this.lastRenderJson = json;
+		this.lastHighlightedBlock = payload.currentBlock;
 		this.pendingRender = payload;
 		if (this.webviewReady) {
 			void this.panel.webview.postMessage(payload);
 		}
 	}
 
-	private buildRenderPayload(ir: ParsedIr): RenderPayload | undefined {
+	private buildRenderPayload(ir: ParsedIr): Extract<ExtensionToWebview, { type: 'render' }> | undefined {
 		if (ir.functions.length === 0) {
 			return {
 				type: 'render',
@@ -162,8 +148,6 @@ export class GraphPanel {
 
 		const fnNames = ir.functions.map(f => f.name);
 		if (!this.activeFunction || !fnNames.includes(this.activeFunction)) {
-			// Default: prefer the function containing the cursor in the
-			// matching editor; otherwise fall back to the first function.
 			this.activeFunction = this.functionAtCursor(ir) ?? fnNames[0];
 		}
 		const graph = cfgFor(ir, this.activeFunction);
@@ -176,32 +160,27 @@ export class GraphPanel {
 			functions: fnNames,
 			activeFunction: graph.functionName,
 			blocks: graph.blocks,
-			currentBlock: this.currentBlock(),
+			currentBlock: this.currentBlockName(ir),
 		};
 	}
 
-	private functionAtCursor(ir: ParsedIr): string | undefined {
+	private cursorLine(): number | undefined {
 		const editor = vscode.window.visibleTextEditors.find(e => e.document === this.linkedDoc);
-		if (!editor) {
-			return undefined;
-		}
-		const line = editor.selection.active.line;
-		const fn = ir.functions.find(f => line >= f.headerLine && line <= f.bodyRange.end.line);
-		return fn?.name;
+		return editor?.selection.active.line;
 	}
 
-	private currentBlock(): string | null {
-		const editor = vscode.window.visibleTextEditors.find(e => e.document === this.linkedDoc);
-		if (!editor) {
+	private functionAtCursor(ir: ParsedIr): string | undefined {
+		const line = this.cursorLine();
+		return line === undefined ? undefined : functionAt(ir, line)?.name;
+	}
+
+	private currentBlockName(ir: ParsedIr): string | null {
+		const line = this.cursorLine();
+		if (line === undefined) {
 			return null;
 		}
-		const ir = irFor(this.linkedDoc);
-		const line = editor.selection.active.line;
-		const block = ir.blocks.find(b =>
-			b.functionName === this.activeFunction &&
-			line >= b.headerLine && line <= b.bodyRange.end.line,
-		);
-		return block?.name ?? null;
+		const block = blockAtLine(ir, line);
+		return block && block.functionName === this.activeFunction ? block.name : null;
 	}
 
 	private postCurrentBlockHighlight(line: number): void {
@@ -209,42 +188,40 @@ export class GraphPanel {
 			return;
 		}
 		const ir = irFor(this.linkedDoc);
-		// If the cursor moved into a different function, switch the rendered
-		// function so the highlight has somewhere to land.
-		const fn = ir.functions.find(f => line >= f.headerLine && line <= f.bodyRange.end.line);
+		const fn = functionAt(ir, line);
+		// Cursor moved into a different function → switch the rendered graph.
 		if (fn && fn.name !== this.activeFunction) {
 			this.activeFunction = fn.name;
 			this.scheduleRender(/* immediate */ true);
 			return;
 		}
-		const block = ir.blocks.find(b =>
-			b.functionName === this.activeFunction &&
-			line >= b.headerLine && line <= b.bodyRange.end.line,
-		);
-		const payload: HighlightPayload = { type: 'highlight', block: block?.name ?? null };
+		const block = blockAtLine(ir, line);
+		const name = block && block.functionName === this.activeFunction ? block.name : null;
+		if (name === this.lastHighlightedBlock) {
+			return; // no-op: cursor moved within the same block
+		}
+		this.lastHighlightedBlock = name;
+		const payload: ExtensionToWebview = { type: 'highlight', block: name };
 		void this.panel.webview.postMessage(payload);
 	}
 
-	private handleMessage(msg: { type: string; [k: string]: unknown }): void {
+	private handleMessage(msg: WebviewToExtension): void {
 		switch (msg.type) {
 		case 'ready':
 			this.webviewReady = true;
 			if (!this.pendingRender) {
-				const ir = irFor(this.linkedDoc);
-				this.pendingRender = this.buildRenderPayload(ir);
+				this.pendingRender = this.buildRenderPayload(irFor(this.linkedDoc));
 			}
 			if (this.pendingRender) {
 				void this.panel.webview.postMessage(this.pendingRender);
 			}
 			return;
 		case 'revealBlock':
-			void this.revealBlock(typeof msg.block === 'string' ? msg.block : '');
+			void this.revealBlock(msg.block);
 			return;
 		case 'selectFunction':
-			if (typeof msg.name === 'string') {
-				this.activeFunction = msg.name;
-				this.scheduleRender(/* immediate */ true);
-			}
+			this.activeFunction = msg.name;
+			this.scheduleRender(/* immediate */ true);
 			return;
 		case 'log':
 			if (msg.level === 'error') {
@@ -263,9 +240,8 @@ export class GraphPanel {
 			preserveFocus: false,
 		});
 		const ir = irFor(this.linkedDoc);
-		const block = ir.blocks.find(b =>
-			b.functionName === this.activeFunction && b.name === blockName,
-		) ?? ir.blocks.find(b => b.name === blockName);
+		const block = ir.functionByName.get(this.activeFunction ?? '')?.blockByName.get(blockName)
+			?? ir.blockByName.get(blockName);
 		if (!block) {
 			return;
 		}
@@ -325,6 +301,10 @@ export class GraphPanel {
 			try { d?.dispose(); } catch { /* ignore */ }
 		}
 	}
+}
+
+function titleFor(document: vscode.TextDocument): string {
+	return `Nautilus IR Graph — ${document.fileName.split(/[\\/]/).pop() ?? ''}`;
 }
 
 function randomNonce(): string {


### PR DESCRIPTION
Synthesizes a Mermaid flowchart from the parsed `.nautilus` text and
renders it in a side webview that is bidirectionally linked to the editor
(click a node to jump to the block; cursor movement highlights the
enclosing block). Works on any IR dump regardless of whether Nautilus was
run with `dump.graph=true`.