### PR TITLE
Default bytecode interpreter to its fastest configuration; pool alloca buffers

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -40,6 +40,10 @@ See [engine.md](engine.md) for how to create modules and override options per mo
 | mlir.enableIntrinsics=[true,false]          | true     | Module  | Registers the MLIR intrinsic plugins for this compilation.                                                                                            |
 | mlir.inline_invoke_calls=[true,false]       | false    | Module  | Allow MLIR Backend to inline functions that were tagged with NAUTILUS_INLINE                                                                          |
 | bc.registerAllocator=[true,false]           | true     | Module  | Enables the linear register allocator in the bytecode backend.                                                                                        |
+| bc.dispatch=[call,switch,threaded]          | threaded | Module  | Selects how the bytecode interpreter dispatches operations. `threaded` (computed-goto) is fastest and falls back to `switch` on compilers without labels-as-values; `call` is the legacy indirect-call table. |
+| bc.regfileReuse=[true,false]                | true     | Module  | Recycles the per-invocation register file (and alloca buffers) from a thread-local pool instead of heap-allocating fresh ones each call. Applies to all dispatch modes. |
+| bc.superinstructions=[true,false]           | true     | Module  | Fuses a single-use trailing compare into the conditional branch. Only takes effect when `bc.dispatch=threaded`.                                       |
+| bc.immediates=[true,false]                  | true     | Module  | Folds small constant operands directly into arithmetic ops. Only takes effect when `bc.dispatch=threaded`.                                            |
 | asmjit.enableIntrinsics=[true,false]        | true     | Module  | Registers the AsmJit intrinsic plugins for this compilation.                                                                                          |
 | asmjit.enablePostRAPeephole=[true,false]    | true     | Module  | Enables post-register-allocation peephole optimizations in the AsmJit backend.                                                                        |
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -1,5 +1,7 @@
 
 #include <cassert>
+#include <cstring>
+#include <nautilus/common/Arena.hpp>
 #include <nautilus/compiler/backends/bc/BCInterpreter.hpp>
 #include <nautilus/compiler/backends/bc/Dyncall.hpp>
 #include <sstream>
@@ -634,40 +636,18 @@ void releaseRegisterFile(RegisterFile&& buf) {
 	tlRegisterFilePool.push_back(std::move(buf));
 }
 
-// Same pooling pattern as tlRegisterFilePool, applied to the per-invocation alloca
-// buffers: each entry is one invocation's full set of alloca slots
-// (std::vector<std::vector<uint8_t>>, matching invoke()'s localAllocaBuffers). No
-// keying by Code identity — like the register-file pool, this is a free list of
-// interchangeable buffers; acquire() always resizes and re-zeroes from the calling
-// Code's allocaBuffers sizes, so a buffer shaped for one function is transparently
-// reshaped for another on its next acquire. Unlike the register file (whose `init`
-// carries real default register values to copy), alloca buffers must always come
-// back zeroed, so acquire() re-zeroes every byte via assign() rather than copying
-// `sizes`' contents — assign() still reuses each inner buffer's existing heap
-// capacity, so after warmup no allocation happens. Used only when bc.regfileReuse
-// is enabled.
-thread_local std::vector<std::vector<std::vector<uint8_t>>> tlAllocaBufferPool;
-
-std::vector<std::vector<uint8_t>> acquireAllocaBuffers(const std::vector<std::vector<uint8_t>>& sizes) {
-	if (tlAllocaBufferPool.empty()) {
-		std::vector<std::vector<uint8_t>> bufs(sizes.size());
-		for (size_t i = 0; i < sizes.size(); i++) {
-			bufs[i].resize(sizes[i].size(), 0);
-		}
-		return bufs;
-	}
-	std::vector<std::vector<uint8_t>> bufs = std::move(tlAllocaBufferPool.back());
-	tlAllocaBufferPool.pop_back();
-	bufs.resize(sizes.size());
-	for (size_t i = 0; i < sizes.size(); i++) {
-		bufs[i].assign(sizes[i].size(), 0);
-	}
-	return bufs;
-}
-
-void releaseAllocaBuffers(std::vector<std::vector<uint8_t>>&& bufs) {
-	tlAllocaBufferPool.push_back(std::move(bufs));
-}
+// Per-invocation alloca buffers are allocated from a pooled bump-pointer arena
+// (nautilus::common::Arena/ArenaPool, already used elsewhere for exactly this
+// "recycle scratch storage across cycles instead of going through malloc every
+// time" pattern — see Arena.hpp) instead of a hand-rolled buffer pool. The pool
+// is thread_local so concurrent threads stay independent; each acquire() hands
+// back a distinct Arena::Handle, so nested bc->bc calls on one thread never
+// alias. Returning a Handle runs Arena::softReset, which resets the bump
+// pointer but keeps the arena's heap chunks for the next acquire to bump into,
+// so after warmup no allocation happens. Used only when bc.regfileReuse is
+// enabled; unlike RegisterFile there is no "default contents" to copy in, so
+// each alloca slot is explicitly zeroed after allocation (see invoke()).
+thread_local common::ArenaPool tlAllocaArenaPool;
 } // namespace
 
 int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
@@ -688,30 +668,18 @@ int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
 		}
 	} guard {&regs, reuse};
 
-	// Per-invocation alloca buffers, zeroed for a clean stack frame. Recycled from a
-	// thread-local pool under the same bc.regfileReuse flag as the register file —
-	// both are per-invocation scratch state, so there is no reason to want one
-	// pooled without the other.
-	std::vector<std::vector<uint8_t>> localAllocaBuffers =
-	    reuse ? acquireAllocaBuffers(code.allocaBuffers) : std::vector<std::vector<uint8_t>>(code.allocaBuffers.size());
-	if (!reuse) {
-		for (const auto& [reg, bufIdx] : code.allocaRegisterMap) {
-			localAllocaBuffers[bufIdx].resize(code.allocaBuffers[bufIdx].size(), 0);
-		}
-	}
-	// Return the recycled buffers to the pool on every exit path, including if
-	// execute() throws.
-	struct AllocaPoolGuard {
-		std::vector<std::vector<uint8_t>>* bufs;
-		bool active;
-		~AllocaPoolGuard() {
-			if (active) {
-				releaseAllocaBuffers(std::move(*bufs));
-			}
-		}
-	} allocaGuard {&localAllocaBuffers, reuse};
+	// Per-invocation alloca buffers, allocated from a pooled bump-pointer arena and
+	// zeroed for a clean stack frame. Recycled from the same thread-local pool under
+	// bc.regfileReuse as the register file — both are per-invocation scratch state, so
+	// there is no reason to want one pooled without the other. The Handle's destructor
+	// returns the arena to the pool (or deletes it, if standalone) on every exit path,
+	// including if execute() throws.
+	common::ArenaPool::Handle allocaArena = reuse ? tlAllocaArenaPool.acquire() : common::ArenaPool::makeStandalone();
 	for (const auto& [reg, bufIdx] : code.allocaRegisterMap) {
-		regs[reg] = reinterpret_cast<int64_t>(localAllocaBuffers[bufIdx].data());
+		auto size = code.allocaBuffers[bufIdx].size();
+		void* mem = allocaArena->allocate(size, alignof(std::max_align_t));
+		std::memset(mem, 0, size);
+		regs[reg] = reinterpret_cast<int64_t>(mem);
 	}
 
 	// Read arguments from DCArgs directly into the local register file.

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -633,6 +633,41 @@ RegisterFile acquireRegisterFile(const RegisterFile& init) {
 void releaseRegisterFile(RegisterFile&& buf) {
 	tlRegisterFilePool.push_back(std::move(buf));
 }
+
+// Same pooling pattern as tlRegisterFilePool, applied to the per-invocation alloca
+// buffers: each entry is one invocation's full set of alloca slots
+// (std::vector<std::vector<uint8_t>>, matching invoke()'s localAllocaBuffers). No
+// keying by Code identity — like the register-file pool, this is a free list of
+// interchangeable buffers; acquire() always resizes and re-zeroes from the calling
+// Code's allocaBuffers sizes, so a buffer shaped for one function is transparently
+// reshaped for another on its next acquire. Unlike the register file (whose `init`
+// carries real default register values to copy), alloca buffers must always come
+// back zeroed, so acquire() re-zeroes every byte via assign() rather than copying
+// `sizes`' contents — assign() still reuses each inner buffer's existing heap
+// capacity, so after warmup no allocation happens. Used only when bc.regfileReuse
+// is enabled.
+thread_local std::vector<std::vector<std::vector<uint8_t>>> tlAllocaBufferPool;
+
+std::vector<std::vector<uint8_t>> acquireAllocaBuffers(const std::vector<std::vector<uint8_t>>& sizes) {
+	if (tlAllocaBufferPool.empty()) {
+		std::vector<std::vector<uint8_t>> bufs(sizes.size());
+		for (size_t i = 0; i < sizes.size(); i++) {
+			bufs[i].resize(sizes[i].size(), 0);
+		}
+		return bufs;
+	}
+	std::vector<std::vector<uint8_t>> bufs = std::move(tlAllocaBufferPool.back());
+	tlAllocaBufferPool.pop_back();
+	bufs.resize(sizes.size());
+	for (size_t i = 0; i < sizes.size(); i++) {
+		bufs[i].assign(sizes[i].size(), 0);
+	}
+	return bufs;
+}
+
+void releaseAllocaBuffers(std::vector<std::vector<uint8_t>>&& bufs) {
+	tlAllocaBufferPool.push_back(std::move(bufs));
+}
 } // namespace
 
 int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
@@ -653,10 +688,29 @@ int64_t BCInterpreter::invoke(DCArgs* args, const std::vector<Type>& argTypes) {
 		}
 	} guard {&regs, reuse};
 
-	// Per-invocation alloca buffers, zeroed for a clean stack frame.
-	std::vector<std::vector<uint8_t>> localAllocaBuffers(code.allocaBuffers.size());
+	// Per-invocation alloca buffers, zeroed for a clean stack frame. Recycled from a
+	// thread-local pool under the same bc.regfileReuse flag as the register file —
+	// both are per-invocation scratch state, so there is no reason to want one
+	// pooled without the other.
+	std::vector<std::vector<uint8_t>> localAllocaBuffers =
+	    reuse ? acquireAllocaBuffers(code.allocaBuffers) : std::vector<std::vector<uint8_t>>(code.allocaBuffers.size());
+	if (!reuse) {
+		for (const auto& [reg, bufIdx] : code.allocaRegisterMap) {
+			localAllocaBuffers[bufIdx].resize(code.allocaBuffers[bufIdx].size(), 0);
+		}
+	}
+	// Return the recycled buffers to the pool on every exit path, including if
+	// execute() throws.
+	struct AllocaPoolGuard {
+		std::vector<std::vector<uint8_t>>* bufs;
+		bool active;
+		~AllocaPoolGuard() {
+			if (active) {
+				releaseAllocaBuffers(std::move(*bufs));
+			}
+		}
+	} allocaGuard {&localAllocaBuffers, reuse};
 	for (const auto& [reg, bufIdx] : code.allocaRegisterMap) {
-		localAllocaBuffers[bufIdx].resize(code.allocaBuffers[bufIdx].size(), 0);
 		regs[reg] = reinterpret_cast<int64_t>(localAllocaBuffers[bufIdx].data());
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -13,7 +13,7 @@ namespace nautilus::compiler::bc {
 /**
  * @brief Selects how the interpreter dispatches bytecode operations.
  *
- * Call:     indirect call through the OpTable function-pointer table (legacy default).
+ * Call:     indirect call through the OpTable function-pointer table (legacy, slowest).
  * Switch:   an inlined switch over the opcode, which lets the compiler inline the
  *           operation bodies and keep the register base hot instead of paying a
  *           non-inlined indirect call per instruction.
@@ -23,6 +23,7 @@ namespace nautilus::compiler::bc {
  *           on compilers without the computed-goto extension (e.g. MSVC). This
  *           is still a pure interpreter — the label table is data, not generated
  *           machine code, so it remains usable where runtime codegen is banned.
+ *           This is the default dispatch mode.
  */
 enum class DispatchMode { Call, Switch, Threaded };
 
@@ -33,18 +34,19 @@ DispatchMode parseDispatchMode(const std::string& value);
  * @brief Per-interpreter options resolved from engine options at compile time.
  *
  * dispatch:           how operations are dispatched (see DispatchMode).
- * reuseRegisterFile:  recycle the per-invocation register file from a thread-local
- *                     pool instead of heap-allocating a fresh copy each call.
+ * reuseRegisterFile:  recycle the per-invocation register file and alloca buffers
+ *                     from thread-local pools instead of heap-allocating fresh
+ *                     copies each call.
  * superinstructions:  fuse compare+branch into a single op in the flattened
  *                     threaded stream (threaded path only).
  * immediates:         fold compile-time-constant operands directly into ops in the
  *                     flattened threaded stream (threaded path only).
  */
 struct BCInterpreterOptions {
-	DispatchMode dispatch = DispatchMode::Call;
-	bool reuseRegisterFile = false;
-	bool superinstructions = false;
-	bool immediates = false;
+	DispatchMode dispatch = DispatchMode::Threaded;
+	bool reuseRegisterFile = true;
+	bool superinstructions = true;
+	bool immediates = true;
 };
 
 /// Data passed to the dyncallback handler for each function.

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -126,16 +126,19 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 	loweringOptions.enableRegisterAllocator = options.getOptionOrDefault("bc.registerAllocator", true);
 
 	// Execution-time options for the interpreter, mirroring the bc.registerAllocator
-	// plumbing so the A/B benchmark harness can compare each in isolation.
+	// plumbing so the A/B benchmark harness can compare each in isolation. All four
+	// default to the fastest validated combination (threaded dispatch with pooling,
+	// superinstructions, and immediate folding); set explicitly to fall back to the
+	// legacy call-dispatch behaviour or to A/B individual knobs.
 	//   bc.dispatch          how each op is dispatched (call / switch / threaded)
 	//   bc.regfileReuse      recycle the per-invocation register file from a pool
 	//   bc.superinstructions fuse compare+branch in the threaded stream
 	//   bc.immediates        fold constant operands in the threaded stream
 	BCInterpreterOptions interpreterOptions;
-	interpreterOptions.dispatch = parseDispatchMode(options.getOptionOrDefault<std::string>("bc.dispatch", "call"));
-	interpreterOptions.reuseRegisterFile = options.getOptionOrDefault("bc.regfileReuse", false);
-	interpreterOptions.superinstructions = options.getOptionOrDefault("bc.superinstructions", false);
-	interpreterOptions.immediates = options.getOptionOrDefault("bc.immediates", false);
+	interpreterOptions.dispatch = parseDispatchMode(options.getOptionOrDefault<std::string>("bc.dispatch", "threaded"));
+	interpreterOptions.reuseRegisterFile = options.getOptionOrDefault("bc.regfileReuse", true);
+	interpreterOptions.superinstructions = options.getOptionOrDefault("bc.superinstructions", true);
+	interpreterOptions.immediates = options.getOptionOrDefault("bc.immediates", true);
 
 	// Phase 1: Allocate callback data and dyncallback thunks for all functions.
 	// The interpreter is not yet set — we need all function pointers resolved first.

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/Engine.hpp"
 #include "nautilus/config.hpp"
+#include "nautilus/val_std.hpp"
 #include <catch2/catch_all.hpp>
 
 namespace nautilus::engine {
@@ -9,6 +10,36 @@ val<int8_t> addExpression(val<int8_t> x) {
 	val<int8_t> y = (int8_t) 2;
 	return y + x;
 }
+
+#ifdef ENABLE_BC_BACKEND
+// A small struct local forces the bytecode backend to allocate a stack slot
+// (AllocaOperation) per invocation. Like addExpression, the rest of the function
+// body is cheap, so per-call allocation/zeroing cost dominates and is isolated by
+// this kernel — used by the bc.regfileReuse A/B benchmark below to show the win
+// from also pooling alloca buffers, not just the register file.
+struct AllocaScratch {
+	int32_t a;
+	int32_t b;
+	int32_t c;
+	int32_t d;
+};
+
+val<int32_t> allocaHeavy(val<int32_t> x) {
+	val<AllocaScratch> scratch;
+	scratch.set(&AllocaScratch::a, x);
+	scratch.set(&AllocaScratch::b, x + 1);
+	scratch.set(&AllocaScratch::c, x + 2);
+	scratch.set(&AllocaScratch::d, x + 3);
+	return scratch.get(&AllocaScratch::a) + scratch.get(&AllocaScratch::b) + scratch.get(&AllocaScratch::c) +
+	       scratch.get(&AllocaScratch::d);
+}
+
+void runAllocaHeavyBenchmark(Catch::Benchmark::Chronometer& meter, Options& options) {
+	auto engine = engine::NautilusEngine(options);
+	auto func = engine.registerFunction(allocaHeavy);
+	meter.measure([&] { return func(42); });
+}
+#endif
 
 val<int32_t> fib(val<int32_t> n) {
 	val<int32_t> a = 0, b = 1, c;
@@ -147,6 +178,24 @@ TEST_CASE("Execution Benchmark") {
 				    func(meter, op);
 			    });
 		}
+	}
+
+	// BC-only A/B benchmark isolating the bc.regfileReuse win for alloca-backed
+	// locals specifically (as opposed to the register file): allocaHeavy's struct
+	// local forces a per-invocation stack-slot allocation that the register-file-only
+	// A/B block above does not exercise.
+	for (bool reuse : {false, true}) {
+		std::string tag = reuse ? "reuse" : "noReuse";
+		Catch::Benchmark::Benchmark("exec_bc_allocaHeavy_threaded_" + tag)
+		    .operator=([reuse](Catch::Benchmark::Chronometer meter) {
+			    auto op = engine::Options();
+			    op.setOption("mlir.eager_compilation", true);
+			    op.setOption("engine.backend", std::string("bc"));
+			    op.setOption("engine.traceMode", "lazyTracing");
+			    op.setOption("bc.dispatch", std::string("threaded"));
+			    op.setOption("bc.regfileReuse", reuse);
+			    runAllocaHeavyBenchmark(meter, op);
+		    });
 	}
 
 	// BC-only A/B for compare+branch superinstructions on the threaded path

--- a/nautilus/test/execution-tests/BCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/BCDispatchModeTest.cpp
@@ -1,6 +1,7 @@
 #include "ExecutionTest.hpp"
 #include "nautilus/Engine.hpp"
 #include "nautilus/val.hpp"
+#include "nautilus/val_std.hpp"
 #include <catch2/catch_all.hpp>
 
 // The bytecode interpreter offers three dispatch strategies selected via the
@@ -63,6 +64,29 @@ val<int64_t> bcModBit(val<int64_t> a, val<int64_t> b) {
 	return m + (a & b) + (a | b) + (a ^ b);
 }
 
+// Plain struct with no user-declared constructor: val<AllocaLocals> default
+// construction does not zero its alloca'd backing memory (val_std.hpp only invokes
+// a constructor for non-trivially-default-constructible types), so its initial
+// contents are exactly whatever the interpreter handed back for that alloca slot.
+// Combined with calling the same compiled function repeatedly below, this is the
+// right shape to catch a regression where pooled alloca buffers (bc.regfileReuse)
+// leak a previous invocation's bytes into the next instead of being re-zeroed.
+struct AllocaLocals {
+	int32_t a;
+	int32_t b;
+};
+
+val<int32_t> bcAllocaReuse(val<int32_t> x) {
+	val<AllocaLocals> value;
+	if (x > 0) {
+		value.set(&AllocaLocals::a, x);
+		value.set(&AllocaLocals::b, x * 2);
+	}
+	// When x <= 0 neither field is written, so a correct implementation must
+	// observe zero-initialized memory here, not leftover values from a prior call.
+	return value.get(&AllocaLocals::a) + value.get(&AllocaLocals::b);
+}
+
 engine::NautilusEngine bcEngine(const std::string& dispatch, bool reuseRegisterFile = false,
                                 bool superinstructions = false, bool immediates = false) {
 	engine::Options options;
@@ -116,6 +140,8 @@ TEST_CASE("BC dispatch modes produce identical results") {
 			auto aCast = alt.registerFunction(bcCasts);
 			auto cMod = call.registerFunction(bcModBit);
 			auto aMod = alt.registerFunction(bcModBit);
+			auto cAllocaReuse = call.registerFunction(bcAllocaReuse);
+			auto aAllocaReuse = alt.registerFunction(bcAllocaReuse);
 
 			for (int64_t a = -20; a <= 20; a += 3) {
 				REQUIRE(aFib(a) == cFib(a));
@@ -129,7 +155,49 @@ TEST_CASE("BC dispatch modes produce identical results") {
 			for (int32_t n = 0; n <= 5000; n += 777) {
 				REQUIRE(aSum(n) == cSum(n));
 			}
+
+			// Call the same compiled function repeatedly, alternating between an input
+			// that writes the alloca-backed struct's fields and one that doesn't. A
+			// regfileReuse=true variant that pooled the alloca buffer without re-zeroing
+			// it would leak the prior call's fields into this call's "untouched" reads.
+			for (int32_t i = 0; i < 4; i++) {
+				REQUIRE(aAllocaReuse(50 + i) == cAllocaReuse(50 + i));
+				REQUIRE(aAllocaReuse(-1) == cAllocaReuse(-1));
+			}
 		}
+	}
+}
+
+TEST_CASE("BC backend with no bc.* options set matches the explicit call/false/false/false reference") {
+	// Pins BCInterpreterBackend's shipped defaults (threaded/true/true/true) against
+	// the same reference used above, without constructing the engine through
+	// bcEngine() — i.e. leaving every "bc.*" option unset, exactly as a production
+	// caller that never heard of these options would.
+	engine::Options defaultOptions;
+	defaultOptions.setOption("engine.backend", std::string("bc"));
+	engine::NautilusEngine withDefaults(defaultOptions);
+
+	auto call = bcEngine("call");
+
+	auto cArith = call.registerFunction(bcArith);
+	auto dArith = withDefaults.registerFunction(bcArith);
+	auto cFib = call.registerFunction(bcFib);
+	auto dFib = withDefaults.registerFunction(bcFib);
+	auto cBranch = call.registerFunction(bcBranchy);
+	auto dBranch = withDefaults.registerFunction(bcBranchy);
+	auto cAllocaReuse = call.registerFunction(bcAllocaReuse);
+	auto dAllocaReuse = withDefaults.registerFunction(bcAllocaReuse);
+
+	for (int64_t a = -20; a <= 20; a += 3) {
+		REQUIRE(dFib(a) == cFib(a));
+		REQUIRE(dBranch(a) == cBranch(a));
+		for (int64_t b = -20; b <= 20; b += 5) {
+			REQUIRE(dArith(a, b) == cArith(a, b));
+		}
+	}
+	for (int32_t i = 0; i < 4; i++) {
+		REQUIRE(dAllocaReuse(50 + i) == cAllocaReuse(50 + i));
+		REQUIRE(dAllocaReuse(-1) == cAllocaReuse(-1));
 	}
 }
 


### PR DESCRIPTION
## Summary

Investigation into bytecode (BC) interpreter performance found that several
already-implemented, already-tested optimizations were never shipped: every one
of them defaulted to the slowest/disabled setting in
`BCInterpreterBackend::compile()`.

- **Flip production defaults to the validated fast combination.**
  `bc.dispatch` now defaults to `"threaded"` (computed-goto) instead of
  `"call"` (legacy indirect-call table), and `bc.regfileReuse`,
  `bc.superinstructions`, `bc.immediates` now default to `true`. This is
  exactly the combination `BCDispatchModeTest.cpp` already validates for
  correctness and `ExecutionBenchmark.cpp`'s `allOpts` A/B benchmark already
  demonstrates is faster — only the shipped defaults were stale. `Threaded`
  safely falls back to `Switch` behavior at runtime on compilers without
  computed-goto support, so this is safe everywhere.
- **Pool per-invocation alloca buffers**, extending `bc.regfileReuse` (which
  already pools the register file) to also pool the per-invocation alloca
  buffers in `BCInterpreter::invoke()`. Previously, any function with an
  alloca-backed local (e.g. `val<Struct>`) heap-allocated and zeroed a fresh
  buffer set on *every* call regardless of this flag.
- Document the four previously-undocumented `bc.*` options in
  `docs/options.md`.

## Test plan

- [x] Added a `BCDispatchModeTest.cpp` kernel (`bcAllocaReuse`) using an
      alloca-backed struct local, called repeatedly with alternating inputs to
      catch a regression where pooled alloca buffers leak stale bytes across
      invocations instead of being re-zeroed; exercised across all existing
      dispatch/flag variants.
- [x] Added a `BCDispatchModeTest.cpp` test case pinning the new no-options-set
      defaults against the explicit `call`/`false`/`false`/`false` reference.
- [x] Added an `ExecutionBenchmark.cpp` A/B benchmark
      (`exec_bc_allocaHeavy_threaded_{reuse,noReuse}`) isolating the alloca
      pooling win.
- [x] Built with Clang 18 (Clang 21 unavailable in this environment) with
      `ENABLE_BC_BACKEND=ON`, `ENABLE_TESTS=ON`, `ENABLE_BENCHMARKS=ON` and ran
      the full execution test suite: 42 test cases, 7192/7192 assertions
      passed (10 skipped tests require MLIR/C/asmjit backends, disabled for a
      faster build).
      - Recommend CI re-verify with Clang 21 per project convention.
- [x] Ran the new `exec_bc_allocaHeavy_threaded_*` benchmark; `reuse` measured
      faster than `noReuse` as expected.
- [x] `clang-format-18 --dry-run --Werror` clean on all changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AYREvMcvtZRkRZnhAiAcpP)_