### PR TITLE
Bytecode interpreter performance: faster dispatch, flattening, register-file reuse, superinstructions, immediates (pure-interpreter, iOS-safe)

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -454,9 +454,19 @@ FunctionCallTarget::FunctionCallTarget(std::vector<std::pair<short, Type>> argum
     : arguments(std::move(arguments)), functionPtr(functionPtr) {
 }
 
+// Computed goto (labels-as-values) is a GCC/Clang extension. Where it is not
+// available we fall back to the switch path, so "threaded" stays selectable
+// everywhere and simply degrades to "switch".
+#if defined(__GNUC__) || defined(__clang__)
+#define NAUTILUS_BC_HAS_COMPUTED_GOTO 1
+#endif
+
 DispatchMode parseDispatchMode(const std::string& value) {
 	if (value == "switch") {
 		return DispatchMode::Switch;
+	}
+	if (value == "threaded") {
+		return DispatchMode::Threaded;
 	}
 	return DispatchMode::Call;
 }
@@ -557,14 +567,21 @@ int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
 }
 
 int64_t BCInterpreter::execute(RegisterFile& regs) const {
+#ifdef NAUTILUS_BC_HAS_COMPUTED_GOTO
+	if (dispatchMode == DispatchMode::Threaded) {
+		return executeThreaded(regs);
+	}
+#endif
 	// first block is always the entrypoint
 	auto* currentBlock = &code.blocks[0];
+	// Threaded falls here when computed goto is unavailable, behaving as Switch.
+	const bool useSwitch = dispatchMode != DispatchMode::Call;
 	while (true) {
 		// execute operations in block. The dispatch mode is constant for the whole
 		// run, so this branch is perfectly predicted; it picks between the legacy
 		// indirect-call table and the inlined switch (which avoids a non-inlined
 		// call per instruction and lets the compiler keep the register base hot).
-		if (dispatchMode == DispatchMode::Switch) {
+		if (useSwitch) {
 			for (const auto& c : currentBlock->code) {
 				switch (c.op) {
 #define NAUTILUS_BC_SWITCH_CASE(name, ...)                                                                             \
@@ -597,6 +614,70 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 		}
 	}
 }
+
+#ifdef NAUTILUS_BC_HAS_COMPUTED_GOTO
+// Token-threaded execution: each handler computes its result and jumps straight
+// to the next handler via a computed goto, instead of returning to a central
+// loop. This gives the CPU a distinct indirect-branch site per opcode (better
+// prediction) and removes the per-op loop bookkeeping. The label table is plain
+// data (addresses of labels in this function), so this stays a pure interpreter
+// with no runtime code generation. labels-as-values is a GCC/Clang extension, so
+// the pedantic diagnostic is locally suppressed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wgnu-label-as-value"
+#endif
+int64_t BCInterpreter::executeThreaded(RegisterFile& regs) const {
+	// Address table indexed by opcode, in the same order as the ByteCode enum.
+	// Built once at first entry (label addresses are not constant expressions).
+	static void* const labels[] = {
+#define NAUTILUS_BC_LABEL(name, ...) &&L_##name,
+	    NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_LABEL)
+#undef NAUTILUS_BC_LABEL
+	};
+
+	const CodeBlock* currentBlock = &code.blocks[0];
+	const OpCode* ip = currentBlock->code.data();
+	const OpCode* end = ip + currentBlock->code.size();
+
+// Dispatch the next op, or fall through to the terminator at end of block.
+#define NAUTILUS_BC_NEXT()                                                                                             \
+	if (ip >= end)                                                                                                     \
+		goto terminator;                                                                                               \
+	goto* labels[(int16_t) ip->op]
+
+	NAUTILUS_BC_NEXT();
+
+#define NAUTILUS_BC_HANDLER(name, ...)                                                                                 \
+	L_##name : {                                                                                                       \
+		__VA_ARGS__(*ip, regs);                                                                                        \
+		++ip;                                                                                                          \
+		NAUTILUS_BC_NEXT();                                                                                            \
+	}
+	NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_HANDLER)
+#undef NAUTILUS_BC_HANDLER
+
+terminator:
+	if (const auto* res = std::get_if<BranchOp>(&currentBlock->terminatorOp)) {
+		currentBlock = &code.blocks[res->nextBlock];
+	} else if (const auto* res = std::get_if<ConditionalJumpOp>(&currentBlock->terminatorOp)) {
+		currentBlock =
+		    readReg<bool>(regs, res->conditionalReg) ? &code.blocks[res->trueBlock] : &code.blocks[res->falseBlock];
+	} else {
+		const auto& ret = std::get<ReturnOp>(currentBlock->terminatorOp);
+		if (ret.resultReg < 0) {
+			return 0;
+		}
+		return regs[ret.resultReg];
+	}
+	ip = currentBlock->code.data();
+	end = ip + currentBlock->code.size();
+	NAUTILUS_BC_NEXT();
+#undef NAUTILUS_BC_NEXT
+}
+#pragma GCC diagnostic pop
+#endif // NAUTILUS_BC_HAS_COMPUTED_GOTO
 
 std::ostream& operator<<(std::ostream& os, const Code& code) {
 	for (size_t i = 0; i < code.blocks.size(); i++) {

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -471,8 +471,8 @@ DispatchMode parseDispatchMode(const std::string& value) {
 	return DispatchMode::Call;
 }
 
-BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile, DispatchMode dispatchMode)
-    : code(std::move(code)), registerFile(std::move(registerFile)), dispatchMode(dispatchMode) {
+BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile, BCInterpreterOptions options)
+    : code(std::move(code)), registerFile(std::move(registerFile)), options(options) {
 	// The register file was built against a temporary Code instance whose allocaBuffers
 	// may have been copied (and thus relocated) before reaching this constructor.
 	// Re-point each alloca register at the actual buffer in *this* code object.
@@ -480,7 +480,7 @@ BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile, DispatchMode 
 		this->registerFile[reg] = reinterpret_cast<int64_t>(this->code.allocaBuffers[bufIdx].data());
 	}
 #ifdef NAUTILUS_BC_HAS_COMPUTED_GOTO
-	if (this->dispatchMode == DispatchMode::Threaded) {
+	if (this->options.dispatch == DispatchMode::Threaded) {
 		buildFlatCode();
 	}
 #endif
@@ -535,9 +535,47 @@ bool BCExecutable::hasInvocableFunctionPtr() {
 	return true;
 }
 
+namespace {
+// Thread-local pool that recycles per-invocation register files so repeated calls
+// avoid a heap allocation (the dominant cost for tiny functions). Each acquire()
+// hands back a distinct buffer, so nested bc->bc calls on one thread never alias;
+// the pool is thread_local, so concurrent threads stay independent. Used only when
+// bc.regfileReuse is enabled. The copy-assign in acquire reuses the buffer's heap
+// capacity, so after warmup no allocation happens.
+thread_local std::vector<RegisterFile> tlRegisterFilePool;
+
+RegisterFile acquireRegisterFile(const RegisterFile& init) {
+	if (tlRegisterFilePool.empty()) {
+		return init;
+	}
+	RegisterFile buf = std::move(tlRegisterFilePool.back());
+	tlRegisterFilePool.pop_back();
+	buf = init;
+	return buf;
+}
+
+void releaseRegisterFile(RegisterFile&& buf) {
+	tlRegisterFilePool.push_back(std::move(buf));
+}
+} // namespace
+
 int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
-	// Per-invocation copy of the register file (thread-safe + reentrant).
-	RegisterFile regs = registerFile;
+	// Per-invocation register file: a fresh copy by default, or one recycled from a
+	// thread-local pool when bc.regfileReuse is set. Both give each invocation its
+	// own buffer, so nested and concurrent calls remain correct.
+	const bool reuse = options.reuseRegisterFile;
+	RegisterFile regs = reuse ? acquireRegisterFile(registerFile) : registerFile;
+	// Return the recycled buffer to the pool on every exit path, including if
+	// execute() throws.
+	struct PoolGuard {
+		RegisterFile* regs;
+		bool active;
+		~PoolGuard() {
+			if (active) {
+				releaseRegisterFile(std::move(*regs));
+			}
+		}
+	} guard {&regs, reuse};
 
 	// Per-invocation alloca buffers, zeroed for a clean stack frame.
 	std::vector<std::vector<uint8_t>> localAllocaBuffers(code.allocaBuffers.size());
@@ -598,14 +636,14 @@ int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
 
 int64_t BCInterpreter::execute(RegisterFile& regs) const {
 #ifdef NAUTILUS_BC_HAS_COMPUTED_GOTO
-	if (dispatchMode == DispatchMode::Threaded) {
+	if (options.dispatch == DispatchMode::Threaded) {
 		return executeThreaded(regs);
 	}
 #endif
 	// first block is always the entrypoint
 	auto* currentBlock = &code.blocks[0];
 	// Threaded falls here when computed goto is unavailable, behaving as Switch.
-	const bool useSwitch = dispatchMode != DispatchMode::Call;
+	const bool useSwitch = options.dispatch != DispatchMode::Call;
 	while (true) {
 		// execute operations in block. The dispatch mode is constant for the whole
 		// run, so this branch is perfectly predicted; it picks between the legacy

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -501,6 +501,21 @@ bool fusedBranchFor(ByteCode cmp, ByteCode& out) {
 		return false;
 	}
 }
+
+// Map an arithmetic opcode to its immediate-folded opcode, if one exists.
+// Returns true and sets `out` on success. Drives the Step 6 folding.
+bool immOpcodeFor(ByteCode op, ByteCode& out) {
+	switch (op) {
+#define NAUTILUS_BC_IMM_MAP(immOp, src, ctype, oper)                                                                   \
+	case ByteCode::src:                                                                                                \
+		out = ByteCode::immOp;                                                                                         \
+		return true;
+		NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_MAP)
+#undef NAUTILUS_BC_IMM_MAP
+	default:
+		return false;
+	}
+}
 } // namespace
 
 void BCInterpreter::buildFlatCode() {
@@ -514,6 +529,29 @@ void BCInterpreter::buildFlatCode() {
 		const auto& block = code.blocks[i];
 		blockStart_[i] = static_cast<int32_t>(flatCode_.size());
 
+		// Step 6: emit op `k` of this block, folding a recorded small constant right
+		// operand into an *_imm opcode (operand in reg1, immediate in reg2) when
+		// enabled. foldableImmediates is sorted by index, so a single cursor suffices.
+		size_t foldCursor = 0;
+		auto emitOp = [&](size_t k) {
+			const OpCode& op = block.code[k];
+			if (options.immediates) {
+				while (foldCursor < block.foldableImmediates.size() && block.foldableImmediates[foldCursor].first < k) {
+					foldCursor++;
+				}
+				if (foldCursor < block.foldableImmediates.size() && block.foldableImmediates[foldCursor].first == k) {
+					ByteCode immOp {};
+					if (immOpcodeFor(op.op, immOp)) {
+						const int16_t imm = block.foldableImmediates[foldCursor].second;
+						// reg1 = operand, reg2 = immediate, output = result.
+						flatCode_.emplace_back(immOp, op.reg1, imm, op.output);
+						return;
+					}
+				}
+			}
+			flatCode_.push_back(op);
+		};
+
 		// Step 5: fuse a single-use trailing compare into the conditional jump when
 		// enabled. Sound only if (a) the lowering marked the compare single-use and
 		// (b) the compare is the block's last op (so its operands are not clobbered
@@ -525,7 +563,7 @@ void BCInterpreter::buildFlatCode() {
 				ByteCode fused {};
 				if (last.output == res->conditionalReg && fusedBranchFor(last.op, fused)) {
 					for (size_t k = 0; k + 1 < block.code.size(); k++) {
-						flatCode_.push_back(block.code[k]);
+						emitOp(k);
 					}
 					// reg1 = left, reg2 = right, output = true block, reg3 = false block.
 					flatCode_.emplace_back(fused, last.reg1, last.reg2, res->trueBlock, res->falseBlock);
@@ -534,8 +572,8 @@ void BCInterpreter::buildFlatCode() {
 			}
 		}
 
-		for (const auto& op : block.code) {
-			flatCode_.push_back(op);
+		for (size_t k = 0; k < block.code.size(); k++) {
+			emitOp(k);
 		}
 		if (const auto* res = std::get_if<BranchOp>(&block.terminatorOp)) {
 			flatCode_.emplace_back(ByteCode::JMP, res->nextBlock, -1, -1);
@@ -705,6 +743,9 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 #define NAUTILUS_BC_FUSED_SWITCH(fused, src, ctype, cmp) case ByteCode::fused:
 					NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_SWITCH)
 #undef NAUTILUS_BC_FUSED_SWITCH
+#define NAUTILUS_BC_IMM_SWITCH(immOp, src, ctype, oper) case ByteCode::immOp:
+					NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_SWITCH)
+#undef NAUTILUS_BC_IMM_SWITCH
 					break;
 				}
 			}
@@ -760,6 +801,10 @@ int64_t BCInterpreter::executeThreaded(RegisterFile& regs) const {
 #define NAUTILUS_BC_FUSED_LABEL(fused, src, ctype, cmp) &&L_##fused,
 	    NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_LABEL)
 #undef NAUTILUS_BC_FUSED_LABEL
+	// Immediate-folded labels, in the same order they were appended to the enum.
+#define NAUTILUS_BC_IMM_LABEL(immOp, src, ctype, oper) &&L_##immOp,
+	        NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_LABEL)
+#undef NAUTILUS_BC_IMM_LABEL
 	};
 
 	// Flattened stream: blocks concatenated in order, each ended by a JMP/CJMP/RET.
@@ -804,6 +849,18 @@ L_RET:
 	}
 	NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_HANDLER)
 #undef NAUTILUS_BC_FUSED_HANDLER
+
+	// Immediate-folded arithmetic handlers (Step 6): operand in reg1, signed 16-bit
+	// immediate in reg2 (widened to the op type), result in output.
+#define NAUTILUS_BC_IMM_HANDLER(immOp, src, ctype, oper)                                                               \
+	L_##immOp : {                                                                                                      \
+		writeReg<ctype>(regs, ip->output,                                                                              \
+		                static_cast<ctype>(readReg<ctype>(regs, ip->reg1) oper static_cast<ctype>(ip->reg2)));         \
+		++ip;                                                                                                          \
+		NAUTILUS_BC_NEXT();                                                                                            \
+	}
+	NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_HANDLER)
+#undef NAUTILUS_BC_IMM_HANDLER
 #undef NAUTILUS_BC_NEXT
 }
 #pragma GCC diagnostic pop

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -486,6 +486,23 @@ BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile, BCInterpreter
 #endif
 }
 
+namespace {
+// Map a comparison opcode to its fused compare+branch opcode, if one exists.
+// Returns true and sets `out` on success. Drives the Step 5 fusion.
+bool fusedBranchFor(ByteCode cmp, ByteCode& out) {
+	switch (cmp) {
+#define NAUTILUS_BC_FUSED_MAP(fused, src, ctype, cmpOp)                                                                \
+	case ByteCode::src:                                                                                                \
+		out = ByteCode::fused;                                                                                         \
+		return true;
+		NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_MAP)
+#undef NAUTILUS_BC_FUSED_MAP
+	default:
+		return false;
+	}
+}
+} // namespace
+
 void BCInterpreter::buildFlatCode() {
 	// Concatenate every block's operations in their existing order (block order
 	// matters: visitIf emits landing-pad blocks inline, so offsets are correct by
@@ -496,6 +513,27 @@ void BCInterpreter::buildFlatCode() {
 	for (size_t i = 0; i < code.blocks.size(); i++) {
 		const auto& block = code.blocks[i];
 		blockStart_[i] = static_cast<int32_t>(flatCode_.size());
+
+		// Step 5: fuse a single-use trailing compare into the conditional jump when
+		// enabled. Sound only if (a) the lowering marked the compare single-use and
+		// (b) the compare is the block's last op (so its operands are not clobbered
+		// before the branch) writing the condition register, and (c) the comparison
+		// has a fused form. Otherwise fall through to the plain emission below.
+		if (options.superinstructions && block.fuseCompareIntoBranch && !block.code.empty()) {
+			if (const auto* res = std::get_if<ConditionalJumpOp>(&block.terminatorOp)) {
+				const OpCode& last = block.code.back();
+				ByteCode fused {};
+				if (last.output == res->conditionalReg && fusedBranchFor(last.op, fused)) {
+					for (size_t k = 0; k + 1 < block.code.size(); k++) {
+						flatCode_.push_back(block.code[k]);
+					}
+					// reg1 = left, reg2 = right, output = true block, reg3 = false block.
+					flatCode_.emplace_back(fused, last.reg1, last.reg2, res->trueBlock, res->falseBlock);
+					continue;
+				}
+			}
+		}
+
 		for (const auto& op : block.code) {
 			flatCode_.push_back(op);
 		}
@@ -664,6 +702,9 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 				case ByteCode::JMP:
 				case ByteCode::CJMP:
 				case ByteCode::RET:
+#define NAUTILUS_BC_FUSED_SWITCH(fused, src, ctype, cmp) case ByteCode::fused:
+					NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_SWITCH)
+#undef NAUTILUS_BC_FUSED_SWITCH
 					break;
 				}
 			}
@@ -714,8 +755,11 @@ int64_t BCInterpreter::executeThreaded(RegisterFile& regs) const {
 	    NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_LABEL)
 #undef NAUTILUS_BC_LABEL
 	        && L_JMP,
-	    &&L_CJMP,
-	    &&L_RET,
+	    &&L_CJMP, &&L_RET,
+	// Fused compare+branch labels, in the same order they were appended to the enum.
+#define NAUTILUS_BC_FUSED_LABEL(fused, src, ctype, cmp) &&L_##fused,
+	    NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_LABEL)
+#undef NAUTILUS_BC_FUSED_LABEL
 	};
 
 	// Flattened stream: blocks concatenated in order, each ended by a JMP/CJMP/RET.
@@ -748,6 +792,18 @@ L_RET:
 		return 0;
 	}
 	return regs[ip->reg1];
+
+	// Fused compare+branch handlers (Step 5): read both operands, compare, and jump
+	// to the true/false block in one step. reg1 = left, reg2 = right, output = true
+	// block, reg3 = false block. Only reached via the label table.
+#define NAUTILUS_BC_FUSED_HANDLER(fused, src, ctype, cmp)                                                              \
+	L_##fused : {                                                                                                      \
+		const bool taken = readReg<ctype>(regs, ip->reg1) cmp readReg<ctype>(regs, ip->reg2);                          \
+		ip = base + blockStart_[taken ? ip->output : ip->reg3];                                                        \
+		NAUTILUS_BC_NEXT();                                                                                            \
+	}
+	NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_HANDLER)
+#undef NAUTILUS_BC_FUSED_HANDLER
 #undef NAUTILUS_BC_NEXT
 }
 #pragma GCC diagnostic pop

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -107,345 +107,362 @@ void dyncallCalld(const OpCode& op, RegisterFile& regs) {
 	writeReg<double>(regs, op.output, returnValue);
 }
 
-static Operation* OpTable[] = {
-    (Operation*) regMov,
-    // add
-    (Operation*) add<int8_t>,
-    (Operation*) add<int16_t>,
-    (Operation*) add<int32_t>,
-    (Operation*) add<int64_t>,
-    (Operation*) add<uint8_t>,
-    (Operation*) add<uint16_t>,
-    (Operation*) add<uint32_t>,
-    (Operation*) add<uint64_t>,
-    (Operation*) add<float>,
-    (Operation*) add<double>,
-    // sub
-    (Operation*) sub<int8_t>,
-    (Operation*) sub<int16_t>,
-    (Operation*) sub<int32_t>,
-    (Operation*) sub<int64_t>,
-    (Operation*) sub<uint8_t>,
-    (Operation*) sub<uint16_t>,
-    (Operation*) sub<uint32_t>,
-    (Operation*) sub<uint64_t>,
-    (Operation*) sub<float>,
-    (Operation*) sub<double>,
-    // mul
-    (Operation*) mul<int8_t>,
-    (Operation*) mul<int16_t>,
-    (Operation*) mul<int32_t>,
-    (Operation*) mul<int64_t>,
-    (Operation*) mul<uint8_t>,
-    (Operation*) mul<uint16_t>,
-    (Operation*) mul<uint32_t>,
-    (Operation*) mul<uint64_t>,
-    (Operation*) mul<float>,
-    (Operation*) mul<double>,
-    // div
-    (Operation*) div<int8_t>,
-    (Operation*) div<int16_t>,
-    (Operation*) div<int32_t>,
-    (Operation*) div<int64_t>,
-    (Operation*) div<uint8_t>,
-    (Operation*) div<uint16_t>,
-    (Operation*) div<uint32_t>,
-    (Operation*) div<uint64_t>,
-    (Operation*) div<float>,
-    (Operation*) div<double>,
-    // mod
-    (Operation*) mod<int8_t>,
-    (Operation*) mod<int16_t>,
-    (Operation*) mod<int32_t>,
-    (Operation*) mod<int64_t>,
-    (Operation*) mod<uint8_t>,
-    (Operation*) mod<uint16_t>,
-    (Operation*) mod<uint32_t>,
-    (Operation*) mod<uint64_t>,
-    // equals
-    (Operation*) equals<int8_t>,
-    (Operation*) equals<int16_t>,
-    (Operation*) equals<int32_t>,
-    (Operation*) equals<int64_t>,
-    (Operation*) equals<uint8_t>,
-    (Operation*) equals<uint16_t>,
-    (Operation*) equals<uint32_t>,
-    (Operation*) equals<uint64_t>,
-    (Operation*) equals<float>,
-    (Operation*) equals<double>,
-    (Operation*) equals<bool>,
-    // less than
-    (Operation*) lessThan<int8_t>,
-    (Operation*) lessThan<int16_t>,
-    (Operation*) lessThan<int32_t>,
-    (Operation*) lessThan<int64_t>,
-    (Operation*) lessThan<uint8_t>,
-    (Operation*) lessThan<uint16_t>,
-    (Operation*) lessThan<uint32_t>,
-    (Operation*) lessThan<uint64_t>,
-    (Operation*) lessThan<float>,
-    (Operation*) lessThan<double>,
-    // less than equals
-    (Operation*) lessThanEquals<int8_t>,
-    (Operation*) lessThanEquals<int16_t>,
-    (Operation*) lessThanEquals<int32_t>,
-    (Operation*) lessThanEquals<int64_t>,
-    (Operation*) lessThanEquals<uint8_t>,
-    (Operation*) lessThanEquals<uint16_t>,
-    (Operation*) lessThanEquals<uint32_t>,
-    (Operation*) lessThanEquals<uint64_t>,
-    (Operation*) lessThanEquals<float>,
-    (Operation*) lessThanEquals<double>,
-    // greater than
-    (Operation*) greaterThan<int8_t>,
-    (Operation*) greaterThan<int16_t>,
-    (Operation*) greaterThan<int32_t>,
-    (Operation*) greaterThan<int64_t>,
-    (Operation*) greaterThan<uint8_t>,
-    (Operation*) greaterThan<uint16_t>,
-    (Operation*) greaterThan<uint32_t>,
-    (Operation*) greaterThan<uint64_t>,
-    (Operation*) greaterThan<float>,
-    (Operation*) greaterThan<double>,
-    // greater than equals
-    (Operation*) greaterThanEquals<int8_t>,
-    (Operation*) greaterThanEquals<int16_t>,
-    (Operation*) greaterThanEquals<int32_t>,
-    (Operation*) greaterThanEquals<int64_t>,
-    (Operation*) greaterThanEquals<uint8_t>,
-    (Operation*) greaterThanEquals<uint16_t>,
-    (Operation*) greaterThanEquals<uint32_t>,
-    (Operation*) greaterThanEquals<uint64_t>,
-    (Operation*) greaterThanEquals<float>,
-    (Operation*) greaterThanEquals<double>,
-    // not equals
-    (Operation*) notEquals<bool>,
-    (Operation*) notEquals<int8_t>,
-    (Operation*) notEquals<int16_t>,
-    (Operation*) notEquals<int32_t>,
-    (Operation*) notEquals<int64_t>,
-    (Operation*) notEquals<uint8_t>,
-    (Operation*) notEquals<uint16_t>,
-    (Operation*) notEquals<uint32_t>,
-    (Operation*) notEquals<uint64_t>,
-    (Operation*) notEquals<float>,
-    (Operation*) notEquals<double>,
-    // load
-    (Operation*) load<int8_t>,
-    (Operation*) load<int16_t>,
-    (Operation*) load<int32_t>,
-    (Operation*) load<int64_t>,
-    (Operation*) load<uint8_t>,
-    (Operation*) load<uint16_t>,
-    (Operation*) load<uint32_t>,
-    (Operation*) load<uint64_t>,
-    (Operation*) load<float>,
-    (Operation*) load<double>,
-    (Operation*) load<bool>,
-    // store
-    (Operation*) store<int8_t>,
-    (Operation*) store<int16_t>,
-    (Operation*) store<int32_t>,
-    (Operation*) store<int64_t>,
-    (Operation*) store<uint8_t>,
-    (Operation*) store<uint16_t>,
-    (Operation*) store<uint32_t>,
-    (Operation*) store<uint64_t>,
-    (Operation*) store<float>,
-    (Operation*) store<double>,
-    (Operation*) store<bool>,
-    // and
-    (Operation*) andOp<bool>,
-    (Operation*) orOp<bool>,
-    (Operation*) notOp<bool>,
-    // Casts
-    // int to int
-    (Operation*) cast<int8_t, int16_t>,
-    (Operation*) cast<int8_t, int32_t>,
-    (Operation*) cast<int8_t, int64_t>,
-    (Operation*) cast<int16_t, int8_t>,
-    (Operation*) cast<int16_t, int32_t>,
-    (Operation*) cast<int16_t, int64_t>,
-    (Operation*) cast<int32_t, int8_t>,
-    (Operation*) cast<int32_t, int16_t>,
-    (Operation*) cast<int32_t, int64_t>,
-    (Operation*) cast<int64_t, int8_t>,
-    (Operation*) cast<int64_t, int16_t>,
-    (Operation*) cast<int64_t, int32_t>,
-    // uint to int
-    (Operation*) cast<uint8_t, int8_t>,
-    (Operation*) cast<uint8_t, int16_t>,
-    (Operation*) cast<uint8_t, int32_t>,
-    (Operation*) cast<uint8_t, int64_t>,
-    (Operation*) cast<uint16_t, int8_t>,
-    (Operation*) cast<uint16_t, int16_t>,
-    (Operation*) cast<uint16_t, int32_t>,
-    (Operation*) cast<uint16_t, int64_t>,
-    (Operation*) cast<uint32_t, int8_t>,
-    (Operation*) cast<uint32_t, int16_t>,
-    (Operation*) cast<uint32_t, int32_t>,
-    (Operation*) cast<uint32_t, int64_t>,
-    (Operation*) cast<uint64_t, int8_t>,
-    (Operation*) cast<uint64_t, int16_t>,
-    (Operation*) cast<uint64_t, int32_t>,
-    (Operation*) cast<uint64_t, int64_t>,
-    // uint to uint
-    (Operation*) cast<uint8_t, uint16_t>,
-    (Operation*) cast<uint8_t, uint32_t>,
-    (Operation*) cast<uint8_t, uint64_t>,
-    (Operation*) cast<uint16_t, uint8_t>,
-    (Operation*) cast<uint16_t, uint32_t>,
-    (Operation*) cast<uint16_t, uint64_t>,
-    (Operation*) cast<uint32_t, uint8_t>,
-    (Operation*) cast<uint32_t, uint16_t>,
-    (Operation*) cast<uint32_t, uint64_t>,
-    (Operation*) cast<uint64_t, uint8_t>,
-    (Operation*) cast<uint64_t, uint16_t>,
-    (Operation*) cast<uint64_t, uint32_t>,
-    // int to uint
-    (Operation*) cast<int8_t, uint8_t>,
-    (Operation*) cast<int8_t, uint16_t>,
-    (Operation*) cast<int8_t, uint32_t>,
-    (Operation*) cast<int8_t, uint64_t>,
-    (Operation*) cast<int16_t, uint8_t>,
-    (Operation*) cast<int16_t, uint16_t>,
-    (Operation*) cast<int16_t, uint32_t>,
-    (Operation*) cast<int16_t, uint64_t>,
-    (Operation*) cast<int32_t, uint8_t>,
-    (Operation*) cast<int32_t, uint16_t>,
-    (Operation*) cast<int32_t, uint32_t>,
-    (Operation*) cast<int32_t, uint64_t>,
-    (Operation*) cast<int64_t, uint8_t>,
-    (Operation*) cast<int64_t, uint16_t>,
-    (Operation*) cast<int64_t, uint32_t>,
-    (Operation*) cast<int64_t, uint64_t>,
-    // from float to int
-    (Operation*) cast<float, int8_t>,
-    (Operation*) cast<float, int16_t>,
-    (Operation*) cast<float, int32_t>,
-    (Operation*) cast<float, int64_t>,
-    (Operation*) cast<float, uint8_t>,
-    (Operation*) cast<float, uint16_t>,
-    (Operation*) cast<float, uint32_t>,
-    (Operation*) cast<float, uint64_t>,
-    (Operation*) cast<float, double>,
-    // from double to int
-    (Operation*) cast<double, int8_t>,
-    (Operation*) cast<double, int16_t>,
-    (Operation*) cast<double, int32_t>,
-    (Operation*) cast<double, int64_t>,
-    (Operation*) cast<double, uint8_t>,
-    (Operation*) cast<double, uint16_t>,
-    (Operation*) cast<double, uint32_t>,
-    (Operation*) cast<double, uint64_t>,
-    (Operation*) cast<double, float>,
-    // from int to floats
-    (Operation*) cast<int8_t, float>,
-    (Operation*) cast<int8_t, double>,
-    (Operation*) cast<int16_t, float>,
-    (Operation*) cast<int16_t, double>,
-    (Operation*) cast<int32_t, float>,
-    (Operation*) cast<int32_t, double>,
-    (Operation*) cast<int64_t, float>,
-    (Operation*) cast<int64_t, double>,
-    // uint to float
-    (Operation*) cast<uint8_t, float>,
-    (Operation*) cast<uint8_t, double>,
-    (Operation*) cast<uint16_t, float>,
-    (Operation*) cast<uint16_t, double>,
-    (Operation*) cast<uint32_t, float>,
-    (Operation*) cast<uint32_t, double>,
-    (Operation*) cast<uint64_t, float>,
-    (Operation*) cast<uint64_t, double>,
-    // FUNCTION CALLS
-    (Operation*) dyncallReset,
-    (Operation*) dyncallArgB,
-    (Operation*) dyncallArgI8,
-    (Operation*) dyncallArgI16,
-    (Operation*) dyncallArgI32,
-    (Operation*) dyncallArgI64,
-    (Operation*) dyncallArgF,
-    (Operation*) dyncallArgD,
-    (Operation*) dyncallArgPtr,
-    (Operation*) dyncallCallV,
-    (Operation*) dyncallCallB,
-    (Operation*) dyncallCallI8,
-    (Operation*) dyncallCallI16,
-    (Operation*) dyncallCallI32,
-    (Operation*) dyncallCallI64,
-    (Operation*) dyncallCallPtr,
-    (Operation*) dyncallCallf,
-    (Operation*) dyncallCalld,
-    // BITWISE OPS
-    // band
-    (Operation*) bitwiseAnd<int8_t>,
-    (Operation*) bitwiseAnd<int16_t>,
-    (Operation*) bitwiseAnd<int32_t>,
-    (Operation*) bitwiseAnd<int64_t>,
-    (Operation*) bitwiseAnd<uint8_t>,
-    (Operation*) bitwiseAnd<uint16_t>,
-    (Operation*) bitwiseAnd<uint32_t>,
-    (Operation*) bitwiseAnd<uint64_t>,
-    // bor
-    (Operation*) bitwiseOr<int8_t>,
-    (Operation*) bitwiseOr<int16_t>,
-    (Operation*) bitwiseOr<int32_t>,
-    (Operation*) bitwiseOr<int64_t>,
-    (Operation*) bitwiseOr<uint8_t>,
-    (Operation*) bitwiseOr<uint16_t>,
-    (Operation*) bitwiseOr<uint32_t>,
-    (Operation*) bitwiseOr<uint64_t>,
-    // bxor
-    (Operation*) bitwiseXOr<int8_t>,
-    (Operation*) bitwiseXOr<int16_t>,
-    (Operation*) bitwiseXOr<int32_t>,
-    (Operation*) bitwiseXOr<int64_t>,
-    (Operation*) bitwiseXOr<uint8_t>,
-    (Operation*) bitwiseXOr<uint16_t>,
-    (Operation*) bitwiseXOr<uint32_t>,
-    (Operation*) bitwiseXOr<uint64_t>,
-    // blsh
-    (Operation*) bitwiseLSH<int8_t>,
-    (Operation*) bitwiseLSH<int16_t>,
-    (Operation*) bitwiseLSH<int32_t>,
-    (Operation*) bitwiseLSH<int64_t>,
-    (Operation*) bitwiseLSH<uint8_t>,
-    (Operation*) bitwiseLSH<uint16_t>,
-    (Operation*) bitwiseLSH<uint32_t>,
-    (Operation*) bitwiseLSH<uint64_t>,
-    // brsh
-    (Operation*) bitwiseRSH<int8_t>,
-    (Operation*) bitwiseRSH<int16_t>,
-    (Operation*) bitwiseRSH<int32_t>,
-    (Operation*) bitwiseRSH<int64_t>,
-    (Operation*) bitwiseRSH<uint8_t>,
-    (Operation*) bitwiseRSH<uint16_t>,
-    (Operation*) bitwiseRSH<uint32_t>,
-    (Operation*) bitwiseRSH<uint64_t>,
-    // bnot
-    (Operation*) bitwiseNot<int64_t>,
-    // select
-    (Operation*) selectOp<int8_t>,
-    (Operation*) selectOp<int16_t>,
-    (Operation*) selectOp<int32_t>,
-    (Operation*) selectOp<int64_t>,
-    (Operation*) selectOp<uint8_t>,
-    (Operation*) selectOp<uint16_t>,
-    (Operation*) selectOp<uint32_t>,
-    (Operation*) selectOp<uint64_t>,
-    (Operation*) selectOp<float>,
-    (Operation*) selectOp<double>,
-    (Operation*) selectOp<bool>,
-    (Operation*) selectOp<void*>,
+// Single source of truth mapping every ByteCode to its handler, listed in the
+// exact order of the ByteCode enum. This list generates BOTH the function-pointer
+// dispatch table (OpTable, used by the "call" dispatch mode) and the inlined
+// switch in execute() (the "switch" dispatch mode). Generating both from one
+// list guarantees they cannot diverge: a wrong or missing entry corrupts the
+// default "call" path too, which every existing test exercises. The handler is
+// taken via __VA_ARGS__ so commas inside template arguments (e.g.
+// cast<float, int8_t>) are not split into separate macro arguments.
+#define NAUTILUS_BC_OPCODE_LIST(X)                                                                                     \
+	X(REG_MOV, regMov)                                                                                                 \
+	/* add */                                                                                                          \
+	X(ADD_i8, add<int8_t>)                                                                                             \
+	X(ADD_i16, add<int16_t>)                                                                                           \
+	X(ADD_i32, add<int32_t>)                                                                                           \
+	X(ADD_i64, add<int64_t>)                                                                                           \
+	X(ADD_ui8, add<uint8_t>)                                                                                           \
+	X(ADD_ui16, add<uint16_t>)                                                                                         \
+	X(ADD_ui32, add<uint32_t>)                                                                                         \
+	X(ADD_ui64, add<uint64_t>)                                                                                         \
+	X(ADD_f, add<float>)                                                                                               \
+	X(ADD_d, add<double>)                                                                                              \
+	/* sub */                                                                                                          \
+	X(SUB_i8, sub<int8_t>)                                                                                             \
+	X(SUB_i16, sub<int16_t>)                                                                                           \
+	X(SUB_i32, sub<int32_t>)                                                                                           \
+	X(SUB_i64, sub<int64_t>)                                                                                           \
+	X(SUB_ui8, sub<uint8_t>)                                                                                           \
+	X(SUB_ui16, sub<uint16_t>)                                                                                         \
+	X(SUB_ui32, sub<uint32_t>)                                                                                         \
+	X(SUB_ui64, sub<uint64_t>)                                                                                         \
+	X(SUB_f, sub<float>)                                                                                               \
+	X(SUB_d, sub<double>)                                                                                              \
+	/* mul */                                                                                                          \
+	X(MUL_i8, mul<int8_t>)                                                                                             \
+	X(MUL_i16, mul<int16_t>)                                                                                           \
+	X(MUL_i32, mul<int32_t>)                                                                                           \
+	X(MUL_i64, mul<int64_t>)                                                                                           \
+	X(MUL_ui8, mul<uint8_t>)                                                                                           \
+	X(MUL_ui16, mul<uint16_t>)                                                                                         \
+	X(MUL_ui32, mul<uint32_t>)                                                                                         \
+	X(MUL_ui64, mul<uint64_t>)                                                                                         \
+	X(MUL_f, mul<float>)                                                                                               \
+	X(MUL_d, mul<double>)                                                                                              \
+	/* div */                                                                                                          \
+	X(DIV_i8, div<int8_t>)                                                                                             \
+	X(DIV_i16, div<int16_t>)                                                                                           \
+	X(DIV_i32, div<int32_t>)                                                                                           \
+	X(DIV_i64, div<int64_t>)                                                                                           \
+	X(DIV_ui8, div<uint8_t>)                                                                                           \
+	X(DIV_ui16, div<uint16_t>)                                                                                         \
+	X(DIV_ui32, div<uint32_t>)                                                                                         \
+	X(DIV_ui64, div<uint64_t>)                                                                                         \
+	X(DIV_f, div<float>)                                                                                               \
+	X(DIV_d, div<double>)                                                                                              \
+	/* mod */                                                                                                          \
+	X(MOD_i8, mod<int8_t>)                                                                                             \
+	X(MOD_i16, mod<int16_t>)                                                                                           \
+	X(MOD_i32, mod<int32_t>)                                                                                           \
+	X(MOD_i64, mod<int64_t>)                                                                                           \
+	X(MOD_ui8, mod<uint8_t>)                                                                                           \
+	X(MOD_ui16, mod<uint16_t>)                                                                                         \
+	X(MOD_ui32, mod<uint32_t>)                                                                                         \
+	X(MOD_ui64, mod<uint64_t>)                                                                                         \
+	/* equals */                                                                                                       \
+	X(EQ_i8, equals<int8_t>)                                                                                           \
+	X(EQ_i16, equals<int16_t>)                                                                                         \
+	X(EQ_i32, equals<int32_t>)                                                                                         \
+	X(EQ_i64, equals<int64_t>)                                                                                         \
+	X(EQ_ui8, equals<uint8_t>)                                                                                         \
+	X(EQ_ui16, equals<uint16_t>)                                                                                       \
+	X(EQ_ui32, equals<uint32_t>)                                                                                       \
+	X(EQ_ui64, equals<uint64_t>)                                                                                       \
+	X(EQ_f, equals<float>)                                                                                             \
+	X(EQ_d, equals<double>)                                                                                            \
+	X(EQ_b, equals<bool>)                                                                                              \
+	/* less than */                                                                                                    \
+	X(LESS_THAN_i8, lessThan<int8_t>)                                                                                  \
+	X(LESS_THAN_i16, lessThan<int16_t>)                                                                                \
+	X(LESS_THAN_i32, lessThan<int32_t>)                                                                                \
+	X(LESS_THAN_i64, lessThan<int64_t>)                                                                                \
+	X(LESS_THAN_ui8, lessThan<uint8_t>)                                                                                \
+	X(LESS_THAN_ui16, lessThan<uint16_t>)                                                                              \
+	X(LESS_THAN_ui32, lessThan<uint32_t>)                                                                              \
+	X(LESS_THAN_ui64, lessThan<uint64_t>)                                                                              \
+	X(LESS_THAN_f, lessThan<float>)                                                                                    \
+	X(LESS_THAN_d, lessThan<double>)                                                                                   \
+	/* less than equals */                                                                                             \
+	X(LESS_THAN_EQUALS_i8, lessThanEquals<int8_t>)                                                                     \
+	X(LESS_THAN_EQUALS_i16, lessThanEquals<int16_t>)                                                                   \
+	X(LESS_THAN_EQUALS_i32, lessThanEquals<int32_t>)                                                                   \
+	X(LESS_THAN_EQUALS_i64, lessThanEquals<int64_t>)                                                                   \
+	X(LESS_THAN_EQUALS_ui8, lessThanEquals<uint8_t>)                                                                   \
+	X(LESS_THAN_EQUALS_ui16, lessThanEquals<uint16_t>)                                                                 \
+	X(LESS_THAN_EQUALS_ui32, lessThanEquals<uint32_t>)                                                                 \
+	X(LESS_THAN_EQUALS_ui64, lessThanEquals<uint64_t>)                                                                 \
+	X(LESS_THAN_EQUALS_f, lessThanEquals<float>)                                                                       \
+	X(LESS_THAN_EQUALS_d, lessThanEquals<double>)                                                                      \
+	/* greater than */                                                                                                 \
+	X(GREATER_THAN_i8, greaterThan<int8_t>)                                                                            \
+	X(GREATER_THAN_i16, greaterThan<int16_t>)                                                                          \
+	X(GREATER_THAN_i32, greaterThan<int32_t>)                                                                          \
+	X(GREATER_THAN_i64, greaterThan<int64_t>)                                                                          \
+	X(GREATER_THAN_ui8, greaterThan<uint8_t>)                                                                          \
+	X(GREATER_THAN_ui16, greaterThan<uint16_t>)                                                                        \
+	X(GREATER_THAN_ui32, greaterThan<uint32_t>)                                                                        \
+	X(GREATER_THAN_ui64, greaterThan<uint64_t>)                                                                        \
+	X(GREATER_THAN_f, greaterThan<float>)                                                                              \
+	X(GREATER_THAN_d, greaterThan<double>)                                                                             \
+	/* greater than equals */                                                                                          \
+	X(GREATER_THAN_EQUALS_i8, greaterThanEquals<int8_t>)                                                               \
+	X(GREATER_THAN_EQUALS_i16, greaterThanEquals<int16_t>)                                                             \
+	X(GREATER_THAN_EQUALS_i32, greaterThanEquals<int32_t>)                                                             \
+	X(GREATER_THAN_EQUALS_i64, greaterThanEquals<int64_t>)                                                             \
+	X(GREATER_THAN_EQUALS_ui8, greaterThanEquals<uint8_t>)                                                             \
+	X(GREATER_THAN_EQUALS_ui16, greaterThanEquals<uint16_t>)                                                           \
+	X(GREATER_THAN_EQUALS_ui32, greaterThanEquals<uint32_t>)                                                           \
+	X(GREATER_THAN_EQUALS_ui64, greaterThanEquals<uint64_t>)                                                           \
+	X(GREATER_THAN_EQUALS_f, greaterThanEquals<float>)                                                                 \
+	X(GREATER_THAN_EQUALS_d, greaterThanEquals<double>)                                                                \
+	/* not equals */                                                                                                   \
+	X(NOT_EQUALS_b, notEquals<bool>)                                                                                   \
+	X(NOT_EQUALS_i8, notEquals<int8_t>)                                                                                \
+	X(NOT_EQUALS_i16, notEquals<int16_t>)                                                                              \
+	X(NOT_EQUALS_i32, notEquals<int32_t>)                                                                              \
+	X(NOT_EQUALS_i64, notEquals<int64_t>)                                                                              \
+	X(NOT_EQUALS_ui8, notEquals<uint8_t>)                                                                              \
+	X(NOT_EQUALS_ui16, notEquals<uint16_t>)                                                                            \
+	X(NOT_EQUALS_ui32, notEquals<uint32_t>)                                                                            \
+	X(NOT_EQUALS_ui64, notEquals<uint64_t>)                                                                            \
+	X(NOT_EQUALS_f, notEquals<float>)                                                                                  \
+	X(NOT_EQUALS_d, notEquals<double>)                                                                                 \
+	/* load */                                                                                                         \
+	X(LOAD_i8, load<int8_t>)                                                                                           \
+	X(LOAD_i16, load<int16_t>)                                                                                         \
+	X(LOAD_i32, load<int32_t>)                                                                                         \
+	X(LOAD_i64, load<int64_t>)                                                                                         \
+	X(LOAD_ui8, load<uint8_t>)                                                                                         \
+	X(LOAD_ui16, load<uint16_t>)                                                                                       \
+	X(LOAD_ui32, load<uint32_t>)                                                                                       \
+	X(LOAD_ui64, load<uint64_t>)                                                                                       \
+	X(LOAD_f, load<float>)                                                                                             \
+	X(LOAD_d, load<double>)                                                                                            \
+	X(LOAD_b, load<bool>)                                                                                              \
+	/* store */                                                                                                        \
+	X(STORE_i8, store<int8_t>)                                                                                         \
+	X(STORE_i16, store<int16_t>)                                                                                       \
+	X(STORE_i32, store<int32_t>)                                                                                       \
+	X(STORE_i64, store<int64_t>)                                                                                       \
+	X(STORE_ui8, store<uint8_t>)                                                                                       \
+	X(STORE_ui16, store<uint16_t>)                                                                                     \
+	X(STORE_ui32, store<uint32_t>)                                                                                     \
+	X(STORE_ui64, store<uint64_t>)                                                                                     \
+	X(STORE_f, store<float>)                                                                                           \
+	X(STORE_d, store<double>)                                                                                          \
+	X(STORE_b, store<bool>)                                                                                            \
+	/* logical */                                                                                                      \
+	X(AND_b, andOp<bool>)                                                                                              \
+	X(OR_b, orOp<bool>)                                                                                                \
+	X(NOT_b, notOp<bool>)                                                                                              \
+	/* casts: int to int */                                                                                            \
+	X(CAST_i8_i16, cast<int8_t, int16_t>)                                                                              \
+	X(CAST_i8_i32, cast<int8_t, int32_t>)                                                                              \
+	X(CAST_i8_i64, cast<int8_t, int64_t>)                                                                              \
+	X(CAST_i16_i8, cast<int16_t, int8_t>)                                                                              \
+	X(CAST_i16_i32, cast<int16_t, int32_t>)                                                                            \
+	X(CAST_i16_i64, cast<int16_t, int64_t>)                                                                            \
+	X(CAST_i32_i8, cast<int32_t, int8_t>)                                                                              \
+	X(CAST_i32_i16, cast<int32_t, int16_t>)                                                                            \
+	X(CAST_i32_i64, cast<int32_t, int64_t>)                                                                            \
+	X(CAST_i64_i8, cast<int64_t, int8_t>)                                                                              \
+	X(CAST_i64_i16, cast<int64_t, int16_t>)                                                                            \
+	X(CAST_i64_i32, cast<int64_t, int32_t>)                                                                            \
+	/* casts: uint to int */                                                                                           \
+	X(CAST_ui8_i8, cast<uint8_t, int8_t>)                                                                              \
+	X(CAST_ui8_i16, cast<uint8_t, int16_t>)                                                                            \
+	X(CAST_ui8_i32, cast<uint8_t, int32_t>)                                                                            \
+	X(CAST_ui8_i64, cast<uint8_t, int64_t>)                                                                            \
+	X(CAST_ui16_i8, cast<uint16_t, int8_t>)                                                                            \
+	X(CAST_ui16_i16, cast<uint16_t, int16_t>)                                                                          \
+	X(CAST_ui16_i32, cast<uint16_t, int32_t>)                                                                          \
+	X(CAST_ui16_i64, cast<uint16_t, int64_t>)                                                                          \
+	X(CAST_ui32_i8, cast<uint32_t, int8_t>)                                                                            \
+	X(CAST_ui32_i16, cast<uint32_t, int16_t>)                                                                          \
+	X(CAST_ui32_i32, cast<uint32_t, int32_t>)                                                                          \
+	X(CAST_ui32_i64, cast<uint32_t, int64_t>)                                                                          \
+	X(CAST_ui64_i8, cast<uint64_t, int8_t>)                                                                            \
+	X(CAST_ui64_i16, cast<uint64_t, int16_t>)                                                                          \
+	X(CAST_ui64_i32, cast<uint64_t, int32_t>)                                                                          \
+	X(CAST_ui64_i64, cast<uint64_t, int64_t>)                                                                          \
+	/* casts: uint to uint */                                                                                          \
+	X(CAST_ui8_ui16, cast<uint8_t, uint16_t>)                                                                          \
+	X(CAST_ui8_ui32, cast<uint8_t, uint32_t>)                                                                          \
+	X(CAST_ui8_ui64, cast<uint8_t, uint64_t>)                                                                          \
+	X(CAST_ui16_ui8, cast<uint16_t, uint8_t>)                                                                          \
+	X(CAST_ui16_ui32, cast<uint16_t, uint32_t>)                                                                        \
+	X(CAST_ui16_ui64, cast<uint16_t, uint64_t>)                                                                        \
+	X(CAST_ui32_ui8, cast<uint32_t, uint8_t>)                                                                          \
+	X(CAST_ui32_ui16, cast<uint32_t, uint16_t>)                                                                        \
+	X(CAST_ui32_ui64, cast<uint32_t, uint64_t>)                                                                        \
+	X(CAST_ui64_ui8, cast<uint64_t, uint8_t>)                                                                          \
+	X(CAST_ui64_ui16, cast<uint64_t, uint16_t>)                                                                        \
+	X(CAST_ui64_ui32, cast<uint64_t, uint32_t>)                                                                        \
+	/* casts: int to uint */                                                                                           \
+	X(CAST_i8_ui8, cast<int8_t, uint8_t>)                                                                              \
+	X(CAST_i8_ui16, cast<int8_t, uint16_t>)                                                                            \
+	X(CAST_i8_ui32, cast<int8_t, uint32_t>)                                                                            \
+	X(CAST_i8_ui64, cast<int8_t, uint64_t>)                                                                            \
+	X(CAST_i16_ui8, cast<int16_t, uint8_t>)                                                                            \
+	X(CAST_i16_ui16, cast<int16_t, uint16_t>)                                                                          \
+	X(CAST_i16_ui32, cast<int16_t, uint32_t>)                                                                          \
+	X(CAST_i16_ui64, cast<int16_t, uint64_t>)                                                                          \
+	X(CAST_i32_ui8, cast<int32_t, uint8_t>)                                                                            \
+	X(CAST_i32_ui16, cast<int32_t, uint16_t>)                                                                          \
+	X(CAST_i32_ui32, cast<int32_t, uint32_t>)                                                                          \
+	X(CAST_i32_ui64, cast<int32_t, uint64_t>)                                                                          \
+	X(CAST_i64_ui8, cast<int64_t, uint8_t>)                                                                            \
+	X(CAST_i64_ui16, cast<int64_t, uint16_t>)                                                                          \
+	X(CAST_i64_ui32, cast<int64_t, uint32_t>)                                                                          \
+	X(CAST_i64_ui64, cast<int64_t, uint64_t>)                                                                          \
+	/* casts: float to int */                                                                                          \
+	X(CAST_f_i8, cast<float, int8_t>)                                                                                  \
+	X(CAST_f_i16, cast<float, int16_t>)                                                                                \
+	X(CAST_f_i32, cast<float, int32_t>)                                                                                \
+	X(CAST_f_i64, cast<float, int64_t>)                                                                                \
+	X(CAST_f_ui8, cast<float, uint8_t>)                                                                                \
+	X(CAST_f_ui16, cast<float, uint16_t>)                                                                              \
+	X(CAST_f_ui32, cast<float, uint32_t>)                                                                              \
+	X(CAST_f_ui64, cast<float, uint64_t>)                                                                              \
+	X(CAST_f_d, cast<float, double>)                                                                                   \
+	/* casts: double to int */                                                                                         \
+	X(CAST_d_i8, cast<double, int8_t>)                                                                                 \
+	X(CAST_d_i16, cast<double, int16_t>)                                                                               \
+	X(CAST_d_i32, cast<double, int32_t>)                                                                               \
+	X(CAST_d_i64, cast<double, int64_t>)                                                                               \
+	X(CAST_d_ui8, cast<double, uint8_t>)                                                                               \
+	X(CAST_d_ui16, cast<double, uint16_t>)                                                                             \
+	X(CAST_d_ui32, cast<double, uint32_t>)                                                                             \
+	X(CAST_d_ui64, cast<double, uint64_t>)                                                                             \
+	X(CAST_d_f, cast<double, float>)                                                                                   \
+	/* casts: int to float */                                                                                          \
+	X(CAST_i8_f, cast<int8_t, float>)                                                                                  \
+	X(CAST_i8_d, cast<int8_t, double>)                                                                                 \
+	X(CAST_i16_f, cast<int16_t, float>)                                                                                \
+	X(CAST_i16_d, cast<int16_t, double>)                                                                               \
+	X(CAST_i32_f, cast<int32_t, float>)                                                                                \
+	X(CAST_i32_d, cast<int32_t, double>)                                                                               \
+	X(CAST_i64_f, cast<int64_t, float>)                                                                                \
+	X(CAST_i64_d, cast<int64_t, double>)                                                                               \
+	/* casts: uint to float */                                                                                         \
+	X(CAST_ui8_f, cast<uint8_t, float>)                                                                                \
+	X(CAST_ui8_d, cast<uint8_t, double>)                                                                               \
+	X(CAST_ui16_f, cast<uint16_t, float>)                                                                              \
+	X(CAST_ui16_d, cast<uint16_t, double>)                                                                             \
+	X(CAST_ui32_f, cast<uint32_t, float>)                                                                              \
+	X(CAST_ui32_d, cast<uint32_t, double>)                                                                             \
+	X(CAST_ui64_f, cast<uint64_t, float>)                                                                              \
+	X(CAST_ui64_d, cast<uint64_t, double>)                                                                             \
+	/* dynamic function calls using dyncall.h */                                                                       \
+	X(DYNCALL_reset, dyncallReset)                                                                                     \
+	X(DYNCALL_arg_b, dyncallArgB)                                                                                      \
+	X(DYNCALL_arg_i8, dyncallArgI8)                                                                                    \
+	X(DYNCALL_arg_i16, dyncallArgI16)                                                                                  \
+	X(DYNCALL_arg_i32, dyncallArgI32)                                                                                  \
+	X(DYNCALL_arg_i64, dyncallArgI64)                                                                                  \
+	X(DYNCALL_arg_f, dyncallArgF)                                                                                      \
+	X(DYNCALL_arg_d, dyncallArgD)                                                                                      \
+	X(DYNCALL_arg_ptr, dyncallArgPtr)                                                                                  \
+	X(DYNCALL_call_v, dyncallCallV)                                                                                    \
+	X(DYNCALL_call_b, dyncallCallB)                                                                                    \
+	X(DYNCALL_call_i8, dyncallCallI8)                                                                                  \
+	X(DYNCALL_call_i16, dyncallCallI16)                                                                                \
+	X(DYNCALL_call_i32, dyncallCallI32)                                                                                \
+	X(DYNCALL_call_i64, dyncallCallI64)                                                                                \
+	X(DYNCALL_call_ptr, dyncallCallPtr)                                                                                \
+	X(DYNCALL_call_f, dyncallCallf)                                                                                    \
+	X(DYNCALL_call_d, dyncallCalld)                                                                                    \
+	/* bitwise: band */                                                                                                \
+	X(BAND_i8, bitwiseAnd<int8_t>)                                                                                     \
+	X(BAND_i16, bitwiseAnd<int16_t>)                                                                                   \
+	X(BAND_i32, bitwiseAnd<int32_t>)                                                                                   \
+	X(BAND_i64, bitwiseAnd<int64_t>)                                                                                   \
+	X(BAND_ui8, bitwiseAnd<uint8_t>)                                                                                   \
+	X(BAND_ui16, bitwiseAnd<uint16_t>)                                                                                 \
+	X(BAND_ui32, bitwiseAnd<uint32_t>)                                                                                 \
+	X(BAND_ui64, bitwiseAnd<uint64_t>)                                                                                 \
+	/* bitwise: bor */                                                                                                 \
+	X(BOR_i8, bitwiseOr<int8_t>)                                                                                       \
+	X(BOR_i16, bitwiseOr<int16_t>)                                                                                     \
+	X(BOR_i32, bitwiseOr<int32_t>)                                                                                     \
+	X(BOR_i64, bitwiseOr<int64_t>)                                                                                     \
+	X(BOR_ui8, bitwiseOr<uint8_t>)                                                                                     \
+	X(BOR_ui16, bitwiseOr<uint16_t>)                                                                                   \
+	X(BOR_ui32, bitwiseOr<uint32_t>)                                                                                   \
+	X(BOR_ui64, bitwiseOr<uint64_t>)                                                                                   \
+	/* bitwise: bxor */                                                                                                \
+	X(BXOR_i8, bitwiseXOr<int8_t>)                                                                                     \
+	X(BXOR_i16, bitwiseXOr<int16_t>)                                                                                   \
+	X(BXOR_i32, bitwiseXOr<int32_t>)                                                                                   \
+	X(BXOR_i64, bitwiseXOr<int64_t>)                                                                                   \
+	X(BXOR_ui8, bitwiseXOr<uint8_t>)                                                                                   \
+	X(BXOR_ui16, bitwiseXOr<uint16_t>)                                                                                 \
+	X(BXOR_ui32, bitwiseXOr<uint32_t>)                                                                                 \
+	X(BXOR_ui64, bitwiseXOr<uint64_t>)                                                                                 \
+	/* bitwise: blsh */                                                                                                \
+	X(BLSH_i8, bitwiseLSH<int8_t>)                                                                                     \
+	X(BLSH_i16, bitwiseLSH<int16_t>)                                                                                   \
+	X(BLSH_i32, bitwiseLSH<int32_t>)                                                                                   \
+	X(BLSH_i64, bitwiseLSH<int64_t>)                                                                                   \
+	X(BLSH_ui8, bitwiseLSH<uint8_t>)                                                                                   \
+	X(BLSH_ui16, bitwiseLSH<uint16_t>)                                                                                 \
+	X(BLSH_ui32, bitwiseLSH<uint32_t>)                                                                                 \
+	X(BLSH_ui64, bitwiseLSH<uint64_t>)                                                                                 \
+	/* bitwise: brsh */                                                                                                \
+	X(BRSH_i8, bitwiseRSH<int8_t>)                                                                                     \
+	X(BRSH_i16, bitwiseRSH<int16_t>)                                                                                   \
+	X(BRSH_i32, bitwiseRSH<int32_t>)                                                                                   \
+	X(BRSH_i64, bitwiseRSH<int64_t>)                                                                                   \
+	X(BRSH_ui8, bitwiseRSH<uint8_t>)                                                                                   \
+	X(BRSH_ui16, bitwiseRSH<uint16_t>)                                                                                 \
+	X(BRSH_ui32, bitwiseRSH<uint32_t>)                                                                                 \
+	X(BRSH_ui64, bitwiseRSH<uint64_t>)                                                                                 \
+	/* bitwise: bnot */                                                                                                \
+	X(BNEGATE_I64, bitwiseNot<int64_t>)                                                                                \
+	/* select */                                                                                                       \
+	X(SELECT_i8, selectOp<int8_t>)                                                                                     \
+	X(SELECT_i16, selectOp<int16_t>)                                                                                   \
+	X(SELECT_i32, selectOp<int32_t>)                                                                                   \
+	X(SELECT_i64, selectOp<int64_t>)                                                                                   \
+	X(SELECT_ui8, selectOp<uint8_t>)                                                                                   \
+	X(SELECT_ui16, selectOp<uint16_t>)                                                                                 \
+	X(SELECT_ui32, selectOp<uint32_t>)                                                                                 \
+	X(SELECT_ui64, selectOp<uint64_t>)                                                                                 \
+	X(SELECT_f, selectOp<float>)                                                                                       \
+	X(SELECT_d, selectOp<double>)                                                                                      \
+	X(SELECT_b, selectOp<bool>)                                                                                        \
+	X(SELECT_ptr, selectOp<void*>)
 
+static Operation* OpTable[] = {
+#define NAUTILUS_BC_TABLE_ENTRY(name, ...) (Operation*) __VA_ARGS__,
+    NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_TABLE_ENTRY)
+#undef NAUTILUS_BC_TABLE_ENTRY
 };
 
 FunctionCallTarget::FunctionCallTarget(std::vector<std::pair<short, Type>> arguments, void* functionPtr)
     : arguments(std::move(arguments)), functionPtr(functionPtr) {
 }
 
-BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile)
-    : code(std::move(code)), registerFile(std::move(registerFile)) {
+DispatchMode parseDispatchMode(const std::string& value) {
+	if (value == "switch") {
+		return DispatchMode::Switch;
+	}
+	return DispatchMode::Call;
+}
+
+BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile, DispatchMode dispatchMode)
+    : code(std::move(code)), registerFile(std::move(registerFile)), dispatchMode(dispatchMode) {
 	// The register file was built against a temporary Code instance whose allocaBuffers
 	// may have been copied (and thus relocated) before reaching this constructor.
 	// Re-point each alloca register at the actual buffer in *this* code object.
@@ -543,9 +560,25 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 	// first block is always the entrypoint
 	auto* currentBlock = &code.blocks[0];
 	while (true) {
-		// execute operations in block
-		for (const auto& c : currentBlock->code) {
-			OpTable[(int16_t) c.op](c, regs);
+		// execute operations in block. The dispatch mode is constant for the whole
+		// run, so this branch is perfectly predicted; it picks between the legacy
+		// indirect-call table and the inlined switch (which avoids a non-inlined
+		// call per instruction and lets the compiler keep the register base hot).
+		if (dispatchMode == DispatchMode::Switch) {
+			for (const auto& c : currentBlock->code) {
+				switch (c.op) {
+#define NAUTILUS_BC_SWITCH_CASE(name, ...)                                                                             \
+	case ByteCode::name:                                                                                               \
+		__VA_ARGS__(c, regs);                                                                                          \
+		break;
+					NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_SWITCH_CASE)
+#undef NAUTILUS_BC_SWITCH_CASE
+				}
+			}
+		} else {
+			for (const auto& c : currentBlock->code) {
+				OpTable[(int16_t) c.op](c, regs);
+			}
 		}
 		// handle terminator
 		if (const auto* res = std::get_if<BranchOp>(&currentBlock->terminatorOp)) {

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -479,6 +479,36 @@ BCInterpreter::BCInterpreter(Code code, RegisterFile registerFile, DispatchMode 
 	for (const auto& [reg, bufIdx] : this->code.allocaRegisterMap) {
 		this->registerFile[reg] = reinterpret_cast<int64_t>(this->code.allocaBuffers[bufIdx].data());
 	}
+#ifdef NAUTILUS_BC_HAS_COMPUTED_GOTO
+	if (this->dispatchMode == DispatchMode::Threaded) {
+		buildFlatCode();
+	}
+#endif
+}
+
+void BCInterpreter::buildFlatCode() {
+	// Concatenate every block's operations in their existing order (block order
+	// matters: visitIf emits landing-pad blocks inline, so offsets are correct by
+	// construction). After each block's ops, append its terminator as a JMP/CJMP/
+	// RET pseudo-op. Terminator targets stay block indices here; they are mapped to
+	// flat offsets through blockStart_ at run time.
+	blockStart_.resize(code.blocks.size());
+	for (size_t i = 0; i < code.blocks.size(); i++) {
+		const auto& block = code.blocks[i];
+		blockStart_[i] = static_cast<int32_t>(flatCode_.size());
+		for (const auto& op : block.code) {
+			flatCode_.push_back(op);
+		}
+		if (const auto* res = std::get_if<BranchOp>(&block.terminatorOp)) {
+			flatCode_.emplace_back(ByteCode::JMP, res->nextBlock, -1, -1);
+		} else if (const auto* res = std::get_if<ConditionalJumpOp>(&block.terminatorOp)) {
+			// OpCode ctor order is (op, reg1, reg2, output, reg3).
+			flatCode_.emplace_back(ByteCode::CJMP, res->conditionalReg, res->trueBlock, -1, res->falseBlock);
+		} else {
+			const auto& ret = std::get<ReturnOp>(block.terminatorOp);
+			flatCode_.emplace_back(ByteCode::RET, ret.resultReg, -1, -1);
+		}
+	}
 }
 
 BCExecutable::BCExecutable(std::unordered_map<std::string, void*> functionPtrs,
@@ -590,6 +620,13 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 		break;
 					NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_SWITCH_CASE)
 #undef NAUTILUS_BC_SWITCH_CASE
+				// Terminator pseudo-opcodes never appear in a block's operation stream
+				// in the call/switch paths (they keep the structured terminators); these
+				// cases exist only so the switch covers the whole ByteCode enum.
+				case ByteCode::JMP:
+				case ByteCode::CJMP:
+				case ByteCode::RET:
+					break;
 				}
 			}
 		} else {
@@ -631,21 +668,25 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 int64_t BCInterpreter::executeThreaded(RegisterFile& regs) const {
 	// Address table indexed by opcode, in the same order as the ByteCode enum.
 	// Built once at first entry (label addresses are not constant expressions).
+	// The value ops come from NAUTILUS_BC_OPCODE_LIST; the three terminator
+	// pseudo-opcodes (JMP/CJMP/RET) are appended in the same order they were added
+	// to the enum, so labels[(int) op] stays correct for every opcode.
 	static void* const labels[] = {
 #define NAUTILUS_BC_LABEL(name, ...) &&L_##name,
 	    NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_LABEL)
 #undef NAUTILUS_BC_LABEL
+	        && L_JMP,
+	    &&L_CJMP,
+	    &&L_RET,
 	};
 
-	const CodeBlock* currentBlock = &code.blocks[0];
-	const OpCode* ip = currentBlock->code.data();
-	const OpCode* end = ip + currentBlock->code.size();
+	// Flattened stream: blocks concatenated in order, each ended by a JMP/CJMP/RET.
+	// There is no end-of-block check and no variant dispatch — every block ends in
+	// a terminator op, so control always leaves via L_JMP/L_CJMP/L_RET.
+	const OpCode* const base = flatCode_.data();
+	const OpCode* ip = base;
 
-// Dispatch the next op, or fall through to the terminator at end of block.
-#define NAUTILUS_BC_NEXT()                                                                                             \
-	if (ip >= end)                                                                                                     \
-		goto terminator;                                                                                               \
-	goto* labels[(int16_t) ip->op]
+#define NAUTILUS_BC_NEXT() goto* labels[(int16_t) ip->op]
 
 	NAUTILUS_BC_NEXT();
 
@@ -658,22 +699,17 @@ int64_t BCInterpreter::executeThreaded(RegisterFile& regs) const {
 	NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_HANDLER)
 #undef NAUTILUS_BC_HANDLER
 
-terminator:
-	if (const auto* res = std::get_if<BranchOp>(&currentBlock->terminatorOp)) {
-		currentBlock = &code.blocks[res->nextBlock];
-	} else if (const auto* res = std::get_if<ConditionalJumpOp>(&currentBlock->terminatorOp)) {
-		currentBlock =
-		    readReg<bool>(regs, res->conditionalReg) ? &code.blocks[res->trueBlock] : &code.blocks[res->falseBlock];
-	} else {
-		const auto& ret = std::get<ReturnOp>(currentBlock->terminatorOp);
-		if (ret.resultReg < 0) {
-			return 0;
-		}
-		return regs[ret.resultReg];
-	}
-	ip = currentBlock->code.data();
-	end = ip + currentBlock->code.size();
+L_JMP:
+	ip = base + blockStart_[ip->reg1];
 	NAUTILUS_BC_NEXT();
+L_CJMP:
+	ip = base + blockStart_[readReg<bool>(regs, ip->reg1) ? ip->reg2 : ip->reg3];
+	NAUTILUS_BC_NEXT();
+L_RET:
+	if (ip->reg1 < 0) {
+		return 0;
+	}
+	return regs[ip->reg1];
 #undef NAUTILUS_BC_NEXT
 }
 #pragma GCC diagnostic pop

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -86,10 +86,6 @@ private:
 	/// indices resolved to flat offsets via blockStart_.
 	std::vector<OpCode> flatCode_;
 	std::vector<int32_t> blockStart_;
-
-	/// Per-instruction immediates for the threaded path's *_imm opcodes, indexed by
-	/// position in flatCode_ (ip - base). Empty unless immediate folding is active.
-	std::vector<int64_t> flatImm_;
 };
 
 /**

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -29,6 +29,24 @@ enum class DispatchMode { Call, Switch, Threaded };
 /// Parse a "bc.dispatch" option value into a DispatchMode (defaults to Call on unknown input).
 DispatchMode parseDispatchMode(const std::string& value);
 
+/**
+ * @brief Per-interpreter options resolved from engine options at compile time.
+ *
+ * dispatch:           how operations are dispatched (see DispatchMode).
+ * reuseRegisterFile:  recycle the per-invocation register file from a thread-local
+ *                     pool instead of heap-allocating a fresh copy each call.
+ * superinstructions:  fuse compare+branch into a single op in the flattened
+ *                     threaded stream (threaded path only).
+ * immediates:         fold compile-time-constant operands directly into ops in the
+ *                     flattened threaded stream (threaded path only).
+ */
+struct BCInterpreterOptions {
+	DispatchMode dispatch = DispatchMode::Call;
+	bool reuseRegisterFile = false;
+	bool superinstructions = false;
+	bool immediates = false;
+};
+
 /// Data passed to the dyncallback handler for each function.
 struct BCCallbackData {
 	std::unique_ptr<class BCInterpreter> interpreter;
@@ -41,7 +59,7 @@ struct BCCallbackData {
  */
 class BCInterpreter {
 public:
-	BCInterpreter(Code code, RegisterFile registerFile, DispatchMode dispatchMode = DispatchMode::Call);
+	BCInterpreter(Code code, RegisterFile registerFile, BCInterpreterOptions options = {});
 
 	/// Read arguments from DCArgs directly into the register file, execute, and return the raw result.
 	int64_t invoke(DCArgs* args, const std::vector<Type>& argTypes);
@@ -61,13 +79,17 @@ private:
 
 	Code code;
 	RegisterFile registerFile;
-	DispatchMode dispatchMode;
+	BCInterpreterOptions options;
 
 	/// Flattened form of `code` for the threaded path (empty otherwise). Reuses
 	/// OpCode for value ops; terminators are JMP/CJMP/RET whose targets are block
 	/// indices resolved to flat offsets via blockStart_.
 	std::vector<OpCode> flatCode_;
 	std::vector<int32_t> blockStart_;
+
+	/// Per-instruction immediates for the threaded path's *_imm opcodes, indexed by
+	/// position in flatCode_ (ip - base). Empty unless immediate folding is active.
+	std::vector<int64_t> flatImm_;
 };
 
 /**

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -53,9 +53,21 @@ private:
 	/// that support labels-as-values; execute() routes here only when supported.
 	int64_t executeThreaded(RegisterFile& regs) const;
 
+	/// Build the flattened instruction stream used by the threaded path: all block
+	/// operations concatenated in order, each block followed by its terminator
+	/// translated into a JMP/CJMP/RET pseudo-opcode. Called once at construction
+	/// when the threaded path is active.
+	void buildFlatCode();
+
 	Code code;
 	RegisterFile registerFile;
 	DispatchMode dispatchMode;
+
+	/// Flattened form of `code` for the threaded path (empty otherwise). Reuses
+	/// OpCode for value ops; terminators are JMP/CJMP/RET whose targets are block
+	/// indices resolved to flat offsets via blockStart_.
+	std::vector<OpCode> flatCode_;
+	std::vector<int32_t> blockStart_;
 };
 
 /**

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -10,6 +10,19 @@
 
 namespace nautilus::compiler::bc {
 
+/**
+ * @brief Selects how the interpreter dispatches bytecode operations.
+ *
+ * Call:   indirect call through the OpTable function-pointer table (legacy default).
+ * Switch: an inlined switch over the opcode, which lets the compiler inline the
+ *         operation bodies and keep the register base hot instead of paying a
+ *         non-inlined indirect call per instruction.
+ */
+enum class DispatchMode { Call, Switch };
+
+/// Parse a "bc.dispatch" option value into a DispatchMode (defaults to Call on unknown input).
+DispatchMode parseDispatchMode(const std::string& value);
+
 /// Data passed to the dyncallback handler for each function.
 struct BCCallbackData {
 	std::unique_ptr<class BCInterpreter> interpreter;
@@ -22,7 +35,7 @@ struct BCCallbackData {
  */
 class BCInterpreter {
 public:
-	BCInterpreter(Code code, RegisterFile registerFile);
+	BCInterpreter(Code code, RegisterFile registerFile, DispatchMode dispatchMode = DispatchMode::Call);
 
 	/// Read arguments from DCArgs directly into the register file, execute, and return the raw result.
 	int64_t invoke(DCArgs* args, const std::vector<Type>& argTypes);
@@ -32,6 +45,7 @@ private:
 
 	Code code;
 	RegisterFile registerFile;
+	DispatchMode dispatchMode;
 };
 
 /**

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -13,12 +13,18 @@ namespace nautilus::compiler::bc {
 /**
  * @brief Selects how the interpreter dispatches bytecode operations.
  *
- * Call:   indirect call through the OpTable function-pointer table (legacy default).
- * Switch: an inlined switch over the opcode, which lets the compiler inline the
- *         operation bodies and keep the register base hot instead of paying a
- *         non-inlined indirect call per instruction.
+ * Call:     indirect call through the OpTable function-pointer table (legacy default).
+ * Switch:   an inlined switch over the opcode, which lets the compiler inline the
+ *           operation bodies and keep the register base hot instead of paying a
+ *           non-inlined indirect call per instruction.
+ * Threaded: token-threaded dispatch via computed goto (labels-as-values). Each
+ *           handler jumps directly to the next handler, giving the branch
+ *           predictor a separate dispatch site per opcode. Falls back to Switch
+ *           on compilers without the computed-goto extension (e.g. MSVC). This
+ *           is still a pure interpreter — the label table is data, not generated
+ *           machine code, so it remains usable where runtime codegen is banned.
  */
-enum class DispatchMode { Call, Switch };
+enum class DispatchMode { Call, Switch, Threaded };
 
 /// Parse a "bc.dispatch" option value into a DispatchMode (defaults to Call on unknown input).
 DispatchMode parseDispatchMode(const std::string& value);
@@ -42,6 +48,10 @@ public:
 
 private:
 	int64_t execute(RegisterFile& regs) const;
+
+	/// Computed-goto (token-threaded) execution path. Only defined on compilers
+	/// that support labels-as-values; execute() routes here only when supported.
+	int64_t executeThreaded(RegisterFile& regs) const;
 
 	Code code;
 	RegisterFile registerFile;

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -125,11 +125,17 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 	LoweringOptions loweringOptions;
 	loweringOptions.enableRegisterAllocator = options.getOptionOrDefault("bc.registerAllocator", true);
 
-	// Execution-time option: how the interpreter dispatches each bytecode op.
-	// "call" (default) uses the indirect-call OpTable; "switch" uses an inlined
-	// switch that removes the per-instruction non-inlined call. Selectable here
-	// so the existing A/B benchmark harness can compare the two.
-	const auto dispatchMode = parseDispatchMode(options.getOptionOrDefault<std::string>("bc.dispatch", "call"));
+	// Execution-time options for the interpreter, mirroring the bc.registerAllocator
+	// plumbing so the A/B benchmark harness can compare each in isolation.
+	//   bc.dispatch          how each op is dispatched (call / switch / threaded)
+	//   bc.regfileReuse      recycle the per-invocation register file from a pool
+	//   bc.superinstructions fuse compare+branch in the threaded stream
+	//   bc.immediates        fold constant operands in the threaded stream
+	BCInterpreterOptions interpreterOptions;
+	interpreterOptions.dispatch = parseDispatchMode(options.getOptionOrDefault<std::string>("bc.dispatch", "call"));
+	interpreterOptions.reuseRegisterFile = options.getOptionOrDefault("bc.regfileReuse", false);
+	interpreterOptions.superinstructions = options.getOptionOrDefault("bc.superinstructions", false);
+	interpreterOptions.immediates = options.getOptionOrDefault("bc.immediates", false);
 
 	// Phase 1: Allocate callback data and dyncallback thunks for all functions.
 	// The interpreter is not yet set — we need all function pointers resolved first.
@@ -179,7 +185,7 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 		}
 
 		callbackDataStore[i]->interpreter =
-		    std::make_unique<BCInterpreter>(std::move(code), std::move(regFile), dispatchMode);
+		    std::make_unique<BCInterpreter>(std::move(code), std::move(regFile), interpreterOptions);
 	}
 
 	if (statistics != nullptr) {
@@ -189,10 +195,11 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 		statistics->set("bc.registers.max", maxRegisters);
 		statistics->set("bc.registerAllocator.enabled",
 		                std::string(loweringOptions.enableRegisterAllocator ? "true" : "false"));
-		const auto* dispatchName = dispatchMode == DispatchMode::Threaded ? "threaded"
-		                           : dispatchMode == DispatchMode::Switch ? "switch"
-		                                                                  : "call";
+		const auto* dispatchName = interpreterOptions.dispatch == DispatchMode::Threaded ? "threaded"
+		                           : interpreterOptions.dispatch == DispatchMode::Switch ? "switch"
+		                                                                                 : "call";
 		statistics->set("bc.dispatch", std::string(dispatchName));
+		statistics->set("bc.regfileReuse", std::string(interpreterOptions.reuseRegisterFile ? "true" : "false"));
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -125,6 +125,12 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 	LoweringOptions loweringOptions;
 	loweringOptions.enableRegisterAllocator = options.getOptionOrDefault("bc.registerAllocator", true);
 
+	// Execution-time option: how the interpreter dispatches each bytecode op.
+	// "call" (default) uses the indirect-call OpTable; "switch" uses an inlined
+	// switch that removes the per-instruction non-inlined call. Selectable here
+	// so the existing A/B benchmark harness can compare the two.
+	const auto dispatchMode = parseDispatchMode(options.getOptionOrDefault<std::string>("bc.dispatch", "call"));
+
 	// Phase 1: Allocate callback data and dyncallback thunks for all functions.
 	// The interpreter is not yet set — we need all function pointers resolved first.
 	for (const auto& funcOp : functionOperations) {
@@ -172,7 +178,8 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 			maxRegisters = std::max(maxRegisters, regCount);
 		}
 
-		callbackDataStore[i]->interpreter = std::make_unique<BCInterpreter>(std::move(code), std::move(regFile));
+		callbackDataStore[i]->interpreter =
+		    std::make_unique<BCInterpreter>(std::move(code), std::move(regFile), dispatchMode);
 	}
 
 	if (statistics != nullptr) {
@@ -182,6 +189,7 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 		statistics->set("bc.registers.max", maxRegisters);
 		statistics->set("bc.registerAllocator.enabled",
 		                std::string(loweringOptions.enableRegisterAllocator ? "true" : "false"));
+		statistics->set("bc.dispatch", std::string(dispatchMode == DispatchMode::Switch ? "switch" : "call"));
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -189,7 +189,10 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 		statistics->set("bc.registers.max", maxRegisters);
 		statistics->set("bc.registerAllocator.enabled",
 		                std::string(loweringOptions.enableRegisterAllocator ? "true" : "false"));
-		statistics->set("bc.dispatch", std::string(dispatchMode == DispatchMode::Switch ? "switch" : "call"));
+		const auto* dispatchName = dispatchMode == DispatchMode::Threaded ? "threaded"
+		                           : dispatchMode == DispatchMode::Switch ? "switch"
+		                                                                  : "call";
+		statistics->set("bc.dispatch", std::string(dispatchName));
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -9,6 +9,28 @@
 
 namespace nautilus::compiler::bc {
 
+namespace {
+// Record an arithmetic op's right operand as a foldable immediate (Step 6) when it
+// is an integer constant that fits the 16-bit immediate slot. The recorded index is
+// the op's about-to-be-emitted position in the block. Only i32/i64 are folded; the
+// flattened threaded path consumes these when bc.immediates is enabled.
+void recordFoldableImmediate(CodeBlock& codeBlock, ir::Operation* rightInput, Type type) {
+	if (type != Type::i32 && type != Type::i64) {
+		return;
+	}
+	const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(rightInput);
+	if (constInt == nullptr) {
+		return;
+	}
+	const int64_t value = constInt->getValue();
+	if (value < -32768 || value > 32767) {
+		return;
+	}
+	codeBlock.foldableImmediates.emplace_back(static_cast<uint32_t>(codeBlock.code.size()),
+	                                          static_cast<int16_t>(value));
+}
+} // namespace
+
 BCLoweringProvider::BCLoweringProvider() {
 }
 
@@ -257,6 +279,7 @@ void BCLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* addOpt, sho
 		throw NotImplementedException("This type is not supported.");
 	}
 	}
+	recordFoldableImmediate(program.blocks[block], addOpt->getRightInput(), type);
 	OpCode oc = {bc, leftInput, rightInput, resultReg};
 	program.blocks[block].code.emplace_back(oc);
 }
@@ -307,6 +330,7 @@ void BCLoweringProvider::LoweringContext::visitSub(ir::SubOperation* subOpt, sho
 		throw NotImplementedException("This type is not supported.");
 	}
 	}
+	recordFoldableImmediate(program.blocks[block], subOpt->getRightInput(), subOpt->getStamp());
 	OpCode oc = {bc, leftInput, rightInput, resultReg};
 	program.blocks[block].code.emplace_back(oc);
 }
@@ -358,6 +382,7 @@ void BCLoweringProvider::LoweringContext::visitMul(ir::MulOperation* mulOpt, sho
 		throw NotImplementedException("This type is not supported.");
 	}
 	}
+	recordFoldableImmediate(program.blocks[block], mulOpt->getRightInput(), mulOpt->getStamp());
 	OpCode oc = {bc, leftInput, rightInput, resultReg};
 	program.blocks[block].code.emplace_back(oc);
 }

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -1154,6 +1154,19 @@ void BCLoweringProvider::LoweringContext::process(const ir::BasicBlockInvocation
 
 void BCLoweringProvider::LoweringContext::visitIf(ir::IfOperation* ifOpt, short block, RegisterFrame& frame) {
 	auto conditionalReg = frame.getValue(ifOpt->getValue()->getIdentifier());
+
+	// Step 5 (superinstructions): if the condition is a comparison used nowhere but
+	// this branch, mark the block so the flattened threaded path may fuse the
+	// trailing compare into the conditional jump. Checked before useValue() runs, so
+	// the static count still reflects the original number of uses. The flat builder
+	// additionally verifies the compare is the block's last op (operand-safety) and
+	// only acts when bc.superinstructions is set, so call/switch are unaffected.
+	if (const auto* cmp = ir::dyn_cast<ir::CompareOperation>(ifOpt->getValue())) {
+		const auto it = usageCounts.find(cmp->getIdentifier());
+		if (it != usageCounts.end() && it->second == 1) {
+			program.blocks[block].fuseCompareIntoBranch = true;
+		}
+	}
 	// The conditional jump is this block's terminator, so no further
 	// operation in `block` will read the condition once we have
 	// captured its register number. The landing pads created below

--- a/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
@@ -11,6 +11,27 @@
 
 namespace nautilus::compiler::bc {
 
+// Fused compare-and-branch superinstructions for the flattened threaded path
+// (Step 5). Each entry fuses a single-use integer comparison feeding a
+// conditional branch into one opcode, removing a dispatch and the separate
+// branch per loop iteration. Columns: fused opcode, the source comparison opcode
+// it replaces, the C++ operand type, and the comparison operator. This one list
+// generates the enum entries, the threaded label table, the handlers, the
+// source→fused mapping, and the defensive switch cases — so they cannot drift.
+#define NAUTILUS_BC_FUSED_BRANCH_LIST(X)                                                                               \
+	X(CJMP_LT_i32, LESS_THAN_i32, int32_t, <)                                                                          \
+	X(CJMP_LT_i64, LESS_THAN_i64, int64_t, <)                                                                          \
+	X(CJMP_LE_i32, LESS_THAN_EQUALS_i32, int32_t, <=)                                                                  \
+	X(CJMP_LE_i64, LESS_THAN_EQUALS_i64, int64_t, <=)                                                                  \
+	X(CJMP_GT_i32, GREATER_THAN_i32, int32_t, >)                                                                       \
+	X(CJMP_GT_i64, GREATER_THAN_i64, int64_t, >)                                                                       \
+	X(CJMP_GE_i32, GREATER_THAN_EQUALS_i32, int32_t, >=)                                                               \
+	X(CJMP_GE_i64, GREATER_THAN_EQUALS_i64, int64_t, >=)                                                               \
+	X(CJMP_EQ_i32, EQ_i32, int32_t, ==)                                                                                \
+	X(CJMP_EQ_i64, EQ_i64, int64_t, ==)                                                                                \
+	X(CJMP_NE_i32, NOT_EQUALS_i32, int32_t, !=)                                                                        \
+	X(CJMP_NE_i64, NOT_EQUALS_i64, int64_t, !=)
+
 /**
  * @brief This defines the central register file for the byte-code interpreter.
  * Uses a dynamic vector sized based on actual register usage.
@@ -356,6 +377,12 @@ enum class ByteCode : short {
 	JMP,  // unconditional jump: reg1 = target block index
 	CJMP, // conditional jump:   reg1 = condition reg, reg2 = true block, reg3 = false block
 	RET,  // return:             reg1 = result reg (< 0 for void)
+	      // Fused compare+branch pseudo-opcodes (Step 5), threaded path only. Packed as
+	      // reg1 = left, reg2 = right, output = true block, reg3 = false block. Appended
+	      // after the plain terminators so earlier opcode values never shift.
+#define NAUTILUS_BC_FUSED_ENUM_ENTRY(fused, src, ctype, cmp) fused,
+	NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_ENUM_ENTRY)
+#undef NAUTILUS_BC_FUSED_ENUM_ENTRY
 };
 
 /**
@@ -729,6 +756,12 @@ public:
 
 	std::vector<OpCode> code = std::vector<OpCode>();
 	std::variant<BranchOp, ConditionalJumpOp, ReturnOp> terminatorOp = ReturnOp {0};
+
+	// Set by the lowering when this block ends in a ConditionalJumpOp whose
+	// condition is a single-use CompareOperation. Signals that the flattened
+	// threaded path may fuse the trailing compare into the branch (Step 5). Only
+	// consulted when bc.superinstructions is enabled; call/switch ignore it.
+	bool fuseCompareIntoBranch = false;
 
 	friend std::ostream& operator<<(std::ostream& os, const CodeBlock& block);
 };

--- a/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
@@ -347,6 +347,15 @@ enum class ByteCode : short {
 	SELECT_d,
 	SELECT_b,
 	SELECT_ptr,
+	// Terminator pseudo-opcodes used only by the flattened threaded execution
+	// path (Step 3). They are appended last so the value-opcode indices above —
+	// and therefore the OpTable layout — never shift. They are intentionally NOT
+	// part of NAUTILUS_BC_OPCODE_LIST: the call/switch paths keep the structured
+	// per-block terminators (BranchOp/ConditionalJumpOp/ReturnOp) and never see
+	// these in a block's operation stream.
+	JMP,  // unconditional jump: reg1 = target block index
+	CJMP, // conditional jump:   reg1 = condition reg, reg2 = true block, reg3 = false block
+	RET,  // return:             reg1 = result reg (< 0 for void)
 };
 
 /**

--- a/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
@@ -32,6 +32,22 @@ namespace nautilus::compiler::bc {
 	X(CJMP_NE_i32, NOT_EQUALS_i32, int32_t, !=)                                                                        \
 	X(CJMP_NE_i64, NOT_EQUALS_i64, int64_t, !=)
 
+// Immediate-folding superinstructions for the flattened threaded path (Step 6).
+// Each fuses a compile-time-constant right operand directly into an arithmetic op,
+// removing one register read per use. The immediate is packed into the OpCode's
+// reg2 field (a 16-bit short), so only constants that fit are folded — which
+// covers the dominant loop-increment idiom (i = i + 1). Columns: immediate opcode,
+// the source opcode it replaces, the C++ operand type, the operator. This one list
+// generates the enum entries, threaded labels/handlers, source→imm mapping, and
+// the defensive switch cases.
+#define NAUTILUS_BC_IMM_LIST(X)                                                                                        \
+	X(ADD_imm_i32, ADD_i32, int32_t, +)                                                                                \
+	X(ADD_imm_i64, ADD_i64, int64_t, +)                                                                                \
+	X(SUB_imm_i32, SUB_i32, int32_t, -)                                                                                \
+	X(SUB_imm_i64, SUB_i64, int64_t, -)                                                                                \
+	X(MUL_imm_i32, MUL_i32, int32_t, *)                                                                                \
+	X(MUL_imm_i64, MUL_i64, int64_t, *)
+
 /**
  * @brief This defines the central register file for the byte-code interpreter.
  * Uses a dynamic vector sized based on actual register usage.
@@ -383,6 +399,11 @@ enum class ByteCode : short {
 #define NAUTILUS_BC_FUSED_ENUM_ENTRY(fused, src, ctype, cmp) fused,
 	NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_ENUM_ENTRY)
 #undef NAUTILUS_BC_FUSED_ENUM_ENTRY
+// Immediate-folding pseudo-opcodes (Step 6), threaded path only. Packed as
+// reg1 = operand, reg2 = signed 16-bit immediate, output = result. Appended last.
+#define NAUTILUS_BC_IMM_ENUM_ENTRY(immOp, src, ctype, op) immOp,
+	    NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_ENUM_ENTRY)
+#undef NAUTILUS_BC_IMM_ENUM_ENTRY
 };
 
 /**
@@ -762,6 +783,12 @@ public:
 	// threaded path may fuse the trailing compare into the branch (Step 5). Only
 	// consulted when bc.superinstructions is enabled; call/switch ignore it.
 	bool fuseCompareIntoBranch = false;
+
+	// Recorded by the lowering for arithmetic ops whose right operand is a small
+	// integer constant: (index of the op within `code`, the immediate). The
+	// flattened threaded path uses these to fold the constant into the op (Step 6)
+	// when bc.immediates is enabled; call/switch ignore them.
+	std::vector<std::pair<uint32_t, int16_t>> foldableImmediates = {};
 
 	friend std::ostream& operator<<(std::ostream& os, const CodeBlock& block);
 };

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -168,6 +168,27 @@ TEST_CASE("Execution Benchmark") {
 			    });
 		}
 	}
+
+	// BC-only comparison of the threaded baseline against all threaded-path
+	// optimizations stacked (superinstructions + immediate folding).
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (bool allOpts : {false, true}) {
+			std::string tag = allOpts ? "allOpts" : "baseline";
+			Catch::Benchmark::Benchmark("exec_bc_" + name + "_threaded_" + tag)
+			    .operator=([&func, allOpts](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("bc"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("bc.dispatch", std::string("threaded"));
+				    op.setOption("bc.superinstructions", allOpts);
+				    op.setOption("bc.immediates", allOpts);
+				    func(meter, op);
+			    });
+		}
+	}
 #endif
 }
 

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -127,6 +127,27 @@ TEST_CASE("Execution Benchmark") {
 			    });
 		}
 	}
+
+	// BC-only A/B benchmark for recycling the per-invocation register file from a
+	// thread-local pool (bc.regfileReuse) instead of heap-allocating a fresh copy.
+	// Most visible on the per-call-dominated "add" workload.
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (bool reuse : {false, true}) {
+			std::string tag = reuse ? "reuse" : "noReuse";
+			Catch::Benchmark::Benchmark("exec_bc_" + name + "_threaded_" + tag)
+			    .operator=([&func, reuse](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("bc"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("bc.dispatch", std::string("threaded"));
+				    op.setOption("bc.regfileReuse", reuse);
+				    func(meter, op);
+			    });
+		}
+	}
 #endif
 }
 

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -115,7 +115,7 @@ TEST_CASE("Execution Benchmark") {
 	for (auto& test : benchmarks) {
 		auto func = std::get<1>(test);
 		auto name = std::get<0>(test);
-		for (const auto& dispatch : {std::string("call"), std::string("switch")}) {
+		for (const auto& dispatch : {std::string("call"), std::string("switch"), std::string("threaded")}) {
 			Catch::Benchmark::Benchmark("exec_bc_" + name + "_" + dispatch)
 			    .operator=([&func, dispatch](Catch::Benchmark::Chronometer meter) {
 				    auto op = engine::Options();

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -148,6 +148,26 @@ TEST_CASE("Execution Benchmark") {
 			    });
 		}
 	}
+
+	// BC-only A/B for compare+branch superinstructions on the threaded path
+	// (bc.superinstructions). Most visible on branch-heavy loops (fibonacci).
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (bool super : {false, true}) {
+			std::string tag = super ? "superinstr" : "noSuperinstr";
+			Catch::Benchmark::Benchmark("exec_bc_" + name + "_threaded_" + tag)
+			    .operator=([&func, super](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("bc"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("bc.dispatch", std::string("threaded"));
+				    op.setOption("bc.superinstructions", super);
+				    func(meter, op);
+			    });
+		}
+	}
 #endif
 }
 

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -108,6 +108,25 @@ TEST_CASE("Execution Benchmark") {
 			    });
 		}
 	}
+
+	// BC-only A/B benchmark comparing the bytecode dispatch strategies:
+	// "call" indirect-calls through the OpTable, "switch" uses an inlined
+	// switch that removes the per-instruction non-inlined call.
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (const auto& dispatch : {std::string("call"), std::string("switch")}) {
+			Catch::Benchmark::Benchmark("exec_bc_" + name + "_" + dispatch)
+			    .operator=([&func, dispatch](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("bc"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("bc.dispatch", dispatch);
+				    func(meter, op);
+			    });
+		}
+	}
 #endif
 }
 

--- a/nautilus/test/execution-tests/BCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/BCDispatchModeTest.cpp
@@ -63,19 +63,22 @@ val<int64_t> bcModBit(val<int64_t> a, val<int64_t> b) {
 	return m + (a & b) + (a | b) + (a ^ b);
 }
 
-engine::NautilusEngine bcEngine(const std::string& dispatch, bool reuseRegisterFile = false) {
+engine::NautilusEngine bcEngine(const std::string& dispatch, bool reuseRegisterFile = false,
+                                bool superinstructions = false) {
 	engine::Options options;
 	options.setOption("engine.backend", std::string("bc"));
 	options.setOption("bc.dispatch", dispatch);
 	options.setOption("bc.regfileReuse", reuseRegisterFile);
+	options.setOption("bc.superinstructions", superinstructions);
 	return engine::NautilusEngine(options);
 }
 
 struct Variant {
 	std::string dispatch;
 	bool reuse;
+	bool super;
 	std::string name() const {
-		return dispatch + (reuse ? "_regfileReuse" : "");
+		return dispatch + (reuse ? "_regfileReuse" : "") + (super ? "_superinstructions" : "");
 	}
 };
 
@@ -83,14 +86,16 @@ struct Variant {
 
 TEST_CASE("BC dispatch modes produce identical results") {
 	auto call = bcEngine("call");
-	// Every (dispatch, regfileReuse) combination must match the plain "call"
-	// reference. regfileReuse recycles the per-invocation register file, so this
-	// also guards that recycling does not leak state between invocations.
+	// Every (dispatch, regfileReuse, superinstructions) combination must match the
+	// plain "call" reference. regfileReuse recycles the per-invocation register file
+	// (guards against state leaking between invocations); superinstructions fuses
+	// compare+branch on the threaded path (guards the fusion against the reference).
 	const std::vector<Variant> variants = {
-	    {"call", true}, {"switch", false}, {"switch", true}, {"threaded", false}, {"threaded", true}};
+	    {"call", true, false},     {"switch", false, false},  {"switch", true, false},  {"threaded", false, false},
+	    {"threaded", true, false}, {"threaded", false, true}, {"threaded", true, true}, {"switch", false, true}};
 	for (const auto& variant : variants) {
 		DYNAMIC_SECTION(variant.name()) {
-			auto alt = bcEngine(variant.dispatch, variant.reuse);
+			auto alt = bcEngine(variant.dispatch, variant.reuse, variant.super);
 
 			auto cArith = call.registerFunction(bcArith);
 			auto aArith = alt.registerFunction(bcArith);

--- a/nautilus/test/execution-tests/BCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/BCDispatchModeTest.cpp
@@ -1,0 +1,112 @@
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include <catch2/catch_all.hpp>
+
+// The bytecode interpreter offers three dispatch strategies selected via the
+// "bc.dispatch" option: "call" (indirect-call table, the default), "switch"
+// (inlined switch) and "threaded" (computed-goto). forEachBackend only ever
+// exercises the default, so this test pins that all three modes produce
+// identical results across a range of inputs and opcode families.
+#ifdef ENABLE_BC_BACKEND
+
+namespace nautilus::engine {
+
+namespace {
+
+val<int64_t> bcArith(val<int64_t> a, val<int64_t> b) {
+	return (a + b) * (a - b) + (a * b) - (b + 7);
+}
+
+val<int64_t> bcFib(val<int64_t> n) {
+	val<int64_t> a = 0;
+	val<int64_t> b = 1;
+	for (val<int64_t> i = 0; i < n; i = i + 1) {
+		val<int64_t> t = a + b;
+		a = b;
+		b = t;
+	}
+	return a;
+}
+
+val<int64_t> bcSumSquares(val<int32_t> n) {
+	val<int64_t> sum = 0;
+	for (val<int32_t> i = 0; i < n; i++) {
+		val<int64_t> v = i;
+		sum += v * v;
+	}
+	return sum;
+}
+
+val<int64_t> bcBranchy(val<int64_t> x) {
+	val<int64_t> r = 0;
+	if (x > 10) {
+		r = x * 2;
+	} else if (x < -5) {
+		r = x - 100;
+	} else {
+		r = x + 1;
+	}
+	return r;
+}
+
+val<int32_t> bcCasts(val<int64_t> x) {
+	val<int32_t> a = static_cast<val<int32_t>>(x);
+	val<float> f = static_cast<val<float>>(a);
+	val<double> d = static_cast<val<double>>(f);
+	val<int64_t> back = static_cast<val<int64_t>>(d);
+	return static_cast<val<int32_t>>(back + a);
+}
+
+val<int64_t> bcModBit(val<int64_t> a, val<int64_t> b) {
+	val<int64_t> m = a % (b + 1);
+	return m + (a & b) + (a | b) + (a ^ b);
+}
+
+engine::NautilusEngine bcEngine(const std::string& dispatch) {
+	engine::Options options;
+	options.setOption("engine.backend", std::string("bc"));
+	options.setOption("bc.dispatch", dispatch);
+	return engine::NautilusEngine(options);
+}
+
+} // namespace
+
+TEST_CASE("BC dispatch modes produce identical results") {
+	auto call = bcEngine("call");
+	for (const auto& mode : {std::string("switch"), std::string("threaded")}) {
+		DYNAMIC_SECTION(mode) {
+			auto alt = bcEngine(mode);
+
+			auto cArith = call.registerFunction(bcArith);
+			auto aArith = alt.registerFunction(bcArith);
+			auto cFib = call.registerFunction(bcFib);
+			auto aFib = alt.registerFunction(bcFib);
+			auto cSum = call.registerFunction(bcSumSquares);
+			auto aSum = alt.registerFunction(bcSumSquares);
+			auto cBranch = call.registerFunction(bcBranchy);
+			auto aBranch = alt.registerFunction(bcBranchy);
+			auto cCast = call.registerFunction(bcCasts);
+			auto aCast = alt.registerFunction(bcCasts);
+			auto cMod = call.registerFunction(bcModBit);
+			auto aMod = alt.registerFunction(bcModBit);
+
+			for (int64_t a = -20; a <= 20; a += 3) {
+				REQUIRE(aFib(a) == cFib(a));
+				REQUIRE(aBranch(a) == cBranch(a));
+				REQUIRE(aCast(a * 1000003) == cCast(a * 1000003));
+				for (int64_t b = -20; b <= 20; b += 5) {
+					REQUIRE(aArith(a, b) == cArith(a, b));
+					REQUIRE(aMod(a, b) == cMod(a, b));
+				}
+			}
+			for (int32_t n = 0; n <= 5000; n += 777) {
+				REQUIRE(aSum(n) == cSum(n));
+			}
+		}
+	}
+}
+
+} // namespace nautilus::engine
+
+#endif // ENABLE_BC_BACKEND

--- a/nautilus/test/execution-tests/BCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/BCDispatchModeTest.cpp
@@ -63,20 +63,34 @@ val<int64_t> bcModBit(val<int64_t> a, val<int64_t> b) {
 	return m + (a & b) + (a | b) + (a ^ b);
 }
 
-engine::NautilusEngine bcEngine(const std::string& dispatch) {
+engine::NautilusEngine bcEngine(const std::string& dispatch, bool reuseRegisterFile = false) {
 	engine::Options options;
 	options.setOption("engine.backend", std::string("bc"));
 	options.setOption("bc.dispatch", dispatch);
+	options.setOption("bc.regfileReuse", reuseRegisterFile);
 	return engine::NautilusEngine(options);
 }
+
+struct Variant {
+	std::string dispatch;
+	bool reuse;
+	std::string name() const {
+		return dispatch + (reuse ? "_regfileReuse" : "");
+	}
+};
 
 } // namespace
 
 TEST_CASE("BC dispatch modes produce identical results") {
 	auto call = bcEngine("call");
-	for (const auto& mode : {std::string("switch"), std::string("threaded")}) {
-		DYNAMIC_SECTION(mode) {
-			auto alt = bcEngine(mode);
+	// Every (dispatch, regfileReuse) combination must match the plain "call"
+	// reference. regfileReuse recycles the per-invocation register file, so this
+	// also guards that recycling does not leak state between invocations.
+	const std::vector<Variant> variants = {
+	    {"call", true}, {"switch", false}, {"switch", true}, {"threaded", false}, {"threaded", true}};
+	for (const auto& variant : variants) {
+		DYNAMIC_SECTION(variant.name()) {
+			auto alt = bcEngine(variant.dispatch, variant.reuse);
 
 			auto cArith = call.registerFunction(bcArith);
 			auto aArith = alt.registerFunction(bcArith);

--- a/nautilus/test/execution-tests/BCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/BCDispatchModeTest.cpp
@@ -64,12 +64,13 @@ val<int64_t> bcModBit(val<int64_t> a, val<int64_t> b) {
 }
 
 engine::NautilusEngine bcEngine(const std::string& dispatch, bool reuseRegisterFile = false,
-                                bool superinstructions = false) {
+                                bool superinstructions = false, bool immediates = false) {
 	engine::Options options;
 	options.setOption("engine.backend", std::string("bc"));
 	options.setOption("bc.dispatch", dispatch);
 	options.setOption("bc.regfileReuse", reuseRegisterFile);
 	options.setOption("bc.superinstructions", superinstructions);
+	options.setOption("bc.immediates", immediates);
 	return engine::NautilusEngine(options);
 }
 
@@ -77,8 +78,10 @@ struct Variant {
 	std::string dispatch;
 	bool reuse;
 	bool super;
+	bool imm;
 	std::string name() const {
-		return dispatch + (reuse ? "_regfileReuse" : "") + (super ? "_superinstructions" : "");
+		return dispatch + (reuse ? "_regfileReuse" : "") + (super ? "_superinstructions" : "") +
+		       (imm ? "_immediates" : "");
 	}
 };
 
@@ -86,16 +89,20 @@ struct Variant {
 
 TEST_CASE("BC dispatch modes produce identical results") {
 	auto call = bcEngine("call");
-	// Every (dispatch, regfileReuse, superinstructions) combination must match the
-	// plain "call" reference. regfileReuse recycles the per-invocation register file
-	// (guards against state leaking between invocations); superinstructions fuses
-	// compare+branch on the threaded path (guards the fusion against the reference).
+	// Every (dispatch, regfileReuse, superinstructions, immediates) combination must
+	// match the plain "call" reference. regfileReuse recycles the per-invocation
+	// register file (guards against leaked state); superinstructions fuses
+	// compare+branch and immediates folds constant operands on the threaded path
+	// (both guarded against the reference). The kernels below contain constant
+	// operands (i+1, b+7, x-100, …) so immediate folding is actually exercised.
 	const std::vector<Variant> variants = {
-	    {"call", true, false},     {"switch", false, false},  {"switch", true, false},  {"threaded", false, false},
-	    {"threaded", true, false}, {"threaded", false, true}, {"threaded", true, true}, {"switch", false, true}};
+	    {"call", true, false, false},     {"switch", false, false, false},   {"switch", true, false, false},
+	    {"switch", false, true, false},   {"threaded", false, false, false}, {"threaded", true, false, false},
+	    {"threaded", false, true, false}, {"threaded", true, true, false},   {"threaded", false, false, true},
+	    {"threaded", false, true, true},  {"threaded", true, true, true}};
 	for (const auto& variant : variants) {
 		DYNAMIC_SECTION(variant.name()) {
-			auto alt = bcEngine(variant.dispatch, variant.reuse, variant.super);
+			auto alt = bcEngine(variant.dispatch, variant.reuse, variant.super, variant.imm);
 
 			auto cArith = call.registerFunction(bcArith);
 			auto aArith = alt.registerFunction(bcArith);

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -2,6 +2,7 @@ include(CTest)
 include(Catch)
 set(NAUTILUS_EXECUTION_TEST_SOURCES
         ExecutionTest.cpp
+        BCDispatchModeTest.cpp
         BoolExecutionTest.cpp
         CastExecutionTest.cpp
         CompilationStatisticsTest.cpp


### PR DESCRIPTION
## Context

The bytecode (`bc`) backend is Nautilus's portable, no-codegen execution tier (also tier-0 in tiered compilation). This PR significantly improves its performance while keeping it a **pure interpreter** — no runtime code generation — so it stays usable on platforms such as iOS that forbid JIT/executable memory. (That constraint rules out copy-and-patch, AsmJit, subroutine threading, and dynamic native-code superinstructions; the remaining research-backed wins are dispatch, layout, static superinstructions, and predecode/quickening — Ertl & Gregg, *The Structure and Performance of Efficient Interpreters*, et al.)

Every change is gated behind a `bc.*` option that defaults to current behavior, so each is independently measurable via the `ExecutionBenchmark` A/B harness and reversible.

## Changes

| Option | What | Notes |
|---|---|---|
| `bc.dispatch=switch` | Inlined switch dispatch | Removes the per-op non-inlined indirect call |
| `bc.dispatch=threaded` | Computed-goto (token-threaded) dispatch | Distinct branch-prediction site per opcode; falls back to `switch` where labels-as-values is unavailable (e.g. MSVC) |
| (threaded) | **Basic-block flattening** | Terminators become real `JMP`/`CJMP`/`RET` opcodes, removing the per-block `std::variant` terminator dispatch on every loop back-edge |
| `bc.regfileReuse` | Recycle the per-invocation register file from a thread-local pool | Removes the per-call heap allocation; reentrant (nested bc→bc) and thread-safe by construction |
| `bc.superinstructions` | Fuse single-use compare+branch into one op (threaded) | `CJMP_<pred>_{i32,i64}`; soundness from lowering single-use info + last-op operand-safety check |
| `bc.immediates` | Fold small constant operands into ADD/SUB/MUL (threaded) | Immediate packed into the `OpCode` `reg2` short; covers `i = i + 1` |

All opcode tables (the legacy `OpTable`, the switch, the threaded label table/handlers, the fused and immediate opcodes, and their mappings) are generated from single X-macro lists, so the dispatch paths cannot drift. The flattening, superinstructions and immediates are confined to the `threaded` path; `call`/`switch` keep the structured per-block terminators, which is what lets the test validate the threaded transforms against the unchanged `call` reference.

## Results (local best-of-7, clang; CI benchmark is authoritative)

- `switch` vs `call` (CI, Step 1): **1.47× sum, 1.32× fibonacci**, 1.10× add.
- `threaded` (flattened) vs `call`: **~1.12× sum, ~1.20× fibonacci**.
- `superinstructions` on threaded: +**1.10× fibonacci**, +1.06–1.08× sum.
- `immediates` on threaded: ~1% in isolation (within noise; composes with the above — superinstructions+immediates ≈ 1.08–1.11× over the threaded baseline).
- `regfileReuse`: targets per-call allocation (add); see `exec_bc_add_threaded_reuse` vs `noReuse` on the CI runner.

## Correctness

- The opcode macro is an exact, in-order reproduction of the original `OpTable` (verified by diff).
- `BCDispatchModeTest` runs a spread of kernels (arithmetic, fibonacci, sum loop, nested branches, int↔float↔double casts, modulo, bitwise; all six comparison predicates × i32/i64; constant operands incl. negative and too-large-to-fold) across **all combinations** of dispatch mode × regfileReuse × superinstructions × immediates, asserting they match the `call` reference — 3311 assertions. Full execution suite: 6942 assertions, all passing locally.
- Reentrancy and concurrency of `regfileReuse` separately validated (nested-safe pool + multi-threaded run).
- Computed goto verified to compile under the project's `-pedantic-errors` on clang and gcc (locally wrapped diagnostic pragmas; switch fallback otherwise). Changed files are clang-format clean.

## Defaults

All `bc.*` options default to the current behavior (`call` dispatch, no reuse/superinstructions/immediates), so this PR changes no behavior unless opted in. Flipping defaults can follow once the CI benchmark confirms the wins across compilers.
