### PR TITLE
Scaffold value-content hashing in AliveVariableHash

### DIFF
--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -403,10 +403,17 @@ std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<co
 }
 
 void ExceptionBasedTraceContext::allocateValRef(ValueRef ref) {
-	aliveVars.increment(ref);
+	// Look up the producing op's content hash so two structurally-equivalent
+	// ValueRefs mix identical bits into the alive hash.  When no trace state
+	// is active (transient TypedValueRefHolder copy/move from outside a trace
+	// session) we mix in 0, which AliveVariableHash treats as "fall back to
+	// ID-based hashing" — preserving the legacy behaviour for those edges.
+	uint64_t contentHash = state ? state->executionTrace.getContentHashForValueRef(ref) : 0;
+	aliveVars.increment(ref, contentHash);
 }
 void ExceptionBasedTraceContext::freeValRef(ValueRef ref) {
-	aliveVars.decrement(ref);
+	uint64_t contentHash = state ? state->executionTrace.getContentHashForValueRef(ref) : 0;
+	aliveVars.decrement(ref, contentHash);
 }
 
 std::string TraceContextBase::getMangledName(void* fnptr) {

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
@@ -50,24 +50,41 @@ inline size_t getStaticVarValue(const StaticVarHolder& holder) {
  * of variable IDs while keeping memory usage reasonable. The hash reflects both which variables
  * are alive and their reference counts, updated incrementally in O(1) average time.
  *
- * Implementation details:
- * - Uses XOR-based hashing for O(1) incremental updates
- * - Each variable ID is mixed with a constant multiplier for better hash distribution
- * - The hash incorporates both variable identity (ID) and reference count
- * - Uses unordered_map for sparse storage (only allocates for variables that exist)
+ * The mixed bits per variable are derived from `mix(id, contentHash)`, which by default returns
+ * `id * HASH_MULTIPLIER`.  The contentHash parameter is plumbed through but currently unused
+ * in the mix function — see PathExplosionFunctions.hpp for the motivating use case (collapsing
+ * the M^N inlined-call path explosion).  Wiring contentHash into mix is a one-line change here
+ * but requires complementary work in the SSA phase to bridge cross-path ValueRefs at the merge
+ * points it produces; see /root/.claude/plans/investigate-the-baseline-threecallsnobra-pure-otter.md
+ * for the open follow-up.
  *
  * Performance characteristics:
  * - increment(): O(1) average - hash map lookup + two XOR operations, two multiplications
  * - decrement(): O(1) average - hash map lookup + two XOR operations, two multiplications
  * - hash(): O(1) - returns cached value
- *
- * @note Changed from fixed array to hash map to support uint32_t ValueRef (was uint16_t).
  */
 class AliveVariableHash {
 	static constexpr uint64_t HASH_MULTIPLIER = 0x9e3779b97f4a7c15; // Golden ratio constant for good mixing
 
 	std::unordered_map<uint32_t, uint32_t> counts;
 	uint64_t alive_hash = 0;
+
+	// The mixed bits per variable.  Currently ID-based; contentHash is plumbed
+	// through but unused while the SSA-side bridging work that would let it
+	// safely collapse the M^N path explosion (see PathExplosionFunctions.hpp)
+	// is still open.  Flipping this to `contentHash != 0 ? contentHash :
+	// id * HASH_MULTIPLIER` collapses the fixture's RETURN count (27 -> 3 on
+	// pathExplosion_baseline_threeCallsNoBranch) but trips the SSA
+	// propagation in the postCallBranch_2/_3 fixtures because content-hash
+	// equivalence is not the same as semantic-role equivalence: when two
+	// content-equivalent CONSTs exist in a single block,
+	// ExecutionTrace::bridgeMergeBlockNonLocals cannot tell which one is the
+	// "outer `a`" vs the "leaf-internal const 1".  Landing the flip therefore
+	// needs phi-aware propagation in SSACreationPhase (or a richer "role
+	// tag" on ValueRefs); both are tracked as follow-ups on the plan.
+	static inline uint64_t mix(uint32_t id, [[maybe_unused]] uint64_t contentHash) noexcept {
+		return id * HASH_MULTIPLIER;
+	}
 
 public:
 	/**
@@ -78,31 +95,31 @@ public:
 	/**
 	 * @brief Increments the reference count for a variable and updates the hash.
 	 *
-	 * The hash is updated by XOR-ing out the old contribution ((id * HASH_MULTIPLIER) * old_count)
-	 * and XOR-ing in the new contribution ((id * HASH_MULTIPLIER) * new_count).
-	 *
 	 * @param id Variable identifier (32-bit value)
+	 * @param contentHash Structural hash of the value-producing op (plumbed through
+	 *                    but currently unused — see class doc).
 	 */
-	inline void increment(uint32_t id) noexcept {
+	inline void increment(uint32_t id, uint64_t contentHash) noexcept {
 		uint32_t& c = counts[id];
-		alive_hash ^= (id * HASH_MULTIPLIER) * c;
+		uint64_t m = mix(id, contentHash);
+		alive_hash ^= m * c;
 		++c;
-		alive_hash ^= (id * HASH_MULTIPLIER) * c;
+		alive_hash ^= m * c;
 	}
 
 	/**
 	 * @brief Decrements the reference count for a variable and updates the hash.
 	 *
-	 * The hash is updated by XOR-ing out the old contribution ((id * HASH_MULTIPLIER) * old_count)
-	 * and XOR-ing in the new contribution ((id * HASH_MULTIPLIER) * new_count).
-	 *
 	 * @param id Variable identifier (32-bit value)
+	 * @param contentHash Must match the contentHash used in the matching
+	 *                    increment() call so the XOR-rollover cancels cleanly.
 	 */
-	inline void decrement(uint32_t id) noexcept {
+	inline void decrement(uint32_t id, uint64_t contentHash) noexcept {
 		uint32_t& c = counts[id];
-		alive_hash ^= (id * HASH_MULTIPLIER) * c;
+		uint64_t m = mix(id, contentHash);
+		alive_hash ^= m * c;
 		--c;
-		alive_hash ^= (id * HASH_MULTIPLIER) * c;
+		alive_hash ^= m * c;
 	}
 
 	/**

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -2,10 +2,13 @@
 #include "nautilus/tracing/ExecutionTrace.hpp"
 #include "nautilus/tracing/symbolic_execution/TraceTerminationException.hpp"
 #include <algorithm>
+#include <bit>
+#include <cstring>
 #include <fmt/format.h>
 #include <nautilus/config.hpp>
 #include <nautilus/exceptions/RuntimeException.hpp>
 #include <nautilus/logging.hpp>
+#include <unordered_set>
 
 namespace nautilus::tracing {
 
@@ -78,6 +81,110 @@ std::vector<std::string> TraceModule::getFunctionNames() const {
 	}
 	std::sort(names.begin(), names.end());
 	return names;
+}
+
+namespace {
+
+// Mixing primes used by computeContentHash.  Distinct from the AliveVariableHash
+// multiplier so identical bits in different roles do not collide.
+constexpr uint64_t CONTENT_OP_MIX = 0x100000001b3ULL;
+constexpr uint64_t CONTENT_TYPE_MIX = 0xbf58476d1ce4e5b9ULL;
+constexpr uint64_t CONTENT_INPUT_MIX = 0x94d049bb133111ebULL;
+constexpr uint64_t CONTENT_CONST_BASE = 0xc6a4a7935bd1e995ULL;
+constexpr uint64_t CONTENT_BLOCKREF_MIX = 0x9e3779b97f4a7c15ULL;
+constexpr uint64_t CONTENT_CALL_MIX = 0xff51afd7ed558ccdULL;
+constexpr uint64_t CONTENT_INDCALL_MIX = 0xd6e8feb86659fd93ULL;
+constexpr uint64_t CONTENT_ARGSEED = 0xa5a5a5a5a5a5a5a5ULL;
+
+inline uint64_t mixBits(uint64_t h, uint64_t v) noexcept {
+	h ^= v;
+	h *= CONTENT_INPUT_MIX;
+	h ^= h >> 33;
+	return h;
+}
+
+inline uint64_t hashConstantLiteral(const ConstantLiteral& lit) noexcept {
+	// Mix the alternative index with the raw literal bits.  Two CONSTs with
+	// the same literal value share a content hash even if they were minted
+	// from different source positions, which is exactly the structural
+	// equivalence the snapshot wants.
+	uint64_t h = CONTENT_CONST_BASE * (static_cast<uint64_t>(lit.index()) + 1);
+	std::visit(
+	    [&h](auto&& v) noexcept {
+		    using V = std::decay_t<decltype(v)>;
+		    if constexpr (std::is_same_v<V, void*>) {
+			    h = mixBits(h, std::bit_cast<uint64_t>(v));
+		    } else {
+			    uint64_t bits = 0;
+			    std::memcpy(&bits, &v, sizeof(v));
+			    h = mixBits(h, bits);
+		    }
+	    },
+	    lit);
+	return h;
+}
+
+} // namespace
+
+uint64_t ExecutionTrace::computeContentHash(Op op, Type resultType,
+                                            std::span<const InputVariant> inputs) const noexcept {
+	uint64_t h = CONTENT_OP_MIX * (static_cast<uint64_t>(op) + 1);
+	h = mixBits(h, CONTENT_TYPE_MIX * (static_cast<uint64_t>(resultType) + 1));
+	for (const auto& input : inputs) {
+		uint64_t inputBits = std::visit(
+		    [this](auto&& v) noexcept -> uint64_t {
+			    using V = std::decay_t<decltype(v)>;
+			    if constexpr (std::is_same_v<V, TypedValueRef>) {
+				    return getContentHashForValueRef(v.ref);
+			    } else if constexpr (std::is_same_v<V, ConstantLiteral>) {
+				    return hashConstantLiteral(v);
+			    } else if constexpr (std::is_same_v<V, BlockRef*>) {
+				    return v == nullptr ? 0 : CONTENT_BLOCKREF_MIX * (static_cast<uint64_t>(v->block) + 1);
+			    } else if constexpr (std::is_same_v<V, FunctionCall*>) {
+				    if (v == nullptr) {
+					    return 0;
+				    }
+				    uint64_t fh = CONTENT_CALL_MIX;
+				    fh = mixBits(fh, std::hash<std::string> {}(v->functionName));
+				    for (const auto& arg : v->arguments) {
+					    fh = mixBits(fh, getContentHashForValueRef(arg.ref));
+				    }
+				    return fh;
+			    } else if constexpr (std::is_same_v<V, IndirectFunctionCall*>) {
+				    if (v == nullptr) {
+					    return 0;
+				    }
+				    uint64_t fh = CONTENT_INDCALL_MIX;
+				    fh = mixBits(fh, getContentHashForValueRef(v->fnPtr.ref));
+				    for (const auto& arg : v->arguments) {
+					    fh = mixBits(fh, getContentHashForValueRef(arg.ref));
+				    }
+				    return fh;
+			    } else if constexpr (std::is_same_v<V, BranchProbability>) {
+				    uint64_t bits;
+				    std::memcpy(&bits, &v, sizeof(v));
+				    return bits;
+			    } else if constexpr (std::is_same_v<V, AllocaIndex>) {
+				    // Each ALLOCA must produce a distinct value-content even though every
+				    // alloca op shares the same op code; mixing the table index ensures
+				    // alloca-derived pointer ValueRefs do not all collapse into one
+				    // content class.
+				    return CONTENT_CALL_MIX * (static_cast<uint64_t>(v) + 1);
+			    } else {
+				    return 0; // None
+			    }
+		    },
+		    input);
+		h = mixBits(h, inputBits);
+	}
+	return h;
+}
+
+void ExecutionTrace::storeContentHashForValueRef(ValueRef ref, uint64_t contentHash) {
+	if (ref >= valueRefContentHashes.size()) {
+		valueRefContentHashes.resize(ref + 1, 0);
+	}
+	valueRefContentHashes[ref] = contentHash;
 }
 
 ExecutionTrace::ExecutionTrace(Arena& arena) : arena(&arena), currentBlockIndex(0), currentOperationIndex(0), blocks() {
@@ -178,6 +285,17 @@ TypedValueRef& ExecutionTrace::addAssignmentOperation(Snapshot& snapshot, const 
 	auto& operations = blocks[currentBlockIndex]->operations;
 	auto op = ASSIGN;
 	auto* operation = makeTraceOp(*arena, snapshot, op, resultType, targetRef, srcRef);
+	// An assignment forwards its source's value to the target; the target's
+	// content-class is therefore the source's content hash, not a new mixture.
+	// We deliberately do not overwrite valueRefContentHashes[targetRef.ref]: the
+	// alive hash for an already-allocated target must stay stable for the
+	// XOR-rollover scheme to remain self-cancelling on free.  The pass-through
+	// here only affects fresh result refs (e.g. traceCopy, the const-aliasing
+	// path in traceConstant) where targetRef was minted by getNextValueRef().
+	operation->contentHash = getContentHashForValueRef(srcRef.ref);
+	if (targetRef.ref >= valueRefContentHashes.size() || valueRefContentHashes[targetRef.ref] == 0) {
+		storeContentHashForValueRef(targetRef.ref, operation->contentHash);
+	}
 	operations.push_back(operation);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
@@ -202,6 +320,8 @@ TypedValueRef& ExecutionTrace::addOperationWithResult(Snapshot& snapshot, Op& op
 	auto& operations = blocks[currentBlockIndex]->operations;
 	auto* to =
 	    makeTraceOp(*arena, snapshot, operation, resultType, TypedValueRef(getNextValueRef(), resultType), inputs);
+	to->contentHash = computeContentHash(operation, resultType, to->input);
+	storeContentHashForValueRef(to->resultRef.ref, to->contentHash);
 	operations.push_back(to);
 
 	auto operationIdentifier = getNextOperationIdentifier();
@@ -333,6 +453,85 @@ Block& ExecutionTrace::processControlFlowMerge(operation_identifier oi) {
 	return mergeBlock;
 }
 
+void ExecutionTrace::bridgeMergeBlockNonLocals(Block& mergeBlock, Block& currentBlock) {
+	// Locals defined inside mergeBlock itself are already SSA-bridgeable.
+	std::unordered_set<ValueRef> definedInMerge;
+	for (auto* op : mergeBlock.operations) {
+		if (op->resultRef.ref != 0) {
+			definedInMerge.insert(op->resultRef.ref);
+		}
+	}
+
+	// Refs already defined locally in currentBlock — either by a path-Y op
+	// that minted them, or by an earlier ASSIGN bridge added by this routine
+	// or by traceConstant's aliasing path.
+	std::unordered_set<ValueRef> definedInCurrent;
+	for (auto* op : currentBlock.operations) {
+		if (op->resultRef.ref != 0) {
+			definedInCurrent.insert(op->resultRef.ref);
+		}
+	}
+
+	// Walk mergeBlock collecting non-local ValueRef uses.  We dedupe via
+	// `bridged` so a given (refToBridge, bridgeSource) only gets one ASSIGN
+	// even if the merge block references the same ref many times.
+	std::unordered_set<ValueRef> bridged;
+	for (auto* op : mergeBlock.operations) {
+		for (auto& input : op->input) {
+			auto* v = std::get_if<TypedValueRef>(&input);
+			if (v == nullptr || v->ref == 0) {
+				continue;
+			}
+			ValueRef refUsed = v->ref;
+			if (definedInMerge.contains(refUsed) || definedInCurrent.contains(refUsed) || bridged.contains(refUsed)) {
+				continue;
+			}
+			uint64_t targetHash = getContentHashForValueRef(refUsed);
+			if (targetHash == 0) {
+				// No content fingerprint recorded for this ref (transient
+				// sentinel or a ref minted before contentHash was wired up).
+				// Cannot pick a safe bridge candidate.
+				continue;
+			}
+			// Find a currentBlock-local op with the matching content hash.
+			TraceOperation* match = nullptr;
+			for (auto* candidate : currentBlock.operations) {
+				if (candidate->resultRef.ref == 0 || candidate->contentHash != targetHash) {
+					continue;
+				}
+				if (candidate->resultRef.ref == refUsed) {
+					// Already locally defined under the canonical ref — no
+					// bridge needed.
+					definedInCurrent.insert(refUsed);
+					break;
+				}
+				match = candidate;
+				break;
+			}
+			if (match == nullptr || definedInCurrent.contains(refUsed)) {
+				continue;
+			}
+			// Emit ASSIGN <refUsed> <match-ref> using a synthetic snapshot
+			// (no tag-map registration needed; bridges are intentionally
+			// outside the dedup machinery).
+			Snapshot bridgeTag {};
+			Type bridgeType = match->resultType;
+			auto* bridgeOp = makeTraceOp(*arena, bridgeTag, Op::ASSIGN, bridgeType, TypedValueRef(refUsed, bridgeType),
+			                             TypedValueRef(match->resultRef.ref, bridgeType));
+			// Re-derive contentHash so downstream users of this bridge value
+			// continue to see the same hash class.
+			bridgeOp->contentHash = targetHash;
+			// We add to block.operations directly: the public add* helpers
+			// would also push the synthetic snapshot into the global / local
+			// tag maps, which we deliberately avoid (the tag has no source-
+			// level meaning and would confuse subsequent checkTag matches).
+			currentBlock.operations.push_back(bridgeOp);
+			definedInCurrent.insert(refUsed);
+			bridged.insert(refUsed);
+		}
+	}
+}
+
 TypedValueRef& ExecutionTrace::setArgument(Type type, size_t index) {
 	++lastValueRef;
 	ValueRef argRef = index + 1;
@@ -341,6 +540,13 @@ TypedValueRef& ExecutionTrace::setArgument(Type type, size_t index) {
 		arguments.resize(argRef);
 	}
 	arguments[index] = TypedValueRef(argRef, type);
+	// Seed the argument's content hash deterministically from (index, type).
+	// Re-tracing the same function across iterations therefore produces the
+	// same argument content hash, which is the precondition that lets the
+	// alive-hash mixing cancel cleanly on freeValRef.
+	uint64_t argHash = CONTENT_ARGSEED ^ (static_cast<uint64_t>(index + 1) * CONTENT_OP_MIX);
+	argHash = mixBits(argHash, CONTENT_TYPE_MIX * (static_cast<uint64_t>(type) + 1));
+	storeContentHashForValueRef(argRef, argHash);
 	return arguments[index];
 }
 

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
@@ -281,6 +281,19 @@ public:
 	 */
 	ValueRef getNextValueRef();
 
+	/**
+	 * @brief Returns the structural content hash recorded for @p ref, or 0
+	 * when the ValueRef has no associated producing operation yet (e.g. dummy
+	 * refs or untracked sentinels).
+	 *
+	 * Used by the trace contexts in allocateValRef / freeValRef so the
+	 * AliveVariableHash is keyed on value-content rather than the arbitrary
+	 * sequential ValueRef ID assigned by getNextValueRef().
+	 */
+	uint64_t getContentHashForValueRef(ValueRef ref) const noexcept {
+		return ref < valueRefContentHashes.size() ? valueRefContentHashes[ref] : 0;
+	}
+
 private:
 	/**
 	 * @brief Adds a tag for the given snapshot
@@ -288,6 +301,39 @@ private:
 	 * @param identifier The operation identifier to associate with the tag
 	 */
 	void addTag(Snapshot& snapshot, operation_identifier& identifier);
+
+	/**
+	 * @brief Computes the value-content hash for an operation about to be
+	 * created.  Mixes the op code, result type, and each input's structural
+	 * fingerprint (ValueRef inputs are dereferenced through
+	 * valueRefContentHashes so the hash transitively reflects the producing
+	 * tree).  ConstantLiteral inputs contribute their literal bits, so two
+	 * CONSTs with the same value compare equal regardless of which iteration
+	 * minted them.
+	 */
+	uint64_t computeContentHash(Op op, Type resultType, std::span<const InputVariant> inputs) const noexcept;
+
+	/**
+	 * @brief After a control-flow merge moves operations into @p mergeBlock,
+	 * any ValueRef those operations reference that is not defined in
+	 * mergeBlock itself must be locally defined in every predecessor for the
+	 * SSA pass to find it.  The reference path already has those defs from
+	 * before the split; this routine bridges the *current* path by inserting
+	 * `ASSIGN <ref> <equivalent-local-ref>` for every non-local ValueRef in
+	 * mergeBlock that has a content-equivalent producer locally in
+	 * currentBlock.  Without this, content-hash-based alive mixing would
+	 * leak inlined-callee locals up to the function entry as phantom
+	 * arguments.
+	 */
+	void bridgeMergeBlockNonLocals(Block& mergeBlock, Block& currentBlock);
+
+	/**
+	 * @brief Records the content hash of the operation that minted @p ref.
+	 * Grows the lookup vector as needed.  Idempotent overwrite is safe because
+	 * the producing operation never changes once an Op-with-result is
+	 * appended.
+	 */
+	void storeContentHashForValueRef(ValueRef ref, uint64_t contentHash);
 
 public:
 	/**
@@ -304,6 +350,13 @@ public:
 	ValueRef lastValueRef = 0;
 	std::unordered_map<Snapshot, operation_identifier> globalTagMap;
 	std::unordered_map<Snapshot, operation_identifier> localTagMap;
+
+	/// Per-ValueRef content hash, indexed by ValueRef ID.  Populated whenever a
+	/// new value-producing operation is appended; consulted in allocate/freeValRef
+	/// to mix value-content (not ValueRef identity) into AliveVariableHash.
+	/// Grows monotonically with lastValueRef; persists across iterations because
+	/// the producing operations themselves persist.
+	std::vector<uint64_t> valueRefContentHashes;
 
 	/// Per-function alloca table.  Each Op::ALLOCA trace operation carries an
 	/// AllocaIndex pointing at an entry here.  Copied wholesale to the

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -412,14 +412,16 @@ void LazyTraceContext::allocateValRef(ValueRef ref) {
 	if (paused_) {
 		return;
 	}
-	aliveVars.increment(ref);
+	uint64_t contentHash = state ? state->executionTrace.getContentHashForValueRef(ref) : 0;
+	aliveVars.increment(ref, contentHash);
 }
 
 void LazyTraceContext::freeValRef(ValueRef ref) {
 	if (paused_) {
 		return;
 	}
-	aliveVars.decrement(ref);
+	uint64_t contentHash = state ? state->executionTrace.getContentHashForValueRef(ref) : 0;
+	aliveVars.decrement(ref, contentHash);
 }
 
 void LazyTraceContext::pushStaticVal(void* valPtr, size_t size) {

--- a/nautilus/src/nautilus/tracing/TraceOperation.hpp
+++ b/nautilus/src/nautilus/tracing/TraceOperation.hpp
@@ -135,6 +135,14 @@ public:
 	/// View over the Arena-allocated input array.  The storage is adjacent to
 	/// (and has the same lifetime as) this TraceOperation.
 	std::span<InputVariant> input;
+	/// Structural hash of the operation tree that produced this op's result, used to
+	/// key AliveVariableHash by value content rather than by ValueRef identity so
+	/// inlined-callee paths that synthesise the same value-shape do not fork the
+	/// snapshot tag of downstream control flow.  Zero for ops without a usable
+	/// result (CMP, RETURN, JMP) and for ops whose result the trace creates outside
+	/// the makeTraceOp call site (the trace context populates it before storing
+	/// the hash in ExecutionTrace::valueRefContentHashes).
+	uint64_t contentHash = 0;
 };
 
 namespace detail {


### PR DESCRIPTION
## Summary

Investigation of `pathExplosion_baseline_threeCallsNoBranch` (27 RETURNs from a chain of three 3-return-leaf calls) plus the full set of scaffolding needed to land the value-content-hashing strategy from the plan.

The user-facing path-explosion reduction is **NOT activated** in this PR (mix() still returns `id * HASH_MULTIPLIER`) because flipping it breaks tests in ways the bridging code can almost-but-not-quite paper over. The scaffolding is committed so that the follow-up SSA-side work has a clean substrate to plug into.

## What's in this PR

- `TraceOperation.contentHash` — populated at op-creation time from the op kind, result type, and each input's structural fingerprint. `ConstantLiteral` inputs mix their literal bits.
- `ExecutionTrace.valueRefContentHashes` — per-`ValueRef` lookup so the trace contexts can resolve a content hash on every `allocate/freeValRef`. Assignments forward the source's content hash to the target; function arguments seed deterministically from `(index, type)`.
- `ExecutionTrace.bridgeMergeBlockNonLocals` — utility that, given a freshly-created merge block and a current-path block, emits `ASSIGN <reference-ref> <currentBlock-ref>` for each non-local `ValueRef` whose content hash matches a value produced locally on the current path. Wired in privately; not invoked yet (see below).
- `AliveVariableHash::increment/decrement` now take `(id, contentHash)`. Both trace contexts plumb the hash through `allocate/freeValRef`.

## What was prototyped on this branch and reverted

Three orthogonal switches that *individually* each break a different subset of tests; all kept out of this PR:

1. **Flipping `AliveVariableHash::mix` to use `contentHash`.** Collapses `pathExplosion_baseline_threeCallsNoBranch` exactly to its theoretical minimum (27 → 3 RETURNs, ~6 blocks). However, `pathExplosion_postCallBranch_2` / `_3` then crash in `SSACreationPhase` with `Wrong number of arguments in trace: expected 1, got N` (N up to 8). Root cause: content-hash equivalence is **not** the same as semantic-role equivalence. When two CONST 1 ops live in the same block (one is the leaf-internal `v == 1` literal, the other is from the post-call branch's `a + 1` etc.), `bridgeMergeBlockNonLocals` cannot tell which one represents the canonical outer-scope variable, and SSA propagation through the wrong bridge ends up promoting unrelated ValueRefs to phantom function arguments.
2. **Modular-addition combine in `AliveVariableHash`.** Motivated by the XOR-rollover canceling pair of same-content alive vars. Addition fixes that aliasing but trips the same SSA failure mode on a wider set of fixtures.
3. **Generalising `traceConstant`'s alias-via-ASSIGN trick to every value-producing op.** Sidesteps `processControlFlowMerge` entirely for value ops. Preserves the `pathExplosion_*` shape but regresses 534/4364 tracing assertions because every other test that legitimately wanted a control-flow merge (e.g. `selectFnPtr` INDIRECT_CALL + RETURN merge) gets per-path duplication instead.

## Why land just the scaffolding

All three viable variants need a **phi-aware** SSA propagator (or a richer ValueRef metadata channel) that can distinguish "this ValueRef is the outer `a`" from "this ValueRef happens to hold CONST 1 today." Both are out of scope for this branch — but both are unblocked by the plumbing here: a follow-up PR can flip `mix()` and call `bridgeMergeBlockNonLocals(...)` from `processControlFlowMerge` *after* SSACreationPhase learns to bridge properly.

The full strategy taxonomy and the catalogue of explored variants is documented in `/root/.claude/plans/investigate-the-baseline-threecallsnobra-pure-otter.md`.

## Test plan

- [x] `nautilus-execution-tests` — 10003/10003 assertions pass across 59 cases
- [x] `nautilus-tracing-tests` — 4490/4490 assertions pass across 15 cases
- [x] Built Release / Clang 18; no behavioural change so cross-compiler matrix CI is the source of truth
- [ ] (Follow-up) Re-run when phi-aware SSA propagation lands; expect path-explosion reference dumps to shrink substantially and `mix()` to flip in the same PR

https://claude.ai/code/session_01CMziZcUBzyfHf2h2uBuv65
