### PR TITLE
Bump version to 0.3 after v0.2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22.1)
 include(CMakeDependentOption)
 
-project(nautilus VERSION 0.2)
+project(nautilus VERSION 0.3)
 
 option(ENABLE_LOGGING "Enable logging support" ON)
 option(ENABLE_STACKTRACE "Enable stacktrace support" ON)


### PR DESCRIPTION
## Summary

Bumps the project version in `CMakeLists.txt` from `0.2` to `0.3` so that `main` reflects ongoing post-release development.

This is the second half of the **release v0.2 / bump main to v0.3** task:
- **Release v0.2** — cut from the current `main` (commit `d63bd8f`, which carries `project(nautilus VERSION 0.2)`).
- **Bump main to v0.3** — this PR.

## ⚠️ Release step requires a maintainer

The `v0.2` git tag and the corresponding GitHub Release could **not** be created from this environment:
- Tag pushes are rejected by the git proxy (`HTTP 403`); only the working branch is pushable.
- The available GitHub MCP tooling can read releases/tags but cannot create a tag, ref, or Release object.

A maintainer with push/release rights should cut the release from current `main` (before this bump merges, or by pointing the tag at `d63bd8f`):

```bash
git tag -a v0.2 d63bd8f -m "Release v0.2"
git push origin v0.2
# then publish the GitHub Release from tag v0.2
```

## Changes
- `CMakeLists.txt`: `project(nautilus VERSION 0.2)` → `project(nautilus VERSION 0.3)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WMv2YZHjZTosonxcrsdRz)_