### PR TITLE
Add nautilus_assume_noalias for noalias/restrict specialization

### DIFF
--- a/plugins/specialization/include/nautilus/specialization/assume.hpp
+++ b/plugins/specialization/include/nautilus/specialization/assume.hpp
@@ -25,4 +25,25 @@ side effects; only its value is used for optimization.
 */
 void nautilus_assume_aligned(val<void*> ptr, int alignment);
 
+/*
+The two pointer arguments are assumed to point into separate, non-overlapping
+storage; i.e. memory accessed through one pointer never aliases memory accessed
+through the other. This is the equivalent of the C `restrict` qualifier or the
+LLVM `noalias` attribute, expressed as an assumption between two concrete
+pointers.
+
+The optimizer may use this information to reorder, hoist, or vectorize memory
+accesses through the pointers that it would otherwise have to keep ordered
+because of a potential alias.
+
+If the pointers actually alias (overlap) at runtime, the behavior is undefined.
+
+Like the other assume helpers, the pointer expressions are never evaluated for
+side effects; only their values are used for optimization.
+
+Typed pointers (e.g. `val<int32_t*>`) implicitly convert to `val<void*>`, so
+they can be passed directly without an explicit cast.
+*/
+void nautilus_assume_noalias(val<void*> a, val<void*> b);
+
 } // namespace nautilus

--- a/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
+++ b/plugins/specialization/src/MLIRAssumeIntrinsics.cpp
@@ -31,6 +31,21 @@ public:
 			                                            ::mlir::LLVM::AssumeAlignTag {}, ptr, align);
 			    return true;
 		    });
+		manager.addIntrinsic(
+		    reinterpret_cast<void*>(&nautilus_assume_noalias_stub),
+		    [](std::unique_ptr<::mlir::OpBuilder>& builder, const compiler::ir::ProxyCallOperation* call,
+		       [[maybe_unused]] compiler::mlir::MLIRLoweringProvider::ValueFrame& frame) -> bool {
+			    // Lower to `llvm.assume(true) ["separate_storage"(a, b)]`, which tells LLVM the
+			    // two pointers point into separate storage, i.e. they do not alias (noalias/restrict).
+			    auto constOp =
+			        builder->create<::mlir::arith::ConstantOp>(builder->getUnknownLoc(), builder->getI1Type(),
+			                                                   builder->getIntegerAttr(builder->getI1Type(), true));
+			    auto a = frame.getValue(call->getInputArguments()[0]->getIdentifier());
+			    auto b = frame.getValue(call->getInputArguments()[1]->getIdentifier());
+			    builder->create<::mlir::LLVM::AssumeOp>(builder->getUnknownLoc(), constOp,
+			                                            ::mlir::LLVM::AssumeSeparateStorageTag {}, a, b);
+			    return true;
+		    });
 	}
 	~NautilusAssumeIntrinsicPlugin() override = default;
 };

--- a/plugins/specialization/src/assume.cpp
+++ b/plugins/specialization/src/assume.cpp
@@ -21,4 +21,13 @@ void nautilus_assume_aligned(val<void*> ptr, int alignment) {
 	invoke(nautilus_assume_aligned_stub, ptr, val<int8_t>(alignment));
 }
 
+void nautilus_assume_noalias_stub(void*, void*) {
+	// This function is a stub for optimization purposes.
+	// It does nothing at runtime.
+}
+
+void nautilus_assume_noalias(val<void*> a, val<void*> b) {
+	invoke(nautilus_assume_noalias_stub, a, b);
+}
+
 } // namespace nautilus

--- a/plugins/specialization/src/assume_stubs.hpp
+++ b/plugins/specialization/src/assume_stubs.hpp
@@ -3,4 +3,5 @@
 namespace nautilus {
 void nautlis_assume_stub(bool);
 void nautilus_assume_aligned_stub(void*, int);
+void nautilus_assume_noalias_stub(void*, void*);
 } // namespace nautilus

--- a/plugins/specialization/test/AssumeExecutionTest.cpp
+++ b/plugins/specialization/test/AssumeExecutionTest.cpp
@@ -31,6 +31,14 @@ val<int> cfWithAssumeAlignment(val<int32_t*> a) {
 	return *a + 10;
 }
 
+val<int32_t> cfWithAssumeNoalias(val<int32_t*> a, val<int32_t*> b) {
+	nautilus_assume_noalias(a, b);
+	*a = 1;
+	*b = 2;
+	// With the noalias assumption LLVM may fold this load to the constant 1.
+	return *a;
+}
+
 TEST_CASE("MLIR Intrinsic Function Test") {
 	for (auto useIntrinsics : {false, true}) {
 		DYNAMIC_SECTION("useIntrinsics:" << useIntrinsics) {
@@ -51,6 +59,16 @@ TEST_CASE("MLIR Intrinsic Function Test") {
 					REQUIRE(f(42) == 52);
 					REQUIRE_THROWS(f(0));
 				}
+			}
+
+			SECTION("cfWithAssumeNoalias") {
+				auto f = engine.registerFunction(cfWithAssumeNoalias);
+				// Distinct, non-aliasing pointers: result is always the value stored through `a`.
+				int32_t x = 0;
+				int32_t y = 0;
+				REQUIRE(f(&x, &y) == 1);
+				REQUIRE(x == 1);
+				REQUIRE(y == 2);
 			}
 		}
 	}

--- a/plugins/specialization/test/LLVMIRAssumeTest.cpp
+++ b/plugins/specialization/test/LLVMIRAssumeTest.cpp
@@ -12,6 +12,7 @@ namespace nautilus::engine {
 using nautilus::engine::assumeAlignedFunction;
 using nautilus::engine::assumeComplexCondition;
 using nautilus::engine::assumeFunction;
+using nautilus::engine::assumeNoaliasFunction;
 
 // Wrapper for testLLVMIR that uses the plugin's intrinsic-ir directory
 template <typename Func>
@@ -33,8 +34,17 @@ TEST_CASE("LLVM IR Intrinsic Test: assumeAlignedFunction (MLIR intrinsics enable
 	testIntrinsicLLVMIR("assumeAlignedFunction_with_intrinsics", assumeAlignedFunction, true);
 }
 
+TEST_CASE("LLVM IR Intrinsic Test: assumeNoaliasFunction (MLIR intrinsics enabled)", "[profile][assume][intrinsics]") {
+	testIntrinsicLLVMIR("assumeNoaliasFunction_with_intrinsics", assumeNoaliasFunction, true);
+}
+
 TEST_CASE("LLVM IR Intrinsic Test: assumeFunction (MLIR intrinsics disabled)", "[profile][assume][no-intrinsics]") {
 	testIntrinsicLLVMIR("assumeFunction_without_intrinsics", assumeFunction, false);
+}
+
+TEST_CASE("LLVM IR Intrinsic Test: assumeNoaliasFunction (MLIR intrinsics disabled)",
+          "[profile][assume][no-intrinsics]") {
+	testIntrinsicLLVMIR("assumeNoaliasFunction_without_intrinsics", assumeNoaliasFunction, false);
 }
 
 TEST_CASE("LLVM IR Intrinsic Test: assumeComplexCondition (MLIR intrinsics disabled)",

--- a/plugins/specialization/test/common/ProfileFunctions.hpp
+++ b/plugins/specialization/test/common/ProfileFunctions.hpp
@@ -25,4 +25,15 @@ val<int32_t> assumeAlignedFunction(val<int32_t*> ptr) {
 	return *ptr;
 }
 
+// Test function that uses nautilus_assume_noalias. Because `a` and `b` are
+// assumed not to alias, the store through `b` cannot clobber the value stored
+// through `a`, so the final load of `*a` can be folded to the just-stored
+// constant instead of being reloaded from memory.
+val<int32_t> assumeNoaliasFunction(val<int32_t*> a, val<int32_t*> b) {
+	nautilus_assume_noalias(a, b);
+	*a = 1;
+	*b = 2;
+	return *a;
+}
+
 } // namespace nautilus::engine

--- a/plugins/specialization/test/intrinsic-ir/assumeNoaliasFunction_with_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/assumeNoaliasFunction_with_intrinsics.ll
@@ -1,0 +1,63 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write, inaccessiblemem: write)
+define noundef signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
+  store i32 1, ptr %0, align 4
+  store i32 2, ptr %1, align 4
+  ret i32 1
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write, inaccessiblemem: write)
+define noundef signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
+  store i32 1, ptr %0, align 4
+  store i32 2, ptr %1, align 4
+  ret i32 1
+}
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write)
+declare void @llvm.assume(i1 noundef) #1
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: write)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %3, ptr %6) ]
+  store i32 1, ptr %3, align 4
+  store i32 2, ptr %6, align 4
+  %7 = getelementptr i8, ptr %0, i64 16
+  %8 = load ptr, ptr %7, align 8
+  store i32 1, ptr %8, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: write)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  call void @llvm.assume(i1 true) [ "separate_storage"(ptr %3, ptr %6) ]
+  store i32 1, ptr %3, align 4
+  store i32 2, ptr %6, align 4
+  %7 = getelementptr i8, ptr %0, i64 16
+  %8 = load ptr, ptr %7, align 8
+  store i32 1, ptr %8, align 4
+  ret void
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write, inaccessiblemem: write) }
+attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }
+attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: write) }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/plugins/specialization/test/intrinsic-ir/assumeNoaliasFunction_without_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/assumeNoaliasFunction_without_intrinsics.ll
@@ -1,0 +1,64 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: memory(readwrite)
+define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  tail call void @runtimeFunc0(ptr %0, ptr %1)
+  store i32 1, ptr %0, align 4
+  store i32 2, ptr %1, align 4
+  %3 = load i32, ptr %0, align 4
+  ret i32 %3
+}
+
+; Function Attrs: memory(readwrite)
+define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+  tail call void @runtimeFunc0(ptr %0, ptr %1)
+  store i32 1, ptr %0, align 4
+  store i32 2, ptr %1, align 4
+  %3 = load i32, ptr %0, align 4
+  ret i32 %3
+}
+
+; Function Attrs: memory(readwrite)
+declare void @runtimeFunc0(ptr, ptr) local_unnamed_addr #1
+
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  tail call void @runtimeFunc0(ptr %3, ptr %6)
+  store i32 1, ptr %3, align 4
+  store i32 2, ptr %6, align 4
+  %7 = load i32, ptr %3, align 4
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load ptr, ptr %5, align 8
+  tail call void @runtimeFunc0(ptr %3, ptr %6)
+  store i32 1, ptr %3, align 4
+  store i32 2, ptr %6, align 4
+  %7 = load i32, ptr %3, align 4
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+attributes #0 = { memory(readwrite) }
+attributes #1 = { memory(readwrite) }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
## Summary

Adds a way to specify **noalias/restrict** attributes in Nautilus and uses them in the MLIR backend to generate specialized (optimized) code.

The new API lives in the specialization plugin's `assume` header, alongside the existing `nautilus_assume` / `nautilus_assume_aligned` helpers:

```cpp
void nautilus_assume_noalias(val<void*> a, val<void*> b);
```

It declares that two pointers point into **separate, non-overlapping storage** — the equivalent of the C `restrict` qualifier / LLVM `noalias` attribute, expressed as an assumption between two concrete pointers. Typed pointers (e.g. `val<int32_t*>`) convert implicitly to `val<void*>`, so no explicit cast is needed at the call site.

## How it works

The MLIR backend lowers the intrinsic to an `llvm.assume` with a `separate_storage` operand bundle (via `mlir::LLVM::AssumeSeparateStorageTag`):

```mlir
llvm.intr.assume %true ["separate_storage"(%arg0, %arg1 : !llvm.ptr, !llvm.ptr)] : i1
```

LLVM then knows accesses through the two pointers cannot alias and can fold / reorder them.

## Demonstration

For:
```cpp
val<int32_t> f(val<int32_t*> a, val<int32_t*> b) {
    nautilus_assume_noalias(a, b);
    *a = 1; *b = 2;
    return *a;
}
```

**With** the intrinsic, the final load is folded away — `ret i32 1`. **Without** it, the load is preserved because the opaque runtime call could alias — `%3 = load i32, ptr %0; ret i32 %3`.

## Changes

- `assume.hpp` / `assume.cpp` / `assume_stubs.hpp`: new `nautilus_assume_noalias` + runtime stub
- `MLIRAssumeIntrinsics.cpp`: register MLIR lowering to the `separate_storage` assume bundle
- Tests:
  - `AssumeExecutionTest.cpp`: runtime correctness section
  - `LLVMIRAssumeTest.cpp` + `ProfileFunctions.hpp` + reference `.ll` files (with/without intrinsics)

## Testing

Built and ran locally with the MLIR backend:
- `nautilus-specialization-tests` — all passing
- `nautilus-specialization-llvm-ir-test` — all passing (IR matches committed references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeEMTVNLMRdiLStvodZ6oC)_