### PR TITLE
Add compress-store SIMD operation

### DIFF
--- a/docs/simd.md
+++ b/docs/simd.md
@@ -97,6 +97,17 @@ Store elements to non-contiguous memory locations. Stores lane `i` to `base[indi
 v.Scatter(base_ptr, index_ptr);
 ```
 
+### Compress-Store
+
+Write only the lanes whose mask bit is set, packed contiguously starting at `dst`, and return the number of elements written (the popcount of the mask). A lane is active when its mask element is non-zero, so the mask is typically produced by a comparison. This is the core primitive for stream compaction / filtering and lowers to `llvm.masked.compressstore` (AVX-512 `vcompressps`/`vpcompressd`) on the MLIR backend, falling back to a scalar packing loop elsewhere.
+
+```cpp
+// Keep only the elements greater than the threshold, packed contiguously.
+auto v = val<vec<int32_t>>::Load(data);
+auto mask = v > val<vec<int32_t>>::Broadcast(threshold);
+val<int32_t> written = v.CompressStore(out_ptr, mask);
+```
+
 ## Lane Access
 
 ### Extract
@@ -287,6 +298,7 @@ When the MLIR backend is not available, all vector operations fall back to porta
 |--------|---------|-------------|
 | `Store(val<T*> ptr)` | `void` | Store to contiguous memory |
 | `Scatter(val<T*> base, val<const int32_t*> idx)` | `void` | Store to non-contiguous memory |
+| `CompressStore(val<T*> dst, val<vec<T>> mask)` | `val<int32_t>` | Store active lanes packed contiguously; returns count written |
 | `Get(val<int32_t> idx)` | `val<T>` | Extract a single lane |
 | `Set(val<int32_t> idx, val<T> value)` | `val<vec<T>>` | Return vector with one lane replaced |
 | `Abs()` | `val<vec<T>>` | Element-wise absolute value |

--- a/plugins/simd/include/nautilus/vector.hpp
+++ b/plugins/simd/include/nautilus/vector.hpp
@@ -108,6 +108,8 @@ val<vector_data<T, N>*> vec_gather(val<const T*> base, val<const int32_t*> indic
 template <typename T, size_t N>
 void vec_scatter(val<T*> base, val<const int32_t*> indices, val<vector_data<T, N>*> data);
 template <typename T, size_t N>
+val<int32_t> vec_compress_store(val<T*> dst, val<vector_data<T, N>*> mask, val<vector_data<T, N>*> data);
+template <typename T, size_t N>
 val<T> vec_extract(val<vector_data<T, N>*> v, val<int32_t> idx);
 template <typename T, size_t N>
 val<vector_data<T, N>*> vec_insert(val<vector_data<T, N>*> v, val<T> value, val<int32_t> idx);
@@ -253,6 +255,20 @@ public:
 		static_assert(std::is_same_v<IdxT, int32_t>, "Index type must be int32_t");
 		detail::dispatch_by_lanes_void<T>([&](auto N_tag) {
 			detail::vec_scatter<T, N_tag.value>(base, indices, detail::vec_from_max<T, N_tag.value>(ptr_));
+		});
+	}
+
+	/// Compress-store: write only the lanes whose mask bit is set, packed
+	/// contiguously starting at dst, and return the number of elements written
+	/// (the popcount of the mask). A lane is active when its mask element is
+	/// non-zero — pass a mask produced by a comparison (operator<, ==, ...).
+	/// This is the core primitive for stream compaction / filtering and lowers
+	/// to llvm.masked.compressstore (AVX-512 vcompressps/vpcompressd) on the
+	/// MLIR backend.
+	val<int32_t> CompressStore(val<T*> dst, val<vec<T>> mask) const {
+		return detail::dispatch_by_lanes<T>([&](auto N_tag) {
+			return detail::vec_compress_store<T, N_tag.value>(dst, detail::vec_from_max<T, N_tag.value>(mask.Data()),
+			                                                  detail::vec_from_max<T, N_tag.value>(ptr_));
 		});
 	}
 

--- a/plugins/simd/src/MLIRVectorIntrinsics.cpp
+++ b/plugins/simd/src/MLIRVectorIntrinsics.cpp
@@ -611,6 +611,58 @@ bool vectorScatterIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const c
 }
 
 // ============================================================================
+// Compress-store: store the active lanes packed contiguously, return popcount
+//
+// Lowers to llvm.masked.compressstore, which LLVM turns into AVX-512
+// vcompressps/vpcompressd where available and scalarizes elsewhere. The mask
+// follows the same convention as blend: a lane is active when its element is
+// non-zero. We additionally compute the number of stored elements (popcount of
+// the mask) so callers can advance the destination pointer for compaction.
+// ============================================================================
+
+template <typename ElemT, int64_t N>
+bool vectorCompressStoreIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder,
+                                  const compiler::ir::ProxyCallOperation* call,
+                                  MLIRLoweringProvider::ValueFrame& frame) {
+	auto dstPtr = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+	auto maskPtr = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+	auto dataPtr = frame.getValue(call->getInputArguments()[2]->getIdentifier());
+	auto loc = builder->getUnknownLoc();
+
+	auto elemTy = getElemType<ElemT>(*builder);
+	auto vecTy = getVecType(elemTy, N);
+
+	auto mask = loadVecFromPtr(builder, maskPtr, vecTy);
+	auto data = loadVecFromPtr(builder, dataPtr, vecTy);
+
+	// Convert the lane mask to a vector<NxI1> (active == element != 0), matching
+	// the blend convention.
+	::mlir::Value maskI1;
+	if constexpr (std::is_floating_point_v<ElemT>) {
+		auto intElemTy = builder->getIntegerType(elemTy.getIntOrFloatBitWidth());
+		auto intVecTy = getVecType(intElemTy, N);
+		auto maskInt = builder->create<::mlir::LLVM::BitcastOp>(loc, intVecTy, mask);
+		auto zero = builder->create<::mlir::arith::ConstantOp>(loc, intVecTy, builder->getZeroAttr(intVecTy));
+		maskI1 = builder->create<::mlir::LLVM::ICmpOp>(loc, ::mlir::LLVM::ICmpPredicate::ne, maskInt, zero);
+	} else {
+		auto zero = builder->create<::mlir::arith::ConstantOp>(loc, vecTy, builder->getZeroAttr(vecTy));
+		maskI1 = builder->create<::mlir::LLVM::ICmpOp>(loc, ::mlir::LLVM::ICmpPredicate::ne, mask, zero);
+	}
+
+	// Store the active lanes packed contiguously at dst.
+	builder->create<::mlir::LLVM::masked_compressstore>(loc, data, dstPtr, maskI1);
+
+	// Popcount of the mask = number of stored elements: zext i1 -> i32, reduce.add.
+	auto i32Ty = builder->getI32Type();
+	auto i32VecTy = getVecType(i32Ty, N);
+	auto maskExt = builder->create<::mlir::LLVM::ZExtOp>(loc, i32VecTy, maskI1);
+	auto count = builder->create<::mlir::LLVM::vector_reduce_add>(loc, i32Ty, maskExt);
+
+	frame.setValue(call->getIdentifier(), count);
+	return true;
+}
+
+// ============================================================================
 // Extract: get a single lane by runtime index
 // ============================================================================
 
@@ -812,6 +864,11 @@ bool vectorInsertIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const co
 	manager.addIntrinsic(reinterpret_cast<void*>(&vector_scatter_##SUFFIX##_impl),                                   \
 	                     (vectorScatterIntrinsic<T, N>));
 
+// Register compress-store (packed masked store)
+#define REGISTER_VECTOR_COMPRESS_STORE(manager, T, N, SUFFIX)                                                        \
+	manager.addIntrinsic(reinterpret_cast<void*>(&vector_compress_store_##SUFFIX##_impl),                            \
+	                     (vectorCompressStoreIntrinsic<T, N>));
+
 // Register extract (lane access)
 #define REGISTER_VECTOR_EXTRACT(manager, T, N, SUFFIX)                                                               \
 	manager.addIntrinsic(reinterpret_cast<void*>(&vector_extract_##SUFFIX##_impl),                                   \
@@ -844,6 +901,7 @@ bool vectorInsertIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const co
 	REGISTER_VECTOR_BROADCAST(manager, T, N, SUFFIX)                                                                 \
 	REGISTER_VECTOR_GATHER(manager, T, N, SUFFIX)                                                                    \
 	REGISTER_VECTOR_SCATTER(manager, T, N, SUFFIX)                                                                   \
+	REGISTER_VECTOR_COMPRESS_STORE(manager, T, N, SUFFIX)                                                            \
 	REGISTER_VECTOR_EXTRACT(manager, T, N, SUFFIX)                                                                   \
 	REGISTER_VECTOR_INSERT(manager, T, N, SUFFIX)
 
@@ -861,6 +919,7 @@ bool vectorInsertIntrinsic(std::unique_ptr<::mlir::OpBuilder>& builder, const co
 	REGISTER_VECTOR_BROADCAST(manager, T, N, SUFFIX)                                                                 \
 	REGISTER_VECTOR_GATHER(manager, T, N, SUFFIX)                                                                    \
 	REGISTER_VECTOR_SCATTER(manager, T, N, SUFFIX)                                                                   \
+	REGISTER_VECTOR_COMPRESS_STORE(manager, T, N, SUFFIX)                                                            \
 	REGISTER_VECTOR_EXTRACT(manager, T, N, SUFFIX)                                                                   \
 	REGISTER_VECTOR_INSERT(manager, T, N, SUFFIX)                                                                    \
 	REGISTER_VECTOR_SHIFT_INT(manager, T, N, SUFFIX)

--- a/plugins/simd/src/vector.cpp
+++ b/plugins/simd/src/vector.cpp
@@ -215,6 +215,18 @@ static vector_data<T, N>* nextSlot() {
 		for (size_t i = 0; i < N; i++) base[indices[i]] = data->data[i];                                      \
 	}
 
+// Compress-store: write only the lanes whose mask bit is set, packed
+// contiguously at dst. Returns the number of elements written (popcount of
+// the mask). Mirrors LLVM's llvm.masked.compressstore semantics, with a lane
+// considered active when its mask element is non-zero (same convention as blend).
+#define VECTOR_IMPL_COMPRESS_STORE(T, N, SUFFIX)                                                                       \
+	extern "C" int32_t vector_compress_store_##SUFFIX##_impl(T* dst, vector_data<T, N>* mask, vector_data<T, N>* data) { \
+		int32_t count = 0;                                                                                            \
+		for (size_t i = 0; i < N; i++)                                                                                \
+			if (mask->data[i] != T(0)) dst[count++] = data->data[i];                                                  \
+		return count;                                                                                                 \
+	}
+
 #define VECTOR_IMPL_EXTRACT(T, N, SUFFIX)                                                     \
 	extern "C" T vector_extract_##SUFFIX##_impl(vector_data<T, N>* v, int32_t idx) {          \
 		return v->data[idx];                                                                  \
@@ -266,6 +278,7 @@ static vector_data<T, N>* nextSlot() {
 	VECTOR_IMPL_BROADCAST(T, N, SUFFIX)                           \
 	VECTOR_IMPL_GATHER(T, N, SUFFIX)                              \
 	VECTOR_IMPL_SCATTER(T, N, SUFFIX)                             \
+	VECTOR_IMPL_COMPRESS_STORE(T, N, SUFFIX)                      \
 	VECTOR_IMPL_EXTRACT(T, N, SUFFIX)                             \
 	VECTOR_IMPL_INSERT(T, N, SUFFIX)
 
@@ -376,6 +389,14 @@ namespace detail {
 		    vector_scatter_##SUFFIX##_impl, base, indices, data);                                        \
 	}
 
+#define VEC_INVOKE_COMPRESS_STORE(T, N, SUFFIX)                                                           \
+	template <>                                                                                          \
+	val<int32_t> vec_compress_store<T, N>(val<T*> dst, val<vector_data<T, N>*> mask,                     \
+	                                      val<vector_data<T, N>*> data) {                                 \
+		return invoke<int32_t, T*, vector_data<T, N>*, vector_data<T, N>*>(                              \
+		    vector_compress_store_##SUFFIX##_impl, dst, mask, data);                                     \
+	}
+
 #define VEC_INVOKE_EXTRACT(T, N, SUFFIX)                                                                  \
 	template <>                                                                                          \
 	val<T> vec_extract<T, N>(val<vector_data<T, N>*> v, val<int32_t> idx) {                              \
@@ -416,6 +437,7 @@ namespace detail {
 	VEC_INVOKE_BROADCAST(T, N, SUFFIX)                                                                   \
 	VEC_INVOKE_GATHER(T, N, SUFFIX)                                                                      \
 	VEC_INVOKE_SCATTER(T, N, SUFFIX)                                                                     \
+	VEC_INVOKE_COMPRESS_STORE(T, N, SUFFIX)                                                              \
 	VEC_INVOKE_EXTRACT(T, N, SUFFIX)                                                                     \
 	VEC_INVOKE_INSERT(T, N, SUFFIX)
 

--- a/plugins/simd/src/vector_impl.hpp
+++ b/plugins/simd/src/vector_impl.hpp
@@ -36,6 +36,9 @@ namespace nautilus {
 #define DECLARE_VECTOR_SCATTER(T, N, SUFFIX)                               \
 	extern "C" void vector_scatter_##SUFFIX##_impl(T*, const int32_t*, vector_data<T, N>*);
 
+#define DECLARE_VECTOR_COMPRESS_STORE(T, N, SUFFIX)                        \
+	extern "C" int32_t vector_compress_store_##SUFFIX##_impl(T*, vector_data<T, N>*, vector_data<T, N>*);
+
 #define DECLARE_VECTOR_EXTRACT(T, N, SUFFIX)                               \
 	extern "C" T vector_extract_##SUFFIX##_impl(vector_data<T, N>*, int32_t);
 
@@ -68,6 +71,7 @@ namespace nautilus {
 	DECLARE_VECTOR_BROADCAST(T, N, SUFFIX)                                 \
 	DECLARE_VECTOR_GATHER(T, N, SUFFIX)                                    \
 	DECLARE_VECTOR_SCATTER(T, N, SUFFIX)                                   \
+	DECLARE_VECTOR_COMPRESS_STORE(T, N, SUFFIX)                            \
 	DECLARE_VECTOR_EXTRACT(T, N, SUFFIX)                                   \
 	DECLARE_VECTOR_INSERT(T, N, SUFFIX)
 

--- a/plugins/simd/test/VectorExecutionTest.cpp
+++ b/plugins/simd/test/VectorExecutionTest.cpp
@@ -873,6 +873,69 @@ void vectorTests(engine::NautilusEngine& engine) {
 	}
 
 	// ================================================================
+	// Compress-store — packed masked store (stream compaction)
+	// ================================================================
+
+	SECTION("compress-store float (even lanes)") {
+		auto f = engine.registerFunction(vectorCompressStoreFloat);
+		alignas(64) float data[FL_MAX], mask[FL_MAX], out[FL_MAX];
+		size_t expected_count = 0;
+		for (size_t i = 0; i < FL; i++) {
+			data[i] = static_cast<float>((i + 1) * 10);
+			out[i] = -1.0f;
+			uint32_t m = (i % 2 == 0) ? 0xFFFFFFFF : 0x00000000;
+			std::memcpy(&mask[i], &m, sizeof(float));
+			if (i % 2 == 0)
+				expected_count++;
+		}
+		int32_t count = f(data, mask, out);
+		REQUIRE(count == static_cast<int32_t>(expected_count));
+		size_t k = 0;
+		for (size_t i = 0; i < FL; i++)
+			if (i % 2 == 0)
+				REQUIRE(out[k++] == data[i]);
+	}
+
+	SECTION("compress-store int32 (manual mask)") {
+		auto f = engine.registerFunction(vectorCompressStoreInt);
+		alignas(64) int32_t data[IL_MAX], mask[IL_MAX], out[IL_MAX];
+		size_t expected_count = 0;
+		for (size_t i = 0; i < IL; i++) {
+			data[i] = static_cast<int32_t>((i + 1) * 100);
+			out[i] = -1;
+			mask[i] = (i % 3 == 0) ? (int32_t) 0xFFFFFFFF : 0;
+			if (i % 3 == 0)
+				expected_count++;
+		}
+		int32_t count = f(data, mask, out);
+		REQUIRE(count == static_cast<int32_t>(expected_count));
+		size_t k = 0;
+		for (size_t i = 0; i < IL; i++)
+			if (i % 3 == 0)
+				REQUIRE(out[k++] == data[i]);
+	}
+
+	SECTION("compress-store int32 filter > threshold (cmp + compress)") {
+		auto f = engine.registerFunction(vectorFilterGtInt);
+		alignas(64) int32_t data[IL_MAX], thresh[IL_MAX], out[IL_MAX];
+		int32_t t = static_cast<int32_t>(IL / 2);
+		size_t expected_count = 0;
+		for (size_t i = 0; i < IL; i++) {
+			data[i] = static_cast<int32_t>(i);
+			thresh[i] = t;
+			out[i] = -1;
+			if (static_cast<int32_t>(i) > t)
+				expected_count++;
+		}
+		int32_t count = f(data, thresh, out);
+		REQUIRE(count == static_cast<int32_t>(expected_count));
+		size_t k = 0;
+		for (size_t i = 0; i < IL; i++)
+			if (static_cast<int32_t>(i) > t)
+				REQUIRE(out[k++] == data[i]);
+	}
+
+	// ================================================================
 	// Extract — get single lane
 	// ================================================================
 

--- a/plugins/simd/test/VectorFunctions.hpp
+++ b/plugins/simd/test/VectorFunctions.hpp
@@ -409,6 +409,30 @@ void vectorScatterInt(val<const int32_t*> src, val<int32_t*> base, val<const int
 }
 
 // ============================================================================
+// Compress-store — packed masked store (stream compaction)
+// ============================================================================
+
+val<int32_t> vectorCompressStoreFloat(val<const float*> data, val<const float*> mask, val<float*> out) {
+	auto vdata = val<vec<float>>::Load(data);
+	auto vmask = val<vec<float>>::Load(mask);
+	return vdata.CompressStore(out, vmask);
+}
+
+val<int32_t> vectorCompressStoreInt(val<const int32_t*> data, val<const int32_t*> mask, val<int32_t*> out) {
+	auto vdata = val<vec<int32_t>>::Load(data);
+	auto vmask = val<vec<int32_t>>::Load(mask);
+	return vdata.CompressStore(out, vmask);
+}
+
+// Realistic compaction: keep only elements greater than a threshold, packed
+// contiguously, using a comparison to produce the mask.
+val<int32_t> vectorFilterGtInt(val<const int32_t*> data, val<const int32_t*> thresh, val<int32_t*> out) {
+	auto vdata = val<vec<int32_t>>::Load(data);
+	auto vthresh = val<vec<int32_t>>::Load(thresh);
+	return vdata.CompressStore(out, vdata > vthresh);
+}
+
+// ============================================================================
 // Extract — get a single lane
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Implements **compress-store** in the SIMD plugin — a new `CompressStore` member on `val<vec<T>>` that stores only the lanes whose mask bit is set, packed contiguously at the destination, and returns the number of elements written (the popcount of the mask). This is the core primitive for stream compaction / filtering.

```cpp
// Keep only the elements greater than the threshold, packed contiguously.
auto v = val<vec<int32_t>>::Load(data);
auto mask = v > val<vec<int32_t>>::Broadcast(threshold);
val<int32_t> written = v.CompressStore(out_ptr, mask);
```

## Is it available via an MLIR intrinsic?

Yes. The MLIR backend lowers it directly to `llvm.masked.compressstore` (`mlir::LLVM::masked_compressstore`, operands `value, dst, mask`, no result), which LLVM turns into AVX-512 `vcompressps`/`vpcompressd` where available and **scalarizes** on targets that lack it — so the op is portable across architectures. The element count is computed alongside the store as `vector.reduce.add` over the zero-extended `i1` mask.

A lane is active when its mask element is non-zero, matching the existing `Blend` convention, so the mask is naturally produced by a comparison.

## Backend coverage

- **MLIR**: native `llvm.masked.compressstore` + mask popcount, registered for all element types and widths (`f32/f64/i32/i64` × 128/256/512-bit).
- **C++ / bytecode / interpreter**: scalar packing loop fallback in `vector.cpp`.
- **AsmJit**: intentionally left unregistered (same as wider widths today) so it falls through to the scalar fallback.

## Changes

- `plugins/simd/include/nautilus/vector.hpp` — `CompressStore` API + `detail::vec_compress_store` declaration.
- `plugins/simd/src/vector_impl.hpp` — extern "C" impl declaration.
- `plugins/simd/src/vector.cpp` — scalar fallback impl + `invoke` wrapper.
- `plugins/simd/src/MLIRVectorIntrinsics.cpp` — MLIR intrinsic handler + registration.
- `plugins/simd/test/{VectorFunctions.hpp,VectorExecutionTest.cpp}` — test kernels and sections (manual mask + comparison-driven filter).
- `docs/simd.md` — documentation.

## Testing

Full SIMD suite passes — **4853 assertions across all backends** (interpreter, MLIR, C++, bytecode, AsmJit), including the new compress-store sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6qMK5EGZ37MLFmiDYmemd)_