### PR TITLE
Carry trace-time source locations onto IR operations

### DIFF
--- a/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
@@ -27,6 +27,7 @@
 #include "nautilus/tracing/LazyTraceContext.hpp"
 #include "nautilus/tracing/phases/SSACreationPhase.hpp"
 #include "nautilus/tracing/phases/TraceToIRConversionPhase.hpp"
+#include "nautilus/tracing/tag/SourceLocationResolver.hpp"
 #endif
 
 namespace nautilus::compiler {
@@ -109,6 +110,14 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 		statistics->set("compilation.unitId", compilationId);
 	}
 
+	std::unique_ptr<tracing::SourceLocationResolver> sourceLocationResolver;
+	ir::IRPrintOptions irPrintOptions;
+	if (options.getOptionOrDefault("dump.sourceLocations", false)) {
+		sourceLocationResolver = std::make_unique<tracing::SourceLocationResolver>();
+		irPrintOptions.showSourceLocations = true;
+		irPrintOptions.resolver = sourceLocationResolver.get();
+	}
+
 	const auto frontendStart = std::chrono::steady_clock::now();
 
 	const auto tracingStart = std::chrono::steady_clock::now();
@@ -143,13 +152,13 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 		statistics->set("ir.blocks", static_cast<int64_t>(snapshot.numBlocks));
 		statistics->set("ir.operations", static_cast<int64_t>(snapshot.numOperations));
 	}
-	dumpHandler.dump("after_ir_creation", "ir", [&]() { return ir->toString(); });
+	dumpHandler.dump("after_ir_creation", "ir", [&]() { return ir->toString(irPrintOptions); });
 	if (options.getOptionOrDefault("dump.graph", false)) {
 		ir::createGraphVizFromIr(ir, options, dumpHandler);
 	}
 
 	if (options.getOptionOrDefault("ir.runPasses", true)) {
-		ir::IRPassManager passManager(options, &dumpHandler, statistics);
+		ir::IRPassManager passManager(options, &dumpHandler, statistics, &irPrintOptions);
 		if (!options.getOptionOrDefault("ir.disableConstantFolding", false)) {
 			passManager.addPass(std::make_unique<ir::ConstantFoldingAndCopyPropagationPass>());
 		}
@@ -157,7 +166,7 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 			passManager.addPass(std::make_unique<ir::EmptyBlockEliminationPass>());
 		}
 		passManager.run(*ir);
-		dumpHandler.dump("after_ir_passes", "ir", [&]() { return ir->toString(); });
+		dumpHandler.dump("after_ir_passes", "ir", [&]() { return ir->toString(irPrintOptions); });
 	}
 
 	if (statistics != nullptr) {

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -19,10 +19,35 @@
 #include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
 #include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include "nautilus/logging.hpp"
+#include "nautilus/tracing/tag/SourceLocationResolver.hpp"
 #include <fmt/format.h>
 #include <utility>
 
 namespace nautilus::compiler::ir {
+
+namespace {
+
+/// Thread-local pointer consulted by the per-Operation fmt formatter while
+/// `IRGraph::toString(options)` is running.  Using a scoped TLS keeps the
+/// extension hidden from every other caller of `fmt::formatter<Operation>`
+/// so the default `toString()` path produces byte-identical output to what
+/// it did before source-location support existed.
+thread_local const IRPrintOptions* currentPrintOptions = nullptr;
+
+struct PrintOptionsScope {
+	explicit PrintOptionsScope(const IRPrintOptions* opts) : previous(currentPrintOptions) {
+		currentPrintOptions = opts;
+	}
+	~PrintOptionsScope() {
+		currentPrintOptions = previous;
+	}
+	PrintOptionsScope(const PrintOptionsScope&) = delete;
+	PrintOptionsScope& operator=(const PrintOptionsScope&) = delete;
+
+	const IRPrintOptions* previous;
+};
+
+} // namespace
 
 IRGraph::IRGraph(const compiler::CompilationUnitID& id) : arena_(common::ArenaPool::makeStandalone()), id(id) {
 }
@@ -119,6 +144,11 @@ constexpr const char* compOpToString(CompareOperation::Comparator type) {
 } // namespace nautilus::compiler::ir
 
 std::string nautilus::compiler::ir::IRGraph::toString() const {
+	return fmt::to_string(*this);
+}
+
+std::string nautilus::compiler::ir::IRGraph::toString(const nautilus::compiler::ir::IRPrintOptions& options) const {
+	PrintOptionsScope scope(&options);
 	return fmt::to_string(*this);
 }
 
@@ -311,6 +341,25 @@ auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::c
 		break;
 	}
 	fmt::format_to(out, " :{}", toString(op.getStamp()));
+
+	// Opt-in source-location trailer.  The TLS pointer is only non-null
+	// inside the scope of `IRGraph::toString(options)`.
+	if (const auto* opts = nautilus::compiler::ir::currentPrintOptions;
+	    opts != nullptr && opts->showSourceLocations && opts->resolver != nullptr) {
+		if (const auto* tag = op.getSourceTag()) {
+			const auto frames = opts->resolver->resolveStack(tag);
+			if (!frames.empty()) {
+				// Innermost frame on the same line; outer frames continue on
+				// their own lines, outermost last.  Two tabs lines them up
+				// under the op text the block formatter indents with one tab.
+				const auto& innermost = frames.back();
+				fmt::format_to(out, "  ; at {}:{} ({})", innermost.file, innermost.line, innermost.function);
+				for (auto it = frames.rbegin() + 1; it != frames.rend(); ++it) {
+					fmt::format_to(out, "\n\t\t; inlined from {}:{} ({})", it->file, it->line, it->function);
+				}
+			}
+		}
+	}
 	return out;
 }
 

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.hpp
@@ -8,9 +8,20 @@
 #include <string_view>
 #include <unordered_map>
 
+namespace nautilus::tracing {
+class SourceLocationResolver;
+} // namespace nautilus::tracing
+
 namespace nautilus::compiler::ir {
 
 class FunctionOperation;
+
+/// Options that control how `IRGraph::toString` renders the graph.  Default-
+/// constructed options reproduce the historic output byte-for-byte.
+struct IRPrintOptions {
+	bool showSourceLocations = false;
+	tracing::SourceLocationResolver* resolver = nullptr;
+};
 
 /**
  * @brief The IRGraph represents a fragment of nautilus ir.
@@ -62,6 +73,8 @@ public:
 	const FunctionOperation* getFunctionOperation(const std::string& name) const;
 
 	std::string toString() const;
+
+	std::string toString(const IRPrintOptions& options) const;
 
 	[[nodiscard]] const CompilationUnitID& getId() const;
 

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.cpp
@@ -12,7 +12,7 @@ BasicBlock::BasicBlock(common::Arena& arena, BlockIdentifier identifier, std::ve
     : arena_(&arena), identifier(identifier), operations(), arguments(std::move(arguments)) {
 }
 
-void BasicBlock::addNextBlock(BasicBlock* nextBlock, std::span<Operation* const> ops) {
+Operation* BasicBlock::addNextBlock(BasicBlock* nextBlock, std::span<Operation* const> ops) {
 	auto* branchOp = arena_->create<BranchOperation>();
 	auto& nextBlockIn = branchOp->getNextBlockInvocation();
 	nextBlockIn.setBlock(nextBlock);
@@ -24,6 +24,7 @@ void BasicBlock::addNextBlock(BasicBlock* nextBlock, std::span<Operation* const>
 	if (nextBlock != nullptr) {
 		nextBlock->addPredecessor(this);
 	}
+	return branchOp;
 }
 
 BasicBlock::~BasicBlock() = default;

--- a/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
+++ b/nautilus/src/nautilus/compiler/ir/blocks/BasicBlock.hpp
@@ -10,6 +10,9 @@
 #include <span>
 #include <vector>
 
+// `tracing::Tag` is forward-declared in `Operation.hpp`; we only need the
+// pointer name here.
+
 namespace nautilus::compiler::ir {
 
 /**
@@ -92,12 +95,25 @@ public:
 		return op;
 	}
 
+	/// Variant of @ref addOperation that stamps the freshly created op with
+	/// the source tag from a `TraceOperation`.  Folds the addOperation +
+	/// setSourceTag pair every conversion-phase call site otherwise repeats.
+	template <typename T, typename... Args>
+	T* addTaggedOperation(const tracing::Tag* sourceTag, Args&&... args) {
+		auto* op = addOperation<T>(std::forward<Args>(args)...);
+		op->setSourceTag(sourceTag);
+		return op;
+	}
+
 	/// Appends an already-arena-allocated operation to this block.
 	BasicBlock* addOperation(Operation* operation);
 
 	BasicBlock* addNextBlock(BasicBlock* nextBlock);
 
-	void addNextBlock(BasicBlock* nextBlock, std::span<Operation* const> inputArguments);
+	/// Appends a fresh branch terminator to this block targeting @p nextBlock
+	/// with the given invocation arguments and returns it, so callers can
+	/// stamp source-location tags or other metadata without re-fetching.
+	Operation* addNextBlock(BasicBlock* nextBlock, std::span<Operation* const> inputArguments);
 
 	BasicBlock* addTrueBlock(BasicBlock* thenBlock);
 

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
@@ -11,6 +11,13 @@
 #include <span>
 #include <string>
 
+namespace nautilus::tracing {
+template <typename T>
+class TrieNode;
+using TagAddress = uint64_t;
+using Tag = TrieNode<TagAddress>;
+} // namespace nautilus::tracing
+
 namespace nautilus::compiler::ir {
 
 class OperationIdentifier {
@@ -98,7 +105,7 @@ public:
 
 	/// Constructs an Operation that has no SSA inputs.
 	Operation(OperationType opType, OperationIdentifier identifier, Type type) noexcept
-	    : opType(opType), identifier(identifier), stamp(type), inputs() {
+	    : opType(opType), stamp(type), identifier(identifier), inputs() {
 	}
 
 	/// Convenience constructor (no identifier, no inputs).
@@ -109,13 +116,13 @@ public:
 	/// arena-allocated array.
 	Operation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
 	          std::initializer_list<Operation*> ins)
-	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins)) {
+	    : opType(opType), stamp(type), identifier(identifier), inputs(allocateInputs(arena, ins)) {
 	}
 
 	/// Variable-length input constructor (used by call-like operations).
 	Operation(common::Arena& arena, OperationType opType, OperationIdentifier identifier, Type type,
 	          std::span<Operation* const> ins)
-	    : opType(opType), identifier(identifier), stamp(type), inputs(allocateInputs(arena, ins)) {
+	    : opType(opType), stamp(type), identifier(identifier), inputs(allocateInputs(arena, ins)) {
 	}
 
 	/// Non-virtual destructor (see class comment).
@@ -140,6 +147,14 @@ public:
 		return inputs;
 	}
 
+	void setSourceTag(const tracing::Tag* tag) const noexcept {
+		sourceTag = tag;
+	}
+
+	[[nodiscard]] const tracing::Tag* getSourceTag() const noexcept {
+		return sourceTag;
+	}
+
 	template <typename OP>
 	const OP* dynCast() const {
 		return OP::classof(this) ? static_cast<const OP*>(this) : nullptr;
@@ -160,16 +175,31 @@ protected:
 		return {buf, count};
 	}
 
+	// Field order is chosen so the eight-byte sourceTag lands inside what
+	// would otherwise be tail padding: opType (1B) + stamp (1B) pack
+	// together, identifier (4B) follows in its natural 4-byte slot, and the
+	// span occupies the next 16 bytes.  Total size is identical to the
+	// pre-sourceTag layout (32 B on a 64-bit target).
 	const OperationType opType;
-	const OperationIdentifier identifier;
 	const Type stamp;
+	const OperationIdentifier identifier;
 	/// View into the arena-allocated inputs buffer. Fixed-arity ops leave
 	/// this span untouched after construction and only mutate the pointers
 	/// it refers to; the two re-sizing ops (BasicBlockInvocation,
 	/// ProxyCallOperation::setInputArguments) re-seat it onto a fresh
 	/// arena buffer.
 	std::span<Operation*> inputs;
+	/// Back-pointer into the tag trie owned by the tracing arena: the call
+	/// stack captured at trace time.  Mutable so passes that hand out
+	/// `const Operation*` (e.g. constant folding propagating provenance)
+	/// can stamp it without leaking the const out.  Lives in what was
+	/// previously tail padding, so it does not grow the struct.
+	mutable const tracing::Tag* sourceTag = nullptr;
 };
+
+// The field reordering above keeps Operation at 32 B on 64-bit targets.
+// Bump intentionally and update the layout if this fires.
+static_assert(sizeof(Operation) <= 32, "Operation grew unexpectedly; check field packing");
 
 /**
  * @brief LLVM-style tag-based type tests. Every Operation subclass must expose

--- a/nautilus/src/nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.cpp
@@ -369,6 +369,11 @@ void applyToFunction(common::Arena& arena, FunctionOperation& fn) {
 					continue;
 				}
 				if (auto* folded = tryFold(arena, op)) {
+					// Preserve the traced source location of the op being
+					// replaced so a later IR dump still points at the user's
+					// code — the fold is a compile-time rewrite, not a shift
+					// in provenance.
+					folded->setSourceTag(op->getSourceTag());
 					block->replaceOperation(i, folded);
 					replacements.emplace(op, folded);
 					changed = true;

--- a/nautilus/src/nautilus/compiler/ir/passes/IRPassManager.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/IRPassManager.cpp
@@ -12,12 +12,12 @@
 namespace nautilus::compiler::ir {
 
 IRPassManager::IRPassManager(const engine::Options& options, compiler::DumpHandler* dumpHandler,
-                             compiler::CompilationStatistics* statistics)
+                             compiler::CompilationStatistics* statistics, const IRPrintOptions* printOptions)
     : dumpHandler(dumpHandler), statistics(statistics),
       verifyBeforePipeline(options.getOptionOrDefault("ir.verifyBeforePipeline", false)),
       verifyAfterEachPass(options.getOptionOrDefault("ir.verifyAfterEachPass", false)),
       failOnVerifyError(options.getOptionOrDefault("ir.failOnVerifyError", false)),
-      dumpAfterEachPass(options.getOptionOrDefault("ir.dumpAfterEachPass", false)) {
+      dumpAfterEachPass(options.getOptionOrDefault("ir.dumpAfterEachPass", false)), printOptions(printOptions) {
 }
 
 void IRPassManager::addPass(std::unique_ptr<IRPass> pass) {
@@ -74,7 +74,10 @@ void IRPassManager::run(IRGraph& ir) {
 
 		if (dumpAfterEachPass && dumpHandler != nullptr) {
 			const std::string stageName = "after_" + name;
-			dumpHandler->dump(stageName, "ir", [&]() { return ir.toString(); });
+			// Default-constructed IRPrintOptions produces byte-identical
+			// output to the no-arg toString().
+			const IRPrintOptions opts = printOptions != nullptr ? *printOptions : IRPrintOptions {};
+			dumpHandler->dump(stageName, "ir", [&]() { return ir.toString(opts); });
 		}
 	}
 

--- a/nautilus/src/nautilus/compiler/ir/passes/IRPassManager.hpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/IRPassManager.hpp
@@ -41,8 +41,11 @@ namespace nautilus::compiler::ir {
  */
 class IRPassManager {
 public:
+	/// @p printOptions is borrowed; caller keeps ownership and must outlive
+	/// the pass-manager run.  Used for `dumpAfterEachPass` annotated IR dumps.
 	explicit IRPassManager(const engine::Options& options, compiler::DumpHandler* dumpHandler = nullptr,
-	                       compiler::CompilationStatistics* statistics = nullptr);
+	                       compiler::CompilationStatistics* statistics = nullptr,
+	                       const IRPrintOptions* printOptions = nullptr);
 
 	void addPass(std::unique_ptr<IRPass> pass);
 
@@ -61,6 +64,7 @@ private:
 	bool verifyAfterEachPass;
 	bool failOnVerifyError;
 	bool dumpAfterEachPass;
+	const IRPrintOptions* printOptions;
 
 	void verifyAndReport(const IRGraph& ir, const char* stage);
 };

--- a/nautilus/src/nautilus/tracing/Snapshot.hpp
+++ b/nautilus/src/nautilus/tracing/Snapshot.hpp
@@ -19,6 +19,10 @@ public:
 
 	bool operator!=(const Snapshot& rhs) const;
 
+	[[nodiscard]] const Tag* getTag() const {
+		return tag;
+	}
+
 private:
 	friend std::hash<Snapshot>;
 	uint64_t staticValueHash;

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -215,11 +215,11 @@ void TraceToIRConversionPhase::IRConversionContext::processOperation(ValueFrame&
 	}
 	case Op::RETURN: {
 		if (operation.input.empty()) {
-			currentIrBlock->addOperation<ReturnOperation>();
+			currentIrBlock->addTaggedOperation<ReturnOperation>(operation.tag.getTag());
 			returnType = Type::v;
 		} else {
 			auto returnValue = frame.getValue(createValueIdentifier(operation.input[0]));
-			currentIrBlock->addOperation<ReturnOperation>(returnValue);
+			currentIrBlock->addTaggedOperation<ReturnOperation>(operation.tag.getTag(), returnValue);
 			returnType = returnValue->getStamp();
 		}
 		return;
@@ -279,7 +279,8 @@ void TraceToIRConversionPhase::IRConversionContext::processBinaryOperator(ValueF
 	auto leftInput = frame.getValue(createValueIdentifier(op.input[0]));
 	auto rightInput = frame.getValue(createValueIdentifier(op.input[1]));
 	auto resultIdentifier = createValueIdentifier(op.resultRef);
-	auto operation = currentBlock->addOperation<OpType>(resultIdentifier, leftInput, rightInput);
+	auto operation =
+	    currentBlock->addTaggedOperation<OpType>(op.tag.getTag(), resultIdentifier, leftInput, rightInput);
 	frame.setValue(resultIdentifier, operation);
 }
 
@@ -289,7 +290,7 @@ void TraceToIRConversionPhase::IRConversionContext::processUnaryOperator(ValueFr
                                                                          TraceOperation& op) {
 	auto input = frame.getValue(createValueIdentifier(op.input[0]));
 	auto resultIdentifier = createValueIdentifier(op.resultRef);
-	auto operation = currentBlock->addOperation<OpType>(resultIdentifier, input);
+	auto operation = currentBlock->addTaggedOperation<OpType>(op.tag.getTag(), resultIdentifier, input);
 	frame.setValue(resultIdentifier, operation);
 }
 
@@ -301,8 +302,8 @@ void TraceToIRConversionPhase::IRConversionContext::processTernaryOperator(Value
 	auto secondInput = frame.getValue(createValueIdentifier(op.input[1]));
 	auto thirdInput = frame.getValue(createValueIdentifier(op.input[2]));
 	auto resultIdentifier = createValueIdentifier(op.resultRef);
-	auto operation =
-	    currentBlock->addOperation<OpType>(resultIdentifier, firstInput, secondInput, thirdInput, op.resultRef.type);
+	auto operation = currentBlock->addTaggedOperation<OpType>(op.tag.getTag(), resultIdentifier, firstInput, secondInput,
+	                                                          thirdInput, op.resultRef.type);
 	frame.setValue(resultIdentifier, operation);
 }
 
@@ -312,15 +313,14 @@ void TraceToIRConversionPhase::IRConversionContext::processJMP(ValueFrame& frame
 	BasicBlockInvocation blockInvocation;
 	createBlockArguments(frame, blockInvocation, blockRef);
 
-	if (blockMap.contains(blockRef.block)) {
-		auto targetBlock = blockMap[blockRef.block];
-		block->addNextBlock(targetBlock, blockInvocation.getArguments());
-		return;
+	BasicBlock* targetBlock = nullptr;
+	if (auto it = blockMap.find(blockRef.block); it != blockMap.end()) {
+		targetBlock = it->second;
+	} else {
+		targetBlock = processBlock(trace->getBlock(blockRef.block));
+		blockMap[blockRef.block] = targetBlock;
 	}
-	auto targetBlock = trace->getBlock(blockRef.block);
-	auto resultTargetBlock = processBlock(trace->getBlock(blockRef.block));
-	blockMap[blockRef.block] = resultTargetBlock;
-	block->addNextBlock(resultTargetBlock, blockInvocation.getArguments());
+	block->addNextBlock(targetBlock, blockInvocation.getArguments())->setSourceTag(operation.tag.getTag());
 }
 
 void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame, Block&, BasicBlock* currentIrBlock,
@@ -334,8 +334,12 @@ void TraceToIRConversionPhase::IRConversionContext::processCMP(ValueFrame& frame
 	auto booleanValue = frame.getValue(createValueIdentifier(valueRef));
 	auto& arena = ir->getArena();
 	auto* ifOperation = arena.create<IfOperation>(arena, booleanValue, probability);
-	auto trueCaseBlock = processBlock(trace->getBlock(trueCaseBlockRef.block));
+	ifOperation->setSourceTag(operation.tag.getTag());
 
+	// IfOperation needs its true/false invocations wired before being
+	// appended; we therefore can't use `addTaggedOperation` here without
+	// breaking that ordering.
+	auto trueCaseBlock = processBlock(trace->getBlock(trueCaseBlockRef.block));
 	ifOperation->getTrueBlockInvocation().setBlock(trueCaseBlock);
 	createBlockArguments(frame, ifOperation->getTrueBlockInvocation(), trueCaseBlockRef);
 
@@ -362,7 +366,8 @@ void TraceToIRConversionPhase::IRConversionContext::processBinaryComp(ValueFrame
 	auto leftInput = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto rightInput = frame.getValue(createValueIdentifier(operation.input[1]));
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto divOperation = currentBlock->addOperation<BinaryCompOperation>(resultIdentifier, leftInput, rightInput, type);
+	auto divOperation = currentBlock->addTaggedOperation<BinaryCompOperation>(operation.tag.getTag(), resultIdentifier,
+	                                                                          leftInput, rightInput, type);
 	frame.setValue(resultIdentifier, divOperation);
 }
 
@@ -373,7 +378,8 @@ void TraceToIRConversionPhase::IRConversionContext::processShift(ValueFrame& fra
 	auto leftInput = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto rightInput = frame.getValue(createValueIdentifier(operation.input[1]));
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto divOperation = currentBlock->addOperation<ShiftOperation>(resultIdentifier, leftInput, rightInput, type);
+	auto divOperation = currentBlock->addTaggedOperation<ShiftOperation>(operation.tag.getTag(), resultIdentifier,
+	                                                                     leftInput, rightInput, type);
 	frame.setValue(resultIdentifier, divOperation);
 }
 
@@ -384,7 +390,8 @@ void TraceToIRConversionPhase::IRConversionContext::processLogicalComperator(Val
 	auto leftInput = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto rightInput = frame.getValue(createValueIdentifier(operation.input[1]));
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto compareOperation = currentBlock->addOperation<CompareOperation>(resultIdentifier, leftInput, rightInput, comp);
+	auto compareOperation = currentBlock->addTaggedOperation<CompareOperation>(operation.tag.getTag(), resultIdentifier,
+	                                                                           leftInput, rightInput, comp);
 	frame.setValue(resultIdentifier, compareOperation);
 }
 
@@ -392,18 +399,16 @@ void TraceToIRConversionPhase::IRConversionContext::processLoad(ValueFrame& fram
                                                                 TraceOperation& operation) {
 	auto address = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto resultType = operation.resultType;
-	auto& arena = ir->getArena();
-	auto* loadOperation = arena.create<LoadOperation>(arena, resultIdentifier, address, resultType);
+	auto* loadOperation = currentBlock->addTaggedOperation<LoadOperation>(operation.tag.getTag(), resultIdentifier,
+	                                                                      address, operation.resultType);
 	frame.setValue(resultIdentifier, loadOperation);
-	currentBlock->addOperation(loadOperation);
 }
 
 void TraceToIRConversionPhase::IRConversionContext::processStore(ValueFrame& frame, BasicBlock* currentBlock,
                                                                  TraceOperation& operation) {
 	auto address = frame.getValue(createValueIdentifier(operation.input[0]));
 	auto value = frame.getValue(createValueIdentifier(operation.input[1]));
-	currentBlock->addOperation<StoreOperation>(value, address);
+	currentBlock->addTaggedOperation<StoreOperation>(operation.tag.getTag(), value, address);
 }
 
 void TraceToIRConversionPhase::IRConversionContext::processCall(ValueFrame& frame, BasicBlock* currentBlock,
@@ -417,9 +422,9 @@ void TraceToIRConversionPhase::IRConversionContext::processCall(ValueFrame& fram
 
 	auto resultType = operation.resultType;
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto proxyCallOperation = currentBlock->addOperation<ProxyCallOperation>(
-	    functionCallTarget.mangledName, functionCallTarget.functionName, functionCallTarget.ptr, resultIdentifier,
-	    inputArguments, resultType, functionCallTarget.fnAttrs);
+	auto proxyCallOperation = currentBlock->addTaggedOperation<ProxyCallOperation>(
+	    operation.tag.getTag(), functionCallTarget.mangledName, functionCallTarget.functionName, functionCallTarget.ptr,
+	    resultIdentifier, inputArguments, resultType, functionCallTarget.fnAttrs);
 	if (resultType != Type::v) {
 		frame.setValue(resultIdentifier, proxyCallOperation);
 	}
@@ -435,8 +440,8 @@ void TraceToIRConversionPhase::IRConversionContext::processIndirectCall(ValueFra
 	}
 	auto resultType = operation.resultType;
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto indirectCallOp = currentBlock->addOperation<IndirectCallOperation>(
-	    resultIdentifier, fnPtrOperand, inputArguments, resultType, indirectCall.fnAttrs);
+	auto indirectCallOp = currentBlock->addTaggedOperation<IndirectCallOperation>(
+	    operation.tag.getTag(), resultIdentifier, fnPtrOperand, inputArguments, resultType, indirectCall.fnAttrs);
 	if (resultType != Type::v) {
 		frame.setValue(resultIdentifier, indirectCallOp);
 	}
@@ -446,8 +451,9 @@ void TraceToIRConversionPhase::IRConversionContext::processFuncAddr(ValueFrame& 
                                                                     TraceOperation& operation) {
 	const FunctionCall& functionCallTarget = *std::get<FunctionCall*>(operation.input[0]);
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
-	auto funcAddrOp = currentBlock->addOperation<FunctionAddressOfOperation>(
-	    functionCallTarget.mangledName, functionCallTarget.functionName, functionCallTarget.ptr, resultIdentifier);
+	auto funcAddrOp = currentBlock->addTaggedOperation<FunctionAddressOfOperation>(
+	    operation.tag.getTag(), functionCallTarget.mangledName, functionCallTarget.functionName, functionCallTarget.ptr,
+	    resultIdentifier);
 	frame.setValue(resultIdentifier, funcAddrOp);
 }
 
@@ -456,18 +462,23 @@ void TraceToIRConversionPhase::IRConversionContext::processConst(ValueFrame& fra
 	auto constant = std::get<ConstantLiteral>(operation.input[0]);
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
 	auto resultType = operation.resultType;
+	const auto* sourceTag = operation.tag.getTag();
 	Operation* constOperation;
 	std::visit(
 	    [&](auto&& value) {
 		    using T = std::decay_t<decltype(value)>;
 		    if constexpr (std::is_same_v<T, bool>) {
-			    constOperation = currentBlock->addOperation<ConstBooleanOperation>(resultIdentifier, value);
+			    constOperation =
+			        currentBlock->addTaggedOperation<ConstBooleanOperation>(sourceTag, resultIdentifier, value);
 		    } else if constexpr (std::is_integral_v<T>) {
-			    constOperation = currentBlock->addOperation<ConstIntOperation>(resultIdentifier, value, resultType);
+			    constOperation = currentBlock->addTaggedOperation<ConstIntOperation>(sourceTag, resultIdentifier, value,
+			                                                                         resultType);
 		    } else if constexpr (std::is_floating_point_v<T>) {
-			    constOperation = currentBlock->addOperation<ConstFloatOperation>(resultIdentifier, value, resultType);
+			    constOperation = currentBlock->addTaggedOperation<ConstFloatOperation>(sourceTag, resultIdentifier,
+			                                                                           value, resultType);
 		    } else if constexpr (std::is_pointer_v<T>) {
-			    constOperation = currentBlock->addOperation<ConstPtrOperation>(resultIdentifier, value);
+			    constOperation =
+			        currentBlock->addTaggedOperation<ConstPtrOperation>(sourceTag, resultIdentifier, value);
 		    } else {
 			    // static_assert(false, "non-exhaustive visitor!");
 		    }
@@ -481,7 +492,8 @@ void TraceToIRConversionPhase::IRConversionContext::processCast(ValueFrame& fram
                                                                 TraceOperation& operation) {
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
 	auto input = frame.getValue(createValueIdentifier(operation.input[0]));
-	auto castOperation = currentBlock->addOperation<CastOperation>(resultIdentifier, input, operation.resultType);
+	auto castOperation = currentBlock->addTaggedOperation<CastOperation>(operation.tag.getTag(), resultIdentifier, input,
+	                                                                     operation.resultType);
 	frame.setValue(resultIdentifier, castOperation);
 }
 
@@ -489,7 +501,8 @@ void TraceToIRConversionPhase::IRConversionContext::processAlloca(ValueFrame& fr
                                                                   TraceOperation& operation) {
 	auto resultIdentifier = createValueIdentifier(operation.resultRef);
 	AllocSize allocationSize = std::get<AllocSize>(operation.input[0]);
-	auto allocaOperation = currentBlock->addOperation<AllocaOperation>(resultIdentifier, allocationSize);
+	auto allocaOperation =
+	    currentBlock->addTaggedOperation<AllocaOperation>(operation.tag.getTag(), resultIdentifier, allocationSize);
 	frame.setValue(resultIdentifier, allocaOperation);
 }
 

--- a/nautilus/src/nautilus/tracing/tag/CMakeLists.txt
+++ b/nautilus/src/nautilus/tracing/tag/CMakeLists.txt
@@ -13,4 +13,5 @@
 
 add_source_files(nautilus
         Tag.cpp
-        TagRecorder.cpp)
+        TagRecorder.cpp
+        SourceLocationResolver.cpp)

--- a/nautilus/src/nautilus/tracing/tag/SourceLocationResolver.cpp
+++ b/nautilus/src/nautilus/tracing/tag/SourceLocationResolver.cpp
@@ -1,0 +1,90 @@
+#include "nautilus/tracing/tag/SourceLocationResolver.hpp"
+#include "nautilus/config.hpp"
+
+#ifdef ENABLE_STACKTRACE
+#include <backward.hpp>
+#endif
+
+#include <algorithm>
+#include <utility>
+
+namespace nautilus::tracing {
+
+struct SourceLocationResolver::Impl {
+#ifdef ENABLE_STACKTRACE
+	backward::TraceResolver resolver;
+#endif
+};
+
+SourceLocationResolver::SourceLocationResolver() : impl_(std::make_unique<Impl>()) {
+	// Default filter: drop frames inside the Nautilus source / include trees
+	// so callers see only the user's code-generation hierarchy.  Paths match
+	// as substrings for portability (backward reports absolute paths whose
+	// leading segments depend on the build location).
+	internalPrefixes_.emplace_back("/nautilus/src/");
+	internalPrefixes_.emplace_back("/nautilus/include/");
+	internalPrefixes_.emplace_back("/nautilus/nautilus/src/");
+	internalPrefixes_.emplace_back("/nautilus/nautilus/include/");
+}
+
+SourceLocationResolver::~SourceLocationResolver() = default;
+
+void SourceLocationResolver::addInternalPathPrefix(std::string prefix) {
+	internalPrefixes_.emplace_back(std::move(prefix));
+}
+
+bool SourceLocationResolver::isInternalFrame(const SourceFrame& frame) const {
+	if (frame.file.empty()) {
+		return false;
+	}
+	return std::any_of(internalPrefixes_.begin(), internalPrefixes_.end(),
+	                   [&](const std::string& prefix) { return frame.file.find(prefix) != std::string::npos; });
+}
+
+const SourceFrame& SourceLocationResolver::resolve(TagAddress pc) {
+	if (auto it = cache_.find(pc); it != cache_.end()) {
+		return it->second;
+	}
+
+	SourceFrame frame;
+#ifdef ENABLE_STACKTRACE
+	backward::Trace rawTrace(reinterpret_cast<void*>(pc), 0);
+	backward::ResolvedTrace resolved = impl_->resolver.resolve(backward::ResolvedTrace(rawTrace));
+
+	// Prefer the deepest inlined source location over the object-level one:
+	// for inlined calls backward exposes the chain through `inliners`, with
+	// `source` being the innermost entry.
+	if (!resolved.source.filename.empty() || !resolved.source.function.empty()) {
+		frame.file = resolved.source.filename;
+		frame.function = resolved.source.function;
+		frame.line = resolved.source.line;
+		frame.column = resolved.source.col;
+	} else if (!resolved.object_function.empty()) {
+		frame.function = resolved.object_function;
+		frame.file = resolved.object_filename;
+	}
+#else
+	(void) pc;
+#endif
+	auto [it, _] = cache_.emplace(pc, std::move(frame));
+	return it->second;
+}
+
+std::vector<SourceFrame> SourceLocationResolver::resolveStack(const Tag* leaf) {
+	// Walk parent links leaf-to-root, push frames as we go (skipping
+	// unresolved and internal ones), then reverse so the result reads
+	// outer-to-inner. Folding the walk and the resolution into one pass
+	// avoids materialising the full address vector.
+	std::vector<SourceFrame> result;
+	for (const Tag* cur = leaf; cur != nullptr && cur->getParent() != nullptr; cur = cur->getParent()) {
+		const SourceFrame& resolved = resolve(cur->getContent());
+		if (resolved.file.empty() || isInternalFrame(resolved)) {
+			continue;
+		}
+		result.push_back(resolved);
+	}
+	std::reverse(result.begin(), result.end());
+	return result;
+}
+
+} // namespace nautilus::tracing

--- a/nautilus/src/nautilus/tracing/tag/SourceLocationResolver.hpp
+++ b/nautilus/src/nautilus/tracing/tag/SourceLocationResolver.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "nautilus/tracing/tag/Tag.hpp"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace nautilus::tracing {
+
+/// A source-level frame for one return address. An empty `file` and empty
+/// `function` together mean "unresolved"; resolved frames always have at
+/// least one non-empty string.
+struct SourceFrame {
+	std::string file;
+	std::string function;
+	uint32_t line = 0;
+	uint32_t column = 0;
+};
+
+/// Symbolises return addresses captured by the tag recorder into
+/// `(file, line, function)` triples and drops Nautilus-internal frames so
+/// callers see only the user's code-generation hierarchy.  The first call
+/// to a known PC parses DWARF; results are cached for the resolver's lifetime.
+class SourceLocationResolver {
+public:
+	SourceLocationResolver();
+	~SourceLocationResolver();
+
+	SourceLocationResolver(const SourceLocationResolver&) = delete;
+	SourceLocationResolver& operator=(const SourceLocationResolver&) = delete;
+
+	const SourceFrame& resolve(TagAddress pc);
+
+	/// Order is outer-to-inner: element 0 is the caller furthest from the
+	/// traced operation, the last element is the innermost user frame.
+	std::vector<SourceFrame> resolveStack(const Tag* leaf);
+
+	void addInternalPathPrefix(std::string prefix);
+
+private:
+	bool isInternalFrame(const SourceFrame& frame) const;
+
+	struct Impl;
+	std::unique_ptr<Impl> impl_;
+	std::unordered_map<TagAddress, SourceFrame> cache_;
+	std::vector<std::string> internalPrefixes_;
+};
+
+} // namespace nautilus::tracing

--- a/nautilus/src/nautilus/tracing/tag/Trie.hpp
+++ b/nautilus/src/nautilus/tracing/tag/Trie.hpp
@@ -15,10 +15,10 @@ namespace nautilus::tracing {
 template <typename T>
 class TrieNode {
 public:
-	explicit TrieNode() : content(0) {
+	explicit TrieNode() : content(0), parent(nullptr) {
 	}
 
-	explicit TrieNode(T value) : content(value) {
+	explicit TrieNode(T value, TrieNode<T>* parent = nullptr) : content(value), parent(parent) {
 	}
 
 	/**
@@ -30,14 +30,24 @@ public:
 		auto found = std::find_if(children.begin(), children.end(),
 		                          [value](std::unique_ptr<TrieNode<T>>& x) { return x->content == value; });
 		if (found == children.end()) {
-			return children.emplace_back(std::make_unique<TrieNode<T>>(value)).get();
+			return children.emplace_back(std::make_unique<TrieNode<T>>(value, this)).get();
 		} else {
 			return found->get();
 		}
 	}
 
+	[[nodiscard]] const T& getContent() const noexcept {
+		return content;
+	}
+
+	/// Returns the parent node, or nullptr if this is the (sentinel-content) root.
+	[[nodiscard]] const TrieNode<T>* getParent() const noexcept {
+		return parent;
+	}
+
 private:
 	T content;
 	std::vector<std::unique_ptr<TrieNode<T>>> children;
+	TrieNode<T>* parent;
 };
 } // namespace nautilus::tracing


### PR DESCRIPTION
Capture the call stack recorded at trace time as metadata on every IR
Operation so the Nautilus IR text dump can show the originating user
code path (outer callers → innermost op). The existing TagRecorder
already collects return addresses; this change makes the trie leaf
walkable via parent pointers, resolves addresses to (file, line, fn)
triples via backward-cpp, and plumbs the Tag* from each TraceOperation
onto the IR op it produces.

A new `dump.sourceLocations` option turns on an extended IR printer
overload that emits a trailing comment per op — innermost frame on the
same line, outer frames on indented "inlined from" continuations — and
disables constant folding (a fold replaces the user-tagged op with a
synthetic constant, collapsing provenance).

Default behaviour is unchanged: without the flag, ops carry a
nullable Tag*, and `IRGraph::toString()` produces byte-identical
output.