### PR TITLE
Make active-tracer deregistration exception-safe

### DIFF
--- a/nautilus/include/nautilus/tracing/TracingUtil.hpp
+++ b/nautilus/include/nautilus/tracing/TracingUtil.hpp
@@ -28,6 +28,21 @@ TracingInterface* getActiveTracer();
 /// Pass nullptr to indicate that tracing is no longer active.
 void setActiveTracer(TracingInterface* tracer);
 
+/// RAII guard that clears the active tracer on scope exit. Use in tracing entry
+/// points so an exception escaping the symbolic-execution loop (RuntimeException
+/// from ExecutionTrace, TagCreationException, or any exception from the traced
+/// function) still deregisters the thread-local tracer.
+struct ActiveTracerGuard {
+	ActiveTracerGuard() = default;
+	~ActiveTracerGuard() noexcept {
+		setActiveTracer(nullptr);
+	}
+	ActiveTracerGuard(const ActiveTracerGuard&) = delete;
+	ActiveTracerGuard& operator=(const ActiveTracerGuard&) = delete;
+	ActiveTracerGuard(ActiveTracerGuard&&) = delete;
+	ActiveTracerGuard& operator=(ActiveTracerGuard&&) = delete;
+};
+
 TypedValueRef& traceBinaryOp(Op op, Type resultType, const TypedValueRef& left, const TypedValueRef& right);
 TypedValueRef& traceUnaryOp(Op op, Type resultType, const TypedValueRef& input);
 TypedValueRef& traceTernaryOp(Op op, Type resultType, const TypedValueRef& first, const TypedValueRef& second,

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -302,6 +302,9 @@ std::unique_ptr<ExecutionTrace> ExceptionBasedTraceContext::trace(std::function<
 
 	// Initialize ExceptionBasedTraceContext with references to our objects
 	auto tc = initialize(tr, *executionTrace, symbolicExecutionContext, options);
+	// Ensure the thread-local active tracer is cleared even if an exception
+	// other than TraceTerminationException escapes the loop below.
+	ActiveTracerGuard activeTracerGuard;
 	auto traceIteration = 0;
 
 	// Symbolic execution loop: explore all execution paths
@@ -326,8 +329,7 @@ std::unique_ptr<ExecutionTrace> ExceptionBasedTraceContext::trace(std::function<
 		assert(traceContext.staticVars.empty() && "static variable stack not empty after tracing iteration");
 	}
 
-	// Clean up: deregister active tracer and reset state pointer
-	setActiveTracer(nullptr);
+	// Clean up: reset state pointer. activeTracer is cleared by ActiveTracerGuard.
 	tc->state.reset();
 
 	log::debug("Tracing Terminated with {} iterations", traceIteration);
@@ -348,6 +350,9 @@ std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<co
 	functionsToTrace = functions;
 	registeredFunctions.clear();
 	setActiveTracer(this);
+	// Ensure the thread-local active tracer is cleared even if an exception
+	// other than TraceTerminationException escapes the per-function loop below.
+	ActiveTracerGuard activeTracerGuard;
 
 	bool isFirstFunction = true;
 	while (!functionsToTrace.empty()) {
@@ -398,7 +403,7 @@ std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<co
 		log::trace("Final trace: {}", executionTrace);
 	}
 
-	setActiveTracer(nullptr);
+	// activeTracer is cleared by ActiveTracerGuard.
 	return traceModule;
 }
 

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -313,6 +313,10 @@ std::unique_ptr<ExecutionTrace> LazyTraceContext::trace(std::function<void()>& t
 
 	// Initialize LazyTraceContext with references to our objects
 	auto tc = initialize(tr, *executionTrace, symbolicExecutionContext, options);
+	// Ensure the thread-local active tracer is cleared even if an exception
+	// (e.g. RuntimeException from ExecutionTrace or from the traced function)
+	// escapes the loop below - this variant has no try/catch by design.
+	ActiveTracerGuard activeTracerGuard;
 	auto traceIteration = 0;
 
 	// Symbolic execution loop: explore all execution paths
@@ -335,8 +339,7 @@ std::unique_ptr<ExecutionTrace> LazyTraceContext::trace(std::function<void()>& t
 		assert(completingTraceContext.staticVars.empty() && "static variable stack not empty after tracing iteration");
 	}
 
-	// Clean up: deregister active tracer and reset state pointer
-	setActiveTracer(nullptr);
+	// Clean up: reset state pointer. activeTracer is cleared by ActiveTracerGuard.
 	tc->state.reset();
 
 	log::debug("Completing Tracing Terminated with {} iterations", traceIteration);
@@ -357,6 +360,9 @@ std::unique_ptr<TraceModule> LazyTraceContext::startTrace(std::list<compiler::Co
 	functionsToTrace = functions;
 	registeredFunctions.clear();
 	setActiveTracer(this);
+	// Ensure the thread-local active tracer is cleared even if an exception
+	// escapes the per-function loop below.
+	ActiveTracerGuard activeTracerGuard;
 
 	bool isFirstFunction = true;
 	while (!functionsToTrace.empty()) {
@@ -404,7 +410,7 @@ std::unique_ptr<TraceModule> LazyTraceContext::startTrace(std::list<compiler::Co
 		log::trace("Final trace: {}", executionTrace);
 	}
 
-	setActiveTracer(nullptr);
+	// activeTracer is cleared by ActiveTracerGuard.
 	return traceModule;
 }
 


### PR DESCRIPTION
## Summary

`setActiveTracer(nullptr)` was placed after the symbolic-execution loop in all four tracing entry points without RAII protection. `TraceTerminationException` is the only exception caught (the `LazyTraceContext` variants catch nothing). Any other exception escaping the loop skipped the cleanup, leaving `inTracer()` returning `true` on the thread until the next `initialize()` overwrote the stale state.

Reachable throw sites that previously bypassed cleanup:
- `RuntimeException` from `ExecutionTrace.cpp` (block / operation index bounds, "Invalid trace")
- `TagCreationException` from `TagRecorder.cpp` ("Stack is too deep")
- `RuntimeException` from `SSACreationPhase.cpp` ("Wrong number of arguments")
- `NotImplementedException` from `TraceToIRConversionPhase.cpp`
- Anything propagated from the user's `traceFunction()`

## Changes

- New `ActiveTracerGuard` RAII type in `TracingUtil.hpp` that clears the active tracer on scope exit (non-copyable, non-movable, `noexcept` destructor).
- Install one guard at the top of each of the four tracing entry points:
  - `ExceptionBasedTraceContext::trace`
  - `ExceptionBasedTraceContext::startTrace`
  - `LazyTraceContext::trace`
  - `LazyTraceContext::startTrace`
- Remove the now-redundant trailing `setActiveTracer(nullptr)` calls.

## Test plan

- [x] `cmake --build .` — full build green, all backends (`MLIR`, `C`, `BC`, `AsmJit`) enabled
- [x] All tests link (`nautilus-execution-tests`, `nautilus-std-tests`, `nautilus-inlining-tests`, etc.)
- [x] Representative test subset passes (16 Interpreter/Compiler tests, incl. `Engine Compiler Test`)
- [x] `./format.sh` reports no violations in the three touched files


---
_Generated by [Claude Code](https://claude.ai/code/session_012bMZoayDhGmsCt1NVf8gsG)_