### PR TITLE
Erase zero-count entries in AliveVariableHash to stop unbounded memory growth

### DIFF
--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
@@ -10,13 +10,17 @@
 #include "tag/Tag.hpp"
 #include "tag/TagRecorder.hpp"
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <list>
 #include <memory>
+#include <new>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace nautilus {
 class NautilusFunctionDefinition;
@@ -55,6 +59,9 @@ inline size_t getStaticVarValue(const StaticVarHolder& holder) {
  * - Each variable ID is mixed with a constant multiplier for better hash distribution
  * - The hash incorporates both variable identity (ID) and reference count
  * - Uses unordered_map for sparse storage (only allocates for variables that exist)
+ * - Map nodes come from an internal free-list pool (see NodePool); entries are erased
+ *   when their count reaches zero, so memory stays bounded by the peak number of
+ *   alive variables instead of growing with every value ref ever seen
  *
  * Performance characteristics:
  * - increment(): O(1) average - hash map lookup + two XOR operations, two multiplications
@@ -66,7 +73,112 @@ inline size_t getStaticVarValue(const StaticVarHolder& holder) {
 class AliveVariableHash {
 	static constexpr uint64_t HASH_MULTIPLIER = 0x9e3779b97f4a7c15; // Golden ratio constant for good mixing
 
-	std::unordered_map<uint32_t, uint32_t> counts;
+	// Free-list node pool backing the counts map. The tracing workload inserts and
+	// erases one map node per value lifetime; routing those through the general-purpose
+	// allocator costs a malloc/free pair per traced value, which measurably slows
+	// tracing of large functions. The pool hands blocks out of bump-allocated chunks
+	// and recycles freed blocks via per-size free lists (the allocator is rebound to
+	// different types - nodes and bucket arrays - so size classes must not be mixed).
+	// Memory stays bounded by the peak number of alive variables.
+	class NodePool {
+		static constexpr std::size_t CHUNK_SIZE = 16 * 1024;
+		static constexpr std::size_t BLOCK_ALIGN = alignof(std::max_align_t);
+		static constexpr std::size_t MAX_POOLED_SIZE = 4 * BLOCK_ALIGN;
+		static constexpr std::size_t NUM_SIZE_CLASSES = MAX_POOLED_SIZE / BLOCK_ALIGN;
+
+		std::vector<void*> chunks;
+		std::array<void*, NUM_SIZE_CLASSES> freeHeads {};
+		std::byte* cursor = nullptr;
+		std::byte* chunkEnd = nullptr;
+
+		static constexpr std::size_t roundedSize(std::size_t size) noexcept {
+			return (size + BLOCK_ALIGN - 1) & ~(BLOCK_ALIGN - 1);
+		}
+
+	public:
+		NodePool() = default;
+		NodePool(const NodePool&) = delete;
+		NodePool& operator=(const NodePool&) = delete;
+		~NodePool() {
+			for (void* chunk : chunks) {
+				std::free(chunk);
+			}
+		}
+
+		void* allocate(std::size_t size) {
+			const std::size_t step = roundedSize(size);
+			if (step > MAX_POOLED_SIZE) {
+				return ::operator new(size);
+			}
+			void*& freeHead = freeHeads[step / BLOCK_ALIGN - 1];
+			if (freeHead != nullptr) {
+				void* block = freeHead;
+				freeHead = *static_cast<void**>(block);
+				return block;
+			}
+			if (cursor == nullptr || cursor + step > chunkEnd) {
+				void* chunk = std::malloc(CHUNK_SIZE);
+				if (chunk == nullptr) {
+					throw std::bad_alloc();
+				}
+				chunks.push_back(chunk);
+				cursor = static_cast<std::byte*>(chunk);
+				chunkEnd = cursor + CHUNK_SIZE;
+			}
+			void* block = cursor;
+			cursor += step;
+			return block;
+		}
+
+		void deallocate(void* block, std::size_t size) noexcept {
+			const std::size_t step = roundedSize(size);
+			if (step > MAX_POOLED_SIZE) {
+				::operator delete(block);
+				return;
+			}
+			void*& freeHead = freeHeads[step / BLOCK_ALIGN - 1];
+			*static_cast<void**>(block) = freeHead;
+			freeHead = block;
+		}
+	};
+
+	template <typename T>
+	struct PoolAllocator {
+		using value_type = T;
+		NodePool* pool;
+
+		explicit PoolAllocator(NodePool* pool) noexcept : pool(pool) {
+		}
+		template <typename U>
+		PoolAllocator(const PoolAllocator<U>& other) noexcept : pool(other.pool) {
+		}
+		template <typename U>
+		bool operator==(const PoolAllocator<U>& other) const noexcept {
+			return pool == other.pool;
+		}
+
+		T* allocate(std::size_t n) {
+			if (n == 1) {
+				return static_cast<T*>(pool->allocate(sizeof(T)));
+			}
+			// Bucket arrays (n > 1) are few and resize rarely; the heap handles them.
+			return static_cast<T*>(::operator new(n * sizeof(T)));
+		}
+		void deallocate(T* p, std::size_t n) noexcept {
+			if (n == 1) {
+				pool->deallocate(p, sizeof(T));
+			} else {
+				::operator delete(p);
+			}
+		}
+	};
+
+	using CountsMap = std::unordered_map<uint32_t, uint32_t, std::hash<uint32_t>, std::equal_to<uint32_t>,
+	                                     PoolAllocator<std::pair<const uint32_t, uint32_t>>>;
+
+	NodePool pool; // Must be declared before counts so it outlives the map's nodes.
+	CountsMap counts {0, std::hash<uint32_t> {}, std::equal_to<uint32_t> {},
+	                  PoolAllocator<std::pair<const uint32_t, uint32_t>> {&pool}};
 	uint64_t alive_hash = 0;
 
 public:

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
@@ -96,13 +96,23 @@ public:
 	 * The hash is updated by XOR-ing out the old contribution ((id * HASH_MULTIPLIER) * old_count)
 	 * and XOR-ing in the new contribution ((id * HASH_MULTIPLIER) * new_count).
 	 *
+	 * Entries that reach a count of zero are erased. This is hash-neutral (a zero count
+	 * contributes 0 to the XOR hash, identical to an absent entry) and keeps the map size
+	 * proportional to the number of currently-alive variables. Without the erase, the map
+	 * grows with every value ref ever seen and — because the trace context is thread_local —
+	 * persists across trace iterations and across traced functions.
+	 *
 	 * @param id Variable identifier (32-bit value)
 	 */
 	inline void decrement(uint32_t id) noexcept {
-		uint32_t& c = counts[id];
+		const auto it = counts.try_emplace(id, 0).first;
+		uint32_t& c = it->second;
 		alive_hash ^= (id * HASH_MULTIPLIER) * c;
 		--c;
 		alive_hash ^= (id * HASH_MULTIPLIER) * c;
+		if (c == 0) {
+			counts.erase(it);
+		}
 	}
 
 	/**
@@ -119,16 +129,30 @@ public:
 	}
 
 	/**
+	 * @brief Returns the number of tracked entries.
+	 *
+	 * Since zero-count entries are erased by decrement(), this is the number of
+	 * currently-alive variables (variables with a non-zero reference count).
+	 *
+	 * @return Number of entries in the underlying map
+	 */
+	inline size_t size() const noexcept {
+		return counts.size();
+	}
+
+	/**
 	 * @brief Resets all reference counts and hash to initial state.
 	 *
 	 * This efficiently clears all counts without creating a temporary object.
-	 * Optimized: if hash is already 0, we assume counts are already empty and skip the clear.
+	 * Since decrement() erases entries when they reach zero, a balanced trace iteration
+	 * leaves the map empty and this is a no-op. The emptiness check (rather than a hash
+	 * check) also guards against the rare XOR collision where live entries hash to 0.
 	 */
 	inline void reset() noexcept {
-		if (alive_hash != 0) {
+		if (!counts.empty()) {
 			counts.clear();
-			alive_hash = 0;
 		}
+		alive_hash = 0;
 	}
 };
 

--- a/nautilus/test/CMakeLists.txt
+++ b/nautilus/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(benchmark)
 add_subdirectory(execution-tests)
 if (ENABLE_TRACING)
     add_subdirectory(ir-pass-tests)
+    add_subdirectory(tracing-tests)
 endif ()
 add_subdirectory(val-tests)
 

--- a/nautilus/test/tracing-tests/AliveVariableHashTest.cpp
+++ b/nautilus/test/tracing-tests/AliveVariableHashTest.cpp
@@ -1,0 +1,78 @@
+#include "nautilus/tracing/ExceptionBasedTraceContext.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace nautilus::tracing {
+
+TEST_CASE("AliveVariableHash erases entries that reach a zero count", "[AliveVariableHash]") {
+	AliveVariableHash avh;
+	REQUIRE(avh.size() == 0);
+	REQUIRE(avh.hash() == 0);
+
+	avh.increment(1);
+	avh.increment(2);
+	avh.increment(3);
+	REQUIRE(avh.size() == 3);
+
+	avh.decrement(2);
+	REQUIRE(avh.size() == 2);
+
+	avh.decrement(1);
+	avh.decrement(3);
+	REQUIRE(avh.size() == 0);
+	REQUIRE(avh.hash() == 0);
+}
+
+TEST_CASE("AliveVariableHash erasure is hash-neutral", "[AliveVariableHash]") {
+	// A variable that was seen and fully released must leave the hash identical
+	// to one that was never seen. Snapshots key on this hash, so any difference
+	// would change trace deduplication and the generated IR.
+	AliveVariableHash seenAndReleased;
+	seenAndReleased.increment(7);
+	seenAndReleased.increment(42);
+	seenAndReleased.decrement(42);
+
+	AliveVariableHash neverSeen;
+	neverSeen.increment(7);
+
+	REQUIRE(seenAndReleased.hash() == neverSeen.hash());
+	REQUIRE(seenAndReleased.size() == neverSeen.size());
+}
+
+TEST_CASE("AliveVariableHash re-incrementing a released id reproduces the original hash", "[AliveVariableHash]") {
+	AliveVariableHash avh;
+	avh.increment(5);
+	const uint64_t hashWithFive = avh.hash();
+
+	avh.decrement(5);
+	avh.increment(5);
+	REQUIRE(avh.hash() == hashWithFive);
+	REQUIRE(avh.size() == 1);
+}
+
+TEST_CASE("AliveVariableHash hash reflects reference counts", "[AliveVariableHash]") {
+	AliveVariableHash once;
+	once.increment(9);
+
+	AliveVariableHash twice;
+	twice.increment(9);
+	twice.increment(9);
+
+	REQUIRE(once.hash() != twice.hash());
+	REQUIRE(twice.size() == 1);
+
+	twice.decrement(9);
+	REQUIRE(twice.hash() == once.hash());
+}
+
+TEST_CASE("AliveVariableHash reset clears live entries", "[AliveVariableHash]") {
+	AliveVariableHash avh;
+	avh.increment(1);
+	avh.increment(1);
+	avh.increment(2);
+
+	avh.reset();
+	REQUIRE(avh.size() == 0);
+	REQUIRE(avh.hash() == 0);
+}
+
+} // namespace nautilus::tracing

--- a/nautilus/test/tracing-tests/AliveVariableHashTest.cpp
+++ b/nautilus/test/tracing-tests/AliveVariableHashTest.cpp
@@ -3,7 +3,7 @@
 
 namespace nautilus::tracing {
 
-TEST_CASE("AliveVariableHash erases entries that reach a zero count", "[AliveVariableHash]") {
+TEST_CASE("AliveVariableHash tracks the number of alive variables", "[AliveVariableHash]") {
 	AliveVariableHash avh;
 	REQUIRE(avh.size() == 0);
 	REQUIRE(avh.hash() == 0);
@@ -62,6 +62,26 @@ TEST_CASE("AliveVariableHash hash reflects reference counts", "[AliveVariableHas
 
 	twice.decrement(9);
 	REQUIRE(twice.hash() == once.hash());
+}
+
+TEST_CASE("AliveVariableHash id churn neither perturbs the hash nor grows the map", "[AliveVariableHash]") {
+	// Monotonically increasing ids that immediately die mimic the tracing access
+	// pattern: value refs are assigned monotonically and never reused. The churn must
+	// not affect the hash or the size while a long-lived entry survives it.
+	AliveVariableHash avh;
+	avh.increment(1000000);
+	const uint64_t hashWithSurvivor = avh.hash();
+
+	for (uint32_t id = 0; id < 10000; ++id) {
+		avh.increment(id);
+		avh.decrement(id);
+		REQUIRE(avh.hash() == hashWithSurvivor);
+	}
+	REQUIRE(avh.size() == 1);
+
+	avh.decrement(1000000);
+	REQUIRE(avh.size() == 0);
+	REQUIRE(avh.hash() == 0);
 }
 
 TEST_CASE("AliveVariableHash reset clears live entries", "[AliveVariableHash]") {

--- a/nautilus/test/tracing-tests/CMakeLists.txt
+++ b/nautilus/test/tracing-tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+include(CTest)
+include(Catch)
+
+add_executable(nautilus-tracing-unit-tests
+        AliveVariableHashTest.cpp
+)
+
+target_link_libraries(nautilus-tracing-unit-tests PRIVATE nautilus Catch2::Catch2WithMain nautilus-sanitizer-suppressions)
+target_include_directories(nautilus-tracing-unit-tests PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src>
+)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+catch_discover_tests(nautilus-tracing-unit-tests EXTRA_ARGS --allow-running-no-tests)


### PR DESCRIPTION
## Problem

`AliveVariableHash` tracks reference counts of alive value refs and feeds an incrementally maintained XOR hash into `Snapshot`, which keys the tag maps used for trace deduplication. Two behaviors combined into unbounded memory growth:

1. **`decrement()` never removed entries.** When a value ref's count dropped to 0, the entry stayed in the `unordered_map`. Value refs are assigned monotonically and never reused (`lastValueRef` is not reset in `resetExecution()`), so the map grew with *every value ref ever seen across all symbolic-execution iterations*, not with the number of currently-alive values. Path-explosion traces accumulate millions of entries in a single `trace()` call.
2. **`reset()` skipped clearing when the hash was 0** — which is exactly the state a balanced trace iteration ends in (all counts back to 0 ⇒ hash back to 0). So the dead entries survived `reset()`.

Because both trace contexts (`ExceptionBasedTraceContext`, `LazyTraceContext`) are `thread_local` statics, the high-water-mark map persisted for the lifetime of the thread. Standalone measurement of the pathological case: 10M unique value refs retain **~400 MB that `reset()` never frees**; with the fix the structure stays at O(alive variables).

## Fix

- **`decrement()` erases the entry when the count reaches 0** (commit 1). This is **hash-neutral**: a zero count contributes `(id * HASH_MULTIPLIER) * 0 = 0` to the XOR hash, identical to an absent entry — verified op-by-op in simulation and by unit test. Snapshot hashes, trace deduplication, and generated IR are bit-identical.
- **`reset()` checks map emptiness instead of `hash != 0`** (commit 1). Also removes a latent edge case: live entries XOR-colliding to hash 0 would previously skip the clear and leak reference counts into the next trace iteration.
- **The map's nodes come from an internal free-list pool** (commit 3). Eager erasure alone pays a malloc/free pair per traced value, which slowed trace-only microbenchmarks of large functions by up to ~1.3x (the pre-fix baseline was also flattered by the leak: the never-cleared map made re-traces pure lookups with no insertions). The pool bump-allocates 16 KB chunks and recycles freed blocks via per-size free lists (per-size because the allocator is rebound to both node and bucket-array types; mixing size classes in one free list would corrupt the heap). A bump-only arena would not fit: without per-node reclamation, insert/erase churn regrows memory with every value ref — the leak this PR removes.

### Performance (local, back-to-back builds, full tracing suite)

| variant | suite total | worst case (`completing_trace_nestedIf100`) | memory |
|---|---|---|---|
| pre-fix (leak-warmed baseline) | 10.60 ms | 1.50 ms | unbounded high-water mark, never freed |
| eager erase only | 12.36 ms (1.17x) | 1.96 ms (1.31x) | O(alive) |
| eager erase + node pool (final) | **11.02 ms (1.04x)** | 1.78 ms (1.19x) | O(alive); pool retains one 16 KB chunk per trace context across the whole suite (instrumented) |

Several benchmarks beat the old baseline (`trace_deeplyNestedIfElse` 0.85, `completing_trace_chainedIf100` 0.90). End-to-end compilation impact is ~1.02–1.04 since tracing is a thin slice of it.

## Testing

- Full suite passes locally (196 tests; Release, Clang 18, MLIR backend off in this environment), including 6 new `AliveVariableHash` unit tests in a new `tracing-tests` suite covering erasure, hash-neutrality, monotonic-id churn, count sensitivity, and reset.
- All 17 CI checks green, including ASAN (gcc-14 and clang-21), macOS/libc++, and ARM.

https://claude.ai/code/session_01XTX9MjHW7Bgq2uSrFMXhiX