### PR TITLE
Dump AsmJit IR and generated assembly from AsmJit backend

### DIFF
--- a/nautilus/src/nautilus/compiler/DumpHandler.cpp
+++ b/nautilus/src/nautilus/compiler/DumpHandler.cpp
@@ -29,6 +29,8 @@ bool DumpHandler::shallCreateFolder() const {
 	generallyDump = generallyDump or shouldDump("after_llvm_generation");
 	generallyDump = generallyDump or shouldDump("after_cpp_generation");
 	generallyDump = generallyDump or shouldDump("after_bc_generation");
+	generallyDump = generallyDump or shouldDump("after_asmjit_generation");
+	generallyDump = generallyDump or shouldDump("after_asmjit_assembly");
 	return generallyDump and dumpToFile();
 }
 

--- a/nautilus/src/nautilus/compiler/DumpHandler.hpp
+++ b/nautilus/src/nautilus/compiler/DumpHandler.hpp
@@ -15,8 +15,11 @@ public:
 	void forceDump(std::string_view dumpName, std::string_view extension, const std::string& content) const;
 	[[nodiscard]] const std::map<std::string, std::string>& getGeneratedFiles() const;
 
-private:
+	/// Returns whether a dump with the given name is currently enabled. Backends can use this to
+	/// avoid the cost of producing dump content (e.g. attaching an AsmJit logger) when not requested.
 	[[nodiscard]] bool shouldDump(std::string_view dumpName) const;
+
+private:
 	[[nodiscard]] bool shallCreateFolder() const;
 	[[nodiscard]] bool dumpToConsole() const;
 	[[nodiscard]] bool dumpToFile() const;

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp"
 #include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/compiler/DumpHandler.hpp"
 #include "nautilus/exceptions/NotImplementedException.hpp"
 #include <cassert>
 #include <cstring>
@@ -26,11 +27,22 @@ public:
 AsmJitLoweringProvider::LowerResult AsmJitLoweringProvider::lower(std::shared_ptr<ir::IRGraph> ir,
                                                                   ::asmjit::JitRuntime& runtime,
                                                                   const engine::Options& options,
+                                                                  const DumpHandler& dumpHandler,
                                                                   CompilationStatistics* statistics) {
 	CodeHolder code;
 	code.init(runtime.environment(), runtime.cpuFeatures());
 	ThrowOnError errHandler;
 	code.setErrorHandler(&errHandler);
+
+	// Only pay the formatting/logging cost when the corresponding dump is requested.
+	const bool dumpAsmjitIR = dumpHandler.shouldDump("after_asmjit_generation");
+	const bool dumpAssembly = dumpHandler.shouldDump("after_asmjit_assembly");
+
+	// When requested, attach a StringLogger so finalize() records the emitted assembly.
+	StringLogger asmLogger;
+	if (dumpAssembly) {
+		code.setLogger(&asmLogger);
+	}
 
 	// Build the intrinsic manager from the global plugin registry. Gated by
 	// `asmjit.enableIntrinsics` (default true), mirroring `mlir.enableIntrinsics`.
@@ -42,7 +54,8 @@ AsmJitLoweringProvider::LowerResult AsmJitLoweringProvider::lower(std::shared_pt
 	}
 
 	LoweringContext ctx(std::move(ir), code, options, statistics, intrinsicManager);
-	ctx.processAll();
+	std::string asmjitIR;
+	ctx.processAll(dumpAsmjitIR ? &asmjitIR : nullptr);
 
 	std::unordered_map<std::string, uint64_t> offsets;
 	for (const auto& [name, funcNode] : ctx.getFuncNodes()) {
@@ -61,6 +74,10 @@ AsmJitLoweringProvider::LowerResult AsmJitLoweringProvider::lower(std::shared_pt
 	result.codeSize = codeSize;
 	for (const auto& [name, offset] : offsets) {
 		result.jitPtrs[name] = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(basePtr) + offset);
+	}
+	result.asmjitIR = std::move(asmjitIR);
+	if (dumpAssembly) {
+		result.assembly.assign(asmLogger.data(), asmLogger.dataSize());
 	}
 	return result;
 }
@@ -159,7 +176,7 @@ void AsmJitLoweringProvider::LoweringContext::emitMove(const AsmReg& dst, const 
 
 // ── Two-pass compilation ──────────────────────────────────────────────────────
 
-void AsmJitLoweringProvider::LoweringContext::processAll() {
+void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDump) {
 	const auto& functionOperations = ir->getFunctionOperations();
 	if (functionOperations.empty()) {
 		throw std::runtime_error("AsmJit/A64: no functions found in IR graph");
@@ -240,6 +257,15 @@ void AsmJitLoweringProvider::LoweringContext::processAll() {
 
 		processBlock(&funcBlock, rootFrame);
 		cc.endFunc();
+	}
+
+	// Format the builder node list before finalize(): at this point the IR still carries
+	// virtual registers, which is the representation users want to inspect as "asmjit IR".
+	if (asmjitIRDump != nullptr) {
+		::asmjit::String sb;
+		::asmjit::FormatOptions formatOptions;
+		::asmjit::Formatter::formatNodeList(sb, formatOptions, &cc);
+		asmjitIRDump->assign(sb.data(), sb.size());
 	}
 
 	cc.finalize();

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
@@ -16,6 +16,7 @@
 
 namespace nautilus::compiler {
 class CompilationStatistics;
+class DumpHandler;
 } // namespace nautilus::compiler
 
 namespace nautilus::compiler::asmjit {
@@ -36,6 +37,8 @@ public:
 		void* basePtr = nullptr;                        ///< Single JIT allocation base; release exactly once.
 		std::unordered_map<std::string, void*> jitPtrs; ///< Per-function pointers within the allocation.
 		uint64_t codeSize = 0;                          ///< Total emitted machine-code size in bytes.
+		std::string asmjitIR;                           ///< AsmJit builder node list (only captured when dumping).
+		std::string assembly;                           ///< Generated assembly listing (only captured when dumping).
 	};
 
 	/// Compile all functions in the IR graph into one JIT allocation.
@@ -43,8 +46,12 @@ public:
 	/// When @p statistics is non-null, the optional post-RA peephole pass
 	/// (see @ref A64PostRAPeepholePass) records its per-run counters into
 	/// it under the `asmjit.peephole.*` key namespace.
+	///
+	/// When @p dumpHandler requests the `after_asmjit_generation` /
+	/// `after_asmjit_assembly` dumps, the corresponding textual representations
+	/// are captured into @ref LowerResult.
 	LowerResult lower(std::shared_ptr<ir::IRGraph> ir, ::asmjit::JitRuntime& runtime, const engine::Options& options,
-	                  CompilationStatistics* statistics = nullptr);
+	                  const DumpHandler& dumpHandler, CompilationStatistics* statistics = nullptr);
 
 private:
 	// AsmReg / RegisterFrame come from AsmJitRegister.hpp at namespace scope so
@@ -59,7 +66,10 @@ private:
 		                CompilationStatistics* statistics, const AsmJitIntrinsicManager& intrinsicManager);
 
 		/// Pass 1 + Pass 2 + finalize.
-		void processAll();
+		///
+		/// When @p asmjitIRDump is non-null, the AsmJit builder node list is formatted into it
+		/// just before finalize() (i.e. while virtual registers are still present).
+		void processAll(std::string* asmjitIRDump = nullptr);
 
 		/// Must be called after processAll() and before rt.add() to capture label offsets.
 		const std::unordered_map<std::string, ::asmjit::FuncNode*>& getFuncNodes() const {

--- a/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitCompilationBackend.cpp
@@ -13,7 +13,7 @@
 namespace nautilus::compiler::asmjit {
 
 std::unique_ptr<Executable> AsmJitCompilationBackend::compile(const std::shared_ptr<ir::IRGraph>& ir,
-                                                              const DumpHandler& /*dumpHandler*/,
+                                                              const DumpHandler& dumpHandler,
                                                               const engine::Options& options,
                                                               CompilationStatistics* statistics) const {
 	const auto backendStart = std::chrono::steady_clock::now();
@@ -24,11 +24,18 @@ std::unique_ptr<Executable> AsmJitCompilationBackend::compile(const std::shared_
 	const auto compileStart = std::chrono::steady_clock::now();
 	// Thread the statistics sink through lower() so the optional post-RA
 	// peephole pass can record its counters under backend-scoped keys
-	// (asmjit.peephole.*).
-	auto result = provider.lower(ir, *runtime, options, statistics);
+	// (asmjit.peephole.*). The DumpHandler lets lower() capture the AsmJit
+	// builder IR and the generated assembly when those dumps are requested.
+	auto result = provider.lower(ir, *runtime, options, dumpHandler, statistics);
 	if (!result.basePtr) {
 		return nullptr;
 	}
+
+	// Emit the captured textual representations. lower() only fills these in when the
+	// matching dump is enabled, so the dump callbacks are cheap no-ops otherwise.
+	dumpHandler.dump("after_asmjit_generation", "asmjit", [&]() { return result.asmjitIR; });
+	dumpHandler.dump("after_asmjit_assembly", "asm", [&]() { return result.assembly; });
+
 	if (statistics != nullptr) {
 		statistics->recordTimingMs("asmjit.compile.ms", compileStart);
 		statistics->set("asmjit.codeSize.bytes", static_cast<int64_t>(result.codeSize));

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp"
 #include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/compiler/DumpHandler.hpp"
 #include "nautilus/exceptions/NotImplementedException.hpp"
 #include <cassert>
 #include <cstring>
@@ -27,11 +28,22 @@ public:
 AsmJitLoweringProvider::LowerResult AsmJitLoweringProvider::lower(std::shared_ptr<ir::IRGraph> ir,
                                                                   ::asmjit::JitRuntime& runtime,
                                                                   const engine::Options& options,
+                                                                  const DumpHandler& dumpHandler,
                                                                   CompilationStatistics* statistics) {
 	CodeHolder code;
 	code.init(runtime.environment(), runtime.cpuFeatures());
 	ThrowOnError errHandler;
 	code.setErrorHandler(&errHandler);
+
+	// Only pay the formatting/logging cost when the corresponding dump is requested.
+	const bool dumpAsmjitIR = dumpHandler.shouldDump("after_asmjit_generation");
+	const bool dumpAssembly = dumpHandler.shouldDump("after_asmjit_assembly");
+
+	// When requested, attach a StringLogger so finalize() records the emitted assembly.
+	StringLogger asmLogger;
+	if (dumpAssembly) {
+		code.setLogger(&asmLogger);
+	}
 
 	// Build the intrinsic manager from the global plugin registry. Gated by
 	// `asmjit.enableIntrinsics` (default true), mirroring `mlir.enableIntrinsics`.
@@ -43,7 +55,8 @@ AsmJitLoweringProvider::LowerResult AsmJitLoweringProvider::lower(std::shared_pt
 	}
 
 	LoweringContext ctx(std::move(ir), code, options, statistics, intrinsicManager);
-	ctx.processAll();
+	std::string asmjitIR;
+	ctx.processAll(dumpAsmjitIR ? &asmjitIR : nullptr);
 
 	// Capture label offsets while code is still in the CodeHolder (before rt.add resets it).
 	std::unordered_map<std::string, uint64_t> offsets;
@@ -63,6 +76,10 @@ AsmJitLoweringProvider::LowerResult AsmJitLoweringProvider::lower(std::shared_pt
 	result.codeSize = codeSize;
 	for (const auto& [name, offset] : offsets) {
 		result.jitPtrs[name] = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(basePtr) + offset);
+	}
+	result.asmjitIR = std::move(asmjitIR);
+	if (dumpAssembly) {
+		result.assembly.assign(asmLogger.data(), asmLogger.dataSize());
 	}
 	return result;
 }
@@ -176,7 +193,7 @@ void AsmJitLoweringProvider::LoweringContext::emitMove(const AsmReg& dst, const 
 // Pass 2: for each function, call cc.addFunc(funcNode), emit the body,
 //         and call cc.endFunc(). cc.finalize() resolves all label references.
 
-void AsmJitLoweringProvider::LoweringContext::processAll() {
+void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDump) {
 	const auto& functionOperations = ir->getFunctionOperations();
 	if (functionOperations.empty()) {
 		throw std::runtime_error("AsmJit: no functions found in IR graph");
@@ -260,6 +277,15 @@ void AsmJitLoweringProvider::LoweringContext::processAll() {
 
 		processBlock(&funcBlock, rootFrame);
 		cc.endFunc();
+	}
+
+	// Format the builder node list before finalize(): at this point the IR still carries
+	// virtual registers, which is the representation users want to inspect as "asmjit IR".
+	if (asmjitIRDump != nullptr) {
+		::asmjit::String sb;
+		::asmjit::FormatOptions formatOptions;
+		::asmjit::Formatter::formatNodeList(sb, formatOptions, &cc);
+		asmjitIRDump->assign(sb.data(), sb.size());
 	}
 
 	cc.finalize();

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -16,6 +16,7 @@
 
 namespace nautilus::compiler {
 class CompilationStatistics;
+class DumpHandler;
 } // namespace nautilus::compiler
 
 namespace nautilus::compiler::asmjit {
@@ -36,6 +37,8 @@ public:
 		void* basePtr = nullptr;                        ///< Single JIT allocation base; release exactly once.
 		std::unordered_map<std::string, void*> jitPtrs; ///< Per-function pointers within the allocation.
 		uint64_t codeSize = 0;                          ///< Total emitted machine-code size in bytes.
+		std::string asmjitIR;                           ///< AsmJit builder node list (only captured when dumping).
+		std::string assembly;                           ///< Generated assembly listing (only captured when dumping).
 	};
 
 	/// Compile all functions in the IR graph into one JIT allocation.
@@ -43,8 +46,12 @@ public:
 	/// When @p statistics is non-null, the optional post-RA peephole pass
 	/// (see @ref X64PostRAPeepholePass) records its per-run counters into
 	/// it under the `asmjit.peephole.*` key namespace.
+	///
+	/// When @p dumpHandler requests the `after_asmjit_generation` /
+	/// `after_asmjit_assembly` dumps, the corresponding textual representations
+	/// are captured into @ref LowerResult.
 	LowerResult lower(std::shared_ptr<ir::IRGraph> ir, ::asmjit::JitRuntime& runtime, const engine::Options& options,
-	                  CompilationStatistics* statistics = nullptr);
+	                  const DumpHandler& dumpHandler, CompilationStatistics* statistics = nullptr);
 
 private:
 	// AsmReg / RegisterFrame come from AsmJitRegister.hpp at namespace scope so
@@ -59,7 +66,10 @@ private:
 		                CompilationStatistics* statistics, const AsmJitIntrinsicManager& intrinsicManager);
 
 		/// Pass 1 + Pass 2 + finalize.
-		void processAll();
+		///
+		/// When @p asmjitIRDump is non-null, the AsmJit builder node list is formatted into it
+		/// just before finalize() (i.e. while virtual registers are still present).
+		void processAll(std::string* asmjitIRDump = nullptr);
 
 		/// Must be called after processAll() and before rt.add() to capture label offsets.
 		const std::unordered_map<std::string, ::asmjit::FuncNode*>& getFuncNodes() const {


### PR DESCRIPTION
## Summary

`AsmJitCompilationBackend::compile` previously ignored the `DumpHandler`, so the AsmJit pipeline emitted no debug artifacts — unlike the MLIR, C++, and bytecode backends. This wires the `DumpHandler` through the lowering provider and adds two dumps:

- **`after_asmjit_generation`** (`.asmjit`) — the AsmJit builder node list, formatted via `Formatter::formatNodeList` **before** `finalize()` so virtual registers are still visible (the high-level "AsmJit IR").
- **`after_asmjit_assembly`** (`.asm`) — the generated assembly, captured with a `StringLogger` attached to the `CodeHolder` during `finalize()`.

## Details

- Both captures are gated on `DumpHandler::shouldDump(...)`, so the formatting/logging cost is only paid when the dump is requested (matching the lazy behavior of the other backends).
- `DumpHandler::shouldDump` is now public, and the two new dump names participate in `shallCreateFolder()`.
- The capture is threaded through `AsmJitLoweringProvider::lower()` and `processAll()` into `LowerResult`, then emitted by the backend's `compile()` via `dumpHandler.dump(...)`, consistent with how `CPPCompilationBackend`/`MLIRCompilationBackend` dump.
- Applied symmetrically to both the x86-64 (`X64LoweringProvider`) and AArch64 (`A64LoweringProvider`) lowering providers.

## Testing

Configured with the AsmJit backend enabled and compiled the affected translation units (`X64LoweringProvider.cpp`, `AsmJitCompilationBackend.cpp`, `DumpHandler.cpp`) cleanly. The A64 provider mirrors the X64 changes exactly (it is platform-gated and not built on x86 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6Ucp9Eo1qujHR5v3P4CqX)_