### PR TITLE
vscode-nautilus-ir: render SSA values inline while debugging

### DIFF
--- a/tools/vscode-nautilus-ir/README.md
+++ b/tools/vscode-nautilus-ir/README.md
@@ -121,6 +121,12 @@ The extension contributes a `nautilus-ir-gdb` debug adapter that drives
   they remain pending until the JIT registers symbols for the IR file.
 - Step over / into / out, continue, pause, restart.
 - Live **Variables** view (locals, arguments, registers).
+- **Inline values** — while stopped, the live value of every SSA `$N`,
+  function parameter, and block argument is displayed next to its
+  definition in the editor (only for definitions at or above the current
+  stop line, since later defs have not yet been computed). Nautilus emits
+  each IR value `$N` into DWARF as a local named `vN`; the extension
+  rewrites the lookup automatically. Toggle via `nautilusIr.inlineValues`.
 - **Watch** and **Hover** evaluation via `data-evaluate-expression`.
 - Stack trace and frame navigation across host C++ ↔ JIT'd IR frames.
 - Console / stdout / stderr forwarded from gdb and the inferior.
@@ -188,6 +194,7 @@ honored so gdb can locate the IR source.
 | `nautilusIr.highlightDefinitions`    | `true`  | Highlight all uses of an SSA value when the cursor is on its definition.         |
 | `nautilusIr.codeLens`                | `true`  | Show CodeLens above every block.                                                 |
 | `nautilusIr.graph.autoOpen`          | `false` | Open the graph view automatically when a `.nautilus` file is opened.             |
+| `nautilusIr.inlineValues`            | `true`  | Show SSA values inline next to their definitions while debugging.                |
 | `nautilusIr.lastHostProgram`         | `""`    | Remembered host program for the ad-hoc "Debug Current File" command.             |
 
 ### Commands

--- a/tools/vscode-nautilus-ir/package.json
+++ b/tools/vscode-nautilus-ir/package.json
@@ -123,6 +123,11 @@
 					"default": true,
 					"description": "Show CodeLens above blocks (predecessors / successors / argument count)."
 				},
+				"nautilusIr.inlineValues": {
+					"type": "boolean",
+					"default": true,
+					"description": "While debugging, show the live value of each SSA $N next to its definition (and parameters / block arguments). Values are resolved through gdb against Nautilus's DWARF locals (which name $N as vN)."
+				},
 				"nautilusIr.lastHostProgram": {
 					"type": "string",
 					"default": "",

--- a/tools/vscode-nautilus-ir/src/extension.ts
+++ b/tools/vscode-nautilus-ir/src/extension.ts
@@ -9,6 +9,7 @@ import {
 	IrFoldingProvider,
 	IrRenameProvider,
 	IrCodeLensProvider,
+	IrInlineValuesProvider,
 	irFor,
 } from './features';
 import { GdbDescriptorFactory } from './debugAdapter';
@@ -26,6 +27,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.languages.registerFoldingRangeProvider(SELECTOR, new IrFoldingProvider()),
 		vscode.languages.registerRenameProvider(SELECTOR, new IrRenameProvider()),
 		vscode.languages.registerCodeLensProvider(SELECTOR, new IrCodeLensProvider()),
+		vscode.languages.registerInlineValuesProvider(SELECTOR, new IrInlineValuesProvider()),
 	);
 
 	// Diagnostics: light static checks (undefined SSA references, dangling branches).

--- a/tools/vscode-nautilus-ir/src/features.ts
+++ b/tools/vscode-nautilus-ir/src/features.ts
@@ -406,6 +406,105 @@ export class IrRenameProvider implements vscode.RenameProvider {
 	}
 }
 
+// ----- InlineValuesProvider: show SSA value contents next to their defs while debugging -----
+//
+// While stopped in gdb, VS Code asks the provider for variable values to render
+// inline in the editor. Nautilus emits each IR SSA value `$N` into DWARF as a
+// local named `vN`, so we rewrite the IR's `$N` -> `vN` and let VS Code route
+// the lookup through our debug adapter's evaluateRequest, which forwards to
+// `-data-evaluate-expression`.
+//
+// We only emit values for definitions/arguments at or above the stopped line —
+// SSA values defined later have not yet been computed, so showing them would be
+// misleading (gdb would either return optimised-out or a stale frame value).
+
+export class IrInlineValuesProvider implements vscode.InlineValuesProvider {
+	provideInlineValues(
+		document: vscode.TextDocument,
+		viewPort: vscode.Range,
+		context: vscode.InlineValueContext,
+	): vscode.InlineValue[] {
+		const config = vscode.workspace.getConfiguration('nautilusIr');
+		if (!config.get<boolean>('inlineValues', true)) {
+			return [];
+		}
+		const ir = irFor(document);
+		const stoppedLine = context.stoppedLocation.start.line;
+		const fn = functionAt(ir, stoppedLine);
+		if (!fn) {
+			return [];
+		}
+		const startLine = Math.max(viewPort.start.line, fn.headerLine);
+		const endLine = Math.min(viewPort.end.line, fn.bodyRange.end.line);
+		const out: vscode.InlineValue[] = [];
+
+		const inRange = (line: number): boolean =>
+			line >= startLine && line <= endLine && line <= stoppedLine;
+
+		// Function parameters appear on the function header line. Nautilus
+		// emits one DWARF dbg.declare per function arg whose store location
+		// points at this line, so the value is bound here.
+		const paramNames = new Set(fn.args.map(a => a.name));
+		if (inRange(fn.headerLine) && fn.args.length > 0) {
+			const headerText = document.lineAt(fn.headerLine).text;
+			for (const param of fn.args) {
+				const range = locateName(headerText, fn.headerLine, param.name);
+				if (range) {
+					out.push(new vscode.InlineValueEvaluatableExpression(range, dwarfNameFor(param.name)));
+				}
+			}
+		}
+
+		// SSA definitions: `$N = …`
+		for (const def of fn.definitions.values()) {
+			if (!inRange(def.line)) {
+				continue;
+			}
+			const range = new vscode.Range(def.line, def.character, def.line, def.character + def.name.length);
+			out.push(new vscode.InlineValueEvaluatableExpression(range, dwarfNameFor(def.name)));
+		}
+
+		// Block arguments appear on each block's header line. The entry
+		// block's args ARE the function's parameters (same SSA values, same
+		// DWARF scope), so skip those here when we already rendered them on
+		// the function header — otherwise we emit each param's value twice
+		// on adjacent lines.
+		const entryBlock = fn.blocks[0];
+		for (const block of fn.blocks) {
+			if (!inRange(block.headerLine)) {
+				continue;
+			}
+			const headerText = document.lineAt(block.headerLine).text;
+			const isEntry = block === entryBlock;
+			for (const arg of block.args) {
+				if (isEntry && paramNames.has(arg.name)) {
+					continue;
+				}
+				const range = locateName(headerText, block.headerLine, arg.name);
+				if (range) {
+					out.push(new vscode.InlineValueEvaluatableExpression(range, dwarfNameFor(arg.name)));
+				}
+			}
+		}
+
+		return out;
+	}
+}
+
+// Nautilus emits SSA value `$N` into DWARF as a local named `vN`.
+function dwarfNameFor(ssa: string): string {
+	return ssa.startsWith('$') ? `v${ssa.slice(1)}` : ssa;
+}
+
+function locateName(lineText: string, lineNumber: number, name: string): vscode.Range | undefined {
+	const re = new RegExp(`\\${name}\\b`);
+	const m = re.exec(lineText);
+	if (!m) {
+		return undefined;
+	}
+	return new vscode.Range(lineNumber, m.index, lineNumber, m.index + name.length);
+}
+
 // ----- CodeLensProvider: show predecessor/successor counts above each block -----
 
 export class IrCodeLensProvider implements vscode.CodeLensProvider {


### PR DESCRIPTION
Adds an InlineValuesProvider that emits an evaluatable expression for
every SSA definition, function parameter, and block argument visible at
or above the current stop line. Nautilus emits IR value $N into DWARF
as a local named vN, so the provider rewrites $N -> vN and lets gdb
resolve the value via the existing data-evaluate-expression path.

Gated by nautilusIr.inlineValues (default true).