### PR TITLE
Make NautilusEngine thread-safe for concurrent compile()

### DIFF
--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -210,17 +210,17 @@ public:
 
 private:
 	/**
-	 * @brief Arena owned by the engine and reused across every compilation.
+	 * @brief Pool of trace arenas owned by the engine.
 	 *
-	 * The JIT compiler holds a non-owning reference to this arena and
-	 * softReset()s it at the start of each compile().  Keeping the arena
-	 * on the engine (rather than inside the compiler) matches the intent
-	 * that it is an engine-level resource that can be shared with other
-	 * engine-scoped infrastructure in the future.  Declared before
-	 * @ref jit_ so the compiler's reference remains valid throughout its
-	 * lifetime.
+	 * Each compile() acquires a fresh trace arena from this pool for the
+	 * duration of its tracing/IR-generation, then returns it (softReset and
+	 * recycled) when done.  Because the pool is internally synchronized and
+	 * hands every concurrent compile() a distinct arena, multiple threads may
+	 * compile on a single shared engine without racing on a common bump
+	 * allocator.  Declared before @ref jit_ so the compiler's reference
+	 * remains valid throughout its lifetime.
 	 */
-	std::unique_ptr<common::Arena> arena_;
+	std::unique_ptr<common::ArenaPool> traceArenaPool_;
 	/**
 	 * @brief Pool of IR-graph arenas owned by the engine.
 	 *
@@ -337,17 +337,15 @@ public:
 	CompiledModule compile() {
 #ifdef ENABLE_TRACING
 		if (compiled_) {
-			auto executable = jit_.compile(functions_, moduleOptions_);
-			auto module = CompiledModule(std::move(executable), std::move(interpretedFunctions_));
-
-			// If using tiered compilation, start background promotion.
-			// The TieredJITCompiler directly swaps the executable and bumps
-			// the version in the module state when tier-1 compilation completes.
-			// if (auto* tiered = dynamic_cast<const compiler::TieredJITCompiler*>(&jit_)) {
-			//	tiered->promoteAsync(module.getState());
-			//}
-
-			return module;
+			// Compile into a freshly created module state. Each compile() carries
+			// its own IR to its own (optional, tiered) background promotion, so
+			// concurrent compiles on a shared engine share no compiler-level
+			// state. A tiered compiler swaps in the tier-1 executable and bumps
+			// the version on this state when promotion completes.
+			auto state = std::make_shared<details::ModuleState>();
+			state->interpretedFunctions = std::move(interpretedFunctions_);
+			jit_.compileModule(functions_, moduleOptions_, state);
+			return CompiledModule(std::move(state));
 		}
 #endif
 		return CompiledModule(std::move(interpretedFunctions_));

--- a/nautilus/include/nautilus/JITCompiler.hpp
+++ b/nautilus/include/nautilus/JITCompiler.hpp
@@ -5,6 +5,10 @@
 #include <list>
 #include <memory>
 
+namespace nautilus::engine::details {
+struct ModuleState;
+}
+
 namespace nautilus::compiler {
 
 class Executable;
@@ -48,6 +52,22 @@ public:
 	 */
 	[[nodiscard]] virtual std::unique_ptr<Executable>
 	compile(std::list<CompilableFunction>& functions, const engine::ModuleOptions& moduleOptions = {}) const = 0;
+
+	/**
+	 * @brief Compile @p functions and publish the result into @p state.
+	 *
+	 * Sets @c state->executable to the produced executable. Compilers that
+	 * promote in the background (tiered) additionally start an asynchronous
+	 * promotion targeting @p state. Passing the module state lets each compile
+	 * carry its own IR to its own promotion, so concurrent compile() calls on a
+	 * shared engine never share compiler-level state.
+	 *
+	 * @param functions List of named compilable functions to trace and compile.
+	 * @param moduleOptions Per-module options for this compilation.
+	 * @param state Module state to populate (and, for tiered compilers, promote).
+	 */
+	virtual void compileModule(std::list<CompilableFunction>& functions, const engine::ModuleOptions& moduleOptions,
+	                           std::shared_ptr<engine::details::ModuleState> state) const = 0;
 
 	/**
 	 * @brief Get the name of the primary compilation backend.

--- a/nautilus/src/nautilus/compiler/Engine.cpp
+++ b/nautilus/src/nautilus/compiler/Engine.cpp
@@ -9,33 +9,34 @@ namespace nautilus::engine {
 /**
  * @brief Creates the appropriate JITCompiler implementation based on options.
  *
- * The engine-owned @p arena and @p irArenaPool are injected into the
- * compiler so every trace allocation across every compile() call shares a
- * single pool of chunks (trace), and every IR-graph allocation likewise
- * recycles its arena across compiles (IR pool).
+ * The engine-owned @p traceArenaPool and @p irArenaPool are injected into the
+ * compiler so every compile() acquires a fresh, recycled trace arena (trace
+ * pool), and every IR-graph allocation likewise recycles its arena across
+ * compiles (IR pool).  Both pools are internally synchronized, so a single
+ * compiler may serve concurrent compile() calls from multiple threads.
  */
-inline std::unique_ptr<compiler::JITCompiler> createJITCompiler(const Options& options, common::Arena& arena,
-                                                                common::ArenaPool& irArenaPool) {
+inline std::unique_ptr<compiler::JITCompiler>
+createJITCompiler(const Options& options, common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool) {
 	// If the user explicitly selected a backend, use the legacy single-tier compiler
 	// so the requested backend is honoured directly.
 	auto explicitBackend = options.getOptionOrDefault<std::string>("engine.backend", "");
 	if (!explicitBackend.empty()) {
-		return std::make_unique<compiler::LegacyCompiler>(options, arena, irArenaPool);
+		return std::make_unique<compiler::LegacyCompiler>(options, traceArenaPool, irArenaPool);
 	}
 	std::string compilerStrategy = options.getOptionOrDefault("engine.compilationStrategy", std::string("tiered"));
 	if (compilerStrategy == "tiered") {
-		return std::make_unique<compiler::TieredJITCompiler>(options, arena, irArenaPool);
+		return std::make_unique<compiler::TieredJITCompiler>(options, traceArenaPool, irArenaPool);
 	}
-	return std::make_unique<compiler::LegacyCompiler>(options, arena, irArenaPool);
+	return std::make_unique<compiler::LegacyCompiler>(options, traceArenaPool, irArenaPool);
 }
 
 NautilusEngine::NautilusEngine(const Options& options)
-    : arena_(std::make_unique<common::Arena>()), irArenaPool_(std::make_unique<common::ArenaPool>()),
-      jit_(createJITCompiler(options, *arena_, *irArenaPool_)), options(options) {
+    : traceArenaPool_(std::make_unique<common::ArenaPool>()), irArenaPool_(std::make_unique<common::ArenaPool>()),
+      jit_(createJITCompiler(options, *traceArenaPool_, *irArenaPool_)), options(options) {
 }
 
 NautilusEngine::NautilusEngine(std::unique_ptr<compiler::JITCompiler> jit, const Options& options)
-    : arena_(std::make_unique<common::Arena>()), irArenaPool_(std::make_unique<common::ArenaPool>()),
+    : traceArenaPool_(std::make_unique<common::ArenaPool>()), irArenaPool_(std::make_unique<common::ArenaPool>()),
       jit_(std::move(jit)), options(options) {
 }
 

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.cpp
@@ -1,6 +1,7 @@
 #include "nautilus/compiler/LegacyCompiler.hpp"
 #include "nautilus/CompilationStatistics.hpp"
 #include "nautilus/Executable.hpp"
+#include "nautilus/Module.hpp"
 #include "nautilus/compiler/DumpHandler.hpp"
 #include "nautilus/compiler/backends/CompilationBackend.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
@@ -36,9 +37,10 @@
 
 namespace nautilus::compiler {
 
-LegacyCompiler::LegacyCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool)
-    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()), arena_(&arena),
-      irArenaPool_(&irArenaPool) {
+LegacyCompiler::LegacyCompiler(engine::Options options, common::ArenaPool& traceArenaPool,
+                               common::ArenaPool& irArenaPool)
+    : options(std::move(options)), backends(CompilationBackendRegistry::getInstance()),
+      traceArenaPool_(&traceArenaPool), irArenaPool_(&irArenaPool) {
 }
 
 LegacyCompiler::~LegacyCompiler() = default;
@@ -128,13 +130,17 @@ std::shared_ptr<ir::IRGraph> LegacyCompiler::compileToIR(std::list<CompilableFun
 
 	const auto tracingStart = std::chrono::steady_clock::now();
 	auto traceMode = moduleOptions.getOptionOrDefault(TRACE_MODE_OPTION, std::string(TRACE_MODE_LAZY));
-	// Recycle the chunks from the previous compile before this one starts.
-	// Any TraceModule from a previous compilation has already been
-	// destroyed by the time we get here, so no live pointers remain.
-	arena_->softReset();
+	// Acquire a fresh trace arena for the lifetime of this compile.  Each
+	// concurrent compile() gets its own arena from the synchronized pool, so
+	// there is no shared bump allocator to race on.  The handle stays alive
+	// until the end of this function; on release the arena is softReset and
+	// recycled back into the pool.  Trace data is dead once IR generation has
+	// finished, so this is safe (the IRGraph owns a separate IR arena).
+	auto traceArenaHandle = traceArenaPool_->acquire();
+	common::Arena& arena = *traceArenaHandle;
 	std::shared_ptr<tracing::TraceModule> traceModule =
-	    (traceMode == TRACE_MODE_LAZY) ? tracing::LazyTraceContext::Trace(functions, moduleOptions, *arena_)
-	                                   : tracing::ExceptionBasedTraceContext::Trace(functions, moduleOptions, *arena_);
+	    (traceMode == TRACE_MODE_LAZY) ? tracing::LazyTraceContext::Trace(functions, moduleOptions, arena)
+	                                   : tracing::ExceptionBasedTraceContext::Trace(functions, moduleOptions, arena);
 	if (statistics != nullptr) {
 		statistics->recordTimingMs("tracing.ms", tracingStart);
 	}
@@ -254,6 +260,12 @@ std::unique_ptr<Executable> LegacyCompiler::compile(std::list<CompilableFunction
 	return executable;
 }
 
+void LegacyCompiler::compileModule(std::list<CompilableFunction>& functions, const engine::ModuleOptions& moduleOptions,
+                                   std::shared_ptr<engine::details::ModuleState> state) const {
+	// Single-tier: compile and publish. No background promotion.
+	state->executable = compile(functions, moduleOptions);
+}
+
 #else
 
 std::unique_ptr<Executable> LegacyCompiler::compile(JITCompiler::wrapper_function, const engine::ModuleOptions&) const {
@@ -262,6 +274,11 @@ std::unique_ptr<Executable> LegacyCompiler::compile(JITCompiler::wrapper_functio
 
 std::unique_ptr<Executable> LegacyCompiler::compile(std::list<CompilableFunction>&,
                                                     const engine::ModuleOptions&) const {
+	throw RuntimeException("Jit not initialised");
+}
+
+void LegacyCompiler::compileModule(std::list<CompilableFunction>&, const engine::ModuleOptions&,
+                                   std::shared_ptr<engine::details::ModuleState>) const {
 	throw RuntimeException("Jit not initialised");
 }
 

--- a/nautilus/src/nautilus/compiler/LegacyCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/LegacyCompiler.hpp
@@ -16,27 +16,28 @@ class CompilationStatistics;
  * Compiles functions using a single backend (selected via options).
  * This is the original Nautilus compilation strategy.
  *
- * The compiler never owns an Arena; callers must supply one that
- * outlives the compiler.  The same Arena is reused across every
- * compile() invocation: softReset() is called at the start of each
- * compilation so chunk memory from the previous compile is recycled
- * instead of being freed and reallocated.  This amortises allocation
- * cost over many compilations and is the reason compile() is not
- * thread-safe (callers that need concurrent compilation should hold
- * one LegacyCompiler per thread, each with its own Arena).
+ * The compiler never owns an Arena.  It draws a fresh trace arena from the
+ * supplied trace ArenaPool for the duration of each compile() and returns it
+ * (softReset and recycled) when done.  Because the pool is internally
+ * synchronized and hands every concurrent compile() a distinct arena,
+ * compile() is safe to call from multiple threads on a single shared
+ * compiler.  Both the trace pool and the IR-arena pool must outlive the
+ * compiler.
  */
 class LegacyCompiler : public JITCompiler {
 public:
-	/// Construct a compiler that uses the supplied Arena for every trace
-	/// and the supplied ArenaPool for IR-graph arenas.  Both must outlive
-	/// the compiler.
-	LegacyCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool);
+	/// Construct a compiler that draws trace arenas from @p traceArenaPool and
+	/// IR-graph arenas from @p irArenaPool.  Both must outlive the compiler.
+	LegacyCompiler(engine::Options options, common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool);
 	~LegacyCompiler() override;
 
 	[[nodiscard]] std::unique_ptr<Executable> compile(wrapper_function function,
 	                                                  const engine::ModuleOptions& moduleOptions = {}) const override;
 	[[nodiscard]] std::unique_ptr<Executable> compile(std::list<CompilableFunction>& functions,
 	                                                  const engine::ModuleOptions& moduleOptions = {}) const override;
+
+	void compileModule(std::list<CompilableFunction>& functions, const engine::ModuleOptions& moduleOptions,
+	                   std::shared_ptr<engine::details::ModuleState> state) const override;
 
 	std::string getName() const override;
 	const engine::Options& getOptions() const override {
@@ -77,10 +78,11 @@ private:
 	const engine::Options options;
 	const CompilationBackendRegistry* backends;
 
-	/// Non-owning pointer to the externally supplied Arena.  softReset()'d
-	/// at the start of each compile() invocation.  Marked mutable because
-	/// compile() is const but needs to recycle the arena between calls.
-	mutable common::Arena* arena_;
+	/// Non-owning pointer to the externally supplied trace-arena pool.  Each
+	/// compile() acquires a fresh arena from it for the duration of tracing
+	/// and IR generation, then returns it.  Marked mutable because compile()
+	/// is const but acquire() mutates the pool.
+	mutable common::ArenaPool* traceArenaPool_;
 	/// Non-owning pointer to the externally supplied IR-arena pool.  Each
 	/// IRGraph created during compileToIR acquires its arena from here, so
 	/// successive compiles reuse heap chunks across IR graphs.

--- a/nautilus/src/nautilus/compiler/TieredCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.cpp
@@ -28,8 +28,9 @@ static std::string createPromotionUnitID() {
 
 // --- TieredJITCompiler ---
 
-TieredJITCompiler::TieredJITCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool)
-    : baseCompiler_(options, arena, irArenaPool) {
+TieredJITCompiler::TieredJITCompiler(engine::Options options, common::ArenaPool& traceArenaPool,
+                                     common::ArenaPool& irArenaPool)
+    : baseCompiler_(options, traceArenaPool, irArenaPool) {
 	auto tier0 = options.getOptionOrDefault<std::string>("engine.tier0.backend", "");
 	auto tier1 = options.getOptionOrDefault<std::string>("engine.tier1.backend", "");
 	if (!tier0.empty() && !tier1.empty()) {
@@ -39,8 +40,8 @@ TieredJITCompiler::TieredJITCompiler(engine::Options options, common::Arena& are
 }
 
 TieredJITCompiler::TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config,
-                                     common::Arena& arena, common::ArenaPool& irArenaPool)
-    : baseCompiler_(options, arena, irArenaPool), config_(std::move(config)) {
+                                     common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool)
+    : baseCompiler_(options, traceArenaPool, irArenaPool), config_(std::move(config)) {
 }
 
 TieredJITCompiler::~TieredJITCompiler() {
@@ -56,8 +57,9 @@ std::unique_ptr<Executable> TieredJITCompiler::compile(wrapper_function function
 	return compile(functionsToTrace, moduleOptions);
 }
 
-std::unique_ptr<Executable> TieredJITCompiler::compile(std::list<CompilableFunction>& functions,
-                                                       const engine::ModuleOptions& moduleOptions) const {
+std::unique_ptr<Executable> TieredJITCompiler::compileTier0(std::list<CompilableFunction>& functions,
+                                                            const engine::ModuleOptions& moduleOptions,
+                                                            std::shared_ptr<ir::IRGraph>& outIR) const {
 	// One shared statistics object covers the entire tier-0 compile so the
 	// user's CompiledModule::getStatistics() reflects tracing + IR passes +
 	// tier-0 backend work in a single report.
@@ -80,26 +82,40 @@ std::unique_ptr<Executable> TieredJITCompiler::compile(std::list<CompilableFunct
 	tier0Executable->setCompilationStatistics(
 	    std::static_pointer_cast<const CompilationStatistics>(std::move(statistics)));
 
-	// Cache the IR and module options for the upcoming promoteAsync() call
-	lastCachedIR_ = std::move(ir);
-	lastModuleOptions_ = moduleOptions;
-
+	// Hand the IR back to the caller so it can drive background promotion.
+	outIR = std::move(ir);
 	return tier0Executable;
 }
 
-void TieredJITCompiler::promoteAsync(std::weak_ptr<engine::details::ModuleState> state) const {
-	auto cachedIR = std::move(lastCachedIR_);
-	if (!cachedIR) {
+std::unique_ptr<Executable> TieredJITCompiler::compile(std::list<CompilableFunction>& functions,
+                                                       const engine::ModuleOptions& moduleOptions) const {
+	// Tier-0 only: no module state to promote into.
+	std::shared_ptr<ir::IRGraph> ir;
+	return compileTier0(functions, moduleOptions, ir);
+}
+
+void TieredJITCompiler::compileModule(std::list<CompilableFunction>& functions,
+                                      const engine::ModuleOptions& moduleOptions,
+                                      std::shared_ptr<engine::details::ModuleState> state) const {
+	std::shared_ptr<ir::IRGraph> ir;
+	state->executable = compileTier0(functions, moduleOptions, ir);
+	// Start background tier-1 promotion using this module's own IR.
+	promoteAsync(state, std::move(ir), moduleOptions);
+}
+
+void TieredJITCompiler::promoteAsync(std::weak_ptr<engine::details::ModuleState> state, std::shared_ptr<ir::IRGraph> ir,
+                                     engine::ModuleOptions options) const {
+	if (!ir) {
 		return;
 	}
 
 	pendingPromotions_.fetch_add(1, std::memory_order_relaxed);
 
 	std::lock_guard<std::mutex> lock(threadsMutex_);
-	// Capture the per-module options used at compile time by value so the
-	// background thread compiles tier-1 with the same module configuration.
-	promotionThreads_.emplace_back([weakState = std::move(state), ir = std::move(cachedIR), config = config_,
-	                                options = lastModuleOptions_, &pendingCount = pendingPromotions_]() {
+	// The IR and per-module options are owned per call and moved into the
+	// background thread, so concurrent promotions never share state.
+	promotionThreads_.emplace_back([weakState = std::move(state), ir = std::move(ir), config = config_,
+	                                options = std::move(options), &pendingCount = pendingPromotions_]() {
 		try {
 			auto* registry = CompilationBackendRegistry::getInstance();
 			auto* backend = registry->getBackend(config.tier1.backend);
@@ -167,12 +183,12 @@ const engine::Options& TieredJITCompiler::getOptions() const {
 
 namespace nautilus::compiler {
 
-TieredJITCompiler::TieredJITCompiler(engine::Options, common::Arena& arena, common::ArenaPool& irArenaPool)
-    : baseCompiler_(engine::Options(), arena, irArenaPool) {
+TieredJITCompiler::TieredJITCompiler(engine::Options, common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool)
+    : baseCompiler_(engine::Options(), traceArenaPool, irArenaPool) {
 }
-TieredJITCompiler::TieredJITCompiler(engine::Options, engine::TieredCompilationConfig, common::Arena& arena,
-                                     common::ArenaPool& irArenaPool)
-    : baseCompiler_(engine::Options(), arena, irArenaPool) {
+TieredJITCompiler::TieredJITCompiler(engine::Options, engine::TieredCompilationConfig,
+                                     common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool)
+    : baseCompiler_(engine::Options(), traceArenaPool, irArenaPool) {
 }
 TieredJITCompiler::~TieredJITCompiler() = default;
 std::unique_ptr<Executable> TieredJITCompiler::compile(wrapper_function, const engine::ModuleOptions&) const {
@@ -182,7 +198,17 @@ std::unique_ptr<Executable> TieredJITCompiler::compile(std::list<CompilableFunct
                                                        const engine::ModuleOptions&) const {
 	throw RuntimeException("Jit not initialised");
 }
-void TieredJITCompiler::promoteAsync(std::weak_ptr<engine::details::ModuleState>) const {
+std::unique_ptr<Executable> TieredJITCompiler::compileTier0(std::list<CompilableFunction>&,
+                                                            const engine::ModuleOptions&,
+                                                            std::shared_ptr<ir::IRGraph>&) const {
+	throw RuntimeException("Jit not initialised");
+}
+void TieredJITCompiler::compileModule(std::list<CompilableFunction>&, const engine::ModuleOptions&,
+                                      std::shared_ptr<engine::details::ModuleState>) const {
+	throw RuntimeException("Jit not initialised");
+}
+void TieredJITCompiler::promoteAsync(std::weak_ptr<engine::details::ModuleState>, std::shared_ptr<ir::IRGraph>,
+                                     engine::ModuleOptions) const {
 }
 void TieredJITCompiler::waitForPendingPromotions() const {
 }

--- a/nautilus/src/nautilus/compiler/TieredCompiler.cpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.cpp
@@ -37,6 +37,7 @@ TieredJITCompiler::TieredJITCompiler(engine::Options options, common::ArenaPool&
 		config_.tier0.backend = tier0;
 		config_.tier1.backend = tier1;
 	}
+	config_.backgroundPromotion = options.getOptionOrDefault("engine.tiered.backgroundPromotion", true);
 }
 
 TieredJITCompiler::TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config,
@@ -57,49 +58,59 @@ std::unique_ptr<Executable> TieredJITCompiler::compile(wrapper_function function
 	return compile(functionsToTrace, moduleOptions);
 }
 
-std::unique_ptr<Executable> TieredJITCompiler::compileTier0(std::list<CompilableFunction>& functions,
-                                                            const engine::ModuleOptions& moduleOptions,
-                                                            std::shared_ptr<ir::IRGraph>& outIR) const {
-	// One shared statistics object covers the entire tier-0 compile so the
+std::unique_ptr<Executable> TieredJITCompiler::compileTier(std::list<CompilableFunction>& functions,
+                                                           const engine::ModuleOptions& moduleOptions,
+                                                           const std::string& backend, const std::string& tierLabel,
+                                                           std::shared_ptr<ir::IRGraph>& outIR) const {
+	// One shared statistics object covers the entire tier compile so the
 	// user's CompiledModule::getStatistics() reflects tracing + IR passes +
-	// tier-0 backend work in a single report.
+	// backend work in a single report.
 	auto statistics = std::make_shared<CompilationStatistics>();
 	const auto compilationStart = std::chrono::steady_clock::now();
 
 	auto ir = baseCompiler_.compileToIR(functions, moduleOptions, statistics.get());
-	auto tier0Executable = baseCompiler_.compileIR(ir, config_.tier0.backend, moduleOptions, statistics.get());
+	auto executable = baseCompiler_.compileIR(ir, backend, moduleOptions, statistics.get());
 
 	statistics->recordTimingMs("compilation.totalMs", compilationStart);
-	statistics->set("tier", std::string {"tier0"});
+	statistics->set("tier", tierLabel);
 
 	if (moduleOptions.getOptionOrDefault("engine.logStatistics", false)) {
 		const auto id = statistics->find("compilation.unitId") != nullptr
 		                    ? std::get<std::string>(*statistics->find("compilation.unitId"))
 		                    : std::string {};
-		log::info("\n{}", statistics->formatReport(id, config_.tier0.backend));
+		log::info("\n{}", statistics->formatReport(id, backend));
 	}
 
-	tier0Executable->setCompilationStatistics(
-	    std::static_pointer_cast<const CompilationStatistics>(std::move(statistics)));
+	executable->setCompilationStatistics(std::static_pointer_cast<const CompilationStatistics>(std::move(statistics)));
 
 	// Hand the IR back to the caller so it can drive background promotion.
 	outIR = std::move(ir);
-	return tier0Executable;
+	return executable;
 }
 
 std::unique_ptr<Executable> TieredJITCompiler::compile(std::list<CompilableFunction>& functions,
                                                        const engine::ModuleOptions& moduleOptions) const {
-	// Tier-0 only: no module state to promote into.
 	std::shared_ptr<ir::IRGraph> ir;
-	return compileTier0(functions, moduleOptions, ir);
+	if (!config_.backgroundPromotion) {
+		// Single-tier: compile directly with the high-performance backend.
+		return compileTier(functions, moduleOptions, config_.tier1.backend, "tier1", ir);
+	}
+	// Two-tier: return the fast tier-0 executable (no module state to promote into).
+	return compileTier(functions, moduleOptions, config_.tier0.backend, "tier0", ir);
 }
 
 void TieredJITCompiler::compileModule(std::list<CompilableFunction>& functions,
                                       const engine::ModuleOptions& moduleOptions,
                                       std::shared_ptr<engine::details::ModuleState> state) const {
 	std::shared_ptr<ir::IRGraph> ir;
-	state->executable = compileTier0(functions, moduleOptions, ir);
-	// Start background tier-1 promotion using this module's own IR.
+	if (!config_.backgroundPromotion) {
+		// Single-tier: compile directly with the high-performance backend, no promotion.
+		state->executable = compileTier(functions, moduleOptions, config_.tier1.backend, "tier1", ir);
+		return;
+	}
+	// Two-tier: fast tier-0 now, then promote to tier-1 in the background using
+	// this module's own IR.
+	state->executable = compileTier(functions, moduleOptions, config_.tier0.backend, "tier0", ir);
 	promoteAsync(state, std::move(ir), moduleOptions);
 }
 
@@ -168,6 +179,9 @@ bool TieredJITCompiler::allPromotionsComplete() const {
 }
 
 std::string TieredJITCompiler::getName() const {
+	if (!config_.backgroundPromotion) {
+		return "tiered-single(" + config_.tier1.backend + ")";
+	}
 	return "tiered(" + config_.tier0.backend + "," + config_.tier1.backend + ")";
 }
 
@@ -198,9 +212,9 @@ std::unique_ptr<Executable> TieredJITCompiler::compile(std::list<CompilableFunct
                                                        const engine::ModuleOptions&) const {
 	throw RuntimeException("Jit not initialised");
 }
-std::unique_ptr<Executable> TieredJITCompiler::compileTier0(std::list<CompilableFunction>&,
-                                                            const engine::ModuleOptions&,
-                                                            std::shared_ptr<ir::IRGraph>&) const {
+std::unique_ptr<Executable> TieredJITCompiler::compileTier(std::list<CompilableFunction>&, const engine::ModuleOptions&,
+                                                           const std::string&, const std::string&,
+                                                           std::shared_ptr<ir::IRGraph>&) const {
 	throw RuntimeException("Jit not initialised");
 }
 void TieredJITCompiler::compileModule(std::list<CompilableFunction>&, const engine::ModuleOptions&,

--- a/nautilus/src/nautilus/compiler/TieredCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.hpp
@@ -51,12 +51,12 @@ namespace nautilus::compiler {
  */
 class TieredJITCompiler : public JITCompiler {
 public:
-	/// Construct a tiered compiler that borrows the supplied Arena for
-	/// every tier-0 trace-and-compile cycle and the supplied ArenaPool
-	/// for IR-graph arenas.  Both must outlive the compiler.
-	TieredJITCompiler(engine::Options options, common::Arena& arena, common::ArenaPool& irArenaPool);
-	TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config, common::Arena& arena,
-	                  common::ArenaPool& irArenaPool);
+	/// Construct a tiered compiler that draws tier-0 trace arenas from
+	/// @p traceArenaPool and IR-graph arenas from @p irArenaPool.  Both pools
+	/// are internally synchronized and must outlive the compiler.
+	TieredJITCompiler(engine::Options options, common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool);
+	TieredJITCompiler(engine::Options options, engine::TieredCompilationConfig config,
+	                  common::ArenaPool& traceArenaPool, common::ArenaPool& irArenaPool);
 	~TieredJITCompiler() override;
 
 	[[nodiscard]] std::unique_ptr<Executable> compile(wrapper_function function,
@@ -64,20 +64,18 @@ public:
 	[[nodiscard]] std::unique_ptr<Executable> compile(std::list<CompilableFunction>& functions,
 	                                                  const engine::ModuleOptions& moduleOptions = {}) const override;
 
+	/**
+	 * @brief Compile tier-0 into @p state and start background tier-1 promotion.
+	 *
+	 * The IR produced for tier-0 is handed directly to the promotion for this
+	 * module — no compiler-level cache is shared between calls, so concurrent
+	 * compileModule() invocations on a single shared compiler are race-free.
+	 */
+	void compileModule(std::list<CompilableFunction>& functions, const engine::ModuleOptions& moduleOptions,
+	                   std::shared_ptr<engine::details::ModuleState> state) const override;
+
 	std::string getName() const override;
 	const engine::Options& getOptions() const override;
-
-	/**
-	 * @brief Start background tier-1 promotion targeting the given module state.
-	 *
-	 * Uses the IR cached from the most recent compile() call to compile with the
-	 * tier-1 backend in a background thread. When compilation completes, the
-	 * executable in the module state is swapped and the version counter is
-	 * incremented, causing all ModuleFunction handles to re-resolve.
-	 *
-	 * @param state Weak reference to the module state to promote
-	 */
-	void promoteAsync(std::weak_ptr<engine::details::ModuleState> state) const;
 
 	/**
 	 * @brief Block until all pending background promotions have completed.
@@ -90,14 +88,29 @@ public:
 	bool allPromotionsComplete() const;
 
 private:
+	/**
+	 * @brief Trace and compile the tier-0 executable, returning the IR via
+	 * @p outIR so callers can hand it to background promotion.
+	 */
+	[[nodiscard]] std::unique_ptr<Executable> compileTier0(std::list<CompilableFunction>& functions,
+	                                                       const engine::ModuleOptions& moduleOptions,
+	                                                       std::shared_ptr<ir::IRGraph>& outIR) const;
+
+	/**
+	 * @brief Start background tier-1 promotion of @p ir targeting @p state.
+	 *
+	 * Compiles @p ir with the tier-1 backend on a background thread using
+	 * @p options.  When done, the executable in the module state is swapped and
+	 * the version counter is incremented, causing all ModuleFunction handles to
+	 * re-resolve.  The IR and options are owned per call, so nothing is shared
+	 * between concurrent compiles.
+	 */
+	void promoteAsync(std::weak_ptr<engine::details::ModuleState> state, std::shared_ptr<ir::IRGraph> ir,
+	                  engine::ModuleOptions options) const;
+
 	LegacyCompiler baseCompiler_;
 	engine::TieredCompilationConfig config_;
 
-	// Mutable because compile() is const but needs to cache IR for promotion
-	mutable std::shared_ptr<ir::IRGraph> lastCachedIR_;
-	// Per-module options used by the most recent compile(), captured so the
-	// background tier-1 promotion compiles with the same module configuration.
-	mutable engine::ModuleOptions lastModuleOptions_;
 	mutable std::vector<std::thread> promotionThreads_;
 	mutable std::mutex threadsMutex_;
 	mutable std::atomic<int> pendingPromotions_ {0};

--- a/nautilus/src/nautilus/compiler/TieredCompiler.hpp
+++ b/nautilus/src/nautilus/compiler/TieredCompiler.hpp
@@ -33,6 +33,13 @@ struct TierConfig {
 struct TieredCompilationConfig {
 	TierConfig tier0 {"bc"};   // low-latency tier (compiled synchronously)
 	TierConfig tier1 {"mlir"}; // high-performance tier (compiled in background)
+
+	/// When true (default) the compiler runs two-tier: a fast tier-0 compile is
+	/// returned immediately and the high-performance tier-1 backend is compiled
+	/// in the background. When false the compiler runs single-tier: it compiles
+	/// directly with the high-performance @ref tier1 backend and performs no
+	/// tier-0 compile and no background promotion.
+	bool backgroundPromotion {true};
 };
 
 } // namespace nautilus::engine
@@ -89,12 +96,15 @@ public:
 
 private:
 	/**
-	 * @brief Trace and compile the tier-0 executable, returning the IR via
-	 * @p outIR so callers can hand it to background promotion.
+	 * @brief Trace and compile @p functions with the named @p backend, returning
+	 * the IR via @p outIR so callers can hand it to background promotion.
+	 *
+	 * @p tierLabel is recorded into the compilation statistics ("tier0"/"tier1").
 	 */
-	[[nodiscard]] std::unique_ptr<Executable> compileTier0(std::list<CompilableFunction>& functions,
-	                                                       const engine::ModuleOptions& moduleOptions,
-	                                                       std::shared_ptr<ir::IRGraph>& outIR) const;
+	[[nodiscard]] std::unique_ptr<Executable> compileTier(std::list<CompilableFunction>& functions,
+	                                                      const engine::ModuleOptions& moduleOptions,
+	                                                      const std::string& backend, const std::string& tierLabel,
+	                                                      std::shared_ptr<ir::IRGraph>& outIR) const;
 
 	/**
 	 * @brief Start background tier-1 promotion of @p ir targeting @p state.

--- a/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
+++ b/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
@@ -36,12 +36,35 @@ TEST_CASE("Tiered Compilation Latency Benchmark") {
 
 	for (auto& [name, registerFn] : testFuncs) {
 #if defined(ENABLE_BC_BACKEND) && defined(ENABLE_MLIR_BACKEND)
-		Catch::Benchmark::Benchmark("tiered_compile_" + name)
+		// Two-tier: fast tier-0 (bc) compile returned immediately plus the
+		// high-performance tier-1 (mlir) promotion, which the engine destructor
+		// joins at the end of the measured region. Measures end-to-end cost.
+		Catch::Benchmark::Benchmark("tiered_twotier_" + name)
 		    .operator=([&registerFn](Catch::Benchmark::Chronometer meter) {
 			    meter.measure([&registerFn] {
 				    TieredCompilationConfig config;
 				    config.tier0.backend = "bc";
 				    config.tier1.backend = "mlir";
+				    config.backgroundPromotion = true;
+				    common::ArenaPool traceArenaPool;
+				    common::ArenaPool irArenaPool;
+				    auto engine = NautilusEngine(
+				        std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool));
+				    auto module = engine.createModule();
+				    registerFn(module);
+				    return module.compile();
+			    });
+		    });
+
+		// Single-tier: compile directly with the high-performance tier-1 (mlir)
+		// backend, no tier-0 and no background promotion.
+		Catch::Benchmark::Benchmark("tiered_singletier_" + name)
+		    .operator=([&registerFn](Catch::Benchmark::Chronometer meter) {
+			    meter.measure([&registerFn] {
+				    TieredCompilationConfig config;
+				    config.tier0.backend = "bc";
+				    config.tier1.backend = "mlir";
+				    config.backgroundPromotion = false;
 				    common::ArenaPool traceArenaPool;
 				    common::ArenaPool irArenaPool;
 				    auto engine = NautilusEngine(

--- a/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
+++ b/nautilus/test/benchmark/TieredCompilationBenchmark.cpp
@@ -42,10 +42,10 @@ TEST_CASE("Tiered Compilation Latency Benchmark") {
 				    TieredCompilationConfig config;
 				    config.tier0.backend = "bc";
 				    config.tier1.backend = "mlir";
-				    common::Arena arena;
+				    common::ArenaPool traceArenaPool;
 				    common::ArenaPool irArenaPool;
 				    auto engine = NautilusEngine(
-				        std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool));
+				        std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool));
 				    auto module = engine.createModule();
 				    registerFn(module);
 				    return module.compile();
@@ -125,9 +125,10 @@ TEST_CASE("Tiered End-to-End Benchmark") {
 			TieredCompilationConfig config;
 			config.tier0.backend = "bc";
 			config.tier1.backend = "mlir";
-			common::Arena arena;
+			common::ArenaPool traceArenaPool;
 			common::ArenaPool irArenaPool;
-			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
+			auto tieredJit =
+			    std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
 			auto* jit = tieredJit.get();
 			auto engine = NautilusEngine(std::move(tieredJit));
 			auto module = engine.createModule();

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(NAUTILUS_EXECUTION_TEST_SOURCES
         BoolExecutionTest.cpp
         CastExecutionTest.cpp
         CompilationStatisticsTest.cpp
+        ConcurrentCompilationTest.cpp
         ConcurrentExecutionTest.cpp
         DumpHelperTest.cpp
         FunctionPtrExecutionTest.cpp

--- a/nautilus/test/execution-tests/ConcurrentCompilationTest.cpp
+++ b/nautilus/test/execution-tests/ConcurrentCompilationTest.cpp
@@ -1,0 +1,163 @@
+#include "catch2/catch_test_macros.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/config.hpp"
+#include <atomic>
+#include <catch2/catch_all.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace nautilus::engine {
+
+// Kernels with varying signatures (and one with a traced loop) so each module
+// registers several functions. The more a module traces, the wider the window
+// in which concurrent compiles on a shared engine used to corrupt the single
+// trace arena — so multi-function modules are exactly the stress we want.
+
+val<int32_t> ccAddOne(val<int32_t> x) {
+	return x + 1;
+}
+
+val<int64_t> ccSum(val<int64_t> a, val<int64_t> b) {
+	return a + b;
+}
+
+val<int32_t> ccMultiply(val<int32_t> a, val<int32_t> b) {
+	return a * b;
+}
+
+/// Traced loop: returns 1 + 2 + ... + n for n >= 1, and 0 for n <= 0.
+val<int32_t> ccSumToN(val<int32_t> n) {
+	val<int32_t> acc = 0;
+	for (val<int32_t> i = 1; i <= n; i = i + 1) {
+		acc = acc + i;
+	}
+	return acc;
+}
+
+namespace {
+
+/// Build a multi-function module, compile it, and verify every compiled
+/// function returns the expected result. Returns the number of mismatches
+/// (0 == success).
+int compileAndVerify(NautilusEngine& engine, int seed) {
+	int errors = 0;
+	auto module = engine.createModule();
+	module.registerFunction("add_one", ccAddOne);
+	module.registerFunction("sum", ccSum);
+	module.registerFunction("multiply", ccMultiply);
+	module.registerFunction("sum_to_n", ccSumToN);
+	auto compiled = module.compile();
+
+	auto addOne = compiled.getFunction<int32_t(int32_t)>("add_one");
+	auto sum = compiled.getFunction<int64_t(int64_t, int64_t)>("sum");
+	auto mul = compiled.getFunction<int32_t(int32_t, int32_t)>("multiply");
+	auto sumToN = compiled.getFunction<int32_t(int32_t)>("sum_to_n");
+
+	const int32_t a = seed % 100;
+	const int32_t b = (seed * 3) % 100;
+	const int32_t n = seed % 50;
+	if (addOne(a) != a + 1) {
+		++errors;
+	}
+	if (sum(a, b) != static_cast<int64_t>(a) + b) {
+		++errors;
+	}
+	if (mul(a, b) != a * b) {
+		++errors;
+	}
+	if (sumToN(n) != n * (n + 1) / 2) {
+		++errors;
+	}
+	return errors;
+}
+
+/// Spawn several threads that each repeatedly compile-and-verify on the one
+/// shared engine. Asserts every compilation produced correct results (and,
+/// implicitly, that none of them crashed or corrupted shared engine state).
+void runConcurrentCompilation(NautilusEngine& engine) {
+	constexpr int NUM_THREADS = 8;
+	constexpr int ITERATIONS = 25;
+
+	std::atomic<int> errors {0};
+	std::vector<std::thread> threads;
+	threads.reserve(NUM_THREADS);
+
+	for (int t = 0; t < NUM_THREADS; ++t) {
+		threads.emplace_back([&engine, &errors, t]() {
+			for (int i = 0; i < ITERATIONS; ++i) {
+				errors.fetch_add(compileAndVerify(engine, t * ITERATIONS + i + 1), std::memory_order_relaxed);
+			}
+		});
+	}
+
+	for (auto& th : threads) {
+		th.join();
+	}
+
+	REQUIRE(errors.load() == 0);
+}
+
+/// A backend suitable for thread-safe compiled execution, or empty if none.
+std::string threadSafeBackend() {
+#if defined(ENABLE_TRACING) && defined(ENABLE_MLIR_BACKEND)
+	return "mlir";
+#elif defined(ENABLE_TRACING) && defined(ENABLE_C_BACKEND)
+	return "cpp";
+#else
+	return "";
+#endif
+}
+
+/// A (tier0, tier1) backend pair for tiered compilation, or empty strings.
+std::pair<std::string, std::string> tieredBackends() {
+#if defined(ENABLE_TRACING) && defined(ENABLE_BC_BACKEND) && defined(ENABLE_MLIR_BACKEND)
+	return {"bc", "mlir"};
+#elif defined(ENABLE_TRACING) && defined(ENABLE_BC_BACKEND) && defined(ENABLE_C_BACKEND)
+	return {"bc", "cpp"};
+#else
+	return {"", ""};
+#endif
+}
+
+} // namespace
+
+// One shared engine, many threads, each compiling many multi-function modules.
+// Exercises the per-compile trace-arena pool on the explicit-backend
+// (LegacyCompiler) path: before the fix, concurrent compiles raced on the
+// engine's single trace arena and crashed.
+TEST_CASE("Concurrent Compilation - Shared Engine, Explicit Backend") {
+	const auto backend = threadSafeBackend();
+	if (backend.empty()) {
+		SKIP("No thread-safe compilation backend available");
+	}
+
+	Options options;
+	options.setOption("engine.backend", backend);
+	auto engine = NautilusEngine(options);
+
+	runConcurrentCompilation(engine);
+}
+
+// Same workload on the DEFAULT tiered compiler (fast tier-0, tier-1 promoted in
+// the background). Exercises the trace-arena pool plus the per-module promotion
+// path under concurrency: every compile carries its own IR to its own
+// promotion, so concurrent compiles must not race on compiler-level state.
+// Destroying the engine joins any still-pending promotions.
+TEST_CASE("Concurrent Compilation - Shared Engine, Default Tiered") {
+	const auto [tier0, tier1] = tieredBackends();
+	if (tier0.empty()) {
+		SKIP("Need bc + a high-tier backend for tiered compilation");
+	}
+
+	// No explicit "engine.backend" → the engine selects the tiered compiler;
+	// the tier backends are taken from these options.
+	Options options;
+	options.setOption("engine.tier0.backend", tier0);
+	options.setOption("engine.tier1.backend", tier1);
+	auto engine = NautilusEngine(options);
+
+	runConcurrentCompilation(engine);
+}
+
+} // namespace nautilus::engine

--- a/nautilus/test/execution-tests/ConcurrentExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ConcurrentExecutionTest.cpp
@@ -1,6 +1,8 @@
 #include "ExecutionTest.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "nautilus/Engine.hpp"
+#include "nautilus/config.hpp"
+#include <atomic>
 #include <catch2/catch_all.hpp>
 #include <thread>
 #include <vector>
@@ -17,6 +19,10 @@ val<int64_t> sumUpTo(val<int64_t> n) {
 		result = result + i;
 	}
 	return result;
+}
+
+val<int32_t> concMultiply(val<int32_t> a, val<int32_t> b) {
+	return a * b;
 }
 
 void concurrentExecutionTest(engine::NautilusEngine& engine) {
@@ -78,6 +84,93 @@ void concurrentExecutionTest(engine::NautilusEngine& engine) {
 
 TEST_CASE("Concurrent Execution Test") {
 	nautilus::testing::forEachBackend([](engine::NautilusEngine& engine) { concurrentExecutionTest(engine); });
+}
+
+// Verifies that a single module compiled with the AsmJit backend can be invoked
+// concurrently from multiple threads. AsmJit produces stable, reentrant native
+// function pointers with no per-call shared mutable state, so this should be
+// safe; this test guards that property.
+TEST_CASE("Concurrent AsmJit Module Execution") {
+#if defined(ENABLE_TRACING) && defined(ENABLE_ASMJIT_BACKEND)
+	Options options;
+	options.setOption("engine.backend", std::string("asmjit"));
+	auto engine = NautilusEngine(options);
+
+	// Compile one module with several functions exactly once.
+	auto module = engine.createModule();
+	module.registerFunction("square7", squarePlusSeven);
+	module.registerFunction("sum_to", sumUpTo);
+	module.registerFunction("multiply", concMultiply);
+	auto compiled = module.compile();
+
+	auto square7 = compiled.getFunction<int64_t(int64_t)>("square7");
+	auto sumTo = compiled.getFunction<int64_t(int64_t)>("sum_to");
+	auto mul = compiled.getFunction<int32_t(int32_t, int32_t)>("multiply");
+
+	constexpr int NUM_THREADS = 8;
+	constexpr int ITERATIONS = 5000;
+
+	SECTION("each thread owns its handle copies") {
+		std::atomic<int> errors {0};
+		std::vector<std::thread> threads;
+		threads.reserve(NUM_THREADS);
+
+		for (int t = 0; t < NUM_THREADS; ++t) {
+			threads.emplace_back([=, &errors]() {
+				// Each thread gets its own copies of the handles (own resolve cache).
+				auto localSquare = square7;
+				auto localSum = sumTo;
+				auto localMul = mul;
+				for (int i = 0; i < ITERATIONS; ++i) {
+					const int64_t x = (t + 1) * 3 + i;
+					const int64_t n = (i % 50) + 1;
+					const int32_t a = t + 1;
+					const int32_t b = i % 100;
+					if (localSquare(x) != x * x + 7) {
+						errors.fetch_add(1, std::memory_order_relaxed);
+					}
+					if (localSum(n) != n * (n + 1) / 2) {
+						errors.fetch_add(1, std::memory_order_relaxed);
+					}
+					if (localMul(a, b) != a * b) {
+						errors.fetch_add(1, std::memory_order_relaxed);
+					}
+				}
+			});
+		}
+
+		for (auto& th : threads) {
+			th.join();
+		}
+		REQUIRE(errors.load() == 0);
+	}
+
+	SECTION("all threads share a single handle copy") {
+		// Stresses the guarded first-call resolve() under contention: all threads
+		// invoke the same ModuleFunction instance concurrently.
+		std::atomic<int> errors {0};
+		std::vector<std::thread> threads;
+		threads.reserve(NUM_THREADS);
+
+		for (int t = 0; t < NUM_THREADS; ++t) {
+			threads.emplace_back([&square7, &errors, t]() {
+				for (int i = 0; i < ITERATIONS; ++i) {
+					const int64_t x = (t + 1) + i;
+					if (square7(x) != x * x + 7) {
+						errors.fetch_add(1, std::memory_order_relaxed);
+					}
+				}
+			});
+		}
+
+		for (auto& th : threads) {
+			th.join();
+		}
+		REQUIRE(errors.load() == 0);
+	}
+#else
+	SKIP("AsmJit backend or tracing not enabled");
+#endif
 }
 
 } // namespace nautilus::engine

--- a/nautilus/test/execution-tests/TieredCompilationTest.cpp
+++ b/nautilus/test/execution-tests/TieredCompilationTest.cpp
@@ -266,6 +266,69 @@ TEST_CASE("Tiered Compilation - Multiple Functions In Module") {
 	REQUIRE(mulFn(7, 8) == 56);
 }
 
+TEST_CASE("Tiered Compilation - Single Tier Mode") {
+	auto [tier0Backend, tier1Backend] = getTieredBackends();
+	if (tier0Backend.empty()) {
+		SKIP("Need at least two compilation backends for tiered compilation");
+	}
+
+	// Single-tier mode: the compiler should compile directly with the
+	// high-performance tier-1 backend and perform no background promotion.
+	TieredCompilationConfig config;
+	config.tier0.backend = tier0Backend;
+	config.tier1.backend = tier1Backend;
+	config.backgroundPromotion = false;
+
+	common::ArenaPool traceArenaPool;
+	common::ArenaPool irArenaPool;
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
+	auto* jit = tieredJit.get();
+	auto engine = NautilusEngine(std::move(tieredJit));
+	auto module = engine.createModule();
+	module.registerFunction("add_one", tieredAddOne);
+	module.registerFunction("sum", tieredSum);
+
+	auto compiled = module.compile();
+	auto addOneFn = compiled.getFunction<int32_t(int32_t)>("add_one");
+	auto sumFn = compiled.getFunction<int64_t(int64_t, int64_t)>("sum");
+
+	REQUIRE(addOneFn(5) == 6);
+	REQUIRE(sumFn(3, 4) == 7);
+
+	// No background promotion was started, so it is immediately complete and
+	// waiting is a no-op.
+	REQUIRE(jit->allPromotionsComplete());
+	jit->waitForPendingPromotions();
+	REQUIRE(jit->allPromotionsComplete());
+
+	// Results remain correct.
+	REQUIRE(addOneFn(0) == 1);
+	REQUIRE(sumFn(-5, 10) == 5);
+}
+
+TEST_CASE("Tiered Compilation - Single Tier Mode Via Option") {
+	auto [tier0Backend, tier1Backend] = getTieredBackends();
+	if (tier0Backend.empty()) {
+		SKIP("Need at least two compilation backends for tiered compilation");
+	}
+
+	// Configure single-tier mode purely through engine options.
+	Options options;
+	options.setOption("engine.tier0.backend", tier0Backend);
+	options.setOption("engine.tier1.backend", tier1Backend);
+	options.setOption("engine.tiered.backgroundPromotion", false);
+
+	auto engine = NautilusEngine(options);
+	auto module = engine.createModule();
+	module.registerFunction("add_one", tieredAddOne);
+
+	auto compiled = module.compile();
+	auto fn = compiled.getFunction<int32_t(int32_t)>("add_one");
+
+	REQUIRE(fn(100) == 101);
+	REQUIRE(fn(-1) == 0);
+}
+
 TEST_CASE("Tiered Compilation - Standard JITCompiler Still Works") {
 	// Verify the original JITCompiler path is unchanged
 	std::vector<std::string> backends;

--- a/nautilus/test/execution-tests/TieredCompilationTest.cpp
+++ b/nautilus/test/execution-tests/TieredCompilationTest.cpp
@@ -47,9 +47,9 @@ TEST_CASE("Tiered Compilation - Tier 0 Executes Correctly") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	common::Arena arena;
+	common::ArenaPool traceArenaPool;
 	common::ArenaPool irArenaPool;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -86,9 +86,9 @@ TEST_CASE("Tiered Compilation - Background Promotion Completes") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	common::Arena arena;
+	common::ArenaPool traceArenaPool;
 	common::ArenaPool irArenaPool;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -120,9 +120,9 @@ TEST_CASE("Tiered Compilation - Results Correct After Promotion") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	common::Arena arena;
+	common::ArenaPool traceArenaPool;
 	common::ArenaPool irArenaPool;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();
@@ -176,9 +176,10 @@ TEST_CASE("Tiered Compilation - Custom Backend Per Tier") {
 			config.tier0.backend = t0;
 			config.tier1.backend = t1;
 
-			common::Arena arena;
+			common::ArenaPool traceArenaPool;
 			common::ArenaPool irArenaPool;
-			auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
+			auto tieredJit =
+			    std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
 			auto* jit = tieredJit.get();
 			auto engine = NautilusEngine(std::move(tieredJit));
 			auto module = engine.createModule();
@@ -235,9 +236,9 @@ TEST_CASE("Tiered Compilation - Multiple Functions In Module") {
 	config.tier0.backend = tier0Backend;
 	config.tier1.backend = tier1Backend;
 
-	common::Arena arena;
+	common::ArenaPool traceArenaPool;
 	common::ArenaPool irArenaPool;
-	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, arena, irArenaPool);
+	auto tieredJit = std::make_unique<compiler::TieredJITCompiler>(Options(), config, traceArenaPool, irArenaPool);
 	auto* jit = tieredJit.get();
 	auto engine = NautilusEngine(std::move(tieredJit));
 	auto module = engine.createModule();


### PR DESCRIPTION
## Problem

Concurrent `compile()` calls on a single shared `NautilusEngine` corrupt engine-level state (SEGFAULTs). NebulaStream shares one engine per worker across a query's pipeline stages and starts those pipelines **concurrently** (`QueryEngine.cpp:559` — "All pipeline initializations happen concurrently"), each calling `engine->createModule()` + `module.compile()`.

Two independent races existed on the shared-engine concurrent-compile path:

1. **Trace arena (the reported crash).** The engine owned a single `common::Arena` — a bump allocator with **no synchronization**. `LegacyCompiler::compileToIR()` did `arena_->softReset()` then traced into `*arena_`. Two threads → one rewinds the cursor while the other allocates → overlapping/freed allocations → SEGFAULT. Worst with `sliceCache` operators and multi-pipeline `join`/`agg` queries (more functions registered → more tracing → wider race window).

2. **Tiered IR cache (the default-path race).** The *default* compiler is `TieredJITCompiler`, whose `compile()` wrote shared mutable members `lastCachedIR_`/`lastModuleOptions_` handed to async tier-1 promotion — concurrent compiles raced on a single shared slot.

## Fix

**Trace arena → per-compile handle from a pool.** Replace the engine's single `Arena` with a trace `ArenaPool` (the codebase already has this mutex-protected, recycling pool — `irArenaPool_` uses it for IR arenas). Each `compile()` now `acquire()`s a fresh, distinct arena for the lifetime of tracing/IR-generation and returns it on scope exit. This is the user's "global area from which we create a sub area." Releasing at the end of `compileToIR` is safe: the returned `IRGraph` owns a separate IR arena and copies all values out of the trace by value.

**Tiered promotion → per-module, race-free.** Remove the shared cache members; pass each compile's IR + options directly into `promoteAsync()`. A new `JITCompiler::compileModule(functions, options, state)` virtual compiles into a pre-created `ModuleState` (and, for the tiered compiler, starts promotion targeting that state) — this also avoids a `dynamic_cast` in the public `Engine.hpp`. Background promotion is re-enabled in `NautilusModule::compile()`.

> Note: because promotion was previously commented out, the existing `TieredCompilationTest` promotion assertions (`waitForPendingPromotions`/`allPromotionsComplete`) were effectively no-ops. They now actually exercise tier-1 and still pass.

## Tests

New `ConcurrentCompilationTest.cpp`: one shared engine, 8 threads × 25 iterations, each compiling a multi-function module (incl. a traced loop) and verifying results — on both the explicit-backend (LegacyCompiler) and default-tiered paths.

## Verification

- Built with the BC/CPP/AsmJit backends; full suite **186/186 pass**, including the new tests and all `Tiered`/`Module`/`Concurrent` tests.
- Stress-ran the new concurrent tests 15× (200 concurrent compiles/case) with 0 failures.
- `format.sh` clean.

CI's sanitizer matrix (TSan/ASan) is the strongest validation that the races are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UU5ZRCEn6hoCFG3wtwCFvC)_