### PR TITLE
Remove implicit operator bool from val&lt;T*&gt; and val&lt;FuncPtr&gt;

### DIFF
--- a/nautilus/include/nautilus/val_func.hpp
+++ b/nautilus/include/nautilus/val_func.hpp
@@ -22,7 +22,7 @@ namespace nautilus {
 ///     which handles both tracing and non-tracing paths.  At trace time the
 ///     concrete runtime address is used, so the traced ProxyCallOperation is
 ///     specialised for that specific address.
-///   - Null / boolean check: operator bool(), == nullptr, != nullptr
+///   - Null check via explicit == nullptr / != nullptr (no implicit operator bool())
 ///   - Pointer equality: == and != with another val<FuncPtr> of the same type
 ///   - Implicit conversion to val<void*> for passing to runtime functions that
 ///     accept a generic opaque callback pointer
@@ -100,11 +100,12 @@ public:
 	const tracing::TypedValueRefHolder& state = ptr.state;
 #endif
 
-	// ---- Bool / null check ----
-
-	operator bool() const {
-		return *this != nullptr;
-	}
+	// ---- Null check ----
+	// Intentionally no implicit `operator bool()`. Converting a function pointer to a
+	// native bool materializes the null test into a control-flow branch (traceBool)
+	// that can be split from the call/dereference it guards, leaving an unchecked use
+	// that LLVM assumes non-null and miscompiles at -O3. Use the explicit
+	// `== nullptr` / `!= nullptr` below, which stay symbolic `val<bool>` data values.
 
 	// ---- Equality ----
 

--- a/nautilus/include/nautilus/val_ptr.hpp
+++ b/nautilus/include/nautilus/val_ptr.hpp
@@ -178,9 +178,12 @@ public:
 	}
 #endif
 
-	operator bool() const {
-		return *this != static_cast<val<ValuePtrType>>(nullptr);
-	}
+	// Intentionally no implicit `operator bool()`. Converting a pointer to a native
+	// bool materializes the null test into a control-flow branch (traceBool) that can
+	// be split from the dereference it guards -- in particular across loop back-edges
+	// where the pointer is reassigned -- leaving an unchecked load that LLVM assumes
+	// non-null and miscompiles at -O3. Use explicit `== nullptr` / `!= nullptr`, which
+	// stay symbolic `val<bool>` data values feeding a single condition branch.
 
 	/// Conversion from pointer to arithmetic type (ptr→int, ptr→float).
 	/// Treats the pointer value as a uintptr_t and casts to the target type.
@@ -365,9 +368,12 @@ public:
 		return val<OtherType>(static_cast<OtherType>(reinterpret_cast<uintptr_t>(this->value)));
 	}
 
-	operator bool() const {
-		return *this != static_cast<val<ValuePtrType>>(nullptr);
-	}
+	// Intentionally no implicit `operator bool()`. Converting a pointer to a native
+	// bool materializes the null test into a control-flow branch (traceBool) that can
+	// be split from the dereference it guards -- in particular across loop back-edges
+	// where the pointer is reassigned -- leaving an unchecked load that LLVM assumes
+	// non-null and miscompiles at -O3. Use explicit `== nullptr` / `!= nullptr`, which
+	// stay symbolic `val<bool>` data values feeding a single condition branch.
 
 	template <typename IndexType>
 	    requires is_integral<IndexType> || is_fundamental_val<IndexType>
@@ -438,9 +444,12 @@ public:
 		return val<OtherType>(static_cast<OtherType>(reinterpret_cast<uintptr_t>(this->value)));
 	}
 
-	operator bool() const {
-		return *this != static_cast<val<ValuePtrType>>(nullptr);
-	}
+	// Intentionally no implicit `operator bool()`. Converting a pointer to a native
+	// bool materializes the null test into a control-flow branch (traceBool) that can
+	// be split from the dereference it guards -- in particular across loop back-edges
+	// where the pointer is reassigned -- leaving an unchecked load that LLVM assumes
+	// non-null and miscompiles at -O3. Use explicit `== nullptr` / `!= nullptr`, which
+	// stay symbolic `val<bool>` data values feeding a single condition branch.
 };
 
 template <is_ptr ValueType, is_fundamental_val IndexType>

--- a/nautilus/test/common/BoolOperations.hpp
+++ b/nautilus/test/common/BoolOperations.hpp
@@ -68,6 +68,19 @@ val<bool> operatorBool(val<T> x) {
 	}
 }
 
+// Pointer null check in the explicit, symbolic form. `p != nullptr` stays a
+// val<bool> data value feeding a single condition branch. val<T*> deliberately
+// has no implicit `operator bool()`: that conversion materializes the null test
+// into a separate control-flow branch which can be split from the dereference it
+// guards, leaving an unchecked load that LLVM miscompiles at -O3.
+val<bool> ptrIsNonNull(val<int32_t*> p) {
+	if (p != nullptr) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 // Comparison operators with raw bool (testing NEW operators added to val_bool.hpp)
 val<bool> boolEqualsMixed(val<bool> x, val<bool> y) {
 	// Convert y to raw bool to test mixed operations
@@ -266,6 +279,42 @@ val<uint64_t> invokeU32ThenCastToU64(val<uint32_t> v) {
 	(void) dirty;
 	auto narrow = invoke(returnsU32, v);
 	return static_cast<val<uint64_t>>(narrow);
+}
+
+// --- Pointer null-guard loop regression -------------------------------------
+//
+// Walks a singly linked list, reassigning the cursor inside the loop. This is
+// the shape that crashed in NebulaStream's chained-hash-map probe: the loop
+// condition tests a pointer that is overwritten every iteration
+// (`node = node->next`, which can become null). Written with the explicit
+// `node != nullptr`, the null test stays a symbolic val<bool> feeding the loop
+// condition, so the guard dominates every iteration's load. (The implicit
+// pointer `operator bool()` was removed precisely because, combined with the
+// eager &&/|| operators, it could split the per-iteration null guard from the
+// load and let LLVM treat the dereference as unchecked at -O3.) This kernel must
+// return the correct sum and never dereference a null cursor -- in BOTH bool
+// configs and at the engine's full optimization level.
+struct ListNode {
+	int32_t value;
+	ListNode* next;
+};
+
+inline int32_t listNodeValue(ListNode* n) {
+	return n->value;
+}
+
+inline ListNode* listNodeNext(ListNode* n) {
+	return n->next;
+}
+
+val<int32_t> sumLinkedList(val<ListNode*> head) {
+	val<int32_t> sum = 0;
+	val<ListNode*> node = head;
+	while (node != nullptr) {
+		sum += invoke(listNodeValue, node);
+		node = invoke(listNodeNext, node);
+	}
+	return sum;
 }
 
 #ifdef ENABLE_SHORT_CIRCUIT_BOOL

--- a/nautilus/test/execution-tests/BoolExecutionTest.cpp
+++ b/nautilus/test/execution-tests/BoolExecutionTest.cpp
@@ -91,13 +91,24 @@ void boolTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(false) == false);
 	}
 
-	SECTION("operatorBoolPtr") {
-		auto f = engine.registerFunction(operatorBool<int*>);
-		int* x = nullptr;
-		int tmp = 1234;
-		int* y = &tmp;
-		REQUIRE(f(x) == false);
-		REQUIRE(f(y) == true);
+	SECTION("ptrIsNonNull") {
+		auto f = engine.registerFunction(ptrIsNonNull);
+		int32_t tmp = 1234;
+		REQUIRE(f(nullptr) == false);
+		REQUIRE(f(&tmp) == true);
+	}
+
+	SECTION("sumLinkedList null head") {
+		auto f = engine.registerFunction(sumLinkedList);
+		REQUIRE(f(nullptr) == 0);
+	}
+
+	SECTION("sumLinkedList walks and reassigns cursor") {
+		auto f = engine.registerFunction(sumLinkedList);
+		ListNode n2 {30, nullptr};
+		ListNode n1 {20, &n2};
+		ListNode n0 {10, &n1};
+		REQUIRE(f(&n0) == 60);
 	}
 
 	SECTION("boolEqualsMixed") {

--- a/nautilus/test/val-tests/FunctionPtrValTypeTest.cpp
+++ b/nautilus/test/val-tests/FunctionPtrValTypeTest.cpp
@@ -36,14 +36,17 @@ TEST_CASE("FunctionPtr Val Test") {
 		REQUIRE((fn != nullptr) == true);
 	}
 
-	SECTION("operator bool - null is false") {
+	// val<FuncPtr> has no implicit operator bool() (it would materialize the null
+	// test into a control-flow branch); the null check is the explicit `!= nullptr`,
+	// which stays a symbolic val<bool>.
+	SECTION("null check via != nullptr - null is false") {
 		val<BinFn> fn(nullptr);
-		REQUIRE(!static_cast<bool>(fn));
+		REQUIRE((fn != nullptr) == false);
 	}
 
-	SECTION("operator bool - non-null is true") {
+	SECTION("null check via != nullptr - non-null is true") {
 		val<BinFn> fn(addHelper);
-		REQUIRE(static_cast<bool>(fn));
+		REQUIRE((fn != nullptr) == true);
 	}
 
 	SECTION("copy constructor preserves pointer") {


### PR DESCRIPTION
## Problem

An implicit `operator bool()` on a pointer wrapper must return a **native `bool`**. That single C++ requirement is the root of a `-O3` miscompile:

1. **It collapses a symbolic value into control flow.** A symbolic null test should stay a `val<bool>` — an SSA data value (`NEQ ptr, null`). But `operator bool` forces it through `val<bool>::operator bool` → `tracing::traceBool`, which records a **`CMP` branch op** and forks symbolic execution. The null test stops being *data* and becomes *control flow*, at the point of the implicit conversion.

2. **Combined with `&&`/`||`, the guard gets split from the dereference it protects.** In the default build the boolean operators are the eager, non-short-circuiting `lAnd`/`lOr`. In a guard like `while (entry && !found)` the materialized null `CMP` ends up separate from the loop-condition branch that gates the body. When the pointer is **reassigned inside the loop** (`entry = entry->next`, which can become null), the per-iteration null guard no longer dominates the body's load. The load becomes effectively unconditional; LLVM then assumes the pointer is non-null and miscompiles — a crash in NebulaStream's chained-hash-map probe. This is the "null check that doesn't show up in the trace anymore, so LLVM treats the dereference as unchecked."

3. **There is no safe version of the operator.** Because it must return a native `bool`, it can only ever produce the fragile materialized-branch form. Writing the null test explicitly (`ptr != nullptr`) keeps it a `val<bool>` data value that flows into a single condition branch dominating the guarded dereference. Removing the implicit conversion is therefore the underlying fix, not a workaround — and it applies equally to `val<FuncPtr>`, which had the byte-for-byte identical operator.

## Changes

- **`val_ptr.hpp`**: remove the three null-check `operator bool()` overloads (`base_ptr_val`, the non-void and void pointer specializations). The `bool*` dereference proxy's `operator bool` is **kept** — it performs a value *load*, not a null test.
- **`val_func.hpp`**: remove the identical `operator bool()`; `val<FuncPtr>` already exposes `== / != (nullptr)`.

## Tests

- Replace `operatorBool<int*>` with `ptrIsNonNull`, using the explicit `!= nullptr` form.
- Add `sumLinkedList`: a loop that **reassigns its pointer cursor every iteration** (the probe shape that crashed), driven with a real list and a null head. Deliberately **not** gated on `ENABLE_SHORT_CIRCUIT_BOOL`, so it runs in both bool configs.
- Update the `FunctionPtr` val tests to check null via `!= nullptr`.

## Verification

- Built and ran the full execution + value-type suites with **both** `ENABLE_SHORT_CIRCUIT_BOOL=OFF` (eager) and `=ON` (short-circuit): all pass (eager 7881 assertions, short-circuit 8014).
- Confirmed `if (ptr)` on a `val<T*>` is now a compile error in both configs, forcing the explicit form.
- `clang-format-18` clean on all changed files.

> Note: the MLIR backend (where the `-O3` LLVM miscompile actually manifests) was disabled in the local build for speed; the CI matrix exercises it. The unsigned right-shift fix from the same downstream report is already on `main` (#293) and is not part of this PR.

https://claude.ai/code/session_01HQBbKJc57ykdLJDRNjHXBL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQBbKJc57ykdLJDRNjHXBL)_