### PR TITLE
Fix threeCallsNoBranch fixture description to match the 27-RETURN trace

### DIFF
--- a/nautilus/test/common/PathExplosionFunctions.hpp
+++ b/nautilus/test/common/PathExplosionFunctions.hpp
@@ -91,7 +91,10 @@
 // Fixture taxonomy
 // -----------------------------------------------------------------------------
 //
-//   pathExplosion_baseline*           — "no explosion" controls (Tier 1)
+//   pathExplosion_baseline_oneCall            — "no explosion" control (Tier 0)
+//   pathExplosion_baseline_threeCallsNoBranch — Tier 3 (no post-call branch
+//                                                still explodes inside the
+//                                                callee chain)
 //   pathExplosion_independentIfs*     — Tier (1): linear
 //   pathExplosion_postCallBranch*     — Tier (2)/(3): multiplicative
 //   pathExplosion_constraintBlind*    — Tier (4): dead-branch
@@ -128,12 +131,19 @@ val<int32_t> pathExplosion_baseline_oneCall(val<int32_t> v) {
 	return peLeafThreeReturns(v);
 }
 
-// Baseline control: chain three leaf calls without post-call branches.
-// Expected: 3 RETURNs (still — each call's three internal paths flow
-// straight into the next call's argument, so they fan in at the call
-// boundary instead of forking the trace).  Useful to demonstrate that
-// the explosion below is caused by the *branch on the result*, not by
-// the call chain itself.
+// Tier 3 demonstration: chain three leaf calls *without* any post-call
+// branch.  Naively this looks like a "no explosion" control — there is no
+// CMP on the inlined return value, and two of the three leaf returns are
+// statically-known constants.  In practice the trace forks O(M^N) anyway
+// because each chained call's *internal* CMPs see a fresh argument
+// ValueRef per upstream path, get fresh tags, and are re-explored both
+// ways even on paths where the argument is a known constant.  See the
+// Tier-3 entry in the intro (`How the tracer enumerates paths`, point 3)
+// for the full mechanism.
+//
+// Expected: 27 RETURNs in the raw trace (= 3^3), 26 CMPs, 53 blocks.
+// Reference: nautilus/test/data/path-explosion-tests/tracing/
+// pathExplosion_baseline_threeCallsNoBranch.trace.
 val<int32_t> pathExplosion_baseline_threeCallsNoBranch(val<int32_t> v) {
 	val<int32_t> a = peLeafThreeReturns(v);
 	val<int32_t> b = peLeafThreeReturns(a);


### PR DESCRIPTION
## Summary

The per-fixture comment on `pathExplosion_baseline_threeCallsNoBranch` in `nautilus/test/common/PathExplosionFunctions.hpp` claimed "Expected: 3 RETURNs" and described the call chain as fanning in at the call boundary, but the committed trace fixture has **27 RETURNs** (= 3^3). The intro comment in the same file (point 3, *"the surprising one"*) already documented the correct behaviour — the per-fixture comment was the outlier.

## Root cause (why 27, not 3)

`peLeafThreeReturns` has three return paths, two of which are static constants (`1` and `42`). One might expect the constant arms to collapse in the next call. They don't, because of the tracer's tag scheme:

1. `recordSnapshot` builds a tag `(stack_trace_hash, staticValueHash ^ aliveVars.hash())` (`ExceptionBasedTraceContext.cpp:473`).
2. `aliveVars` is keyed by **ValueRef**, not by value. When the second call inlines, its argument carries a fresh SSA name per upstream path (in the trace: `$7`, `$22`, `$37`, ...) even on the paths where the argument is the constant `1` or `42`.
3. The second call's internal `v == 1` CMP is therefore a different SSA op per upstream path → different tag.
4. `SymbolicExecutionContext` explores each distinct tag twice; there is no constraint propagation, so the inner CMP gets both arms even when the outer path makes one arm dead.

Each call forks every upstream path into 3 leaf paths. Three chained calls: 3 × 3 × 3 = 27.

## What changed

Comment-only edits in `nautilus/test/common/PathExplosionFunctions.hpp`:

- Rewrote the per-fixture block above `pathExplosion_baseline_threeCallsNoBranch` to state the true expected counts (27 RETURNs, 26 CMPs, 53 blocks) and explain the mechanism by referring to the existing Tier-3 entry in the intro.
- Split the fixture-taxonomy bullet so `baseline_oneCall` stays in "no explosion" (Tier 0) and `baseline_threeCallsNoBranch` is labelled as Tier 3.

No tracer changes, no test changes, no fixture changes — the existing `.trace` files were already telling the truth.

## Test plan

- [x] `./format.sh` reports no errors on `PathExplosionFunctions.hpp` (pre-existing format errors in unrelated `plugins/gpu/test/data/...` files are out of scope).
- [x] No lines exceed the 120-char limit in the edited file.
- [x] `grep -c RETURN nautilus/test/data/path-explosion-tests/tracing/pathExplosion_baseline_threeCallsNoBranch.trace` prints `27`, matching the new comment.
- [ ] CI `Path Explosion Trace Test` stays green (unchanged behaviour; comment-only edit).


---
_Generated by [Claude Code](https://claude.ai/code/session_01J78c17H1Nbv23MvgjhhdCF)_