### PR TITLE
Add nautilus_assume_noalias for restrict-style aliasing hints

### DIFF
--- a/plugins/specialization/include/nautilus/specialization/assume.hpp
+++ b/plugins/specialization/include/nautilus/specialization/assume.hpp
@@ -25,4 +25,18 @@ side effects; only its value is used for optimization.
 */
 void nautilus_assume_aligned(val<void*> ptr, int alignment);
 
+/*
+Declares that the two pointers refer to separate (non-overlapping) storage,
+i.e. neither aliases the other. This is the tracing equivalent of the C
+`restrict` qualifier: the optimizer may use the information to reorder or
+eliminate memory accesses and to vectorize loops that would otherwise be
+blocked by potential aliasing.
+
+If the pointers actually overlap at runtime, the behavior is undefined.
+
+Like the other assume helpers, the pointer expressions are never evaluated for
+side effects; only their values are used for optimization.
+*/
+void nautilus_assume_noalias(val<void*> a, val<void*> b);
+
 } // namespace nautilus

--- a/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
+++ b/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
@@ -31,6 +31,19 @@ public:
 			                                            ::mlir::LLVM::AssumeAlignTag {}, ptr, align);
 			    return true;
 		    });
+		manager.addIntrinsic(
+		    reinterpret_cast<void*>(&nautilus_assume_separate_storage_stub),
+		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
+		       [[maybe_unused]] compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) -> bool {
+			    auto constOp =
+			        builder->create<::mlir::arith::ConstantOp>(builder->getUnknownLoc(), builder->getI1Type(),
+			                                                   builder->getIntegerAttr(builder->getI1Type(), true));
+			    auto ptrA = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+			    auto ptrB = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), constOp,
+			                                            ::mlir::LLVM::AssumeSeparateStorageTag {}, ptrA, ptrB);
+			    return true;
+		    });
 	}
 	~NautilusAssumeIntrinsicPlugin() override = default;
 };

--- a/plugins/specialization/src/assume.cpp
+++ b/plugins/specialization/src/assume.cpp
@@ -21,4 +21,13 @@ void nautilus_assume_aligned(val<void*> ptr, int alignment) {
 	invoke(nautilus_assume_aligned_stub, ptr, val<int8_t>(alignment));
 }
 
+void nautilus_assume_separate_storage_stub(void*, void*) {
+	// This function is a stub for optimization purposes.
+	// It does nothing at runtime.
+}
+
+void nautilus_assume_noalias(val<void*> a, val<void*> b) {
+	invoke(nautilus_assume_separate_storage_stub, a, b);
+}
+
 } // namespace nautilus

--- a/plugins/specialization/src/assume_stubs.hpp
+++ b/plugins/specialization/src/assume_stubs.hpp
@@ -3,4 +3,5 @@
 namespace nautilus {
 void nautlis_assume_stub(bool);
 void nautilus_assume_aligned_stub(void*, int);
+void nautilus_assume_separate_storage_stub(void*, void*);
 } // namespace nautilus

--- a/plugins/specialization/test/AssumeExecutionTest.cpp
+++ b/plugins/specialization/test/AssumeExecutionTest.cpp
@@ -31,6 +31,13 @@ val<int> cfWithAssumeAlignment(val<int32_t*> a) {
 	return *a + 10;
 }
 
+val<int32_t> cfWithNoalias(val<int32_t*> a, val<int32_t*> b) {
+	nautilus_assume_noalias((val<void*>) a, (val<void*>) b);
+	*a = 1;              // store through a
+	val<int32_t> r = *b; // load from b - provably independent of *a
+	return r + *a;
+}
+
 TEST_CASE("MLIR Intrinsic Function Test") {
 	for (auto useIntrinsics : {false, true}) {
 		DYNAMIC_SECTION("useIntrinsics:" << useIntrinsics) {
@@ -51,6 +58,16 @@ TEST_CASE("MLIR Intrinsic Function Test") {
 					REQUIRE(f(42) == 52);
 					REQUIRE_THROWS(f(0));
 				}
+			}
+
+			SECTION("cfWithNoalias") {
+				// The separate_storage hint is a compile-time no-op for the
+				// observable result; verify the intrinsic lowers and runs.
+				auto f = engine.registerFunction(cfWithNoalias);
+				int32_t x = 0;
+				int32_t y = 7;
+				REQUIRE(f(&x, &y) == 8); // r (==7) + *a (==1)
+				REQUIRE(x == 1);
 			}
 		}
 	}

--- a/plugins/specialization/test/LLVMIRAssumeTest.cpp
+++ b/plugins/specialization/test/LLVMIRAssumeTest.cpp
@@ -12,6 +12,7 @@ namespace nautilus::engine {
 using nautilus::engine::assumeAlignedFunction;
 using nautilus::engine::assumeComplexCondition;
 using nautilus::engine::assumeFunction;
+using nautilus::engine::noaliasFunction;
 
 // Wrapper for testLLVMIR that uses the plugin's intrinsic-ir directory
 template <typename Func>
@@ -33,6 +34,10 @@ TEST_CASE("LLVM IR Intrinsic Test: assumeAlignedFunction (MLIR intrinsics enable
 	testIntrinsicLLVMIR("assumeAlignedFunction_with_intrinsics", assumeAlignedFunction, true);
 }
 
+TEST_CASE("LLVM IR Intrinsic Test: noaliasFunction (MLIR intrinsics enabled)", "[profile][assume][intrinsics]") {
+	testIntrinsicLLVMIR("noaliasFunction_with_intrinsics", noaliasFunction, true);
+}
+
 TEST_CASE("LLVM IR Intrinsic Test: assumeFunction (MLIR intrinsics disabled)", "[profile][assume][no-intrinsics]") {
 	testIntrinsicLLVMIR("assumeFunction_without_intrinsics", assumeFunction, false);
 }
@@ -45,6 +50,10 @@ TEST_CASE("LLVM IR Intrinsic Test: assumeComplexCondition (MLIR intrinsics disab
 TEST_CASE("LLVM IR Intrinsic Test: assumeAlignedFunction (MLIR intrinsics disabled)",
           "[profile][assume][no-intrinsics]") {
 	testIntrinsicLLVMIR("assumeAlignedFunction_without_intrinsics", assumeAlignedFunction, false);
+}
+
+TEST_CASE("LLVM IR Intrinsic Test: noaliasFunction (MLIR intrinsics disabled)", "[profile][assume][no-intrinsics]") {
+	testIntrinsicLLVMIR("noaliasFunction_without_intrinsics", noaliasFunction, false);
 }
 
 } // namespace nautilus::engine

--- a/plugins/specialization/test/common/ProfileFunctions.hpp
+++ b/plugins/specialization/test/common/ProfileFunctions.hpp
@@ -25,4 +25,11 @@ val<int32_t> assumeAlignedFunction(val<int32_t*> ptr) {
 	return *ptr;
 }
 
+// Test function that uses nautilus_assume_noalias (separate storage)
+val<int32_t> noaliasFunction(val<int32_t*> a, val<int32_t*> b) {
+	nautilus_assume_noalias((val<void*>) a, (val<void*>) b);
+	*a = 1;
+	return *b;
+}
+
 } // namespace nautilus::engine

--- a/plugins/specialization/test/intrinsic-ir/noaliasFunction_with_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/noaliasFunction_with_intrinsics.ll
@@ -1,0 +1,63 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: write)
+define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
+  store i32 1, ptr %0, align 4
+  %3 = load i32, ptr %1, align 4
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: write)
+define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
+  store i32 1, ptr %0, align 4
+  %3 = load i32, ptr %1, align 4
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write)
+declare void @llvm.assume(i1 noundef) #1
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: write)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %3, ptr %6) ]
+  store i32 1, ptr %3, align 4
+  %7 = load i32, ptr %6, align 4
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: write)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %3, ptr %6) ]
+  store i32 1, ptr %3, align 4
+  %7 = load i32, ptr %6, align 4
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: write) }
+attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }
+attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: write) }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/plugins/specialization/test/intrinsic-ir/noaliasFunction_without_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/noaliasFunction_without_intrinsics.ll
@@ -1,0 +1,60 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: memory(readwrite)
+define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  tail call void @runtimeFunc0(ptr %0, ptr %1)
+  store i32 1, ptr %0, align 4
+  %3 = load i32, ptr %1, align 4
+  ret i32 %3
+}
+
+; Function Attrs: memory(readwrite)
+define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  tail call void @runtimeFunc0(ptr %0, ptr %1)
+  store i32 1, ptr %0, align 4
+  %3 = load i32, ptr %1, align 4
+  ret i32 %3
+}
+
+; Function Attrs: memory(readwrite)
+declare void @runtimeFunc0(ptr, ptr) local_unnamed_addr #1
+
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  tail call void @runtimeFunc0(ptr %3, ptr %6)
+  store i32 1, ptr %3, align 4
+  %7 = load i32, ptr %6, align 4
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  tail call void @runtimeFunc0(ptr %3, ptr %6)
+  store i32 1, ptr %3, align 4
+  %7 = load i32, ptr %6, align 4
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+attributes #0 = { memory(readwrite) }
+attributes #1 = { memory(readwrite) }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
## Summary

Adds a way to express the C `restrict` / `noalias` property from traced Nautilus code, and has the MLIR backend use it to generate specialized code.

A new helper in the `nautilus-specialization` plugin:

```cpp
void nautilus_assume_noalias(val<void*> a, val<void*> b);
```

declares that two pointers refer to **separate (non-overlapping) storage**. With this information LLVM's alias analysis can reorder/eliminate memory accesses and vectorize loops that would otherwise be blocked by potential aliasing. If the pointers actually overlap at runtime, behavior is undefined (same contract as the other `assume` helpers).

## Approach

This rides the existing `assume` mechanism exactly — same plugin, same stub + `invoke()` + MLIR intrinsic pattern as `nautilus_assume_aligned` — so **no changes to the tracing → IR → argument pipeline** were needed. The MLIR backend lowers the hint to `llvm.assume` with a `separate_storage` operand bundle (`mlir::LLVM::AssumeSeparateStorageTag`).

Generated IR for a two-pointer kernel:

```llvm
define signext i32 @execute(ptr %0, ptr %1) ... {
  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
  store i32 1, ptr %0, align 4
  %3 = load i32, ptr %1, align 4   ; provably independent of the store
  ret i32 %3
}
```

## Changes

- `assume.hpp` — declare `nautilus_assume_noalias`
- `assume_stubs.hpp` / `assume.cpp` — add stub + wrapper
- `MLIRAssumeIntrinsics.cpp` — register + lower to `AssumeOp` with `AssumeSeparateStorageTag`
- Tests: execution (`AssumeExecutionTest.cpp`), LLVM IR reference (`LLVMIRAssumeTest.cpp`, `ProfileFunctions.hpp`) for both intrinsics-enabled and disabled paths, plus the two generated reference `.ll` files.

## Verification

- `nautilus-specialization` library builds (confirms `AssumeSeparateStorageTag` for the pinned MLIR 21.1.2).
- Execution tests pass (`8 assertions in 1 test case`).
- LLVM IR tests pass (`14 assertions in 8 test cases`); the new `_with_intrinsics.ll` reference contains the `separate_storage` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7oJcnP7CvrDkZ5CvWZ5wb)_