### PR TITLE
Add iOS-safe libffi closure path to the bytecode backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ cmake_dependent_option(NAUTILUS_DOWNLOAD_MLIR "Download pre-built MLIR binaries"
 cmake_dependent_option(ENABLE_C_BACKEND "Enable the C compiler backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_BC_BACKEND "Enable the bytecode interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_TBC_BACKEND "Enable the threaded bytecode interpreter backend" ON "ENABLE_TRACING" OFF)
+cmake_dependent_option(ENABLE_BC_LIBFFI "Use libffi static-trampoline closures for the bytecode backend instead of dyncall callbacks (iOS-safe: no runtime-generated executable memory)" OFF "ENABLE_BC_BACKEND" OFF)
 cmake_dependent_option(ENABLE_ASMJIT_BACKEND "Enable the asmjit interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_SHORT_CIRCUIT_BOOL "Trace val<bool> && / || with C++ short-circuit semantics (drops the operator overloads so the built-in operators route through val<bool>::operator bool())" OFF "ENABLE_TRACING" OFF)
 
@@ -170,6 +171,19 @@ endif ()
 if (ENABLE_BC_BACKEND OR ENABLE_TBC_BACKEND)
     add_subdirectory(${THIRD_PARTY_DIR}/dyncall)
     list(APPEND EXPORT_TARGETS dyncall_s)
+
+    if (ENABLE_BC_LIBFFI)
+        # The bytecode backend exposes each compiled function as a real C
+        # function pointer. By default this uses a dyncall callback, which
+        # writes a trampoline into RWX memory at runtime — forbidden on iOS.
+        # libffi (>= 3.4) builds closures via static trampolines (a read-only
+        # code page + a separate writable data page, no runtime PROT_EXEC), so
+        # the closure pointer stays usable where runtime codegen is banned.
+        # We locate libffi rather than vendor it: desktop/CI provide it via the
+        # system package; an iOS toolchain points at Apple's static-trampoline
+        # libffi the same way.
+        include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindNautilusFFI.cmake)
+    endif ()
 endif ()
 
 if (ENABLE_ASMJIT_BACKEND)

--- a/cmake/FindNautilusFFI.cmake
+++ b/cmake/FindNautilusFFI.cmake
@@ -1,0 +1,55 @@
+# Locate libffi for the bytecode backend's iOS-safe closure path and expose it
+# as the imported target `nautilus::ffi`.
+#
+# The bytecode backend uses libffi closures (built with static trampolines) to
+# hand out a real C function pointer without allocating runtime-executable (RWX)
+# memory, which is required on iOS. libffi >= 3.4 enables static trampolines by
+# default on Apple and Linux targets.
+#
+# Resolution order:
+#   1. pkg-config (libffi), which is how desktop/CI and cross toolchains ship it.
+#   2. A manual find_path/find_library fallback.
+#
+# An iOS toolchain provides Apple's static-trampoline libffi through the same
+# discovery (sysroot pkg-config / CMAKE_PREFIX_PATH), so no code change is needed
+# to target the device.
+
+if (TARGET nautilus::ffi)
+    return()
+endif ()
+
+find_package(PkgConfig QUIET)
+if (PkgConfig_FOUND)
+    pkg_check_modules(NAUTILUS_FFI QUIET libffi)
+endif ()
+
+if (NAUTILUS_FFI_FOUND)
+    set(_nautilus_ffi_include_dirs "${NAUTILUS_FFI_INCLUDE_DIRS}")
+    # Prefer the static archive when pkg-config resolves a concrete path.
+    if (NAUTILUS_FFI_LINK_LIBRARIES)
+        set(_nautilus_ffi_link "${NAUTILUS_FFI_LINK_LIBRARIES}")
+    else ()
+        set(_nautilus_ffi_link "${NAUTILUS_FFI_LIBRARIES}")
+    endif ()
+    set(_nautilus_ffi_version "${NAUTILUS_FFI_VERSION}")
+else ()
+    find_path(NAUTILUS_FFI_INCLUDE_DIR ffi.h)
+    find_library(NAUTILUS_FFI_LIBRARY NAMES ffi libffi)
+    if (NOT NAUTILUS_FFI_INCLUDE_DIR OR NOT NAUTILUS_FFI_LIBRARY)
+        message(FATAL_ERROR
+                "ENABLE_BC_LIBFFI is ON but libffi was not found. Install libffi "
+                ">= 3.4 (e.g. 'apt install libffi-dev' / 'brew install libffi') or "
+                "point CMAKE_PREFIX_PATH / a toolchain file at a libffi build that "
+                "uses static trampolines.")
+    endif ()
+    set(_nautilus_ffi_include_dirs "${NAUTILUS_FFI_INCLUDE_DIR}")
+    set(_nautilus_ffi_link "${NAUTILUS_FFI_LIBRARY}")
+    set(_nautilus_ffi_version "unknown")
+endif ()
+
+add_library(nautilus::ffi INTERFACE IMPORTED)
+set_target_properties(nautilus::ffi PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_nautilus_ffi_include_dirs}"
+        INTERFACE_LINK_LIBRARIES "${_nautilus_ffi_link}")
+
+message(STATUS "Bytecode backend: using libffi closures (version ${_nautilus_ffi_version}) for iOS-safe function pointers")

--- a/nautilus/CMakeLists.txt
+++ b/nautilus/CMakeLists.txt
@@ -6,6 +6,9 @@ if (ENABLE_TESTS)
     set(TEST_DATA_FOLDER "${CMAKE_CURRENT_SOURCE_DIR}/test/data/")
 endif ()
 # create config file with all compile time options
+# The libffi closure path is selected by the ENABLE_BC_LIBFFI option but exposed to
+# source as NAUTILUS_BC_LIBFFI; mirror the value so #cmakedefine emits the define.
+set(NAUTILUS_BC_LIBFFI ${ENABLE_BC_LIBFFI})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/nautilus/common/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/nautilus/config.hpp)
 
 add_subdirectory(src)
@@ -58,7 +61,7 @@ endif ()
 include(GNUInstallDirs)
 add_library(${PROJECT_NAME}::nautilus ALIAS nautilus)
 
-if (ENABLE_BC_BACKEND AND TARGET dyncallback_s)
+if (ENABLE_BC_BACKEND AND NOT ENABLE_BC_LIBFFI AND TARGET dyncallback_s)
     list(APPEND EXPORT_TARGETS dyncallback_s)
 endif ()
 

--- a/nautilus/include/nautilus/common/config.h.in
+++ b/nautilus/include/nautilus/common/config.h.in
@@ -4,6 +4,7 @@
 #cmakedefine ENABLE_LOGGING
 #cmakedefine ENABLE_BC_BACKEND
 #cmakedefine ENABLE_TBC_BACKEND
+#cmakedefine NAUTILUS_BC_LIBFFI
 #cmakedefine ENABLE_C_BACKEND
 #cmakedefine ENABLE_MLIR_BACKEND
 #cmakedefine ENABLE_ASMJIT_BACKEND

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -592,13 +592,17 @@ void BCInterpreter::buildFlatCode() {
 
 BCExecutable::BCExecutable(std::unordered_map<std::string, void*> functionPtrs,
                            std::vector<std::unique_ptr<BCCallbackData>> callbackData,
-                           std::vector<DCCallback*> callbacks)
+                           std::vector<BCClosureHandle> callbacks)
     : functionPtrs_(std::move(functionPtrs)), callbackData_(std::move(callbackData)), callbacks_(std::move(callbacks)) {
 }
 
 BCExecutable::~BCExecutable() {
 	for (auto* cb : callbacks_) {
+#ifdef NAUTILUS_BC_LIBFFI
+		ffi_closure_free(cb);
+#else
 		dcbFreeCallback(cb);
+#endif
 	}
 }
 
@@ -638,7 +642,8 @@ void releaseRegisterFile(RegisterFile&& buf) {
 }
 } // namespace
 
-int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
+template <class Reader>
+int64_t BCInterpreter::invokeImpl(const std::vector<Type>& argTypes, Reader reader) {
 	// Per-invocation register file: a fresh copy by default, or one recycled from a
 	// thread-local pool when bc.regfileReuse is set. Both give each invocation its
 	// own buffer, so nested and concurrent calls remain correct.
@@ -663,10 +668,68 @@ int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
 		regs[reg] = reinterpret_cast<int64_t>(localAllocaBuffers[bufIdx].data());
 	}
 
-	// Read arguments from DCArgs directly into the local register file.
+	// Load arguments into the local register file. The reader is the only part that
+	// differs between the dyncall and libffi entry points.
 	for (size_t i = 0; i < argTypes.size(); i++) {
-		auto reg = code.arguments[i];
-		switch (argTypes[i]) {
+		reader(regs, code.arguments[i], argTypes[i], i);
+	}
+
+	return execute(regs);
+}
+
+#ifdef NAUTILUS_BC_LIBFFI
+int64_t BCInterpreter::invoke(void** args, const std::vector<Type>& argTypes) {
+	// libffi passes each argument as a pointer to its native value in args[i].
+	return invokeImpl(argTypes, [args](RegisterFile& regs, short reg, Type type, size_t i) {
+		switch (type) {
+		case Type::b:
+			// bool is mapped to ffi_type_uint8; read a single byte.
+			writeReg<bool>(regs, reg, *reinterpret_cast<uint8_t*>(args[i]) != 0);
+			break;
+		case Type::i8:
+			writeReg<int8_t>(regs, reg, *reinterpret_cast<int8_t*>(args[i]));
+			break;
+		case Type::i16:
+			writeReg<int16_t>(regs, reg, *reinterpret_cast<int16_t*>(args[i]));
+			break;
+		case Type::i32:
+			writeReg<int32_t>(regs, reg, *reinterpret_cast<int32_t*>(args[i]));
+			break;
+		case Type::i64:
+			writeReg<int64_t>(regs, reg, *reinterpret_cast<int64_t*>(args[i]));
+			break;
+		case Type::ui8:
+			writeReg<uint8_t>(regs, reg, *reinterpret_cast<uint8_t*>(args[i]));
+			break;
+		case Type::ui16:
+			writeReg<uint16_t>(regs, reg, *reinterpret_cast<uint16_t*>(args[i]));
+			break;
+		case Type::ui32:
+			writeReg<uint32_t>(regs, reg, *reinterpret_cast<uint32_t*>(args[i]));
+			break;
+		case Type::ui64:
+			writeReg<uint64_t>(regs, reg, *reinterpret_cast<uint64_t*>(args[i]));
+			break;
+		case Type::f32:
+			writeReg<float>(regs, reg, *reinterpret_cast<float*>(args[i]));
+			break;
+		case Type::f64:
+			writeReg<double>(regs, reg, *reinterpret_cast<double*>(args[i]));
+			break;
+		case Type::ptr:
+			regs[reg] = reinterpret_cast<int64_t>(*reinterpret_cast<void**>(args[i]));
+			break;
+		default:
+			break;
+		}
+	});
+}
+#else
+int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
+	// dyncall reads arguments sequentially from the DCArgs cursor, so the reader must
+	// consume them in order; invokeImpl iterates argTypes in order.
+	return invokeImpl(argTypes, [args](RegisterFile& regs, short reg, Type type, size_t) {
+		switch (type) {
 		case Type::b:
 			// dyncall's dcbArgBool returns DCbool (int); mask to the low
 			// byte before converting to bool — see Dyncall::callB.
@@ -708,10 +771,9 @@ int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
 		default:
 			break;
 		}
-	}
-
-	return execute(regs);
+	});
 }
+#endif
 
 int64_t BCInterpreter::execute(RegisterFile& regs) const {
 #ifdef NAUTILUS_BC_HAS_COMPUTED_GOTO

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -2,11 +2,24 @@
 
 #include "nautilus/Executable.hpp"
 #include "nautilus/compiler/backends/bc/ByteCode.hpp"
-#include <dyncall_args.h>
-#include <dyncall_callback.h>
+#include "nautilus/config.hpp"
 #include <memory>
 #include <unordered_map>
 #include <vector>
+
+// The bytecode backend hands each compiled function to its caller as a real C
+// function pointer. The default mechanism is a dyncall callback (dcbNewCallback),
+// which writes a trampoline into RWX memory at runtime. When NAUTILUS_BC_LIBFFI is
+// defined the function pointer is instead a libffi closure built with static
+// trampolines (no runtime-executable memory), which is what makes the backend
+// usable on iOS where runtime codegen is banned. The two paths differ only at the
+// closure boundary; the interpreter core is shared.
+#ifdef NAUTILUS_BC_LIBFFI
+#include <ffi.h>
+#else
+#include <dyncall_args.h>
+#include <dyncall_callback.h>
+#endif
 
 namespace nautilus::compiler::bc {
 
@@ -47,12 +60,29 @@ struct BCInterpreterOptions {
 	bool immediates = false;
 };
 
-/// Data passed to the dyncallback handler for each function.
+/// Data passed to the closure handler for each function.
 struct BCCallbackData {
 	std::unique_ptr<class BCInterpreter> interpreter;
 	std::vector<Type> argTypes;
 	Type returnType;
+#ifdef NAUTILUS_BC_LIBFFI
+	// The cif and its argument-type array must outlive the closure: ffi_prep_cif
+	// stores a pointer into argFFITypes, and the closure references the cif.
+	ffi_cif cif {};
+	std::vector<ffi_type*> argFFITypes;
+	ffi_closure* closure = nullptr;
+	void* code = nullptr;
+#endif
 };
+
+#ifdef NAUTILUS_BC_LIBFFI
+/// Handle to the per-function closure that owns the executable thunk; freed when
+/// the executable is destroyed. libffi static-trampoline closure (iOS-safe).
+using BCClosureHandle = ffi_closure*;
+#else
+/// dyncall callback handle (runtime-generated thunk).
+using BCClosureHandle = DCCallback*;
+#endif
 
 /**
  * @brief Interprets a single bytecode function.
@@ -61,10 +91,24 @@ class BCInterpreter {
 public:
 	BCInterpreter(Code code, RegisterFile registerFile, BCInterpreterOptions options = {});
 
+#ifdef NAUTILUS_BC_LIBFFI
+	/// Read arguments from a libffi closure's argument array (args[i] points to the
+	/// i-th argument) into the register file, execute, and return the raw result.
+	int64_t invoke(void** args, const std::vector<Type>& argTypes);
+#else
 	/// Read arguments from DCArgs directly into the register file, execute, and return the raw result.
 	int64_t invoke(DCArgs* args, const std::vector<Type>& argTypes);
+#endif
 
 private:
+	/// Shared invocation core: set up the per-invocation register file (recycled or
+	/// fresh) and alloca buffers, load arguments via @p reader, then execute. The
+	/// @p reader is called once per argument as reader(regs, reg, type, index) and is
+	/// the only part that differs between the dyncall and libffi entry points, so the
+	/// register-file/alloca setup and execution stay identical across both.
+	template <class Reader>
+	int64_t invokeImpl(const std::vector<Type>& argTypes, Reader reader);
+
 	int64_t execute(RegisterFile& regs) const;
 
 	/// Computed-goto (token-threaded) execution path. Only defined on compilers
@@ -98,7 +142,7 @@ private:
 class BCExecutable : public Executable {
 public:
 	BCExecutable(std::unordered_map<std::string, void*> functionPtrs,
-	             std::vector<std::unique_ptr<BCCallbackData>> callbackData, std::vector<DCCallback*> callbacks);
+	             std::vector<std::unique_ptr<BCCallbackData>> callbackData, std::vector<BCClosureHandle> callbacks);
 
 	~BCExecutable() override;
 
@@ -109,7 +153,7 @@ public:
 private:
 	std::unordered_map<std::string, void*> functionPtrs_;
 	std::vector<std::unique_ptr<BCCallbackData>> callbackData_;
-	std::vector<DCCallback*> callbacks_;
+	std::vector<BCClosureHandle> callbacks_;
 };
 
 } // namespace nautilus::compiler::bc

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -2,15 +2,119 @@
 
 #include <chrono>
 #include <cstdint>
-#include <dyncall_callback.h>
+#include <cstring>
 #include <nautilus/CompilationStatistics.hpp>
 #include <nautilus/compiler/backends/bc/BCInterpreter.hpp>
 #include <nautilus/compiler/backends/bc/BCInterpreterBackend.hpp>
 #include <nautilus/compiler/backends/bc/BCLoweringProvider.hpp>
 #include <nautilus/compiler/backends/bc/ByteCode.hpp>
 #include <nautilus/compiler/ir/operations/FunctionOperation.hpp>
+#include <nautilus/config.hpp>
+#include <stdexcept>
+
+#ifdef NAUTILUS_BC_LIBFFI
+#include <ffi.h>
+#else
+#include <dyncall_callback.h>
+#endif
 
 namespace nautilus::compiler::bc {
+
+#ifdef NAUTILUS_BC_LIBFFI
+
+/// Map a nautilus Type to the libffi type used in the closure signature.
+static ffi_type* typeToFFIType(Type type) {
+	switch (type) {
+	case Type::b:
+		// C++ bool is one byte; there is no ffi_type_bool.
+		return &ffi_type_uint8;
+	case Type::i8:
+		return &ffi_type_sint8;
+	case Type::i16:
+		return &ffi_type_sint16;
+	case Type::i32:
+		return &ffi_type_sint32;
+	case Type::i64:
+		return &ffi_type_sint64;
+	case Type::ui8:
+		return &ffi_type_uint8;
+	case Type::ui16:
+		return &ffi_type_uint16;
+	case Type::ui32:
+		return &ffi_type_uint32;
+	case Type::ui64:
+		return &ffi_type_uint64;
+	case Type::f32:
+		return &ffi_type_float;
+	case Type::f64:
+		return &ffi_type_double;
+	case Type::ptr:
+		return &ffi_type_pointer;
+	case Type::v:
+		return &ffi_type_void;
+	}
+	return &ffi_type_void;
+}
+
+/// libffi closure handler: reads arguments from the libffi argument array into the
+/// interpreter's register file, executes, and writes the typed result to `ret`.
+static void bcFFIHandler(ffi_cif* /*cif*/, void* ret, void** args, void* userdata) {
+	auto* data = static_cast<BCCallbackData*>(userdata);
+	auto raw = data->interpreter->invoke(args, data->argTypes);
+
+	switch (data->returnType) {
+	case Type::v:
+		return;
+	case Type::b:
+		// Integral/pointer returns must be written at ffi_arg width; cast through
+		// the concrete type first so libffi's truncation yields the right value.
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<bool>(raw));
+		return;
+	case Type::i8:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<int8_t>(raw));
+		return;
+	case Type::i16:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<int16_t>(raw));
+		return;
+	case Type::i32:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<int32_t>(raw));
+		return;
+	case Type::i64:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<int64_t>(raw));
+		return;
+	case Type::ui8:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<uint8_t>(raw));
+		return;
+	case Type::ui16:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<uint16_t>(raw));
+		return;
+	case Type::ui32:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<uint32_t>(raw));
+		return;
+	case Type::ui64:
+		*static_cast<ffi_arg*>(ret) = static_cast<ffi_arg>(static_cast<uint64_t>(raw));
+		return;
+	case Type::f32: {
+		// The result register holds the float's bit pattern; reinterpret, do not
+		// numerically convert.
+		float value;
+		std::memcpy(&value, &raw, sizeof(float));
+		*static_cast<float*>(ret) = value;
+		return;
+	}
+	case Type::f64: {
+		double value;
+		std::memcpy(&value, &raw, sizeof(double));
+		*static_cast<double*>(ret) = value;
+		return;
+	}
+	case Type::ptr:
+		*static_cast<void**>(ret) = reinterpret_cast<void*>(raw);
+		return;
+	}
+}
+
+#else
 
 static char typeToDCSigChar(Type type) {
 	switch (type) {
@@ -107,6 +211,8 @@ static DCsigchar bcCallbackHandler(DCCallback* /*pcb*/, DCArgs* args, DCValue* r
 	return DC_SIGCHAR_VOID;
 }
 
+#endif // NAUTILUS_BC_LIBFFI
+
 std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<ir::IRGraph>& ir,
                                                           const DumpHandler& dumpHandler,
                                                           const engine::Options& options,
@@ -116,7 +222,7 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 
 	std::unordered_map<std::string, void*> functionPtrs;
 	std::vector<std::unique_ptr<BCCallbackData>> callbackDataStore;
-	std::vector<DCCallback*> callbackPtrs;
+	std::vector<BCClosureHandle> callbackPtrs;
 
 	// Lowering-time option: the simple linear register allocator is
 	// enabled by default but can be turned off via "bc.registerAllocator"
@@ -146,7 +252,7 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 	interpreterOptions.superinstructions = options.getOptionOrDefault("bc.superinstructions", false);
 	interpreterOptions.immediates = options.getOptionOrDefault("bc.immediates", false);
 
-	// Phase 1: Allocate callback data and dyncallback thunks for all functions.
+	// Phase 1: Allocate callback data and closure thunks for all functions.
 	// The interpreter is not yet set — we need all function pointers resolved first.
 	for (const auto& funcOp : functionOperations) {
 		auto data = std::make_unique<BCCallbackData>();
@@ -156,10 +262,35 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 		}
 		data->returnType = funcOp->getOutputArg();
 
+#ifdef NAUTILUS_BC_LIBFFI
+		// Build a libffi closure with a static-trampoline thunk (no runtime RWX
+		// memory). The cif and its argument-type array are stored in `data` so they
+		// outlive the closure.
+		data->argFFITypes.reserve(data->argTypes.size());
+		for (auto argType : data->argTypes) {
+			data->argFFITypes.push_back(typeToFFIType(argType));
+		}
+		void* code = nullptr;
+		data->closure = static_cast<ffi_closure*>(ffi_closure_alloc(sizeof(ffi_closure), &code));
+		if (data->closure == nullptr) {
+			throw std::runtime_error("Failed to allocate libffi closure for bytecode function");
+		}
+		if (ffi_prep_cif(&data->cif, FFI_DEFAULT_ABI, static_cast<unsigned int>(data->argFFITypes.size()),
+		                 typeToFFIType(data->returnType), data->argFFITypes.data()) != FFI_OK) {
+			throw std::runtime_error("Failed to prepare libffi call interface for bytecode function");
+		}
+		if (ffi_prep_closure_loc(data->closure, &data->cif, bcFFIHandler, data.get(), code) != FFI_OK) {
+			throw std::runtime_error("Failed to prepare libffi closure for bytecode function");
+		}
+		data->code = code;
+		functionPtrs[funcOp->getName()] = code;
+		callbackPtrs.push_back(data->closure);
+#else
 		auto sig = buildDCSignature(data->argTypes, data->returnType);
 		auto* cb = dcbNewCallback(sig.c_str(), bcCallbackHandler, data.get());
 		functionPtrs[funcOp->getName()] = reinterpret_cast<void*>(cb);
 		callbackPtrs.push_back(cb);
+#endif
 		callbackDataStore.push_back(std::move(data));
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/bc/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/bc/CMakeLists.txt
@@ -1,11 +1,23 @@
 
 
 if (ENABLE_BC_BACKEND)
-    # Link the external library to nes-runtime
-    target_link_libraries(nautilus PRIVATE dyncall_s dyncallback_s)
+    # dyncall forward-call VM (Dyncall.cpp / DYNCALL_* opcodes) is used in both
+    # modes for external proxy/runtime calls. Forward calls do not generate code
+    # at runtime, so they are iOS-safe and always linked.
+    target_link_libraries(nautilus PRIVATE dyncall_s)
 
-    # Add dyncallback include path for dyncall_callback.h
-    target_include_directories(nautilus PRIVATE ${PROJECT_SOURCE_DIR}/third_party/dyncall/dyncallback)
+    if (ENABLE_BC_LIBFFI)
+        # iOS-safe closures via libffi static trampolines instead of dyncall
+        # callbacks. dyncallback is intentionally not linked here so no
+        # RWX-allocating callback code is reachable.
+        target_link_libraries(nautilus PRIVATE nautilus::ffi)
+    else ()
+        # Default: dyncall callbacks (dcbNewCallback) expose each function as a
+        # C function pointer. Writes a trampoline into RWX memory at runtime.
+        target_link_libraries(nautilus PRIVATE dyncallback_s)
+        # Add dyncallback include path for dyncall_callback.h
+        target_include_directories(nautilus PRIVATE ${PROJECT_SOURCE_DIR}/third_party/dyncall/dyncallback)
+    endif ()
 
     add_source_files(nautilus
             BCInterpreterBackend.cpp


### PR DESCRIPTION
## Why

The bytecode interpreter is the only backend that can run on iOS — MLIR/LLVM-JIT, AsmJit, and the C++ backend all generate executable machine code at runtime, which Apple forbids for App Store apps (no JIT entitlement on iOS).

But despite the interpreter core being a pure-data interpreter, the BC backend exposes **every** compiled function through a dyncall **callback** (`dcbNewCallback`). That callback writes a trampoline into **RWX executable memory** at runtime (`third_party/dyncall/dyncallback/dyncall_alloc_wx_mmap.c` → `PROT_READ|PROT_WRITE|PROT_EXEC` + `mprotect(..., PROT_EXEC)`), which faults / is rejected on iOS. So the backend can't actually run on-device today.

## What

Adds an **opt-in** `ENABLE_BC_LIBFFI` CMake flag (default **OFF**) that swaps the dyncall callback for a **libffi closure**. libffi ≥ 3.4 builds closures with **static trampolines** — a read-only code page plus a separate writable data page, with no runtime `PROT_EXEC` — so the closure is still a real C function pointer (callable by external native code) but needs no runtime-executable memory. This is the same mechanism that lets ctypes/Python work on iOS.

Only the closure boundary differs between the two modes; the interpreter core, register marshalling, IR lowering, and the `Executable` function-pointer contract are shared. dyncall **forward** calls (`dcCall*`) stay in both modes for external proxy/runtime calls — they generate no code and are already iOS-safe.

### Changes
- `ENABLE_BC_LIBFFI` option → `NAUTILUS_BC_LIBFFI` config define.
- `cmake/FindNautilusFFI.cmake` locates libffi (pkg-config, then `find_library` fallback) and exposes it as the imported target `nautilus::ffi`. An iOS toolchain provides Apple's static-trampoline libffi through the same discovery, so no code change is needed to target the device.
- BC backend links `ffi` when ON, `dyncallback_s` when OFF; `dyncall_s` (forward) is always linked.
- `bcFFIHandler` + a `Type → ffi_type` mapping; `ffi_cif`/`ffi_closure` created per function, with the cif and its argument-type array stored to outlive the closure.
- `BCInterpreter::invoke(void**)` reads arguments from the libffi argument array; a shared `invokeImpl` keeps the per-invocation register-file and alloca setup identical to the dyncall path.

## Default behavior unchanged

With `ENABLE_BC_LIBFFI=OFF` (the default) the backend is byte-for-byte as before: dyncall callbacks, `dyncallback_s` linked, libffi not built/required.

## Verification

Built and tested on Linux x86-64 (clang) with **both** flag values — all 180 tests pass in each config, including `BCDispatchModeTest`, `ModuleTest`, `TieredCompilationTest` (BC as tier-0, exercising internal multi-function calls through the libffi `code` pointers), and `FunctionPtrExecutionTest`.

In the `ON` build the final binary links `libffi` (`ffi_closure_alloc` / `ffi_prep_cif` / `ffi_prep_closure_loc`) and contains **zero** `dcbNewCallback` references — the code-level proxy for the iOS executable-memory ban (no iOS device/toolchain is available in CI here). The iOS-safety guarantee is `FFI_EXEC_STATIC_TRAMP`, a property of the libffi build used (Apple's iOS libffi enables it).

## Notes / follow-ups (out of scope)
- A future change could consolidate onto a single FFI library by also moving dyncall forward calls to libffi `ffi_call`, dropping the dyncall dependency entirely.
- Dispatch-mode defaults and new performance superinstructions remain opt-in / deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xuz3fvuoaaKmGVW9SNLZ9B)_