### PR TITLE
Extend differential fuzzer to int↔float casts and bounded loops; fix signed-zero negation bug

### DIFF
--- a/nautilus/include/nautilus/val_arith.hpp
+++ b/nautilus/include/nautilus/val_arith.hpp
@@ -175,7 +175,18 @@ public:
 	/// Unary negation operator.
 	/// Const-qualified to work on const values, matching C++ semantics.
 	val<ValueType> operator-() const {
-		return (ValueType) 0 - *this;
+		if constexpr (std::floating_point<ValueType>) {
+			// `0 - x` is not IEEE-754 negation: subtraction of two exactly
+			// equal-magnitude operands rounds to +0.0 in the default
+			// round-to-nearest mode, so `0.0 - 0.0` is `+0.0`, not the `-0.0`
+			// that negating `+0.0` must produce. Multiplication's sign is
+			// always the XOR of its operands' signs, so `-1 * x` flips the
+			// sign bit correctly for zero (and every other value) instead of
+			// going through cancellation.
+			return (ValueType) -1 * *this;
+		} else {
+			return (ValueType) 0 - *this;
+		}
 	}
 
 	/// Prefix decrement operator.

--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -40,12 +40,26 @@ enum class Kind : uint8_t {
 	// Unary
 	Neg, // integer and float domains: -x
 	Not, // integer domain only: ~x
-	// Cast: round-trips the single child through another same-domain type,
-	// i.e. (T)(To)x. imm holds the target TypeId (an integer TypeId for the
-	// integer domain, a float TypeId for the float domain). int<->float
-	// casts are intentionally unsupported (would need UB-safe range
-	// clamping before casting an out-of-range float to an integer type).
-	Cast
+	// Cast: round-trips the single child through another type, i.e. (T)(To)x.
+	// imm holds the target TypeId, drawn from any of the ten types -- this
+	// can cross the int/float domain boundary (the output type is always T,
+	// the surrounding tree's type, exactly like a same-domain cast; only the
+	// intermediate type's domain changes). Whichever leg of the round trip
+	// is float->int is range-clamped (NaN -> 0, out-of-range -> min/max) so
+	// the cast is well-defined for every input; see castThrough in
+	// EvalNative.hpp / EvalNautilus.hpp.
+	Cast,
+	// Bounded, data-dependent fold: kid[0]=count, kid[1]=init, kid[2]=body.
+	// trips = clamp(eval(count)) in [0, LOOP_MAX_TRIPS]; acc = eval(init);
+	// acc = eval(body) repeated `trips` times, with LoopIndex/LoopAcc bound
+	// to the current iteration inside body. Lowered to a real traced `for`
+	// loop on the Nautilus side, exercising loop-lowering (not unrolling).
+	Loop,
+	// Leaves, only legal while generating inside a Loop body: current
+	// iteration index / accumulator of the innermost enclosing Loop. No imm
+	// payload -- nesting uses simple shadowing (innermost wins).
+	LoopIndex,
+	LoopAcc
 };
 
 struct Node {
@@ -61,17 +75,21 @@ struct Ast {
 
 namespace detail {
 
-inline constexpr Kind INT_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul,    Kind::Div, Kind::Mod, Kind::And, Kind::Or,
-                                     Kind::Xor, Kind::Shl, Kind::Shr,    Kind::Eq,  Kind::Ne,  Kind::Lt,  Kind::Le,
-                                     Kind::Gt,  Kind::Ge,  Kind::Select, Kind::If,  Kind::Neg, Kind::Not, Kind::Cast};
+inline constexpr Kind INT_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul,  Kind::Div, Kind::Mod,    Kind::And,
+                                     Kind::Or,  Kind::Xor, Kind::Shl,  Kind::Shr, Kind::Eq,     Kind::Ne,
+                                     Kind::Lt,  Kind::Le,  Kind::Gt,   Kind::Ge,  Kind::Select, Kind::If,
+                                     Kind::Neg, Kind::Not, Kind::Cast, Kind::Loop};
 
-inline constexpr Kind FLOAT_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul, Kind::Div,    Kind::Eq, Kind::Ne,  Kind::Lt,
-                                       Kind::Le,  Kind::Gt,  Kind::Ge,  Kind::Select, Kind::If, Kind::Neg, Kind::Cast};
+inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,    Kind::Sub, Kind::Mul, Kind::Div,  Kind::Eq,
+                                       Kind::Ne,     Kind::Lt,  Kind::Le,  Kind::Gt,   Kind::Ge,
+                                       Kind::Select, Kind::If,  Kind::Neg, Kind::Cast, Kind::Loop};
 
 inline int arity(Kind k) {
 	switch (k) {
 	case Kind::Const:
 	case Kind::Param:
+	case Kind::LoopIndex:
+	case Kind::LoopAcc:
 		return 0;
 	case Kind::Neg:
 	case Kind::Not:
@@ -79,14 +97,19 @@ inline int arity(Kind k) {
 		return 1;
 	case Kind::Select:
 	case Kind::If:
+	case Kind::Loop:
 		return 3;
 	default:
 		return 2;
 	}
 }
 
+/// `loopDepth` counts how many Loop bodies the recursion is currently
+/// nested inside; LoopIndex/LoopAcc are only legal leaves while it's > 0.
+/// Passed by value: it naturally "pops" back down via the call stack on
+/// return, no explicit restore needed.
 template <typename T>
-int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
+int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth) {
 	const uint8_t sel = reader.byte();
 	bool leaf = depth <= 0 || budget <= 1 || reader.exhausted();
 	if (!leaf) {
@@ -96,7 +119,10 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
 
 	Node node;
 	if (leaf) {
-		if (sel & 0x4) {
+		if (loopDepth > 0 && (sel & 0x6) == 0x6) {
+			// ~1/4 of in-loop leaves reference the innermost loop's index/acc.
+			node.kind = (sel & 0x1) ? Kind::LoopAcc : Kind::LoopIndex;
+		} else if (sel & 0x4) {
 			node.kind = Kind::Param;
 			node.imm = reader.byte() % NUM_PARAMS;
 		} else {
@@ -118,19 +144,27 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
 	--budget;
 
 	if (node.kind == Kind::Cast) {
-		if constexpr (std::is_floating_point_v<T>) {
-			node.imm = static_cast<uint64_t>(FLOAT_TYPE_IDS[reader.byte() % 2]);
-		} else {
-			node.imm = static_cast<uint64_t>(INT_TYPE_IDS[reader.byte() % 8]);
-		}
+		// Target may be any of the ten types, crossing the int/float domain
+		// boundary (see the Kind::Cast comment for why this stays sound).
+		constexpr uint32_t typeCount = sizeof(ALL_TYPES) / sizeof(ALL_TYPES[0]);
+		node.imm = static_cast<uint64_t>(ALL_TYPES[reader.byte() % typeCount]);
 	}
 
 	const int childCount = arity(node.kind);
 	// Children must be generated before the parent is pushed so that parent
 	// indices stay greater than their children (handy for evaluation/printing).
 	int kids[3] = {-1, -1, -1};
-	for (int i = 0; i < childCount; ++i) {
-		kids[i] = generateNode<T>(ast, reader, depth - 1, budget);
+	if (node.kind == Kind::Loop) {
+		// count (kid[0]) and init (kid[1]) live in the *outer* scope -- they
+		// must not see this loop's own LoopIndex/LoopAcc. Only the body
+		// (kid[2]) is generated one loop deeper.
+		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
+	} else {
+		for (int i = 0; i < childCount; ++i) {
+			kids[i] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		}
 	}
 	node.kid[0] = kids[0];
 	node.kid[1] = kids[1];
@@ -148,6 +182,13 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget) {
 inline constexpr int MAX_DEPTH = 6;
 inline constexpr int MAX_NODES = 64;
 
+/// Upper bound on a Loop node's trip count (inclusive), enforced identically
+/// by EvalNative.hpp and EvalNautilus.hpp. Compile cost is governed by AST
+/// node count, not trip count -- the body is traced once regardless of how
+/// many times the compiled loop executes it -- so this only bounds oracle
+/// interpretation cost (which multiplies with loop nesting).
+inline constexpr int LOOP_MAX_TRIPS = 8;
+
 /// Build a random, always-valid AST of type T from the reader. Never returns
 /// an empty tree: an empty buffer yields a single Const(0) leaf.
 template <typename T>
@@ -155,7 +196,7 @@ Ast generate(ByteReader& reader) {
 	Ast ast;
 	ast.nodes.reserve(MAX_NODES + 1);
 	int budget = MAX_NODES;
-	ast.root = detail::generateNode<T>(ast, reader, MAX_DEPTH, budget);
+	ast.root = detail::generateNode<T>(ast, reader, MAX_DEPTH, budget, /*loopDepth=*/0);
 	return ast;
 }
 
@@ -210,6 +251,15 @@ void print(const Ast& ast, int idx, std::string& out) {
 	case Kind::Param:
 		out += "p" + std::to_string(n.imm);
 		return;
+	case Kind::LoopIndex:
+		// Always refers to the innermost enclosing loop -- ambiguous to read
+		// back out of a nested-loop printout, but this is a debug-only
+		// printer; crash reports also include the full args + expected/got.
+		out += "li";
+		return;
+	case Kind::LoopAcc:
+		out += "la";
+		return;
 	case Kind::Neg:
 		out += "(-";
 		print<T>(ast, n.kid[0], out);
@@ -244,6 +294,15 @@ void print(const Ast& ast, int idx, std::string& out) {
 		out += " != 0, ";
 		print<T>(ast, n.kid[1], out);
 		out += ", ";
+		print<T>(ast, n.kid[2], out);
+		out += ")";
+		return;
+	case Kind::Loop:
+		out += "loop(count=";
+		print<T>(ast, n.kid[0], out);
+		out += ", init=";
+		print<T>(ast, n.kid[1], out);
+		out += ", body=";
 		print<T>(ast, n.kid[2], out);
 		out += ")";
 		return;

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -3,9 +3,11 @@
 #include "Ast.hpp"
 #include "Types.hpp"
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
+#include <vector>
 
 namespace nautilus::fuzz {
 
@@ -24,8 +26,15 @@ namespace nautilus::fuzz {
  *     signed types additionally forced away from -1 (the one divisor value
  *     for which TYPE_MIN / divisor overflows and traps via `idiv` on x86),
  *   - shift amounts are masked to [0, bit-width(T)),
- *   - the float domain needs none of the above: IEEE 754 arithmetic
- *     (including division by zero, producing +-inf/NaN) is fully defined.
+ *   - float->int casts (directly, or as one leg of a Cast node routed
+ *     through the other domain) clamp out-of-range/NaN inputs to a defined
+ *     result instead of invoking C++'s float-to-int UB; int->float casts
+ *     need no such handling (precision loss only, never UB),
+ *   - Loop trip counts are clamped to [0, LOOP_MAX_TRIPS] via the same
+ *     unsigned-reinterpret-then-modulo on both the native and traced side,
+ *   - the float domain otherwise needs none of the above: IEEE 754
+ *     arithmetic (including division by zero, producing +-inf/NaN) is
+ *     fully defined.
  * Because every operation is well-defined, a disagreement between this
  * oracle and any Nautilus backend is an unambiguous miscompile (or tracing
  * bug).
@@ -69,37 +78,120 @@ T safeDivisor(T r) {
 	return d;
 }
 
-template <typename From>
-From castThroughInt(From v, TypeId target) {
-	return dispatchIntType(target, [&]<typename To>() -> From { return static_cast<From>(static_cast<To>(v)); });
+/// The only UB-prone leg of any cast crossing the int/float domain: clamp a
+/// float into To's representable range before truncating, using the
+/// power-of-two boundary helpers from Types.hpp (shared verbatim with
+/// EvalNautilus.hpp so the boundary math can't drift between the two).
+/// NaN maps to 0; out-of-range maps to To's min/max.
+template <typename From, typename To>
+To clampFloatToInt(From v) {
+	if (std::isnan(v)) {
+		return To(0);
+	}
+	if (v < loLimitInclusive<From, To>()) {
+		return std::numeric_limits<To>::min();
+	}
+	if (v >= hiLimitExclusive<From, To>()) {
+		return std::numeric_limits<To>::max();
+	}
+	return static_cast<To>(v);
 }
 
+/// Unified "cast through" dispatch: (From)(To)v for any target TypeId,
+/// same-domain or crossing int<->float. Exactly one leg of a
+/// domain-crossing round trip is float->int (the only UB-prone direction);
+/// that leg always goes through clampFloatToInt, the other leg is a plain
+/// (always-safe) static_cast.
 template <typename From>
-From castThroughFloat(From v, TypeId target) {
-	return dispatchFloatType(target, [&]<typename To>() -> From { return static_cast<From>(static_cast<To>(v)); });
+From castThrough(From v, TypeId target) {
+	if constexpr (std::is_floating_point_v<From>) {
+		if (isFloatType(target)) {
+			return dispatchFloatType(target,
+			                         [&]<typename To>() -> From { return static_cast<From>(static_cast<To>(v)); });
+		}
+		// From=float, target=int: clamp v into the integer range, then cast
+		// that integer back up to From (always safe, no clamp needed).
+		return dispatchIntType(target,
+		                       [&]<typename To>() -> From { return static_cast<From>(clampFloatToInt<From, To>(v)); });
+	} else {
+		if (!isFloatType(target)) {
+			return dispatchIntType(target,
+			                       [&]<typename To>() -> From { return static_cast<From>(static_cast<To>(v)); });
+		}
+		// From=int, target=float: int->float is safe; the *return* leg
+		// (float back down to the integer From) is what needs clamping.
+		return dispatchFloatType(target,
+		                         [&]<typename To>() -> From { return clampFloatToInt<To, From>(static_cast<To>(v)); });
+	}
 }
+
+/// Reduce a raw loop-count value of type T to a small, defined trip count in
+/// [0, LOOP_MAX_TRIPS]. Reinterprets to the unsigned-width representation
+/// first (well-defined bit-pattern reinterpret for ints; clamp-through-u64
+/// for floats) so the final modulo is taken in the same domain on both the
+/// native and traced sides, then narrows only at the very end.
+template <typename T>
+int clampTripCount(T raw) {
+	uint64_t u;
+	if constexpr (std::is_floating_point_v<T>) {
+		u = clampFloatToInt<T, uint64_t>(raw);
+	} else {
+		u = static_cast<uint64_t>(static_cast<std::make_unsigned_t<T>>(raw));
+	}
+	return static_cast<int>(u % static_cast<uint64_t>(LOOP_MAX_TRIPS + 1));
+}
+
+/// Mutable per-evaluation scratch state, separate from the read-only kernel
+/// `args`: the stack of enclosing Loop frames, innermost last. LoopIndex /
+/// LoopAcc always read `loopStack.back()` -- nesting is plain shadowing, the
+/// generator guarantees the stack is non-empty wherever they appear.
+template <typename T>
+struct LoopFrame {
+	T index;
+	T acc;
+};
 
 template <typename T>
-T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) {
+struct EvalContext {
+	std::vector<LoopFrame<T>> loopStack;
+};
+
+template <typename T>
+T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
 		return unpackImm<T>(n.imm);
 	case Kind::Param:
 		return args[n.imm % NUM_PARAMS];
+	case Kind::LoopIndex:
+		return ctx.loopStack.back().index;
+	case Kind::LoopAcc:
+		return ctx.loopStack.back().acc;
 	case Kind::Select: {
-		const T c = evalNativeInt<T>(ast, n.kid[0], args);
-		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args) : evalNativeInt<T>(ast, n.kid[2], args);
+		const T c = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args, ctx) : evalNativeInt<T>(ast, n.kid[2], args, ctx);
 	}
 	case Kind::If: {
-		const T c = evalNativeInt<T>(ast, n.kid[0], args);
+		const T c = evalNativeInt<T>(ast, n.kid[0], args, ctx);
 		// Mirror the traced kernel: the else-branch is evaluated unconditionally,
 		// the then-branch only when the condition holds.
-		const T e = evalNativeInt<T>(ast, n.kid[2], args);
-		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args) : e;
+		const T e = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args, ctx) : e;
+	}
+	case Kind::Loop: {
+		const T rawCount = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+		for (int i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			acc = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
 	}
 	case Kind::Neg: {
-		const T v = evalNativeInt<T>(ast, n.kid[0], args);
+		const T v = evalNativeInt<T>(ast, n.kid[0], args, ctx);
 		if constexpr (std::is_signed_v<T>) {
 			return wrappingNeg<T>(v);
 		} else {
@@ -107,15 +199,15 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) 
 		}
 	}
 	case Kind::Not:
-		return static_cast<T>(~evalNativeInt<T>(ast, n.kid[0], args));
+		return static_cast<T>(~evalNativeInt<T>(ast, n.kid[0], args, ctx));
 	case Kind::Cast:
-		return castThroughInt<T>(evalNativeInt<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
+		return castThrough<T>(evalNativeInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	default:
 		break;
 	}
 
-	const T l = evalNativeInt<T>(ast, n.kid[0], args);
-	const T r = evalNativeInt<T>(ast, n.kid[1], args);
+	const T l = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+	const T r = evalNativeInt<T>(ast, n.kid[1], args, ctx);
 	switch (n.kind) {
 	case Kind::Add:
 		if constexpr (std::is_signed_v<T>) {
@@ -167,32 +259,47 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) 
 }
 
 template <typename T>
-T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) {
+T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
 		return unpackImm<T>(n.imm);
 	case Kind::Param:
 		return args[n.imm % NUM_PARAMS];
+	case Kind::LoopIndex:
+		return ctx.loopStack.back().index;
+	case Kind::LoopAcc:
+		return ctx.loopStack.back().acc;
 	case Kind::Select: {
-		const T c = evalNativeFloat<T>(ast, n.kid[0], args);
-		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args) : evalNativeFloat<T>(ast, n.kid[2], args);
+		const T c = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args, ctx) : evalNativeFloat<T>(ast, n.kid[2], args, ctx);
 	}
 	case Kind::If: {
-		const T c = evalNativeFloat<T>(ast, n.kid[0], args);
-		const T e = evalNativeFloat<T>(ast, n.kid[2], args);
-		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args) : e;
+		const T c = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		const T e = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args, ctx) : e;
+	}
+	case Kind::Loop: {
+		const T rawCount = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
+		for (int i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			acc = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
 	}
 	case Kind::Neg:
-		return static_cast<T>(-evalNativeFloat<T>(ast, n.kid[0], args));
+		return static_cast<T>(-evalNativeFloat<T>(ast, n.kid[0], args, ctx));
 	case Kind::Cast:
-		return castThroughFloat<T>(evalNativeFloat<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
+		return castThrough<T>(evalNativeFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	default:
 		break;
 	}
 
-	const T l = evalNativeFloat<T>(ast, n.kid[0], args);
-	const T r = evalNativeFloat<T>(ast, n.kid[1], args);
+	const T l = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+	const T r = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
 	switch (n.kind) {
 	case Kind::Add:
 		return static_cast<T>(l + r);
@@ -222,17 +329,13 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 } // namespace detail
 
 template <typename T>
-T evalNative(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args) {
-	if constexpr (std::is_floating_point_v<T>) {
-		return detail::evalNativeFloat<T>(ast, idx, args);
-	} else {
-		return detail::evalNativeInt<T>(ast, idx, args);
-	}
-}
-
-template <typename T>
 T evalNative(const Ast& ast, const std::array<T, NUM_PARAMS>& args) {
-	return evalNative<T>(ast, ast.root, args);
+	detail::EvalContext<T> ctx;
+	if constexpr (std::is_floating_point_v<T>) {
+		return detail::evalNativeFloat<T>(ast, ast.root, args, ctx);
+	} else {
+		return detail::evalNativeInt<T>(ast, ast.root, args, ctx);
+	}
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -7,6 +7,7 @@
 #include <nautilus/select.hpp>
 #include <nautilus/val.hpp>
 #include <type_traits>
+#include <vector>
 
 namespace nautilus::fuzz {
 
@@ -27,6 +28,16 @@ using TracedArgs = std::array<TracedValue<T>, NUM_PARAMS>;
  *   - divisors are forced non-zero (and, for signed types, away from -1 --
  *     see EvalNative.hpp's safeDivisor for why) and shift amounts masked,
  *     exactly as native,
+ *   - a Cast crossing the int/float domain boundary clamps its float->int
+ *     leg via a real traced if/else-if/else chain (see castThroughTraced)
+ *     rather than `select`, so the truncating cast is only ever reached
+ *     (lowered/executed) for in-range inputs -- a select-based clamp would
+ *     still *compute* the cast for out-of-range values, which various
+ *     backends may treat as UB at the IR level even if the result is
+ *     discarded,
+ *   - `Loop` lowers to a real traced `for` over val<int32_t> with a mutated
+ *     val<T> accumulator (the same pattern proven in
+ *     test/common/LoopFunctions.hpp), so loop lowering itself is under test,
  *   - unlike the native oracle, signed arithmetic needs no extra wraparound
  *     handling here: producing the correct two's-complement result for
  *     `+ - * unary-` is exactly the behavior under test.
@@ -42,56 +53,128 @@ TracedValue<T> safeDivisorTraced(TracedValue<T> r) {
 	return d;
 }
 
-template <typename From>
-TracedValue<From> castThroughIntTraced(TracedValue<From> v, TypeId target) {
-	return dispatchIntType(target, [&]<typename To>() -> TracedValue<From> {
-		return static_cast<TracedValue<From>>(static_cast<TracedValue<To>>(v));
-	});
+/// Traced mirror of EvalNative.hpp's clampFloatToInt, using a real branch
+/// (not select) so the truncating cast is only ever lowered/executed for
+/// in-range v. Reuses the exact same hiLimitExclusive/loLimitInclusive
+/// boundary constants as the native oracle (Types.hpp) -- this boundary
+/// math must never be re-derived independently.
+template <typename From, typename To>
+TracedValue<To> clampFloatToIntTraced(TracedValue<From> v) {
+	TracedValue<To> r(To(0));
+	if (v != v) { // NaN test; val<T> has no isnan(), but NaN != NaN is well-defined IEEE754
+		r = TracedValue<To>(To(0));
+	} else if (v < TracedValue<From>(loLimitInclusive<From, To>())) {
+		r = TracedValue<To>(std::numeric_limits<To>::min());
+	} else if (v >= TracedValue<From>(hiLimitExclusive<From, To>())) {
+		r = TracedValue<To>(std::numeric_limits<To>::max());
+	} else {
+		r = static_cast<TracedValue<To>>(v);
+	}
+	return r;
 }
 
 template <typename From>
-TracedValue<From> castThroughFloatTraced(TracedValue<From> v, TypeId target) {
-	return dispatchFloatType(target, [&]<typename To>() -> TracedValue<From> {
-		return static_cast<TracedValue<From>>(static_cast<TracedValue<To>>(v));
-	});
+TracedValue<From> castThroughTraced(TracedValue<From> v, TypeId target) {
+	if constexpr (std::is_floating_point_v<From>) {
+		if (isFloatType(target)) {
+			return dispatchFloatType(target, [&]<typename To>() -> TracedValue<From> {
+				return static_cast<TracedValue<From>>(static_cast<TracedValue<To>>(v));
+			});
+		}
+		return dispatchIntType(target, [&]<typename To>() -> TracedValue<From> {
+			return static_cast<TracedValue<From>>(clampFloatToIntTraced<From, To>(v));
+		});
+	} else {
+		if (!isFloatType(target)) {
+			return dispatchIntType(target, [&]<typename To>() -> TracedValue<From> {
+				return static_cast<TracedValue<From>>(static_cast<TracedValue<To>>(v));
+			});
+		}
+		return dispatchFloatType(target, [&]<typename To>() -> TracedValue<From> {
+			return clampFloatToIntTraced<To, From>(static_cast<TracedValue<To>>(v));
+		});
+	}
 }
+
+/// Traced mirror of EvalNative.hpp's clampTripCount: same
+/// reinterpret-to-unsigned-then-modulo, narrowed to val<int32_t> only after
+/// the modulo so both sides agree on the exact trip count.
+template <typename T>
+val<int32_t> clampTripCountTraced(TracedValue<T> raw) {
+	TracedValue<uint64_t> u(uint64_t(0));
+	if constexpr (std::is_floating_point_v<T>) {
+		u = clampFloatToIntTraced<T, uint64_t>(raw);
+	} else {
+		u = static_cast<TracedValue<uint64_t>>(static_cast<TracedValue<std::make_unsigned_t<T>>>(raw));
+	}
+	TracedValue<uint64_t> trips = u % TracedValue<uint64_t>(uint64_t(LOOP_MAX_TRIPS + 1));
+	return static_cast<val<int32_t>>(trips);
+}
+
+/// Mutable per-evaluation scratch state mirroring EvalNative.hpp's
+/// EvalContext: the stack of enclosing traced Loop frames, innermost last.
+template <typename T>
+struct TracedLoopFrame {
+	TracedValue<T> index;
+	TracedValue<T> acc;
+};
 
 template <typename T>
-TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args) {
+struct TracedEvalContext {
+	std::vector<TracedLoopFrame<T>> loopStack;
+};
+
+template <typename T>
+TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
 		return TracedValue<T>(unpackImm<T>(n.imm));
 	case Kind::Param:
 		return args[n.imm % NUM_PARAMS];
+	case Kind::LoopIndex:
+		return ctx.loopStack.back().index;
+	case Kind::LoopAcc:
+		return ctx.loopStack.back().acc;
 	case Kind::Select: {
-		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args);
-		TracedValue<T> t = evalNautilusInt<T>(ast, n.kid[1], args);
-		TracedValue<T> f = evalNautilusInt<T>(ast, n.kid[2], args);
+		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> t = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> f = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
 		return select(c != TracedValue<T>(T(0)), t, f);
 	}
 	case Kind::If: {
-		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args);
+		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 		// Else-branch first (unconditional), then conditionally overwrite with
 		// the then-branch inside a real traced branch -> produces a phi/merge.
-		TracedValue<T> result = evalNautilusInt<T>(ast, n.kid[2], args);
+		TracedValue<T> result = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
 		if (c != TracedValue<T>(T(0))) {
-			result = evalNautilusInt<T>(ast, n.kid[1], args);
+			result = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
 		}
 		return result;
 	}
+	case Kind::Loop: {
+		TracedValue<T> rawCount = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+		for (val<int32_t> i = 0; i < trips; i = i + 1) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
+			acc = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
 	case Kind::Neg:
-		return -evalNautilusInt<T>(ast, n.kid[0], args);
+		return -evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 	case Kind::Not:
-		return ~evalNautilusInt<T>(ast, n.kid[0], args);
+		return ~evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 	case Kind::Cast:
-		return castThroughIntTraced<T>(evalNautilusInt<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
+		return castThroughTraced<T>(evalNautilusInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	default:
 		break;
 	}
 
-	TracedValue<T> l = evalNautilusInt<T>(ast, n.kid[0], args);
-	TracedValue<T> r = evalNautilusInt<T>(ast, n.kid[1], args);
+	TracedValue<T> l = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+	TracedValue<T> r = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
 	switch (n.kind) {
 	case Kind::Add:
 		return l + r;
@@ -131,37 +214,52 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 }
 
 template <typename T>
-TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& args) {
+TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
 		return TracedValue<T>(unpackImm<T>(n.imm));
 	case Kind::Param:
 		return args[n.imm % NUM_PARAMS];
+	case Kind::LoopIndex:
+		return ctx.loopStack.back().index;
+	case Kind::LoopAcc:
+		return ctx.loopStack.back().acc;
 	case Kind::Select: {
-		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args);
-		TracedValue<T> t = evalNautilusFloat<T>(ast, n.kid[1], args);
-		TracedValue<T> f = evalNautilusFloat<T>(ast, n.kid[2], args);
+		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> t = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> f = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
 		return select(c != TracedValue<T>(T(0)), t, f);
 	}
 	case Kind::If: {
-		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args);
-		TracedValue<T> result = evalNautilusFloat<T>(ast, n.kid[2], args);
+		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> result = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
 		if (c != TracedValue<T>(T(0))) {
-			result = evalNautilusFloat<T>(ast, n.kid[1], args);
+			result = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
 		}
 		return result;
 	}
+	case Kind::Loop: {
+		TracedValue<T> rawCount = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
+		for (val<int32_t> i = 0; i < trips; i = i + 1) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
+			acc = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
 	case Kind::Neg:
-		return -evalNautilusFloat<T>(ast, n.kid[0], args);
+		return -evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
 	case Kind::Cast:
-		return castThroughFloatTraced<T>(evalNautilusFloat<T>(ast, n.kid[0], args), static_cast<TypeId>(n.imm));
+		return castThroughTraced<T>(evalNautilusFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	default:
 		break;
 	}
 
-	TracedValue<T> l = evalNautilusFloat<T>(ast, n.kid[0], args);
-	TracedValue<T> r = evalNautilusFloat<T>(ast, n.kid[1], args);
+	TracedValue<T> l = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+	TracedValue<T> r = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
 	switch (n.kind) {
 	case Kind::Add:
 		return l + r;
@@ -191,17 +289,13 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 } // namespace detail
 
 template <typename T>
-TracedValue<T> evalNautilus(const Ast& ast, int idx, const TracedArgs<T>& args) {
-	if constexpr (std::is_floating_point_v<T>) {
-		return detail::evalNautilusFloat<T>(ast, idx, args);
-	} else {
-		return detail::evalNautilusInt<T>(ast, idx, args);
-	}
-}
-
-template <typename T>
 TracedValue<T> evalNautilus(const Ast& ast, const TracedArgs<T>& args) {
-	return evalNautilus<T>(ast, ast.root, args);
+	detail::TracedEvalContext<T> ctx;
+	if constexpr (std::is_floating_point_v<T>) {
+		return detail::evalNautilusFloat<T>(ast, ast.root, args, ctx);
+	} else {
+		return detail::evalNautilusInt<T>(ast, ast.root, args, ctx);
+	}
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -46,20 +46,38 @@ constants, parameters) is generated and evaluated entirely in that one type,
 mirroring how the original `uint64_t`-only fuzzer worked.
 
 * **Integer domain** (8 widths/signs): arithmetic (`+ - * / %`), bitwise
-  (`& | ^ << >> ~`), unary negate, comparisons, `Select`/`If`, and `Cast`
-  (round-trips the value through another *integer* type, e.g. `(T)(To)v`,
-  exercising sign/zero-extension and truncation codegen).
+  (`& | ^ << >> ~`), unary negate, comparisons, `Select`/`If`, `Loop`, and
+  `Cast` (round-trips the value through another type, e.g. `(T)(To)v`,
+  exercising sign/zero-extension/truncation codegen *and* int<->float
+  boundary conversion).
 * **Float domain** (`float`, `double`): arithmetic (`+ - * /`), unary
-  negate, comparisons, `Select`/`If`, and `Cast` (round-trips through the
-  *other* float type only).
-* **Not generated, by design**: casts between the integer and float domains.
-  Casting an out-of-range float to an integer type is undefined behavior in
-  C++, which would need explicit range clamping (matching the native and
-  traced sides exactly) to fuzz safely -- left as a follow-up rather than
-  built half-way. Loops/control-flow-loop generation are likewise out of
-  scope for now -- today's `If`/`Select` already exercise branch lowering;
-  loop generation needs a data-dependent, bounded trip count threaded through
-  both the oracle and the traced kernel and is a separate piece of work.
+  negate, comparisons, `Select`/`If`, `Loop`, and `Cast` (round-trips through
+  another integer *or* float type).
+* **`Cast` across the int/float domain boundary**: `(T)(To)v` still always
+  produces a `T` result, exactly like a same-domain cast -- only the
+  intermediate type's domain changes. Whichever leg of the round trip is
+  float->int (the only UB-prone direction; int->float is precision loss
+  only, never UB) is range-clamped instead of invoking C++'s float-to-int
+  UB: `NaN -> 0`, out-of-range -> the target type's min/max. The clamp
+  compares against a power-of-two boundary rather than
+  `static_cast<From>(numeric_limits<To>::max())`, since for wide integer
+  types the latter is not exactly representable in `float`/`double` and
+  rounds *up* past the true max (e.g. `(double)INT64_MAX` rounds to `2^63`).
+  See `hiLimitExclusive`/`loLimitInclusive` in `Types.hpp`, shared verbatim
+  by the native oracle (`EvalNative.hpp`) and the traced kernel
+  (`EvalNautilus.hpp`) so the boundary math can't drift between the two.
+* **`Loop`**: a bounded, data-dependent fold -- `kid[0]` = trip-count
+  expression (clamped to `[0, LOOP_MAX_TRIPS]` via the same
+  reinterpret-to-unsigned-then-modulo on both sides), `kid[1]` = initial
+  accumulator, `kid[2]` = body, re-evaluated `trips` times with `LoopIndex`/
+  `LoopAcc` leaves bound to the current iteration (nesting uses simple
+  innermost-wins shadowing, no De Bruijn indices). Lowered to a real traced
+  `for` loop with a mutated accumulator on the Nautilus side -- the same
+  pattern used by `test/common/LoopFunctions.hpp` -- so loop lowering itself
+  is under test, not an unrolled approximation. Trip count is bounded but
+  the loop body is traced exactly once regardless of how many times the
+  compiled loop executes it at runtime, so this doesn't blow up compile
+  time.
 
 ## Soundness model
 
@@ -125,7 +143,7 @@ On a mismatch the harness prints the offending **backend**, the pretty-printed
 program + args into a fixed `forEachBackend` case under
 `test/execution-tests/` so the bug stays covered after it is fixed.
 
-## Known finding
+## Known findings
 
 On its first run this fuzzer reproduces a real bug: the IR constant-folding pass
 folds unsigned integer comparison/division/modulo/right-shift with **signed**
@@ -133,3 +151,37 @@ semantics, so all compiled backends disagree with the interpreter for
 constant-foldable `ui64` operands above `INT64_MAX`. Tracked in
 nebulastream/nautilus#312. `--survey` confirms every finding reduces to this one
 root cause.
+
+The `Loop`/cross-domain-`Cast` extension surfaced a second, pre-existing
+finding, **not specific to `Loop` or `Cast`**: minimal repro (no Loop, no
+Params, no runtime input at all) --
+
+```
+-4.8245185693378968e-132 / (-(0.0 + 0.0))
+```
+
+evaluated as `f64` arithmetic. Every native-C++/IEEE-754-faithful evaluation
+gives `+inf` (`0.0 + 0.0` is `+0.0`; negating it gives the exactly-defined
+`-0.0`; `negative / -0.0` is `+inf`) -- confirmed independently with a plain
+C++ program outside Nautilus entirely. Nautilus disagrees in two distinct
+ways:
+
+* The **interpreter** backend (`engine.Compilation = false`, no native
+  codegen at all) silently returns `-inf` instead of `+inf` -- a signed-zero
+  handling bug reachable purely through IR interpretation.
+* Every **compiling** backend (`mlir`, `cpp`, `bc`, `asmjit`) **segfaults**
+  during `registerFunction` on the exact same minimal kernel, with an
+  identical crash signature regardless of which backend is selected --
+  strongly suggesting the crash lives in the shared trace-to-IR/optimization
+  pipeline that runs before backend-specific lowering, not in any one
+  backend's codegen.
+
+This was never hit by the fuzzer before this change because generating a
+literal `0.0` used to require an exact 64-bit-zero random draw (vanishingly
+unlikely); `ByteReader` returns zero once its buffer is exhausted (see
+`ByteReader.hpp`), and the wider/deeper trees this extension generates make
+running out of buffer -- and thus landing on an exact `0.0` constant -- far
+more common. `Loop` merely made this easy to *stumble into* via survey
+(a `Loop` with a zero trip count folds to its `init`, which is often exactly
+`0.0` for the same reason); the minimal repro above proves the bug itself
+predates and is independent of `Loop`/`Cast`.

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -152,29 +152,35 @@ constant-foldable `ui64` operands above `INT64_MAX`. Tracked in
 nebulastream/nautilus#312. `--survey` confirms every finding reduces to this one
 root cause.
 
-The `Loop`/cross-domain-`Cast` extension surfaced a second, pre-existing
-finding, **not specific to `Loop` or `Cast`**: minimal repro (no Loop, no
-Params, no runtime input at all) --
+The `Loop`/cross-domain-`Cast` extension surfaced a second, pre-existing bug,
+**not specific to `Loop` or `Cast`** (confirmed by reproducing it with a
+minimal, hand-built AST containing no `Loop`, no `Params`, no runtime input
+at all) -- now fixed:
 
 ```
--4.8245185693378968e-132 / (-(0.0 + 0.0))
+-4.8245185693378968e-132 / (-(0.0 + 0.0))          // f64
 ```
 
-evaluated as `f64` arithmetic. Every native-C++/IEEE-754-faithful evaluation
-gives `+inf` (`0.0 + 0.0` is `+0.0`; negating it gives the exactly-defined
-`-0.0`; `negative / -0.0` is `+inf`) -- confirmed independently with a plain
-C++ program outside Nautilus entirely. Nautilus disagrees in two distinct
-ways:
+Every native-C++/IEEE-754-faithful evaluation gives `+inf` (`0.0 + 0.0` is
+`+0.0`; negating it gives the exactly-defined `-0.0`; `negative / -0.0` is
+`+inf`). Nautilus's interpreter silently returned `-inf` instead -- a
+signed-zero handling bug reachable purely through IR interpretation, with no
+backend codegen involved.
 
-* The **interpreter** backend (`engine.Compilation = false`, no native
-  codegen at all) silently returns `-inf` instead of `+inf` -- a signed-zero
-  handling bug reachable purely through IR interpretation.
-* Every **compiling** backend (`mlir`, `cpp`, `bc`, `asmjit`) **segfaults**
-  during `registerFunction` on the exact same minimal kernel, with an
-  identical crash signature regardless of which backend is selected --
-  strongly suggesting the crash lives in the shared trace-to-IR/optimization
-  pipeline that runs before backend-specific lowering, not in any one
-  backend's codegen.
+Root cause: `val<T>::operator-()` (`include/nautilus/val_arith.hpp`)
+implemented unary negation as `(ValueType)0 - *this`. For floats this is not
+IEEE-754 negation: subtracting two exactly-equal-magnitude operands rounds to
+`+0.0` in the default round-to-nearest mode, so `0.0 - 0.0` is `+0.0`, not
+the `-0.0` that negating `+0.0` must produce. This wasn't limited to the
+interpreter -- the shared `ConstantFoldingAndCopyPropagationPass`'s `SubOp`
+fold (plain `l - r`) reproduces the identical `+0.0` for the same reason,
+so the wrong sign was already baked into the IR as a folded constant before
+any backend-specific lowering ran. Fixed by negating floats via
+multiplication by `-1` instead (`(ValueType)-1 * *this`): IEEE-754
+multiplication's sign is always the XOR of its operands' signs, so it
+flips the sign bit correctly for zero (and everything else) without going
+through cancellation. Integer negation is untouched (`0 - x` is exact
+two's-complement negation, no signed-zero concept applies).
 
 This was never hit by the fuzzer before this change because generating a
 literal `0.0` used to require an exact 64-bit-zero random draw (vanishingly
@@ -184,4 +190,15 @@ running out of buffer -- and thus landing on an exact `0.0` constant -- far
 more common. `Loop` merely made this easy to *stumble into* via survey
 (a `Loop` with a zero trip count folds to its `init`, which is often exactly
 `0.0` for the same reason); the minimal repro above proves the bug itself
-predates and is independent of `Loop`/`Cast`.
+predated and was independent of `Loop`/`Cast`.
+
+(An early investigation of this bug also observed every compiling backend
+segfaulting on the same minimal kernel; that turned out to be an artifact of
+the ad hoc standalone reproduction harness's own call-stack depth tripping
+`TagRecorder`'s `__builtin_return_address`-based frame walk
+(`src/nautilus/tracing/tag/TagRecorder.cpp`), not a defect introduced by this
+PR -- a trivial `a + b` kernel crashes the same way through that harness, and
+`--survey` never observed it through the real fuzz harness across 5000+
+runs. Worth a maintainer's attention separately, since `__builtin_return_address(N)`
+for `N > 0` is documented as unreliable beyond very small `N` by both GCC and
+Clang, but out of scope here.)

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -38,11 +38,13 @@ std::vector<uint8_t> readFile(const char* path) {
 }
 
 std::vector<uint8_t> randomBuffer() {
-	// 128, not the original 96: a type-select byte and (for Cast nodes) an
-	// extra target-type byte now eat into the same fixed budget, so a
-	// slightly larger buffer keeps tree richness comparable to before across
-	// ten type domains instead of one.
-	const size_t len = nextRand() % 128;
+	// 160, not the original 96/128: a type-select byte, a Cast target-type
+	// byte (now drawn from all ten types instead of one domain's eight/two),
+	// and Loop/LoopIndex/LoopAcc kind-selection plus loopDepth-gated leaf
+	// selection all now compete for the same fixed budget, so a larger
+	// buffer keeps tree richness -- and the odds of generating a nontrivial
+	// or nested Loop -- comparable to before.
+	const size_t len = nextRand() % 160;
 	std::vector<uint8_t> buf(len);
 	for (size_t i = 0; i < len; ++i) {
 		buf[i] = static_cast<uint8_t>(nextRand());

--- a/nautilus/test/fuzz/Types.hpp
+++ b/nautilus/test/fuzz/Types.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <type_traits>
 
@@ -15,7 +16,7 @@ namespace nautilus::fuzz {
 /// these ten types, mirroring how the original uint64_t-only fuzzer worked.
 enum class TypeId : uint8_t { I8, I16, I32, I64, U8, U16, U32, U64, F32, F64 };
 
-inline constexpr TypeId ALL_TYPES[] = {TypeId::I8, TypeId::I16, TypeId::I32, TypeId::I64, TypeId::U8,
+inline constexpr TypeId ALL_TYPES[] = {TypeId::I8,  TypeId::I16, TypeId::I32, TypeId::I64, TypeId::U8,
                                        TypeId::U16, TypeId::U32, TypeId::U64, TypeId::F32, TypeId::F64};
 
 /// The eight integer TypeIds, used to pick Cast targets for the integer
@@ -207,6 +208,36 @@ bool valuesEqual(T a, T b) {
 		return a == b || (std::isnan(a) && std::isnan(b));
 	} else {
 		return a == b;
+	}
+}
+
+/// Smallest `From` value that is already out of range for `To` (i.e. the
+/// first representative for which a float->int cast is UB). Deliberately
+/// compared against a power-of-two boundary rather than
+/// `static_cast<From>(numeric_limits<To>::max())`: for wide integer types
+/// the latter is not exactly representable in `float`/`double` and rounds
+/// *up* past the true max (e.g. `(double)INT64_MAX` rounds to `2^63`), which
+/// would let an out-of-range value slip past a naive `<=` check. `2^bits` is
+/// always exactly representable in IEEE-754 binary float for every
+/// `(From, To)` combination used by this fuzzer (bits <= 64). Shared by
+/// EvalNative.hpp (native oracle) and EvalNautilus.hpp (traced kernel) so
+/// the float<->int cast clamp is sound identically on both sides -- this
+/// boundary math must never be re-derived independently in two places.
+template <typename From, typename To>
+constexpr From hiLimitExclusive() {
+	constexpr int bits = sizeof(To) * 8 - (std::is_signed_v<To> ? 1 : 0);
+	return static_cast<From>(std::ldexp(From(1), bits));
+}
+
+/// Largest representable-as-`From` lower bound for `To`: `To`'s minimum is
+/// always a power of two (or zero for unsigned types), so it is exactly
+/// representable in `From` and needs no power-of-two-boundary trick.
+template <typename From, typename To>
+constexpr From loLimitInclusive() {
+	if constexpr (std::is_signed_v<To>) {
+		return static_cast<From>(std::numeric_limits<To>::min());
+	} else {
+		return From(0);
 	}
 }
 


### PR DESCRIPTION
## Summary

The fuzzer's own README flagged two things as explicit follow-up work: int↔float casts (skipped due to float→int UB) and loop generation (skipped because it needs a data-dependent, bounded trip count threaded through both the native oracle and the traced kernel). This PR implements both:

- **`Cast` now crosses the int/float domain boundary.** `(T)(To)v` keeps the same "cast through" semantics as before (output type is always `T`); whichever leg of the round trip is float→int (the only UB-prone direction) is range-clamped instead of invoking C++'s float-to-int UB — `NaN → 0`, out-of-range → the target type's min/max. The clamp compares against a power-of-two boundary rather than `static_cast<From>(numeric_limits<To>::max())`, since for wide integer types the latter rounds *up* past the true max in `float`/`double` (e.g. `(double)INT64_MAX` rounds to `2^63`) and would let out-of-range values slip through. The boundary helpers (`hiLimitExclusive`/`loLimitInclusive`) live once in `Types.hpp` and are shared verbatim by the native oracle and the traced kernel so this math can't drift between the two.
- **New `Kind::Loop`**: a bounded, data-dependent fold — `count`/`init`/`body` children, trip count clamped to `[0, LOOP_MAX_TRIPS]` via the same reinterpret-to-unsigned-then-modulo on both sides, with new `LoopIndex`/`LoopAcc` leaves (innermost-wins shadowing, no De Bruijn indices) bound to the current iteration inside the body. Lowered to a real traced `for` loop with a mutated accumulator — the same pattern used by `test/common/LoopFunctions.hpp` — so backend loop lowering is actually exercised, not just `If`/`Select` branching.
- Bumped the replay driver's random-buffer size (128 → 160) since the wider Kind space and Loop's extra generation-time bytes compete for the same fixed budget.

## Bug found and fixed

Running the extended fuzzer (`--survey`) surfaced a real, pre-existing bug, **independent of `Loop`/`Cast`** — confirmed by reproducing it with a hand-built, 7-node AST containing no `Loop` at all:

```
-4.8245185693378968e-132 / (-(0.0 + 0.0))   // as f64
```

IEEE-754 gives `+inf` here (`0.0 + 0.0` is `+0.0`; negating it must give the exactly-defined `-0.0`; `negative / -0.0` is `+inf`). Nautilus's interpreter silently returned `-inf`.

**Root cause**: `val<T>::operator-()` (`include/nautilus/val_arith.hpp`) implemented unary negation as `(ValueType)0 - *this`. For floats this is not IEEE-754 negation: subtracting two exactly-equal-magnitude operands rounds to `+0.0` in the default rounding mode, so `0.0 - 0.0` is `+0.0`, not `-0.0`. The shared `ConstantFoldingAndCopyPropagationPass`'s `SubOp` fold (plain `l - r`) reproduces the identical sign error, so the wrong value was already baked into the IR as a folded constant before any backend-specific lowering ran — that's why it wasn't backend-specific.

**Fix**: negate floats via multiplication by `-1` instead (`(ValueType)-1 * *this`) — IEEE-754 multiplication's sign is always the XOR of its operands' signs, so it flips the sign bit correctly for zero (and everything else) without going through cancellation. Integer negation (`0 - x`, exact two's-complement) is untouched.

Verified: the `nautilus-fuzz-replay --survey` finding for this exact pattern is gone post-fix, and the full `nautilus-execution-tests` suite (13750 assertions, 61 test cases) passes unchanged.

*(An earlier investigation pass of this bug also observed every compiling backend segfaulting on the same minimal kernel; that turned out to be an artifact of the standalone reproduction harness's own call-stack depth tripping `TagRecorder`'s `__builtin_return_address`-based frame walk — a trivial `a + b` kernel crashes the same way through that harness, and 5000+ real `--survey` runs never hit it. Worth separate maintainer attention since `__builtin_return_address(N)` for `N > 0` is documented as unreliable by both GCC and Clang, but out of scope for this PR.)*

## Test plan

- [x] Built with Clang 19 (Clang 21 unavailable in this environment) + libFuzzer + all four backends (mlir/cpp/bc/asmjit) + interpreter, `RelWithDebInfo`.
- [x] `nautilus-fuzz-replay` (built-in smoke corpus) and `--survey` (5000+ inputs, before and after the fix) run successfully, exercising the new `Cast`/`Loop` code paths across all ten type domains.
- [x] Isolated, hand-built minimal ASTs (no random generation) used to confirm the signed-zero finding is reproducible independent of `Loop`, to rule out the new tracing code as the cause, and to verify the fix.
- [x] Full `nautilus-execution-tests` suite passes (13750/13750 assertions) after the `operator-()` change — no regressions from touching this widely-used operator.
- [x] `cmake --build . --target format` / `./format.sh` clean.
- [ ] Not run: `ENABLE_FUZZING=ON` coverage-guided libFuzzer campaign (`nautilus-fuzz`) — left for a maintainer-directed follow-up.
