### PR TITLE
Harden CUDA backend for production use

### DIFF
--- a/plugins/gpu/src/GPULoweringProviderBase.hpp
+++ b/plugins/gpu/src/GPULoweringProviderBase.hpp
@@ -84,7 +84,14 @@ inline void registerLaunchConfigIntrinsic(std::unordered_map<void*, IntrinsicHan
 	map[fnPtr] = [&outX, &outY, &outZ, &hasConfig](ir::ProxyCallOperation* call, short, RegisterFrame& frame,
 	                                               std::stringstream&, std::vector<std::stringstream>&,
 	                                               std::string (*)(const ir::OperationIdentifier&)) -> bool {
-		auto inputArgs = call->getInputArguments();
+		const auto& inputArgs = call->getInputArguments();
+		// setGrid / setBlock are always emitted with exactly three uint32_t dims
+		// by gpu::launch. Anything else means the caller is using these intrinsics
+		// directly, which is unsupported.
+		if (inputArgs.size() != 3) {
+			throw RuntimeException("GPU launch config intrinsic expected 3 arguments, got " +
+			                       std::to_string(inputArgs.size()));
+		}
 		outX = frame.getValue(inputArgs[0]->getIdentifier());
 		outY = frame.getValue(inputArgs[1]->getIdentifier());
 		outZ = frame.getValue(inputArgs[2]->getIdentifier());

--- a/plugins/gpu/src/cuda/CUDACompilationBackend.cpp
+++ b/plugins/gpu/src/cuda/CUDACompilationBackend.cpp
@@ -15,8 +15,7 @@ std::unique_ptr<Executable> CUDACompilationBackend::compile(const std::shared_pt
 
 	std::string identifier = "nautilus_cuda_" + ir->getId();
 
-	// Compile .cu to shared library via nvcc
-	auto lib = CUDACompiler::compile(identifier, code);
+	auto lib = CUDACompiler::compile(identifier, code, options);
 	return std::make_unique<CUDAExecutable>(lib);
 }
 

--- a/plugins/gpu/src/cuda/CUDACompiler.cpp
+++ b/plugins/gpu/src/cuda/CUDACompiler.cpp
@@ -1,95 +1,180 @@
 
 #include "CUDACompiler.hpp"
 #include "nautilus/common/File.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <random>
 #include <sstream>
-#include <stdexcept>
+#include <string>
+#include <unistd.h>
 
 namespace nautilus::compiler::cuda {
 
-std::string CUDACompiler::findNvcc() {
-	// Try the PATH first
-	auto tryWhich = [](const std::string& name) -> std::string {
-		std::string cmd = "which " + name + " 2>/dev/null";
-		FILE* fp = popen(cmd.c_str(), "r");
-		if (!fp) {
-			return {};
-		}
-		char buf[512];
-		std::string result;
-		while (fgets(buf, sizeof(buf), fp) != nullptr) {
-			result += buf;
-		}
-		if (pclose(fp) == 0 && !result.empty()) {
-			while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
-				result.pop_back();
-			}
-			return result;
-		}
-		return {};
-	};
-
-	auto path = tryWhich("nvcc");
-	if (!path.empty()) {
-		return path;
-	}
-
-	// Common CUDA installation paths
-	for (auto& candidate : {"/usr/local/cuda/bin/nvcc", "/opt/cuda/bin/nvcc"}) {
-		if (std::filesystem::exists(candidate)) {
-			return candidate;
+std::string CUDACompiler::shellQuote(const std::string& s) {
+	// Wrap in single quotes for /bin/sh and escape any embedded single quotes
+	// using the standard 'foo'\''bar' trick. This is the safe form that works
+	// even with paths containing spaces, $, ;, &, etc.
+	std::string out;
+	out.reserve(s.size() + 2);
+	out.push_back('\'');
+	for (char c : s) {
+		if (c == '\'') {
+			out += "'\\''";
+		} else {
+			out.push_back(c);
 		}
 	}
-
-	// Check CUDA_HOME environment variable
-	if (auto* cudaHome = std::getenv("CUDA_HOME")) {
-		auto candidate = std::string(cudaHome) + "/bin/nvcc";
-		if (std::filesystem::exists(candidate)) {
-			return candidate;
-		}
-	}
-
-	throw std::runtime_error("CUDACompiler: could not find 'nvcc'. Ensure CUDA toolkit is installed.");
+	out.push_back('\'');
+	return out;
 }
 
-cpp::SharedLibraryPtr CUDACompiler::compile(const std::string& identifier, const std::string& code) {
-	auto tmpDir = std::filesystem::temp_directory_path();
-	auto sourceFileName = (tmpDir / (identifier + ".cu")).string();
-	auto libraryFileName = (tmpDir / (identifier +
-#ifdef __linux__
-	                                  ".so"
-#elif defined(__APPLE__)
-	                                  ".dylib"
-#else
-#error "Unknown platform"
-#endif
-	                                  ))
-	                           .string();
+std::string CUDACompiler::makeUniqueStem(const std::string& identifier) {
+	// Collision-resistant suffix: PID + monotonic counter + a single random
+	// 32-bit value. Avoids the race where two threads (or processes) compile
+	// the same IR identifier simultaneously and clobber each other's source.
+	static std::atomic<uint64_t> counter {0};
+	static thread_local std::mt19937_64 rng {
+	    static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count()) ^
+	    static_cast<uint64_t>(::getpid())};
 
-	// Write CUDA source
-	common::File::createFile(sourceFileName, code);
+	std::ostringstream stem;
+	stem << identifier << "-" << ::getpid() << "-" << counter.fetch_add(1, std::memory_order_relaxed) << "-" << std::hex
+	     << rng();
+	return stem.str();
+}
 
-	auto nvcc = findNvcc();
+std::string CUDACompiler::findNvcc(const engine::Options& options) {
+	// 1. Explicit override always wins.
+	auto explicitPath = options.getOptionOrDefault<std::string>("gpu.cuda.nvccPath", "");
+	if (!explicitPath.empty()) {
+		if (!std::filesystem::exists(explicitPath)) {
+			throw RuntimeException("CUDACompiler: gpu.cuda.nvccPath points to non-existent file: " + explicitPath);
+		}
+		return explicitPath;
+	}
 
-	// Build nvcc command: compile to shared library
+	// 2. Honour CUDA_HOME / CUDA_PATH before falling back to PATH lookup.
+	for (const char* var : {"CUDA_HOME", "CUDA_PATH"}) {
+		if (auto* home = std::getenv(var)) {
+			auto candidate = std::filesystem::path(home) / "bin" / "nvcc";
+			if (std::filesystem::exists(candidate)) {
+				return candidate.string();
+			}
+		}
+	}
+
+	// 3. PATH lookup — pure C++ to avoid spawning a shell.
+	if (auto* pathEnv = std::getenv("PATH")) {
+		std::string path = pathEnv;
+		size_t start = 0;
+		while (start <= path.size()) {
+			auto end = path.find(':', start);
+			auto dir = path.substr(start, end == std::string::npos ? std::string::npos : end - start);
+			if (!dir.empty()) {
+				auto candidate = std::filesystem::path(dir) / "nvcc";
+				if (std::filesystem::exists(candidate)) {
+					return candidate.string();
+				}
+			}
+			if (end == std::string::npos) {
+				break;
+			}
+			start = end + 1;
+		}
+	}
+
+	// 4. Common install locations.
+	for (const auto* candidate : {"/usr/local/cuda/bin/nvcc", "/opt/cuda/bin/nvcc"}) {
+		if (std::filesystem::exists(candidate)) {
+			return candidate;
+		}
+	}
+
+	throw RuntimeException("CUDACompiler: could not locate 'nvcc'. Install the CUDA toolkit, set CUDA_HOME, "
+	                       "or set the 'gpu.cuda.nvccPath' option.");
+}
+
+std::string CUDACompiler::buildNvccCommand(const std::string& nvcc, const std::string& sourcePath,
+                                           const std::string& outputPath, const engine::Options& options) {
+	auto arch = options.getOptionOrDefault<std::string>("gpu.cuda.arch", "");
+	auto optLevel = options.getOptionOrDefault<int>("gpu.cuda.optLevel", 3);
+	auto fastMath = options.getOptionOrDefault<bool>("gpu.cuda.fastMath", false);
+	auto debug = options.getOptionOrDefault<bool>("gpu.cuda.debug", false);
+	auto extraFlags = options.getOptionOrDefault<std::string>("gpu.cuda.extraFlags", "");
+
 	std::ostringstream cmd;
-	cmd << nvcc;
+	cmd << shellQuote(nvcc);
 	cmd << " -shared";
 	cmd << " -Xcompiler -fPIC";
 	cmd << " -std=c++20";
-	cmd << " -o " << libraryFileName;
-	cmd << " " << sourceFileName;
+	cmd << " -O" << optLevel;
+	if (!arch.empty()) {
+		cmd << " -arch=" << shellQuote(arch);
+	}
+	if (fastMath) {
+		cmd << " --use_fast_math";
+	}
+	if (debug) {
+		// `-g` for host, `-G` for device, `-lineinfo` for sane stack traces.
+		cmd << " -g -G -lineinfo";
+	}
+	if (!extraFlags.empty()) {
+		// Trusted, advanced-user knob — passed verbatim, intentionally not quoted.
+		cmd << " " << extraFlags;
+	}
+	cmd << " -o " << shellQuote(outputPath);
+	cmd << " " << shellQuote(sourcePath);
+	return cmd.str();
+}
 
-	runCommand(cmd.str());
+cpp::SharedLibraryPtr CUDACompiler::compile(const std::string& identifier, const std::string& code,
+                                            const engine::Options& options) {
+	auto tmpDir = std::filesystem::temp_directory_path();
+	auto stem = makeUniqueStem(identifier);
 
-	// Load the shared library
-	auto sharedLibrary = cpp::SharedLibrary::load(libraryFileName);
+	auto sourcePath = (tmpDir / (stem + ".cu")).string();
+	auto libraryPath = (tmpDir / (stem +
+#ifdef __linux__
+	                              ".so"
+#elif defined(__APPLE__)
+	                              ".dylib"
+#else
+#error "Unknown platform"
+#endif
+	                              ))
+	                       .string();
 
-	// Clean up
-	std::filesystem::remove(sourceFileName);
-	std::filesystem::remove(libraryFileName);
+	common::File::createFile(sourcePath, code);
+
+	auto nvcc = findNvcc(options);
+	auto cmd = buildNvccCommand(nvcc, sourcePath, libraryPath, options);
+
+	const bool keepArtifacts = options.getOptionOrDefault<bool>("gpu.cuda.keepArtifacts", true);
+
+	try {
+		runCommand(cmd);
+	} catch (const std::exception& e) {
+		// Compilation failed: surface the path to the offending source so the
+		// user can reproduce the failure outside the JIT pipeline.
+		if (!keepArtifacts) {
+			std::error_code ec;
+			std::filesystem::remove(sourcePath, ec);
+			std::filesystem::remove(libraryPath, ec);
+			throw;
+		}
+		throw RuntimeException(std::string(e.what()) + "\n[nautilus-cuda] failing source kept at: " + sourcePath);
+	}
+
+	auto sharedLibrary = cpp::SharedLibrary::load(libraryPath);
+
+	// Source is no longer needed; the loaded library is mmaped, so it survives
+	// the unlink. SharedLibrary's destructor cleans up the .so on shutdown.
+	std::error_code ec;
+	std::filesystem::remove(sourcePath, ec);
 
 	return sharedLibrary;
 }
@@ -98,7 +183,7 @@ void CUDACompiler::runCommand(const std::string& cmd) {
 	std::string fullCmd = cmd + " 2>&1";
 	FILE* fp = popen(fullCmd.c_str(), "r");
 	if (fp == nullptr) {
-		throw std::runtime_error("CUDACompiler: failed to run command: " + cmd);
+		throw RuntimeException("CUDACompiler: failed to spawn shell for command: " + cmd);
 	}
 
 	std::ostringstream output;
@@ -109,7 +194,8 @@ void CUDACompiler::runCommand(const std::string& cmd) {
 
 	auto ret = pclose(fp);
 	if (ret != 0) {
-		throw std::runtime_error("CUDACompiler: compilation failed:\n" + output.str());
+		throw RuntimeException("CUDACompiler: nvcc invocation failed (exit=" + std::to_string(ret) +
+		                       "):\ncommand: " + cmd + "\noutput:\n" + output.str());
 	}
 }
 

--- a/plugins/gpu/src/cuda/CUDACompiler.hpp
+++ b/plugins/gpu/src/cuda/CUDACompiler.hpp
@@ -1,19 +1,39 @@
 #pragma once
 
 #include "nautilus/compiler/backends/cpp/SharedLibrary.hpp"
+#include "nautilus/options.hpp"
 #include <string>
 
 namespace nautilus::compiler::cuda {
 
 /// Compiles CUDA source code (.cu) to a shared library using nvcc.
+///
+/// All knobs are read from `engine::Options`:
+///   - `gpu.cuda.nvccPath`     (string): explicit path to nvcc (overrides discovery)
+///   - `gpu.cuda.arch`         (string): `-arch=` value (e.g. "sm_75"); empty = let nvcc decide
+///   - `gpu.cuda.optLevel`     (int):    `-O` level for host & device (default 3)
+///   - `gpu.cuda.fastMath`     (bool):   add `--use_fast_math` (default false)
+///   - `gpu.cuda.debug`        (bool):   add `-g -G` device debug + line info (default false)
+///   - `gpu.cuda.extraFlags`   (string): extra space-separated nvcc flags (advanced)
+///   - `gpu.cuda.keepArtifacts`(bool):   on compile failure, keep the .cu next to the
+///                                      shared library and include the path in the
+///                                      thrown error (default true).
 class CUDACompiler {
 public:
-	/// Compiles .cu source to a shared library. Returns a SharedLibrary.
-	static cpp::SharedLibraryPtr compile(const std::string& identifier, const std::string& code);
+	/// Compiles `.cu` source to a shared library. Returns a loaded SharedLibrary.
+	static cpp::SharedLibraryPtr compile(const std::string& identifier, const std::string& code,
+	                                     const engine::Options& options);
 
 private:
-	static std::string findNvcc();
+	static std::string findNvcc(const engine::Options& options);
+	static std::string buildNvccCommand(const std::string& nvcc, const std::string& sourcePath,
+	                                    const std::string& outputPath, const engine::Options& options);
 	static void runCommand(const std::string& cmd);
+	/// Returns the supplied path quoted for safe inclusion in a /bin/sh command line.
+	static std::string shellQuote(const std::string& s);
+	/// Generates a unique temp-file stem (`identifier`-PID-random) to avoid clashes
+	/// between concurrent compilations of the same IR graph.
+	static std::string makeUniqueStem(const std::string& identifier);
 };
 
 } // namespace nautilus::compiler::cuda

--- a/plugins/gpu/src/cuda/CUDALoweringProvider.cpp
+++ b/plugins/gpu/src/cuda/CUDALoweringProvider.cpp
@@ -1,6 +1,6 @@
 
 #include "CUDALoweringProvider.hpp"
-#include <cassert>
+#include "nautilus/exceptions/RuntimeException.hpp"
 #include <string>
 #include <utility>
 
@@ -76,13 +76,26 @@ std::string CUDALoweringProvider::LoweringContext::getType(const Type& stamp) {
 	case Type::ptr:
 		return "uint8_t*";
 	}
-	assert(false);
-	return "unknown";
+	throw RuntimeException(
+	    "CUDALoweringProvider: unsupported IR type stamp (value=" + std::to_string(static_cast<int>(stamp)) + ")");
 }
 
 CUDALoweringProvider::LoweringContext::Code CUDALoweringProvider::LoweringContext::process() {
 	Code pipelineCode;
 	pipelineCode << "\n#include <cstdint>\n#include <cuda_runtime.h>\n\n";
+
+	// When enabled, emit a header-only helper that aborts with a useful message
+	// on any non-success CUDA error. Default is off so existing codegen
+	// reference outputs and downstream consumers stay byte-identical.
+	if (options.getOptionOrDefault<bool>("gpu.cuda.errorCheck", false)) {
+		pipelineCode << "#include <cstdio>\n"
+		             << "#include <cstdlib>\n"
+		             << "static inline void nautilus_cuda_check(cudaError_t e, const char* where) {\n"
+		             << "if (e != cudaSuccess) {\n"
+		             << "fprintf(stderr, \"[nautilus-cuda] %s: %s\\n\", where, cudaGetErrorString(e));\n"
+		             << "abort();\n"
+		             << "}\n}\n\n";
+	}
 
 	classifyKernelFunctions();
 
@@ -229,7 +242,16 @@ void CUDALoweringProvider::LoweringContext::processProxyCall(ir::ProxyCallOperat
 			blocks[blockIndex] << opt->getFunctionName() << "<<<dim3(" << gx << "," << gy << "," << gz << "),dim3("
 			                   << bx << "," << by << "," << bz << ")>>>(" << args.str() << ");\n";
 		}
-		blocks[blockIndex] << "cudaDeviceSynchronize();\n";
+		if (options.getOptionOrDefault<bool>("gpu.cuda.errorCheck", false)) {
+			// Check the launch itself (catches invalid configurations) and the
+			// device sync (catches asynchronous in-kernel faults).
+			blocks[blockIndex] << "nautilus_cuda_check(cudaGetLastError(),\"" << opt->getFunctionName()
+			                   << " launch\");\n";
+			blocks[blockIndex] << "nautilus_cuda_check(cudaDeviceSynchronize(),\"" << opt->getFunctionName()
+			                   << " sync\");\n";
+		} else {
+			blocks[blockIndex] << "cudaDeviceSynchronize();\n";
+		}
 		hasLaunchConfig = false; // consumed
 		return;
 	}


### PR DESCRIPTION
- CUDALoweringProvider: replace assert(false) on unknown IR type with a
  RuntimeException so failures are caught in release builds.
- Emit a header-only `nautilus_cuda_check` that wraps cudaGetLastError /
  cudaDeviceSynchronize after kernel launches when the new
  `gpu.cuda.errorCheck` option is set; default off keeps reference codegen
  byte-identical.
- GPULoweringProviderBase: validate that setGrid/setBlock intrinsics receive
  exactly three arguments instead of indexing past the end of the vector.
- CUDACompiler:
    * Look for nvcc via PATH directly (no shell), CUDA_HOME / CUDA_PATH, and
      common install paths; allow `gpu.cuda.nvccPath` override.
    * Make the nvcc invocation configurable: `gpu.cuda.arch`,
      `gpu.cuda.optLevel` (default -O3), `gpu.cuda.fastMath`,
      `gpu.cuda.debug` (-g -G -lineinfo), `gpu.cuda.extraFlags`.
    * Quote all interpolated paths so temp directories with spaces or shell
      metacharacters can't break the command.
    * Use a unique temp-file stem (PID + counter + random) so concurrent
      compilations of the same IR id don't clobber each other.
    * On failure, surface the path to the offending .cu so users can
      reproduce; opt-out via `gpu.cuda.keepArtifacts=false`.
    * Stop manually unlinking the .so after load — SharedLibrary's destructor
      already does it; remove the redundant double-unlink.
    * Replace std::runtime_error with RuntimeException for consistency with
      the rest of the codebase.