### PR TITLE
Extend the differential fuzzer to multi-width ints, casts, and floats

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -142,6 +142,32 @@ bool AsmJitLoweringProvider::LoweringContext::isUnsignedType(Type t) {
 	return t == Type::ui8 || t == Type::ui16 || t == Type::ui32 || t == Type::ui64 || t == Type::b || t == Type::ptr;
 }
 
+void AsmJitLoweringProvider::LoweringContext::narrowToStamp(Gp reg, Type stamp) {
+	switch (stamp) {
+	case Type::i8:
+		cc.movsx(reg.r64(), reg.r8());
+		break;
+	case Type::b:
+	case Type::ui8:
+		cc.movzx(reg.r32(), reg.r8());
+		break;
+	case Type::i16:
+		cc.movsx(reg.r64(), reg.r16());
+		break;
+	case Type::ui16:
+		cc.movzx(reg.r32(), reg.r16());
+		break;
+	case Type::i32:
+		cc.movsxd(reg.r64(), reg.r32());
+		break;
+	case Type::ui32:
+		cc.mov(reg.r32(), reg.r32());
+		break; // zero-extends to 64
+	default:
+		break; // i64, ui64, ptr -- already full-width, no narrowing needed.
+	}
+}
+
 // ── Register allocation ───────────────────────────────────────────────────────
 // All integer/bool/ptr types are represented as 64-bit GP registers.
 // This avoids size-mismatch issues when combining values across operations,
@@ -405,6 +431,11 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 		auto gDst = toGp(result);
 		cc.mov(gDst, toGp(left));
 		cc.add(gDst, toGp(right));
+		// An add that overflows the narrow stamp's width still produces a
+		// "correct" 64-bit sum; re-extend per the result type so its
+		// sign/zero-extension matches the wrapped-around narrow-width value
+		// (see narrowToStamp's doc comment).
+		narrowToStamp(gDst, op->getStamp());
 	}
 	frame.setValue(op->getIdentifier(), result);
 }
@@ -424,6 +455,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, Reg
 		auto gDst = toGp(result);
 		cc.mov(gDst, toGp(left));
 		cc.sub(gDst, toGp(right));
+		narrowToStamp(gDst, op->getStamp());
 	}
 	frame.setValue(op->getIdentifier(), result);
 }
@@ -443,6 +475,7 @@ void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, Reg
 		auto gDst = toGp(result);
 		cc.mov(gDst, toGp(left));
 		cc.imul(gDst, toGp(right));
+		narrowToStamp(gDst, op->getStamp());
 	}
 	frame.setValue(op->getIdentifier(), result);
 }
@@ -505,29 +538,51 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 	const bool leftIsUnsigned = isUnsignedType(op->getLeftInput()->getStamp());
 
 	if (leftIsFloat) {
-		if (op->getLeftInput()->getStamp() == Type::f32)
-			cc.ucomiss(toXmm(left), toXmm(right));
-		else
-			cc.ucomisd(toXmm(left), toXmm(right));
-		// ucomiss/ucomisd is unordered: NaN operands set CF=1 and ZF=1.
-		// This gives correct IEEE 754 semantics (NaN comparisons always false for EQ/LT/LE/GT/GE, true for NE).
+		const bool isF32 = op->getLeftInput()->getStamp() == Type::f32;
+		auto ucomi = [&](Xmm a, Xmm b) {
+			if (isF32)
+				cc.ucomiss(a, b);
+			else
+				cc.ucomisd(a, b);
+		};
+		// ucomiss/ucomisd sets ZF=1,PF=1,CF=1 for an unordered result (either
+		// operand NaN). A single SETcc can't express "ordered and equal" or
+		// "unordered or not-equal" -- EQ/NE additionally need the parity flag
+		// (PF), which signals "unordered". LT/LE instead compare with the
+		// operands swapped and use the "above"/"above-or-equal" condition
+		// (CF=0 required), which is already false for an unordered result;
+		// GT/GE already get this for free without swapping.
 		switch (op->getComparator()) {
-		case ir::CompareOperation::EQ:
+		case ir::CompareOperation::EQ: {
+			ucomi(toXmm(left), toXmm(right));
 			cc.sete(resultGp);
+			auto parity = toGp(allocReg(Type::b)).r8();
+			cc.setnp(parity);
+			cc.and_(resultGp, parity);
 			break;
-		case ir::CompareOperation::NE:
+		}
+		case ir::CompareOperation::NE: {
+			ucomi(toXmm(left), toXmm(right));
 			cc.setne(resultGp);
+			auto parity = toGp(allocReg(Type::b)).r8();
+			cc.setp(parity);
+			cc.or_(resultGp, parity);
 			break;
+		}
 		case ir::CompareOperation::LT:
-			cc.setb(resultGp);
+			ucomi(toXmm(right), toXmm(left));
+			cc.seta(resultGp);
 			break;
 		case ir::CompareOperation::LE:
-			cc.setbe(resultGp);
+			ucomi(toXmm(right), toXmm(left));
+			cc.setae(resultGp);
 			break;
 		case ir::CompareOperation::GT:
+			ucomi(toXmm(left), toXmm(right));
 			cc.seta(resultGp);
 			break;
 		case ir::CompareOperation::GE:
+			ucomi(toXmm(left), toXmm(right));
 			cc.setae(resultGp);
 			break;
 		}
@@ -629,8 +684,14 @@ void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* o
 	// NegateOperation is bitwise NOT (~x): result = input XOR all-ones.
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
-	cc.mov(toGp(result), toGp(src));
-	cc.not_(toGp(result));
+	auto gDst = toGp(result);
+	cc.mov(gDst, toGp(src));
+	cc.not_(gDst);
+	// not_ flips the full 64-bit register, including the extension padding.
+	// That happens to stay correct for signed stamps (flipping a sign bit
+	// flips its replicated extension consistently) but is wrong for unsigned
+	// stamps, whose invariant is a zero-extended (not flipped) upper half.
+	narrowToStamp(gDst, op->getStamp());
 	frame.setValue(op->getIdentifier(), result);
 }
 
@@ -640,16 +701,26 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
-	cc.mov(toGp(result), left);
+	auto gDst = toGp(result);
+	cc.mov(gDst, left);
 	// The shift count operand must be the CL register; AsmJit's Compiler
 	// handles that constraint when a GP register is given as the count.
 	if (op->getType() == ir::ShiftOperation::LS) {
-		cc.shl(toGp(result), right.r8());
+		cc.shl(gDst, right.r8());
 	} else if (isUnsignedType(op->getStamp())) {
-		cc.shr(toGp(result), right.r8());
+		cc.shr(gDst, right.r8());
 	} else {
-		cc.sar(toGp(result), right.r8());
+		cc.sar(gDst, right.r8());
 	}
+	// Shifting the full 64-bit register (rather than just the narrow stamp's
+	// width) can leave the extension padding inconsistent with the
+	// narrow-width result -- e.g. a left shift that overflows the stamp's
+	// width still computes a "correct" 64-bit shift, whose sign-extension no
+	// longer matches the wrapped-around narrow-width value. sar already
+	// shifts in the sign bit, but a shift can still move that bit into
+	// positions that change the narrow-width result's own sign, so this is
+	// needed for all three shift forms.
+	narrowToStamp(gDst, op->getStamp());
 	frame.setValue(op->getIdentifier(), result);
 }
 
@@ -942,7 +1013,15 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 	const bool dstIsFloat = isFloatType(dstType);
 
 	if (!srcIsFloat && !dstIsFloat) {
-		// Integer → integer: sign/zero-extend from source width.
+		// Integer → integer: first extend from source width to get a clean
+		// 64-bit representation, then narrow to destination width. The second
+		// step matters whenever dstWidth <= srcWidth (truncating, or a
+		// same-width signedness change like i16->ui16): the value is then
+		// defined by its low dstWidth bits, and those must be re-extended per
+		// the *destination*'s signedness, not the source's -- e.g. casting
+		// i16(-1) to ui16 must zero-extend the resulting 0xFFFF to produce
+		// 65535, not sign-extend it to 0xFFFFFFFFFFFFFFFF. Mirrors
+		// A64LoweringProvider::visitCast's two-step extend-then-narrow.
 		auto gSrc = toGp(src);
 		auto gDst = toGp(result);
 		switch (srcType) {
@@ -969,6 +1048,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 			cc.mov(gDst, gSrc);
 			break;
 		}
+		narrowToStamp(gDst, dstType);
 	} else if (srcIsFloat && !dstIsFloat) {
 		// Float → integer: truncate toward zero.
 		auto gDst = toGp(result);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -105,6 +105,19 @@ private:
 		static ::asmjit::x86::Gp toGp(const AsmReg& r);
 		static ::asmjit::x86::Xmm toXmm(const AsmReg& r);
 
+		// Re-sign/zero-extend a GP register's low `stamp`-width bits across the
+		// full 64-bit register per `stamp`'s signedness. Integer arithmetic on
+		// sub-64-bit types is computed at full 64-bit width (see the class
+		// comment), which can leave the upper bits inconsistent with the
+		// narrow-width invariant (e.g. an i32 add that overflows 32 bits still
+		// produces a "correct" 64-bit sum, whose 64-bit sign-extension no
+		// longer matches the sign-extension of the wrapped-around 32-bit
+		// result). Every op whose narrow-width result can differ from its
+		// 64-bit computation -- Add/Sub/Mul/Negate(bitwise not)/Shift -- must
+		// restore the invariant afterward so later consumers (comparisons,
+		// casts, ...) that read the full register see the right value.
+		void narrowToStamp(::asmjit::x86::Gp reg, Type stamp);
+
 		::asmjit::Label getOrCreateLabel(ir::BlockIdentifier blockId);
 		void emitMove(const AsmReg& dst, const AsmReg& src);
 

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
@@ -4,7 +4,11 @@
 #include "nautilus/compiler/ir/IRGraph.hpp"
 #include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
+#include <cmath>
+#include <iomanip>
+#include <limits>
 #include <sstream>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 
@@ -92,12 +96,36 @@ private:
 			}
 
 			std::stringstream ss;
-			ss << constValue->getValue();
+			if constexpr (std::is_floating_point_v<decltype(constValue->getValue())>) {
+				const auto value = constValue->getValue();
+				if (std::isnan(value)) {
+					// operator<< prints non-finite doubles as the bare words
+					// "nan"/"inf", which aren't valid C++ literal syntax and
+					// fail to recompile. Emit compiler builtins instead, which
+					// need no extra #include in the generated source.
+					ss << (std::signbit(value) ? "-__builtin_nan(\"\")" : "__builtin_nan(\"\")");
+				} else if (std::isinf(value)) {
+					ss << (value < 0 ? "-__builtin_inf()" : "__builtin_inf()");
+				} else {
+					// Floating-point constants need full round-trip precision:
+					// the default stream precision is 6 significant digits, so
+					// without this the generated C++ source re-parses a
+					// rounded-off literal (e.g. a double could silently lose
+					// ~11 significant digits).
+					ss << std::setprecision(std::numeric_limits<double>::max_digits10);
+					ss << value;
+				}
+			} else {
+				ss << constValue->getValue();
+			}
 			if (ss.str() == "(nil)") {
 				blocks[blockIndex] << var << " = (" << getType(constValue->getStamp()) << ")(nullptr);\n";
 			} else {
-				blocks[blockIndex] << var << " = (" << getType(constValue->getStamp()) << ")" << constValue->getValue()
-				                   << ";\n";
+				// Emit ss.str() (built with round-trip precision above), not a
+				// fresh `<< constValue->getValue()` -- that would re-stream the
+				// raw value at default (6 significant digit) precision and
+				// silently undo the setprecision() above.
+				blocks[blockIndex] << var << " = (" << getType(constValue->getStamp()) << ")" << ss.str() << ";\n";
 			}
 		}
 

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -263,7 +263,14 @@ mlir::arith::CmpFPredicate convertToFloatMLIRComparison(ir::CompareOperation::Co
 	case (ir::CompareOperation::Comparator::GE):
 		return mlir::arith::CmpFPredicate::OGE;
 	case (ir::CompareOperation::Comparator::NE):
-		return mlir::arith::CmpFPredicate::ONE;
+		// Unlike EQ/LT/LE/GT/GE (which are all false whenever either operand is
+		// NaN, matching C++'s "ordered" float comparison semantics), C++'s `!=`
+		// is true whenever either operand is NaN -- it's the negation of `==`,
+		// not an independently-ordered predicate. ONE ("ordered and not-equal")
+		// is false for NaN operands and would silently disagree with `!=` on
+		// every NaN comparison; UNE ("unordered or not-equal") is the correct
+		// match.
+		return mlir::arith::CmpFPredicate::UNE;
 	default:
 		return mlir::arith::CmpFPredicate::OLT;
 	}
@@ -739,7 +746,7 @@ void MLIRLoweringProvider::visitAdd(ir::AddOperation* addOp, ValueFrame& frame) 
 		frame.setValue(addOp->getIdentifier(), elementAddress);
 	} else if (isFloat(addOp->getStamp())) {
 		auto mlirAddOp = builder->create<mlir::LLVM::FAddOp>(getNameLoc("binOpResult"), leftInput.getType(), leftInput,
-		                                                     rightInput, mlir::LLVM::FastmathFlags::fast);
+		                                                     rightInput, mlir::LLVM::FastmathFlags::none);
 		frame.setValue(addOp->getIdentifier(), mlirAddOp);
 	} else {
 		if (!inductionVars.contains(addOp->getLeftInput()->getIdentifier())) {
@@ -766,7 +773,7 @@ void MLIRLoweringProvider::visitSub(ir::SubOperation* subIntOp, ValueFrame& fram
 	} else if (isFloat(subIntOp->getStamp())) {
 		auto mlirSubOp = builder->create<mlir::LLVM::FSubOp>(
 		    getNameLoc("binOpResult"), leftInput, rightInput,
-		    mlir::LLVM::FastmathFlagsAttr::get(context, mlir::LLVM::FastmathFlags::fast));
+		    mlir::LLVM::FastmathFlagsAttr::get(context, mlir::LLVM::FastmathFlags::none));
 		frame.setValue(subIntOp->getIdentifier(), mlirSubOp);
 	} else {
 		auto mlirSubOp = builder->create<mlir::LLVM::SubOp>(getNameLoc("binOpResult"), leftInput, rightInput);
@@ -780,7 +787,7 @@ void MLIRLoweringProvider::visitMul(ir::MulOperation* mulOp, ValueFrame& frame) 
 	auto resultType = leftInput.getType();
 	if (isFloat(mulOp->getStamp())) {
 		auto mlirMulOp = builder->create<mlir::LLVM::FMulOp>(getNameLoc("binOpResult"), resultType, leftInput,
-		                                                     rightInput, mlir::LLVM::FastmathFlags::fast);
+		                                                     rightInput, mlir::LLVM::FastmathFlags::none);
 		frame.setValue(mulOp->getIdentifier(), mlirMulOp);
 	} else {
 		auto mlirMulOp =
@@ -795,7 +802,7 @@ void MLIRLoweringProvider::visitDiv(ir::DivOperation* divIntOp, ValueFrame& fram
 	auto resultType = leftInput.getType();
 	if (isFloat(divIntOp->getStamp())) {
 		auto mlirDivOp = builder->create<mlir::LLVM::FDivOp>(getNameLoc("binOpResult"), resultType, leftInput,
-		                                                     rightInput, mlir::LLVM::FastmathFlags::fast);
+		                                                     rightInput, mlir::LLVM::FastmathFlags::none);
 		frame.setValue(divIntOp->getIdentifier(), mlirDivOp);
 	} else {
 		if (isSignedInteger(divIntOp->getStamp())) {
@@ -816,7 +823,7 @@ void MLIRLoweringProvider::visitMod(ir::ModOperation* modIntOp, ValueFrame& fram
 	auto resultType = leftInput.getType();
 	if (isFloat(modIntOp->getStamp())) {
 		auto mlirDivOp = builder->create<mlir::LLVM::FRemOp>(getNameLoc("binOpResult"), resultType, leftInput,
-		                                                     rightInput, mlir::LLVM::FastmathFlags::fast);
+		                                                     rightInput, mlir::LLVM::FastmathFlags::none);
 		frame.setValue(modIntOp->getIdentifier(), mlirDivOp);
 	} else {
 		if (isSignedInteger(modIntOp->getStamp())) {

--- a/nautilus/src/nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.cpp
@@ -65,8 +65,38 @@ ConstValue readConstant(const Operation* op) {
 	}
 }
 
+/// Truncate a 64-bit-computed fold result down to its stamp's actual bit
+/// width. Every fold below (Add/Sub/Mul/Div/Mod/Shl/Shr) computes correct
+/// 64-bit-wraparound arithmetic, but a narrower stamp (e.g. i32) needs the
+/// result wrapped to *its* width too -- otherwise the resulting
+/// ConstIntOperation holds a value outside its declared stamp's range (e.g.
+/// folding `-613191811i32 << 2` gives the 64-bit value -2452767244, which
+/// doesn't fit in an i32). Most backends happen to re-truncate when they
+/// materialize a typed constant (an explicit cast around a C++ literal, an
+/// MLIR typed attribute, ...), which is why this stayed masked everywhere
+/// except a backend that loads the raw 64-bit value into a same-width
+/// register unmodified.
+int64_t truncateToStamp(int64_t value, Type stamp) {
+	switch (stamp) {
+	case Type::i8:
+		return static_cast<int64_t>(static_cast<int8_t>(value));
+	case Type::ui8:
+		return static_cast<int64_t>(static_cast<uint8_t>(value));
+	case Type::i16:
+		return static_cast<int64_t>(static_cast<int16_t>(value));
+	case Type::ui16:
+		return static_cast<int64_t>(static_cast<uint16_t>(value));
+	case Type::i32:
+		return static_cast<int64_t>(static_cast<int32_t>(value));
+	case Type::ui32:
+		return static_cast<int64_t>(static_cast<uint32_t>(value));
+	default:
+		return value; // i64, ui64 -- already full width.
+	}
+}
+
 Operation* makeIntConst(common::Arena& arena, OperationIdentifier id, int64_t value, Type stamp) {
-	return arena.create<ConstIntOperation>(arena, id, value, stamp);
+	return arena.create<ConstIntOperation>(arena, id, truncateToStamp(value, stamp), stamp);
 }
 
 Operation* makeFloatConst(common::Arena& arena, OperationIdentifier id, double value, Type stamp) {

--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -1,37 +1,33 @@
 #pragma once
 
 #include "ByteReader.hpp"
+#include "Types.hpp"
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace nautilus::fuzz {
 
-/// Number of integer parameters every generated kernel takes.
+/// Number of parameters every generated kernel takes.
 inline constexpr uint32_t NUM_PARAMS = 3;
-
-/// All values flow as uint64_t. Unsigned 64-bit avoids C++ integer-promotion
-/// surprises (uint64_t never promotes) and gives fully-defined wraparound
-/// arithmetic, so the native oracle and the traced kernel agree by
-/// construction. See EvalNative.hpp for the matching semantics.
-using Value = uint64_t;
 
 enum class Kind : uint8_t {
 	// Leaves
-	Const, // imm holds the literal value
+	Const, // imm holds the literal value, packed via packImm<T>
 	Param, // imm holds the parameter index in [0, NUM_PARAMS)
-	// Binary arithmetic / bitwise (well-defined for unsigned operands)
+	// Binary arithmetic / bitwise (integer domain only, except Add/Sub/Mul/Div which also apply to floats)
 	Add,
 	Sub,
 	Mul,
-	Div, // divisor forced non-zero
-	Mod, // divisor forced non-zero
-	And,
-	Or,
-	Xor,
-	Shl, // shift amount masked to [0, 64)
-	Shr, // shift amount masked to [0, 64)
-	// Comparisons, each yielding 0 or 1
+	Div, // integer domain: divisor forced non-zero
+	Mod, // integer domain only
+	And, // integer domain only
+	Or,  // integer domain only
+	Xor, // integer domain only
+	Shl, // integer domain only; shift amount masked to [0, bit-width(T))
+	Shr, // integer domain only; shift amount masked to [0, bit-width(T))
+	// Comparisons, each yielding 0 or 1 (as T)
 	Eq,
 	Ne,
 	Lt,
@@ -40,7 +36,16 @@ enum class Kind : uint8_t {
 	Ge,
 	// Ternaries
 	Select, // (cond, t, f): cond != 0 ? t : f, lowered to an IR select
-	If      // (cond, t, e): cond != 0 ? t : e, lowered to real control flow
+	If,     // (cond, t, e): cond != 0 ? t : e, lowered to real control flow
+	// Unary
+	Neg, // integer and float domains: -x
+	Not, // integer domain only: ~x
+	// Cast: round-trips the single child through another same-domain type,
+	// i.e. (T)(To)x. imm holds the target TypeId (an integer TypeId for the
+	// integer domain, a float TypeId for the float domain). int<->float
+	// casts are intentionally unsupported (would need UB-safe range
+	// clamping before casting an out-of-range float to an integer type).
+	Cast
 };
 
 struct Node {
@@ -56,15 +61,22 @@ struct Ast {
 
 namespace detail {
 
-inline constexpr Kind INTERNAL_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul, Kind::Div, Kind::Mod,    Kind::And,
-                                          Kind::Or,  Kind::Xor, Kind::Shl, Kind::Shr, Kind::Eq,     Kind::Ne,
-                                          Kind::Lt,  Kind::Le,  Kind::Gt,  Kind::Ge,  Kind::Select, Kind::If};
+inline constexpr Kind INT_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul,    Kind::Div, Kind::Mod, Kind::And, Kind::Or,
+                                     Kind::Xor, Kind::Shl, Kind::Shr,    Kind::Eq,  Kind::Ne,  Kind::Lt,  Kind::Le,
+                                     Kind::Gt,  Kind::Ge,  Kind::Select, Kind::If,  Kind::Neg, Kind::Not, Kind::Cast};
+
+inline constexpr Kind FLOAT_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul, Kind::Div,    Kind::Eq, Kind::Ne,  Kind::Lt,
+                                       Kind::Le,  Kind::Gt,  Kind::Ge,  Kind::Select, Kind::If, Kind::Neg, Kind::Cast};
 
 inline int arity(Kind k) {
 	switch (k) {
 	case Kind::Const:
 	case Kind::Param:
 		return 0;
+	case Kind::Neg:
+	case Kind::Not:
+	case Kind::Cast:
+		return 1;
 	case Kind::Select:
 	case Kind::If:
 		return 3;
@@ -73,7 +85,8 @@ inline int arity(Kind k) {
 	}
 }
 
-inline int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
+template <typename T>
+int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
 	const uint8_t sel = reader.byte();
 	bool leaf = depth <= 0 || budget <= 1 || reader.exhausted();
 	if (!leaf) {
@@ -88,22 +101,36 @@ inline int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
 			node.imm = reader.byte() % NUM_PARAMS;
 		} else {
 			node.kind = Kind::Const;
-			node.imm = reader.consume<uint64_t>();
+			node.imm = packImm<T>(reader.consume<T>());
 		}
 		const int idx = static_cast<int>(ast.nodes.size());
 		ast.nodes.push_back(node);
 		return idx;
 	}
 
-	constexpr uint32_t kindCount = sizeof(INTERNAL_KINDS) / sizeof(INTERNAL_KINDS[0]);
-	node.kind = INTERNAL_KINDS[reader.byte() % kindCount];
+	if constexpr (std::is_floating_point_v<T>) {
+		constexpr uint32_t kindCount = sizeof(FLOAT_KINDS) / sizeof(FLOAT_KINDS[0]);
+		node.kind = FLOAT_KINDS[reader.byte() % kindCount];
+	} else {
+		constexpr uint32_t kindCount = sizeof(INT_KINDS) / sizeof(INT_KINDS[0]);
+		node.kind = INT_KINDS[reader.byte() % kindCount];
+	}
 	--budget;
+
+	if (node.kind == Kind::Cast) {
+		if constexpr (std::is_floating_point_v<T>) {
+			node.imm = static_cast<uint64_t>(FLOAT_TYPE_IDS[reader.byte() % 2]);
+		} else {
+			node.imm = static_cast<uint64_t>(INT_TYPE_IDS[reader.byte() % 8]);
+		}
+	}
+
 	const int childCount = arity(node.kind);
 	// Children must be generated before the parent is pushed so that parent
 	// indices stay greater than their children (handy for evaluation/printing).
 	int kids[3] = {-1, -1, -1};
 	for (int i = 0; i < childCount; ++i) {
-		kids[i] = generateNode(ast, reader, depth - 1, budget);
+		kids[i] = generateNode<T>(ast, reader, depth - 1, budget);
 	}
 	node.kid[0] = kids[0];
 	node.kid[1] = kids[1];
@@ -121,13 +148,14 @@ inline int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
 inline constexpr int MAX_DEPTH = 6;
 inline constexpr int MAX_NODES = 64;
 
-/// Build a random, always-valid AST from the reader. Never returns an empty
-/// tree: an empty buffer yields a single Const(0) leaf.
-inline Ast generate(ByteReader& reader) {
+/// Build a random, always-valid AST of type T from the reader. Never returns
+/// an empty tree: an empty buffer yields a single Const(0) leaf.
+template <typename T>
+Ast generate(ByteReader& reader) {
 	Ast ast;
 	ast.nodes.reserve(MAX_NODES + 1);
 	int budget = MAX_NODES;
-	ast.root = detail::generateNode(ast, reader, MAX_DEPTH, budget);
+	ast.root = detail::generateNode<T>(ast, reader, MAX_DEPTH, budget);
 	return ast;
 }
 
@@ -172,31 +200,51 @@ inline const char* opSymbol(Kind k) {
 	}
 }
 
-inline void print(const Ast& ast, int idx, std::string& out) {
+template <typename T>
+void print(const Ast& ast, int idx, std::string& out) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
-		out += std::to_string(n.imm) + "u";
+		out += formatValue<T>(unpackImm<T>(n.imm)) + typeSuffix<T>();
 		return;
 	case Kind::Param:
 		out += "p" + std::to_string(n.imm);
 		return;
+	case Kind::Neg:
+		out += "(-";
+		print<T>(ast, n.kid[0], out);
+		out += ")";
+		return;
+	case Kind::Not:
+		out += "(~";
+		print<T>(ast, n.kid[0], out);
+		out += ")";
+		return;
+	case Kind::Cast: {
+		const TypeId target = static_cast<TypeId>(n.imm);
+		out += "(";
+		out += typeName(target);
+		out += ")(";
+		print<T>(ast, n.kid[0], out);
+		out += ")";
+		return;
+	}
 	case Kind::Select:
 		out += "sel(";
-		print(ast, n.kid[0], out);
+		print<T>(ast, n.kid[0], out);
 		out += " != 0, ";
-		print(ast, n.kid[1], out);
+		print<T>(ast, n.kid[1], out);
 		out += ", ";
-		print(ast, n.kid[2], out);
+		print<T>(ast, n.kid[2], out);
 		out += ")";
 		return;
 	case Kind::If:
 		out += "if(";
-		print(ast, n.kid[0], out);
+		print<T>(ast, n.kid[0], out);
 		out += " != 0, ";
-		print(ast, n.kid[1], out);
+		print<T>(ast, n.kid[1], out);
 		out += ", ";
-		print(ast, n.kid[2], out);
+		print<T>(ast, n.kid[2], out);
 		out += ")";
 		return;
 	default:
@@ -208,14 +256,14 @@ inline void print(const Ast& ast, int idx, std::string& out) {
 		out += "(";
 	}
 	out += "(";
-	print(ast, n.kid[0], out);
+	print<T>(ast, n.kid[0], out);
 	out += " ";
 	out += opSymbol(n.kind);
 	out += " ";
-	print(ast, n.kid[1], out);
+	print<T>(ast, n.kid[1], out);
 	out += ")";
 	if (isCmp) {
-		out += " ? 1u : 0u)";
+		out += " ? 1 : 0)";
 	}
 }
 
@@ -223,10 +271,11 @@ inline void print(const Ast& ast, int idx, std::string& out) {
 
 /// Render the AST as a human-readable expression for failure reports and for
 /// turning a saved crash input into a fixed regression test.
-inline std::string toString(const Ast& ast) {
+template <typename T>
+std::string toString(const Ast& ast) {
 	std::string out;
 	if (ast.root >= 0) {
-		detail::print(ast, ast.root, out);
+		detail::print<T>(ast, ast.root, out);
 	}
 	return out;
 }

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "Ast.hpp"
+#include "Types.hpp"
 #include <array>
 #include <cstdint>
+#include <limits>
+#include <type_traits>
 
 namespace nautilus::fuzz {
 
@@ -11,76 +14,225 @@ namespace nautilus::fuzz {
  *
  * Pure C++ scalar arithmetic with the exact, fully-defined semantics the
  * generator guarantees:
- *   - all arithmetic is unsigned uint64_t (defined wraparound),
- *   - division/modulo divisors are forced non-zero (`| 1`),
- *   - shift amounts are masked to [0, 64).
- * Because every operation is well-defined, a disagreement between this oracle
- * and any Nautilus backend is an unambiguous miscompile (or tracing bug).
+ *   - unsigned arithmetic uses plain operators (already defined wraparound);
+ *     signed arithmetic (Add/Sub/Mul/Neg) is computed via the unsigned
+ *     counterpart and cast back, since plain signed overflow is UB even
+ *     though two's-complement representation is mandated by C++20 -- this
+ *     produces the exact bit pattern every backend's two's-complement
+ *     codegen actually computes, without inviting UB in the oracle,
+ *   - division/modulo divisors are forced non-zero (`| T(1)`), and for
+ *     signed types additionally forced away from -1 (the one divisor value
+ *     for which TYPE_MIN / divisor overflows and traps via `idiv` on x86),
+ *   - shift amounts are masked to [0, bit-width(T)),
+ *   - the float domain needs none of the above: IEEE 754 arithmetic
+ *     (including division by zero, producing +-inf/NaN) is fully defined.
+ * Because every operation is well-defined, a disagreement between this
+ * oracle and any Nautilus backend is an unambiguous miscompile (or tracing
+ * bug).
  */
-inline Value evalNative(const Ast& ast, int idx, const std::array<Value, NUM_PARAMS>& args) {
+namespace detail {
+
+template <typename T>
+T wrappingAdd(T a, T b) {
+	using U = std::make_unsigned_t<T>;
+	return static_cast<T>(static_cast<U>(a) + static_cast<U>(b));
+}
+
+template <typename T>
+T wrappingSub(T a, T b) {
+	using U = std::make_unsigned_t<T>;
+	return static_cast<T>(static_cast<U>(a) - static_cast<U>(b));
+}
+
+template <typename T>
+T wrappingMul(T a, T b) {
+	using U = std::make_unsigned_t<T>;
+	return static_cast<T>(static_cast<U>(a) * static_cast<U>(b));
+}
+
+template <typename T>
+T wrappingNeg(T a) {
+	using U = std::make_unsigned_t<T>;
+	return static_cast<T>(-static_cast<U>(a));
+}
+
+/// Force a non-zero divisor; for signed T also steer away from -1, the only
+/// divisor for which TYPE_MIN / divisor overflows (and traps on x86 idiv).
+template <typename T>
+T safeDivisor(T r) {
+	T d = static_cast<T>(r | T(1));
+	if constexpr (std::is_signed_v<T>) {
+		if (d == T(-1)) {
+			d = T(1);
+		}
+	}
+	return d;
+}
+
+template <typename From>
+From castThroughInt(From v, TypeId target) {
+	return dispatchIntType(target, [&]<typename To>() -> From { return static_cast<From>(static_cast<To>(v)); });
+}
+
+template <typename From>
+From castThroughFloat(From v, TypeId target) {
+	return dispatchFloatType(target, [&]<typename To>() -> From { return static_cast<From>(static_cast<To>(v)); });
+}
+
+template <typename T>
+T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
-		return n.imm;
+		return unpackImm<T>(n.imm);
 	case Kind::Param:
 		return args[n.imm % NUM_PARAMS];
 	case Kind::Select: {
-		const Value c = evalNative(ast, n.kid[0], args);
-		return c != 0 ? evalNative(ast, n.kid[1], args) : evalNative(ast, n.kid[2], args);
+		const T c = evalNativeInt<T>(ast, n.kid[0], args);
+		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args) : evalNativeInt<T>(ast, n.kid[2], args);
 	}
 	case Kind::If: {
-		const Value c = evalNative(ast, n.kid[0], args);
+		const T c = evalNativeInt<T>(ast, n.kid[0], args);
 		// Mirror the traced kernel: the else-branch is evaluated unconditionally,
 		// the then-branch only when the condition holds.
-		const Value e = evalNative(ast, n.kid[2], args);
-		return c != 0 ? evalNative(ast, n.kid[1], args) : e;
+		const T e = evalNativeInt<T>(ast, n.kid[2], args);
+		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args) : e;
 	}
+	case Kind::Neg: {
+		const T v = evalNativeInt<T>(ast, n.kid[0], args);
+		if constexpr (std::is_signed_v<T>) {
+			return wrappingNeg<T>(v);
+		} else {
+			return static_cast<T>(-v);
+		}
+	}
+	case Kind::Not:
+		return static_cast<T>(~evalNativeInt<T>(ast, n.kid[0], args));
+	case Kind::Cast:
+		return castThroughInt<T>(evalNativeInt<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
 	default:
 		break;
 	}
 
-	const Value l = evalNative(ast, n.kid[0], args);
-	const Value r = evalNative(ast, n.kid[1], args);
+	const T l = evalNativeInt<T>(ast, n.kid[0], args);
+	const T r = evalNativeInt<T>(ast, n.kid[1], args);
 	switch (n.kind) {
 	case Kind::Add:
-		return l + r;
+		if constexpr (std::is_signed_v<T>) {
+			return wrappingAdd<T>(l, r);
+		} else {
+			return static_cast<T>(l + r);
+		}
 	case Kind::Sub:
-		return l - r;
+		if constexpr (std::is_signed_v<T>) {
+			return wrappingSub<T>(l, r);
+		} else {
+			return static_cast<T>(l - r);
+		}
 	case Kind::Mul:
-		return l * r;
+		if constexpr (std::is_signed_v<T>) {
+			return wrappingMul<T>(l, r);
+		} else {
+			return static_cast<T>(l * r);
+		}
 	case Kind::Div:
-		return l / (r | 1u);
+		return static_cast<T>(l / safeDivisor<T>(r));
 	case Kind::Mod:
-		return l % (r | 1u);
+		return static_cast<T>(l % safeDivisor<T>(r));
 	case Kind::And:
-		return l & r;
+		return static_cast<T>(l & r);
 	case Kind::Or:
-		return l | r;
+		return static_cast<T>(l | r);
 	case Kind::Xor:
-		return l ^ r;
+		return static_cast<T>(l ^ r);
 	case Kind::Shl:
-		return l << (r & 63u);
+		return static_cast<T>(l << (r & T(sizeof(T) * 8 - 1)));
 	case Kind::Shr:
-		return l >> (r & 63u);
+		return static_cast<T>(l >> (r & T(sizeof(T) * 8 - 1)));
 	case Kind::Eq:
-		return l == r ? 1u : 0u;
+		return l == r ? T(1) : T(0);
 	case Kind::Ne:
-		return l != r ? 1u : 0u;
+		return l != r ? T(1) : T(0);
 	case Kind::Lt:
-		return l < r ? 1u : 0u;
+		return l < r ? T(1) : T(0);
 	case Kind::Le:
-		return l <= r ? 1u : 0u;
+		return l <= r ? T(1) : T(0);
 	case Kind::Gt:
-		return l > r ? 1u : 0u;
+		return l > r ? T(1) : T(0);
 	case Kind::Ge:
-		return l >= r ? 1u : 0u;
+		return l >= r ? T(1) : T(0);
 	default:
-		return 0; // unreachable
+		return T(0); // unreachable
 	}
 }
 
-inline Value evalNative(const Ast& ast, const std::array<Value, NUM_PARAMS>& args) {
-	return evalNative(ast, ast.root, args);
+template <typename T>
+T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) {
+	const Node& n = ast.nodes[idx];
+	switch (n.kind) {
+	case Kind::Const:
+		return unpackImm<T>(n.imm);
+	case Kind::Param:
+		return args[n.imm % NUM_PARAMS];
+	case Kind::Select: {
+		const T c = evalNativeFloat<T>(ast, n.kid[0], args);
+		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args) : evalNativeFloat<T>(ast, n.kid[2], args);
+	}
+	case Kind::If: {
+		const T c = evalNativeFloat<T>(ast, n.kid[0], args);
+		const T e = evalNativeFloat<T>(ast, n.kid[2], args);
+		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args) : e;
+	}
+	case Kind::Neg:
+		return static_cast<T>(-evalNativeFloat<T>(ast, n.kid[0], args));
+	case Kind::Cast:
+		return castThroughFloat<T>(evalNativeFloat<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
+	default:
+		break;
+	}
+
+	const T l = evalNativeFloat<T>(ast, n.kid[0], args);
+	const T r = evalNativeFloat<T>(ast, n.kid[1], args);
+	switch (n.kind) {
+	case Kind::Add:
+		return static_cast<T>(l + r);
+	case Kind::Sub:
+		return static_cast<T>(l - r);
+	case Kind::Mul:
+		return static_cast<T>(l * r);
+	case Kind::Div:
+		return static_cast<T>(l / r); // well-defined IEEE 754: produces +-inf / NaN for r == 0
+	case Kind::Eq:
+		return l == r ? T(1) : T(0);
+	case Kind::Ne:
+		return l != r ? T(1) : T(0);
+	case Kind::Lt:
+		return l < r ? T(1) : T(0);
+	case Kind::Le:
+		return l <= r ? T(1) : T(0);
+	case Kind::Gt:
+		return l > r ? T(1) : T(0);
+	case Kind::Ge:
+		return l >= r ? T(1) : T(0);
+	default:
+		return T(0); // unreachable
+	}
+}
+
+} // namespace detail
+
+template <typename T>
+T evalNative(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return detail::evalNativeFloat<T>(ast, idx, args);
+	} else {
+		return detail::evalNativeInt<T>(ast, idx, args);
+	}
+}
+
+template <typename T>
+T evalNative(const Ast& ast, const std::array<T, NUM_PARAMS>& args) {
+	return evalNative<T>(ast, ast.root, args);
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -1,55 +1,97 @@
 #pragma once
 
 #include "Ast.hpp"
+#include "Types.hpp"
 #include <array>
-#include <nautilus/Engine.hpp>
+#include <limits>
 #include <nautilus/select.hpp>
 #include <nautilus/val.hpp>
+#include <type_traits>
 
 namespace nautilus::fuzz {
 
-using TracedValue = val<Value>;
-using TracedArgs = std::array<TracedValue, NUM_PARAMS>;
+template <typename T>
+using TracedValue = val<T>;
+
+template <typename T>
+using TracedArgs = std::array<TracedValue<T>, NUM_PARAMS>;
 
 /**
  * @brief Realize an AST as traced Nautilus operations.
  *
- * Walks the exact same tree as evalNative, but emits val<uint64_t> operations
- * so the function can be traced, optimized and lowered through every backend.
- * Each construct is the well-defined counterpart of the native oracle:
+ * Walks the exact same tree as evalNative, but emits val<T> operations so the
+ * function can be traced, optimized and lowered through every backend. Each
+ * construct is the well-defined counterpart of the native oracle:
  *   - comparisons become `select(cond, 1, 0)` (an IR compare + select),
  *   - `If` uses real traced control flow so branch lowering is exercised,
- *   - divisors are forced non-zero and shift amounts masked, exactly as native.
+ *   - divisors are forced non-zero (and, for signed types, away from -1 --
+ *     see EvalNative.hpp's safeDivisor for why) and shift amounts masked,
+ *     exactly as native,
+ *   - unlike the native oracle, signed arithmetic needs no extra wraparound
+ *     handling here: producing the correct two's-complement result for
+ *     `+ - * unary-` is exactly the behavior under test.
  */
-inline TracedValue evalNautilus(const Ast& ast, int idx, const TracedArgs& args) {
+namespace detail {
+
+template <typename T>
+TracedValue<T> safeDivisorTraced(TracedValue<T> r) {
+	TracedValue<T> d = r | TracedValue<T>(T(1));
+	if constexpr (std::is_signed_v<T>) {
+		d = select(d == TracedValue<T>(T(-1)), TracedValue<T>(T(1)), d);
+	}
+	return d;
+}
+
+template <typename From>
+TracedValue<From> castThroughIntTraced(TracedValue<From> v, TypeId target) {
+	return dispatchIntType(target, [&]<typename To>() -> TracedValue<From> {
+		return static_cast<TracedValue<From>>(static_cast<TracedValue<To>>(v));
+	});
+}
+
+template <typename From>
+TracedValue<From> castThroughFloatTraced(TracedValue<From> v, TypeId target) {
+	return dispatchFloatType(target, [&]<typename To>() -> TracedValue<From> {
+		return static_cast<TracedValue<From>>(static_cast<TracedValue<To>>(v));
+	});
+}
+
+template <typename T>
+TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
-		return TracedValue(static_cast<Value>(n.imm));
+		return TracedValue<T>(unpackImm<T>(n.imm));
 	case Kind::Param:
 		return args[n.imm % NUM_PARAMS];
 	case Kind::Select: {
-		TracedValue c = evalNautilus(ast, n.kid[0], args);
-		TracedValue t = evalNautilus(ast, n.kid[1], args);
-		TracedValue f = evalNautilus(ast, n.kid[2], args);
-		return select(c != TracedValue(0), t, f);
+		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args);
+		TracedValue<T> t = evalNautilusInt<T>(ast, n.kid[1], args);
+		TracedValue<T> f = evalNautilusInt<T>(ast, n.kid[2], args);
+		return select(c != TracedValue<T>(T(0)), t, f);
 	}
 	case Kind::If: {
-		TracedValue c = evalNautilus(ast, n.kid[0], args);
+		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args);
 		// Else-branch first (unconditional), then conditionally overwrite with
 		// the then-branch inside a real traced branch -> produces a phi/merge.
-		TracedValue result = evalNautilus(ast, n.kid[2], args);
-		if (c != TracedValue(0)) {
-			result = evalNautilus(ast, n.kid[1], args);
+		TracedValue<T> result = evalNautilusInt<T>(ast, n.kid[2], args);
+		if (c != TracedValue<T>(T(0))) {
+			result = evalNautilusInt<T>(ast, n.kid[1], args);
 		}
 		return result;
 	}
+	case Kind::Neg:
+		return -evalNautilusInt<T>(ast, n.kid[0], args);
+	case Kind::Not:
+		return ~evalNautilusInt<T>(ast, n.kid[0], args);
+	case Kind::Cast:
+		return castThroughIntTraced<T>(evalNautilusInt<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
 	default:
 		break;
 	}
 
-	TracedValue l = evalNautilus(ast, n.kid[0], args);
-	TracedValue r = evalNautilus(ast, n.kid[1], args);
+	TracedValue<T> l = evalNautilusInt<T>(ast, n.kid[0], args);
+	TracedValue<T> r = evalNautilusInt<T>(ast, n.kid[1], args);
 	switch (n.kind) {
 	case Kind::Add:
 		return l + r;
@@ -58,9 +100,9 @@ inline TracedValue evalNautilus(const Ast& ast, int idx, const TracedArgs& args)
 	case Kind::Mul:
 		return l * r;
 	case Kind::Div:
-		return l / (r | TracedValue(1));
+		return l / safeDivisorTraced<T>(r);
 	case Kind::Mod:
-		return l % (r | TracedValue(1));
+		return l % safeDivisorTraced<T>(r);
 	case Kind::And:
 		return l & r;
 	case Kind::Or:
@@ -68,28 +110,98 @@ inline TracedValue evalNautilus(const Ast& ast, int idx, const TracedArgs& args)
 	case Kind::Xor:
 		return l ^ r;
 	case Kind::Shl:
-		return l << (r & TracedValue(63));
+		return l << (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
 	case Kind::Shr:
-		return l >> (r & TracedValue(63));
+		return l >> (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
 	case Kind::Eq:
-		return select(l == r, TracedValue(1), TracedValue(0));
+		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Ne:
-		return select(l != r, TracedValue(1), TracedValue(0));
+		return select(l != r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Lt:
-		return select(l < r, TracedValue(1), TracedValue(0));
+		return select(l < r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Le:
-		return select(l <= r, TracedValue(1), TracedValue(0));
+		return select(l <= r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Gt:
-		return select(l > r, TracedValue(1), TracedValue(0));
+		return select(l > r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Ge:
-		return select(l >= r, TracedValue(1), TracedValue(0));
+		return select(l >= r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	default:
-		return TracedValue(0); // unreachable
+		return TracedValue<T>(T(0)); // unreachable
 	}
 }
 
-inline TracedValue evalNautilus(const Ast& ast, const TracedArgs& args) {
-	return evalNautilus(ast, ast.root, args);
+template <typename T>
+TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& args) {
+	const Node& n = ast.nodes[idx];
+	switch (n.kind) {
+	case Kind::Const:
+		return TracedValue<T>(unpackImm<T>(n.imm));
+	case Kind::Param:
+		return args[n.imm % NUM_PARAMS];
+	case Kind::Select: {
+		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args);
+		TracedValue<T> t = evalNautilusFloat<T>(ast, n.kid[1], args);
+		TracedValue<T> f = evalNautilusFloat<T>(ast, n.kid[2], args);
+		return select(c != TracedValue<T>(T(0)), t, f);
+	}
+	case Kind::If: {
+		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args);
+		TracedValue<T> result = evalNautilusFloat<T>(ast, n.kid[2], args);
+		if (c != TracedValue<T>(T(0))) {
+			result = evalNautilusFloat<T>(ast, n.kid[1], args);
+		}
+		return result;
+	}
+	case Kind::Neg:
+		return -evalNautilusFloat<T>(ast, n.kid[0], args);
+	case Kind::Cast:
+		return castThroughFloatTraced<T>(evalNautilusFloat<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
+	default:
+		break;
+	}
+
+	TracedValue<T> l = evalNautilusFloat<T>(ast, n.kid[0], args);
+	TracedValue<T> r = evalNautilusFloat<T>(ast, n.kid[1], args);
+	switch (n.kind) {
+	case Kind::Add:
+		return l + r;
+	case Kind::Sub:
+		return l - r;
+	case Kind::Mul:
+		return l * r;
+	case Kind::Div:
+		return l / r; // well-defined IEEE 754: produces +-inf / NaN for r == 0
+	case Kind::Eq:
+		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	case Kind::Ne:
+		return select(l != r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	case Kind::Lt:
+		return select(l < r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	case Kind::Le:
+		return select(l <= r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	case Kind::Gt:
+		return select(l > r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	case Kind::Ge:
+		return select(l >= r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	default:
+		return TracedValue<T>(T(0)); // unreachable
+	}
+}
+
+} // namespace detail
+
+template <typename T>
+TracedValue<T> evalNautilus(const Ast& ast, int idx, const TracedArgs<T>& args) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return detail::evalNautilusFloat<T>(ast, idx, args);
+	} else {
+		return detail::evalNautilusInt<T>(ast, idx, args);
+	}
+}
+
+template <typename T>
+TracedValue<T> evalNautilus(const Ast& ast, const TracedArgs<T>& args) {
+	return evalNautilus<T>(ast, ast.root, args);
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -4,6 +4,7 @@
 #include "ByteReader.hpp"
 #include "EvalNative.hpp"
 #include "EvalNautilus.hpp"
+#include "Types.hpp"
 #include <array>
 #include <cstdint>
 #include <cstdio>
@@ -16,11 +17,12 @@
 
 namespace nautilus::fuzz {
 
-static_assert(NUM_PARAMS == 3, "The harness wires exactly three uint64_t parameters.");
+static_assert(NUM_PARAMS == 3, "The harness wires exactly three same-typed parameters.");
 
 // registerFunction expects the traced (val<>) return type in the signature; the
-// resulting CompiledFunction is then callable with — and returns — raw scalars.
-using KernelSignature = val<Value>(val<Value>, val<Value>, val<Value>);
+// resulting CompiledFunction is then callable with -- and returns -- raw scalars.
+template <typename T>
+using KernelSignature = val<T>(val<T>, val<T>, val<T>);
 
 /// Backends compiled into this build, mirroring testing::availableBackends().
 /// The interpreter is always present and acts as an extra differential peer.
@@ -52,13 +54,17 @@ inline engine::NautilusEngine makeEngine(const std::string& backend) {
 	return engine::NautilusEngine(options);
 }
 
-/// A single backend disagreeing with the native oracle (or throwing).
+/// A single backend disagreeing with the native oracle (or throwing). All
+/// value fields are pre-formatted strings (built where the concrete type T
+/// is still known, inside checkOneTyped<T>) so this struct itself stays
+/// type-agnostic across all ten generated domains.
 struct Finding {
 	std::string backend;
+	std::string typeName;
 	std::string program;
-	std::array<Value, NUM_PARAMS> args {};
-	Value expected = 0;
-	Value got = 0;
+	std::vector<std::string> args;
+	std::string expected = "";
+	std::string got = "";
 	bool exception = false;
 	std::string what; // exception message, when exception == true
 	bool hasParam = false;
@@ -68,17 +74,18 @@ inline void printFinding(const Finding& f) {
 	if (f.exception) {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: EXCEPTION ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
+		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
 		std::fprintf(stderr, "what()   : %s\n", f.what.c_str());
 		std::fprintf(stderr, "=================================================\n");
 	} else {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: MISMATCH ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
+		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
-		std::fprintf(stderr, "args     : p0=%llu p1=%llu p2=%llu\n", (unsigned long long) f.args[0],
-		             (unsigned long long) f.args[1], (unsigned long long) f.args[2]);
-		std::fprintf(stderr, "expected : %llu (native oracle)\n", (unsigned long long) f.expected);
-		std::fprintf(stderr, "got      : %llu\n", (unsigned long long) f.got);
+		std::fprintf(stderr, "args     : p0=%s p1=%s p2=%s\n", f.args[0].c_str(), f.args[1].c_str(), f.args[2].c_str());
+		std::fprintf(stderr, "expected : %s (native oracle)\n", f.expected.c_str());
+		std::fprintf(stderr, "got      : %s\n", f.got.c_str());
 		std::fprintf(stderr, "================================================\n");
 	}
 	std::fflush(stderr);
@@ -93,39 +100,59 @@ inline bool astHasParam(const Ast& ast) {
 	return false;
 }
 
-/// Core differential check for one input: build a program + args, evaluate it
-/// natively, compile/run on every backend + interpreter, and collect every
-/// backend that disagrees or throws. Does not abort — callers decide.
-inline std::vector<Finding> checkOne(const uint8_t* data, size_t size) {
-	ByteReader reader(data, size);
-	const Ast ast = generate(reader);
+/// Core differential check for one input at a fixed concrete type T: build a
+/// program + args, evaluate it natively, compile/run on every backend +
+/// interpreter, and collect every backend that disagrees or throws. Does not
+/// abort -- callers decide. `reader` continues from wherever the caller (the
+/// type-dispatching checkOne) left off, so the whole pipeline -- type
+/// selection, AST generation, arg generation -- is one linear, deterministic
+/// pass over a single buffer.
+template <typename T>
+std::vector<Finding> checkOneTyped(ByteReader& reader) {
+	const Ast ast = generate<T>(reader);
 	const bool hasParam = astHasParam(ast);
 
-	std::array<Value, NUM_PARAMS> args {};
+	std::array<T, NUM_PARAMS> args {};
 	for (uint32_t i = 0; i < NUM_PARAMS; ++i) {
-		args[i] = reader.consume<Value>();
+		args[i] = reader.consume<T>();
 	}
 
-	const Value expected = evalNative(ast, args);
+	const T expected = evalNative<T>(ast, args);
+	const std::string program = toString<T>(ast);
+	std::vector<std::string> argStrs;
+	argStrs.reserve(NUM_PARAMS);
+	for (T a : args) {
+		argStrs.push_back(formatValue<T>(a));
+	}
 
 	std::vector<Finding> findings;
 	for (const auto& backend : configs()) {
 		try {
 			auto engine = makeEngine(backend);
-			std::function<KernelSignature> kernel = [&ast](val<Value> a, val<Value> b, val<Value> c) {
-				const TracedArgs traced {a, b, c};
-				return evalNautilus(ast, traced);
+			std::function<KernelSignature<T>> kernel = [&ast](val<T> a, val<T> b, val<T> c) {
+				const TracedArgs<T> traced {a, b, c};
+				return evalNautilus<T>(ast, traced);
 			};
 			auto compiled = engine.registerFunction(kernel);
-			const Value got = compiled(args[0], args[1], args[2]);
-			if (got != expected) {
-				findings.push_back({backend, toString(ast), args, expected, got, false, "", hasParam});
+			const T got = compiled(args[0], args[1], args[2]);
+			if (!valuesEqual<T>(got, expected)) {
+				findings.push_back({backend, typeSuffix<T>(), program, argStrs, formatValue<T>(expected),
+				                    formatValue<T>(got), false, "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back({backend, toString(ast), args, expected, 0, true, e.what(), hasParam});
+			findings.push_back({backend, typeSuffix<T>(), program, argStrs, "", "", true, e.what(), hasParam});
 		}
 	}
 	return findings;
+}
+
+/// Pick one of the ten generated types from the first byte of the buffer,
+/// then dispatch into the matching checkOneTyped<T> instantiation, passing
+/// the same reader along so determinism/replay is preserved end to end.
+inline std::vector<Finding> checkOne(const uint8_t* data, size_t size) {
+	ByteReader reader(data, size);
+	const TypeId ty = ALL_TYPES[reader.byte() % (sizeof(ALL_TYPES) / sizeof(ALL_TYPES[0]))];
+	return dispatchAnyType(ty, [&]<typename T>() { return checkOneTyped<T>(reader); });
 }
 
 /// libFuzzer behavior: abort (so the input is captured as a reproducer) on the

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -14,11 +14,12 @@ bug because every generated program is fully defined by construction.
 
 | File | Role |
 |------|------|
+| `Types.hpp`        | The `TypeId` domain (10 types), imm pack/unpack, type dispatch helpers, value formatting/equality. |
 | `ByteReader.hpp`   | Deterministic `FuzzedDataProvider`-style view over the fuzzer buffer. |
-| `Ast.hpp`          | Tagged AST, depth/node-budgeted generator, and a pretty printer. |
-| `EvalNative.hpp`   | Independent C++ ground-truth interpreter (the oracle). |
+| `Ast.hpp`          | Tagged AST, depth/node-budgeted generator (templated on the value type), and a pretty printer. |
+| `EvalNative.hpp`   | Independent C++ ground-truth interpreter (the oracle), templated on the value type. |
 | `EvalNautilus.hpp` | Walks the same AST emitting `val<T>` ops for tracing/compilation. |
-| `Harness.hpp`      | Shared differential check (`checkOne`/`runOne`) used by both drivers. |
+| `Harness.hpp`      | Shared differential check (`checkOne`/`runOne`) used by both drivers; dispatches each input to the right `T`. |
 | `FuzzMain.cpp`     | `LLVMFuzzerTestOneInput`: coverage-guided libFuzzer entry point. |
 | `ReplayMain.cpp`   | Plain-`main` driver: replay saved inputs, smoke corpus, or `--survey`. |
 
@@ -32,17 +33,57 @@ bug because every generated program is fully defined by construction.
     first finding, like libFuzzer).
   * `nautilus-fuzz-replay <file> ...` — replay specific saved inputs.
   * `nautilus-fuzz-replay --survey [N]` — run N inputs **without** aborting and
-    print findings bucketed by `(backend, kind)`, to triage how many distinct
-    bug classes exist.
+    print findings bucketed by `(backend, type, kind)`, to triage how many
+    distinct bug classes exist (e.g. an `i8`-only bug breaks out from an
+    `f64`-only one instead of merging into one bucket).
+
+## Scope: ten value domains
+
+Each generated program is monomorphic in one of ten types, picked from the
+first byte of the fuzzer input: `int8_t/16/32/64_t`, `uint8/16/32/64_t`,
+`float`, `double` (`TypeId` in `Types.hpp`). The rest of the input (AST shape,
+constants, parameters) is generated and evaluated entirely in that one type,
+mirroring how the original `uint64_t`-only fuzzer worked.
+
+* **Integer domain** (8 widths/signs): arithmetic (`+ - * / %`), bitwise
+  (`& | ^ << >> ~`), unary negate, comparisons, `Select`/`If`, and `Cast`
+  (round-trips the value through another *integer* type, e.g. `(T)(To)v`,
+  exercising sign/zero-extension and truncation codegen).
+* **Float domain** (`float`, `double`): arithmetic (`+ - * /`), unary
+  negate, comparisons, `Select`/`If`, and `Cast` (round-trips through the
+  *other* float type only).
+* **Not generated, by design**: casts between the integer and float domains.
+  Casting an out-of-range float to an integer type is undefined behavior in
+  C++, which would need explicit range clamping (matching the native and
+  traced sides exactly) to fuzz safely -- left as a follow-up rather than
+  built half-way. Loops/control-flow-loop generation are likewise out of
+  scope for now -- today's `If`/`Select` already exercise branch lowering;
+  loop generation needs a data-dependent, bounded trip count threaded through
+  both the oracle and the traced kernel and is a separate piece of work.
 
 ## Soundness model
 
-All values are `uint64_t`, which never integer-promotes and has defined
-wraparound, so native and traced arithmetic match by construction. Partial
-operations are made total during generation: division/modulo divisors are
-`| 1` (never zero) and shift amounts are masked to `[0, 64)`. This is what makes
-the native oracle a valid reference. Floating point and signed overflow are
-intentionally excluded (see the plan / follow-ups).
+Within the integer domain, unsigned arithmetic uses plain operators (defined
+wraparound). Signed arithmetic (`Add`/`Sub`/`Mul`/`Neg`) is computed by
+promoting to the type's unsigned counterpart, operating there (defined
+wraparound), and converting back (well-defined modulo 2^n) -- plain signed
+overflow is still undefined behavior in C++20 even though two's-complement
+representation is mandated, so the oracle avoids it explicitly while still
+producing the same bit pattern every backend's two's-complement codegen
+actually computes. Division/modulo divisors are forced non-zero (`| T(1)`),
+and for signed types additionally forced away from `-1` -- the one divisor
+value for which `TYPE_MIN / divisor` overflows (and traps via `idiv` on
+x86) -- and shift amounts are masked to `[0, bit-width(T))`.
+
+The float domain needs none of this: IEEE 754 arithmetic (including division
+by zero, which produces `+-inf`/`NaN` rather than trapping) is fully defined,
+so `+ - * /` and comparisons are generated unconstrained. Oracle-vs-backend
+equality is NaN-aware (`a == b || (isnan(a) && isnan(b))`), since a generated
+program routinely producing `NaN` on both sides is expected behavior, not a
+mismatch.
+
+This is what makes the native oracle (`EvalNative.hpp`) a valid reference for
+every one of the ten domains.
 
 ## Build & run
 
@@ -54,6 +95,11 @@ cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++-21 -DCMAKE_BUILD_TYPE=Rel
 cmake --build . --target nautilus-fuzz
 ./nautilus/test/fuzz/nautilus-fuzz -max_total_time=120        # or -runs=100000
 ```
+
+`nautilus-fuzz` needs `-fsanitize=fuzzer` support, so it specifically needs a
+recent Clang; `clang++-21` is the project default but any reasonably-recent
+Clang works. `nautilus-fuzz-replay` (`-DENABLE_FUZZER_REPLAY=ON`) has no
+libFuzzer dependency and builds with any C++20 compiler.
 
 Add memory/UB checking by also configuring with `-DENABLE_ADDRESS_SANITIZER=ON`
 (or `-DENABLE_UB_SANITIZER=ON`); those flags are applied globally and compose

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -38,7 +38,11 @@ std::vector<uint8_t> readFile(const char* path) {
 }
 
 std::vector<uint8_t> randomBuffer() {
-	const size_t len = nextRand() % 96;
+	// 128, not the original 96: a type-select byte and (for Cast nodes) an
+	// extra target-type byte now eat into the same fixed budget, so a
+	// slightly larger buffer keeps tree richness comparable to before across
+	// ten type domains instead of one.
+	const size_t len = nextRand() % 128;
 	std::vector<uint8_t> buf(len);
 	for (size_t i = 0; i < len; ++i) {
 		buf[i] = static_cast<uint8_t>(nextRand());
@@ -60,9 +64,10 @@ int builtinCorpus() {
 }
 
 // Survey mode: run many inputs WITHOUT aborting, bucketing findings by
-// (backend, has-runtime-parameter) and keeping one example per bucket. Used to
-// see whether distinct bug classes exist (e.g. a mismatch involving a runtime
-// parameter would point to a codegen bug rather than constant folding).
+// (backend, type, has-runtime-parameter) and keeping one example per bucket.
+// Used to see whether distinct bug classes exist (e.g. a mismatch involving a
+// runtime parameter would point to a codegen bug rather than constant
+// folding; the type breaks out e.g. an i8-only bug from an f64-only one).
 int survey(int iterations) {
 	std::map<std::string, nautilus::fuzz::Finding> buckets;
 	std::map<std::string, int> counts;
@@ -72,8 +77,8 @@ int survey(int iterations) {
 		const std::vector<uint8_t> buf = randomBuffer();
 		for (const auto& f : nautilus::fuzz::checkOne(buf.data(), buf.size())) {
 			++totalFindings;
-			const std::string key =
-			    f.backend + (f.exception ? "|exception" : (f.hasParam ? "|has-param" : "|all-const"));
+			const std::string key = f.backend + "|" + f.typeName +
+			                        (f.exception ? "|exception" : (f.hasParam ? "|has-param" : "|all-const"));
 			counts[key]++;
 			if (!buckets.count(key)) {
 				buckets.emplace(key, f);
@@ -89,10 +94,9 @@ int survey(int iterations) {
 	for (const auto& [key, example] : buckets) {
 		std::printf("\n[%s]  x%d\n  example: %s\n", key.c_str(), counts[key], example.program.c_str());
 		if (!example.exception) {
-			std::printf("  args p0=%llu p1=%llu p2=%llu  expected=%llu got=%llu\n",
-			            (unsigned long long) example.args[0], (unsigned long long) example.args[1],
-			            (unsigned long long) example.args[2], (unsigned long long) example.expected,
-			            (unsigned long long) example.got);
+			std::printf("  args p0=%s p1=%s p2=%s  expected=%s got=%s\n", example.args[0].c_str(),
+			            example.args[1].c_str(), example.args[2].c_str(), example.expected.c_str(),
+			            example.got.c_str());
 		} else {
 			std::printf("  exception: %s\n", example.what.c_str());
 		}

--- a/nautilus/test/fuzz/Types.hpp
+++ b/nautilus/test/fuzz/Types.hpp
@@ -1,0 +1,213 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <type_traits>
+
+namespace nautilus::fuzz {
+
+/// Every concrete C++ type the fuzzer can generate a kernel over. Picked once
+/// per fuzzer input (the very first byte) and held fixed for the rest of
+/// generation/evaluation -- each generated program is monomorphic in one of
+/// these ten types, mirroring how the original uint64_t-only fuzzer worked.
+enum class TypeId : uint8_t { I8, I16, I32, I64, U8, U16, U32, U64, F32, F64 };
+
+inline constexpr TypeId ALL_TYPES[] = {TypeId::I8, TypeId::I16, TypeId::I32, TypeId::I64, TypeId::U8,
+                                       TypeId::U16, TypeId::U32, TypeId::U64, TypeId::F32, TypeId::F64};
+
+/// The eight integer TypeIds, used to pick Cast targets for the integer
+/// domain (int<->float casts are intentionally out of scope -- casting an
+/// out-of-range float to an integer type is undefined behavior in C++ and
+/// would need explicit range clamping to fuzz safely).
+inline constexpr TypeId INT_TYPE_IDS[] = {TypeId::I8, TypeId::I16, TypeId::I32, TypeId::I64,
+                                          TypeId::U8, TypeId::U16, TypeId::U32, TypeId::U64};
+
+/// The two float TypeIds, used to pick Cast targets for the float domain.
+inline constexpr TypeId FLOAT_TYPE_IDS[] = {TypeId::F32, TypeId::F64};
+
+inline bool isFloatType(TypeId t) {
+	return t == TypeId::F32 || t == TypeId::F64;
+}
+
+inline const char* typeName(TypeId t) {
+	switch (t) {
+	case TypeId::I8:
+		return "i8";
+	case TypeId::I16:
+		return "i16";
+	case TypeId::I32:
+		return "i32";
+	case TypeId::I64:
+		return "i64";
+	case TypeId::U8:
+		return "u8";
+	case TypeId::U16:
+		return "u16";
+	case TypeId::U32:
+		return "u32";
+	case TypeId::U64:
+		return "u64";
+	case TypeId::F32:
+		return "f32";
+	case TypeId::F64:
+		return "f64";
+	}
+	return "?";
+}
+
+/// Pack a value's raw bytes into a uint64_t so Node (shared, untemplated
+/// across all ten type instantiations) can store any of them in one
+/// uint64_t `imm` field. Uses memcpy rather than std::bit_cast because
+/// bit_cast requires equal source/destination sizes, which doesn't hold for
+/// e.g. int8_t -> uint64_t.
+template <typename T>
+uint64_t packImm(T v) {
+	uint64_t buf = 0;
+	std::memcpy(&buf, &v, sizeof(T));
+	return buf;
+}
+
+template <typename T>
+T unpackImm(uint64_t buf) {
+	T v {};
+	std::memcpy(&v, &buf, sizeof(T));
+	return v;
+}
+
+/// Runtime TypeId -> compile-time type dispatch, restricted to the integer
+/// domain. Invokes `fn.template operator()<To>()` for the concrete type `To`
+/// matching `target`. Used to evaluate Cast nodes without hand-writing an
+/// eight-way switch at every call site.
+template <typename Fn>
+auto dispatchIntType(TypeId target, Fn&& fn) {
+	switch (target) {
+	case TypeId::I8:
+		return fn.template operator()<int8_t>();
+	case TypeId::I16:
+		return fn.template operator()<int16_t>();
+	case TypeId::I32:
+		return fn.template operator()<int32_t>();
+	case TypeId::I64:
+		return fn.template operator()<int64_t>();
+	case TypeId::U8:
+		return fn.template operator()<uint8_t>();
+	case TypeId::U16:
+		return fn.template operator()<uint16_t>();
+	case TypeId::U32:
+		return fn.template operator()<uint32_t>();
+	case TypeId::U64:
+		return fn.template operator()<uint64_t>();
+	default:
+		__builtin_unreachable();
+	}
+}
+
+/// Same as dispatchIntType, restricted to the float domain (float, double).
+template <typename Fn>
+auto dispatchFloatType(TypeId target, Fn&& fn) {
+	switch (target) {
+	case TypeId::F32:
+		return fn.template operator()<float>();
+	case TypeId::F64:
+		return fn.template operator()<double>();
+	default:
+		__builtin_unreachable();
+	}
+}
+
+/// Top-level dispatch across all ten types, used once per fuzzer input to
+/// pick which monomorphic instantiation of the generator/evaluator to run.
+template <typename Fn>
+auto dispatchAnyType(TypeId target, Fn&& fn) {
+	switch (target) {
+	case TypeId::I8:
+		return fn.template operator()<int8_t>();
+	case TypeId::I16:
+		return fn.template operator()<int16_t>();
+	case TypeId::I32:
+		return fn.template operator()<int32_t>();
+	case TypeId::I64:
+		return fn.template operator()<int64_t>();
+	case TypeId::U8:
+		return fn.template operator()<uint8_t>();
+	case TypeId::U16:
+		return fn.template operator()<uint16_t>();
+	case TypeId::U32:
+		return fn.template operator()<uint32_t>();
+	case TypeId::U64:
+		return fn.template operator()<uint64_t>();
+	case TypeId::F32:
+		return fn.template operator()<float>();
+	case TypeId::F64:
+		return fn.template operator()<double>();
+	}
+	__builtin_unreachable();
+}
+
+/// Compile-time type -> short suffix, the mirror of typeName(TypeId) for use
+/// in templated contexts (e.g. annotating a printed Const literal).
+template <typename T>
+constexpr const char* typeSuffix() {
+	if constexpr (std::is_same_v<T, int8_t>) {
+		return "i8";
+	} else if constexpr (std::is_same_v<T, int16_t>) {
+		return "i16";
+	} else if constexpr (std::is_same_v<T, int32_t>) {
+		return "i32";
+	} else if constexpr (std::is_same_v<T, int64_t>) {
+		return "i64";
+	} else if constexpr (std::is_same_v<T, uint8_t>) {
+		return "u8";
+	} else if constexpr (std::is_same_v<T, uint16_t>) {
+		return "u16";
+	} else if constexpr (std::is_same_v<T, uint32_t>) {
+		return "u32";
+	} else if constexpr (std::is_same_v<T, uint64_t>) {
+		return "u64";
+	} else if constexpr (std::is_same_v<T, float>) {
+		return "f32";
+	} else if constexpr (std::is_same_v<T, double>) {
+		return "f64";
+	} else {
+		static_assert(!sizeof(T), "unsupported fuzz value type");
+	}
+}
+
+/// Diagnostic-only formatting for failure reports. 1-byte integer types are
+/// widened before formatting so they print numerically rather than risking
+/// char-like interpretation. Floats use enough significant digits (17) to
+/// round-trip a double exactly (9 suffices for float; 17 is a safe superset
+/// for both).
+template <typename T>
+std::string formatValue(T v) {
+	if constexpr (std::is_floating_point_v<T>) {
+		char buf[64];
+		std::snprintf(buf, sizeof(buf), "%.17g", static_cast<double>(v));
+		return buf;
+	} else if constexpr (sizeof(T) == 1) {
+		if constexpr (std::is_signed_v<T>) {
+			return std::to_string(static_cast<int>(v));
+		} else {
+			return std::to_string(static_cast<unsigned int>(v));
+		}
+	} else {
+		return std::to_string(v);
+	}
+}
+
+/// Oracle-vs-backend equality. Exact for integers; NaN-aware for floats so
+/// that two NaN results (a routine, expected outcome of generated float
+/// programs) aren't reported as a mismatch.
+template <typename T>
+bool valuesEqual(T a, T b) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return a == b || (std::isnan(a) && std::isnan(b));
+	} else {
+		return a == b;
+	}
+}
+
+} // namespace nautilus::fuzz


### PR DESCRIPTION
Widen the fuzzer's generated programs from a single uint64_t domain to
all 8 integer widths/signs plus float/double, add a Cast node (round-trips
through another same-domain type) and unary negate/bitwise-not, and make
oracle-vs-backend equality NaN-aware for the float domain. The generator,
oracle, and traced evaluator are now templated per value type, dispatched
from the first byte of the fuzzer input via a shared TypeId helper
(Types.hpp), keeping the AST/Node structure itself untemplated.

Running the extended fuzzer immediately surfaced several real miscompiles,
now fixed at their root:

- cpp backend: float/double constant literals were printed at default
  (6 significant digit) stream precision in the actual emission line,
  silently discarding precision even though a separate precision-correct
  stream was built and unused (CPPLoweringProvider.hpp).
- cpp backend: NaN/Inf constants printed as the bare words "nan"/"inf",
  which aren't valid C++ literal syntax, so the regenerated source failed
  to recompile; now emitted via __builtin_nan/__builtin_inf
  (CPPLoweringProvider.hpp).
- MLIR backend: float arithmetic was tagged with LLVM's "fast" fastmath
  flag, letting the optimizer assume no NaN/Inf ever occur -- it exploited
  this to fold an entire function to `poison`. Flags are now `none`
  (MLIRLoweringProvider.cpp).
- asmjit x86_64 backend: float EQ/NE/LT/LE used ordered comparison
  predicates on ucomiss/ucomisd flags, giving wrong results whenever a
  NaN was involved; EQ/NE now additionally check the parity flag and
  LT/LE compare with swapped operands (X64LoweringProvider.cpp).
- asmjit x86_64 backend: integer ops (Cast, Add, Sub, Mul, bitwise-not,
  Shift) on narrower-than-64-bit stamps could leave a register's upper
  bits inconsistent with its type's sign/zero-extension invariant after
  the true result overflowed the narrow width, corrupting later
  comparisons/casts that read the full 64-bit register. Every such op now
  re-extends its result via a shared narrowToStamp() helper
  (X64LoweringProvider.cpp/.hpp).
- IR constant folding: folded Add/Sub/Mul/Div/Mod/Shl/Shr results were
  never truncated to the operation's actual stamp width, so a fold could
  bake an out-of-range value (e.g. a shift overflowing i32) into a
  ConstIntOperation. Most backends happened to re-truncate when
  materializing a typed constant from it, masking the bug everywhere
  except a backend that loads the raw value unmodified
  (ConstantFoldingAndCopyPropagationPass.cpp).

The deterministic 2000-iteration smoke corpus now passes cleanly across
all backends for all ten generated types.