### PR TITLE
Make plugins installable

### DIFF
--- a/nautilus/CMakeLists.txt
+++ b/nautilus/CMakeLists.txt
@@ -58,13 +58,16 @@ if (ENABLE_BC_BACKEND AND TARGET dyncallback_s)
     list(APPEND EXPORT_TARGETS dyncallback_s)
 endif ()
 
+# No PUBLIC_HEADER DESTINATION: it would apply to every target in this call,
+# and fmt sets PUBLIC_HEADER with relative paths that CMake resolves against
+# this dir (not fmt's source dir), which breaks `cmake --install`. Nautilus's
+# headers are installed via the install(DIRECTORY ...) calls below instead.
 install(
         TARGETS nautilus ${EXPORT_TARGETS}
         EXPORT ${PROJECT_NAME}-config
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
 )
 
 install(

--- a/plugins/gpu/CMakeLists.txt
+++ b/plugins/gpu/CMakeLists.txt
@@ -38,3 +38,25 @@ target_link_libraries(nautilus-gpu PRIVATE fmt::fmt)
 if (ENABLE_TESTS)
     add_subdirectory(test)
 endif ()
+
+# Install rules: register nautilus-gpu in the same export set used by the
+# core nautilus library so that `find_package(nautilus)` exposes this plugin
+# as `nautilus::nautilus-gpu`.
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME}::nautilus-gpu ALIAS nautilus-gpu)
+
+install(
+        TARGETS nautilus-gpu
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/nautilus/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nautilus)
+
+# The configured config.hpp is generated into the build tree and is part of
+# the public API surface of the GPU plugin.
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/nautilus/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nautilus)

--- a/plugins/inlining/CMakeLists.txt
+++ b/plugins/inlining/CMakeLists.txt
@@ -56,10 +56,38 @@ endif ()
 
 add_subdirectory(pass)
 
-if (TARGET InliningPass)
-    list(APPEND EXPORT_TARGETS InliningPass PARENT_SCOPE)
-endif ()
-
 if (ENABLE_TESTS)
     add_subdirectory(test)
 endif ()
+
+# Install rules: register nautilus-inlining (and the optional InliningPass
+# LLVM pass plugin) in the same export set used by the core nautilus library
+# so that `find_package(nautilus)` exposes the plugin as
+# `nautilus::nautilus-inlining`. The NautilusInline.cmake helper is also
+# shipped so consumers can call `nautilus_inline(target)` after installation.
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME}::nautilus-inlining ALIAS nautilus-inlining)
+
+install(
+        TARGETS nautilus-inlining
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/nautilus/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nautilus)
+
+if (TARGET InliningPass)
+    install(
+            TARGETS InliningPass
+            EXPORT ${PROJECT_NAME}-config
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif ()
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/cmake/NautilusInline.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/plugins/simd/CMakeLists.txt
+++ b/plugins/simd/CMakeLists.txt
@@ -53,3 +53,20 @@ endif ()
 if (ENABLE_TESTS)
     add_subdirectory(test)
 endif ()
+
+# Install rules: register nautilus-simd in the same export set used by the
+# core nautilus library so that `find_package(nautilus)` exposes this plugin
+# as `nautilus::nautilus-simd`.
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME}::nautilus-simd ALIAS nautilus-simd)
+
+install(
+        TARGETS nautilus-simd
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/nautilus/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nautilus)

--- a/plugins/specialization/CMakeLists.txt
+++ b/plugins/specialization/CMakeLists.txt
@@ -39,3 +39,20 @@ endif ()
 if (ENABLE_TESTS)
     add_subdirectory(test)
 endif ()
+
+# Install rules: register nautilus-specialization in the same export set used
+# by the core nautilus library so that `find_package(nautilus)` exposes this
+# plugin as `nautilus::nautilus-specialization`.
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME}::nautilus-specialization ALIAS nautilus-specialization)
+
+install(
+        TARGETS nautilus-specialization
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/nautilus/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nautilus)

--- a/plugins/std/CMakeLists.txt
+++ b/plugins/std/CMakeLists.txt
@@ -45,3 +45,20 @@ endif ()
 if (ENABLE_TESTS)
     add_subdirectory(test)
 endif ()
+
+# Install rules: register nautilus-std in the same export set used by the core
+# nautilus library so that `find_package(nautilus)` exposes this plugin as
+# `nautilus::nautilus-std`.
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME}::nautilus-std ALIAS nautilus-std)
+
+install(
+        TARGETS nautilus-std
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/nautilus/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nautilus)


### PR DESCRIPTION
Each plugin now declares CMake install rules so that `cmake --install` ships
its static library, public headers, and (where applicable) auxiliary CMake
helpers. All plugin targets are registered against the existing
`nautilus-config` export set, so a single `find_package(nautilus)` in
downstream projects exposes them as `nautilus::nautilus-std`,
`nautilus::nautilus-simd`, `nautilus::nautilus-specialization`,
`nautilus::nautilus-inlining`, and `nautilus::nautilus-gpu`.

The inlining plugin additionally installs the optional `InliningPass`
LLVM pass plugin and the `NautilusInline.cmake` helper, and the now-redundant
`list(APPEND EXPORT_TARGETS InliningPass PARENT_SCOPE)` is removed since the
plugin's own `install(TARGETS ...)` handles export registration directly.