### PR TITLE
Bring AsmJit x64 and ARM backends to code-gen parity

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -474,7 +474,15 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 		else
 			condCode = static_cast<uint32_t>(CC::kNE);
 	} else {
-		cc.cmp(toGp(left), toGp(right));
+		// Peephole: `cmp x, <const 0>` → `cmp x, #0` (immediate form). Same
+		// NZCV output, and it avoids depending on a separately-materialized
+		// zero register, which lets that constant be dead-code-eliminated.
+		const auto* rightConst = ir::dyn_cast<ir::ConstIntOperation>(op->getRightInput());
+		if (rightConst != nullptr && rightConst->getValue() == 0) {
+			cc.cmp(toGp(left), Imm(0));
+		} else {
+			cc.cmp(toGp(left), toGp(right));
+		}
 		if (leftIsUnsigned) {
 			switch (op->getComparator()) {
 			case ir::CompareOperation::EQ:

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -788,10 +788,15 @@ void AsmJitLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* o
 void AsmJitLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* op, RegisterFrame& frame) {
 	if (op->hasReturnValue()) {
 		auto retReg = frame.getValue(op->getReturnValue()->getIdentifier());
-		if (std::holds_alternative<Xmm>(retReg))
+		if (std::holds_alternative<Xmm>(retReg)) {
 			cc.ret(toXmm(retReg));
-		else
-			cc.ret(toGp(retReg));
+		} else {
+			auto gp = toGp(retReg);
+			// Narrow the value to its declared stamp so the caller sees a clean
+			// register matching the ABI contract (mirrors A64's visitReturn).
+			narrowToStamp(gp, op->getReturnValue()->getStamp());
+			cc.ret(gp);
+		}
 	} else {
 		cc.ret();
 	}
@@ -1024,6 +1029,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 		// A64LoweringProvider::visitCast's two-step extend-then-narrow.
 		auto gSrc = toGp(src);
 		auto gDst = toGp(result);
+		// Step 1: extend from source width.
 		switch (srcType) {
 		case Type::i8:
 			cc.movsx(gDst.r64(), gSrc.r8());
@@ -1050,13 +1056,16 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 		}
 		narrowToStamp(gDst, dstType);
 	} else if (srcIsFloat && !dstIsFloat) {
-		// Float → integer: truncate toward zero.
+		// Float → integer: truncate toward zero, then narrow to the destination
+		// width so the value is defined by its low dstWidth bits (see the
+		// integer→integer path above). Mirrors A64LoweringProvider::visitCast.
 		auto gDst = toGp(result);
 		auto xSrc = toXmm(src);
 		if (srcType == Type::f32)
 			cc.cvttss2si(gDst.r64(), xSrc);
 		else
 			cc.cvttsd2si(gDst.r64(), xSrc);
+		narrowToStamp(gDst, dstType);
 	} else if (!srcIsFloat && dstIsFloat) {
 		// Integer → float.
 		auto gSrc = toGp(src);

--- a/nautilus/test/execution-tests/CastExecutionTest.cpp
+++ b/nautilus/test/execution-tests/CastExecutionTest.cpp
@@ -147,10 +147,47 @@ void ptrCastTest(engine::NautilusEngine& engine) {
 	}
 }
 
+// Regression for the AsmJit narrowing-cast lowering. A narrowing integer cast
+// must drop the stale high bits *before* the value reaches a full-width
+// consumer. The x64 backend previously only sign/zero-extended from the source
+// width and skipped the narrow-to-destination step, so a value like
+// (int8_t)200 stayed 200 in its 64-bit register instead of -56. Widening casts
+// and re-narrowing casts read sub-registers and therefore masked the bug; a
+// signed comparison reads the full register and exposes it. The ARM backend
+// already performed the narrowing, so this also pins the two backends to the
+// same observable behavior.
+template <typename In, typename Narrow>
+val<int32_t> narrowCastThenSignTest(val<In> x) {
+	val<Narrow> n = static_cast<val<Narrow>>(x);
+	if (n > val<Narrow>(0)) {
+		return val<int32_t>(1);
+	}
+	return val<int32_t>(0);
+}
+
+template <typename In, typename Narrow>
+void checkNarrowCastSign(engine::NautilusEngine& engine, std::string name, std::initializer_list<In> inputs) {
+	DYNAMIC_SECTION(name) {
+		auto f = engine.registerFunction(narrowCastThenSignTest<In, Narrow>);
+		for (In in : inputs) {
+			const int32_t reference = (static_cast<Narrow>(in) > static_cast<Narrow>(0)) ? 1 : 0;
+			REQUIRE(f(in) == reference);
+		}
+	}
+}
+
+void narrowCastSignTest(engine::NautilusEngine& engine) {
+	// Inputs chosen so the narrowed value differs in sign from the source.
+	checkNarrowCastSign<int32_t, int8_t>(engine, "i32_to_i8", {0, 100, 200, 384, -200});
+	checkNarrowCastSign<int32_t, int16_t>(engine, "i32_to_i16", {0, 1000, 40000, 100000, -40000});
+	checkNarrowCastSign<int64_t, int8_t>(engine, "i64_to_i8", {0, 127, 128, 255, 256});
+}
+
 TEST_CASE("Cast Interpreter Test") {
 	auto engine = nautilus::testing::makeEngine("interpreter");
 	castTest(engine);
 	ptrCastTest(engine);
+	narrowCastSignTest(engine);
 }
 
 #ifdef ENABLE_TRACING
@@ -160,6 +197,10 @@ TEST_CASE("Cast Compiler Test") {
 
 TEST_CASE("Pointer Cast Compiler Test") {
 	nautilus::testing::forEachBackendWithTraceMode([](engine::NautilusEngine& engine) { ptrCastTest(engine); });
+}
+
+TEST_CASE("Narrowing Cast Sign Compiler Test") {
+	nautilus::testing::forEachBackendWithTraceMode([](engine::NautilusEngine& engine) { narrowCastSignTest(engine); });
 }
 #endif
 } // namespace nautilus::engine


### PR DESCRIPTION
## Summary

The two AsmJit lowering providers (`X64LoweringProvider` and `A64LoweringProvider`) had each pulled ahead of the other in different areas. The ARM backend had more complete/correct integer-cast and return-value lowering; the x64 backend had a more capable peephole layer. This migrates the stronger code generation **in both directions** so the backends produce equivalent observable results.

## ARM → x64 (lowering completeness / correctness)

- **`visitCast` (int → int):** add the *narrow-to-destination* step the ARM backend already performed. x64 previously only sign/zero-extended from the **source** width, leaving stale high bits on a narrowing cast (e.g. `(int8_t)200` stayed `200` instead of `-56`). Widening casts and re-narrowing reads sub-registers and masked this, but a full-width consumer such as a signed comparison observed the wrong value.
- **`visitCast` (float → int):** narrow the truncated result to sub-32-bit destinations.
- **`visitReturn`:** sign/zero-extend sub-32-bit return values to a clean ABI register, matching the ARM backend.

## x64 → ARM (peephole)

- **`visitCompare`:** fold a constant-zero right operand into the immediate `cmp x, #0` form — the AArch64 analog of x64's `cmp x,0 → test x,x` — avoiding a dependency on a separately materialized zero register.
- The x64 **xor-zero idiom** (`mov r,0 → xor r32,r32`) has no AArch64 benefit (fixed-width encoding, a dedicated zero register `xzr`/`wzr`, no false-dependency hazard) and is already documented as intentionally omitted in `A64PostRAPeepholePass`, so it is deliberately not ported.

## Tests

- Added a `CastExecutionTest` regression that runs a narrowing cast feeding a signed comparison across every backend (interpreter, cpp, bc, asmjit). It **fails on the pre-fix x64 lowering** (verified by reverting the change) and passes after.
- Full execution suite: **11500 assertions, 47 cases (45 passed, 2 skipped)**. Val-tests: **1275 assertions, 102 cases** passing. Built with Clang and the AsmJit backend enabled.

> Note: the ARM (`A64*.cpp`) sources only compile on AArch64 hosts (selected in `amsjit/CMakeLists.txt`), so the ARM-side change was verified by mirroring patterns already present and exercised in that file (`ir::dyn_cast<ir::ConstIntOperation>`, immediate `cmp`); CI's ARM build job will compile-check it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012qoJu1FQsn4aXMkU8nChKh)_