### PR TITLE
Extend differential fuzzer to pointer arithmetic and memory access

### DIFF
--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -59,7 +59,47 @@ enum class Kind : uint8_t {
 	// iteration index / accumulator of the innermost enclosing Loop. No imm
 	// payload -- nesting uses simple shadowing (innermost wins).
 	LoopIndex,
-	LoopAcc
+	LoopAcc,
+	// --- Memory / pointer domain -------------------------------------------
+	// A generated program owns one shared, fixed-size `T` buffer (BUFFER_ELEMS
+	// elements). kid[0] of Load/Store/PtrToInt and both kids of the Ptr*
+	// comparisons are *pointer-domain* nodes (Kind::PtrBase/PtrAdd/PtrSub, see
+	// below) built by generatePtrNode, not by generateNode -- they evaluate to
+	// a `T*` (val<T*> when traced), never to a `T`.
+	//
+	// Load: kid[0] = ptr-domain node. Value-domain result: *ptr.
+	Load,
+	// Store: kid[0] = ptr-domain node, kid[1] = value-domain node. Writes
+	// through the pointer and yields the stored value, mirroring the value of
+	// a C++ assignment expression (`*ptr = v` evaluates to `v`).
+	Store,
+	// PtrToInt: kid[0] = ptr-domain node. `(T)(uintptr_t)ptr`, exactly
+	// `base_ptr_val`'s pointer -> arithmetic conversion.
+	PtrToInt,
+	// PtrEq/Ne/Lt/Le/Gt/Ge: both kids are ptr-domain nodes; yields 0/1 as T,
+	// same convention as the value-domain comparisons above.
+	PtrEq,
+	PtrNe,
+	PtrLt,
+	PtrLe,
+	PtrGt,
+	PtrGe,
+	// --- Pointer-domain nodes -----------------------------------------------
+	// Never chosen directly by generateNode/INT_KINDS/FLOAT_KINDS, and never
+	// the AST root -- only reachable as a kid of one of the memory-domain
+	// nodes above, built by generatePtrNode. Always resolve to an in-bounds
+	// index of the shared buffer (no nesting -- see generatePtrNode), so every
+	// Load/Store/comparison is guaranteed well-defined by construction.
+	//
+	// PtrBase: the raw pointer parameter, i.e. `&memory[0]`.
+	PtrBase,
+	// PtrAdd: kid[0] = value-domain offset expression (type T). Result =
+	// `base + clampBufferIndex<T>(offset)`, exercising val<T*>::operator+.
+	PtrAdd,
+	// PtrSub: kid[0] = value-domain offset expression (type T). Result =
+	// `(base + (BUFFER_ELEMS - 1)) - clampBufferIndex<T>(offset)`, exercising
+	// val<T*>::operator-.
+	PtrSub
 };
 
 struct Node {
@@ -75,14 +115,20 @@ struct Ast {
 
 namespace detail {
 
-inline constexpr Kind INT_KINDS[] = {Kind::Add, Kind::Sub, Kind::Mul,  Kind::Div, Kind::Mod,    Kind::And,
-                                     Kind::Or,  Kind::Xor, Kind::Shl,  Kind::Shr, Kind::Eq,     Kind::Ne,
-                                     Kind::Lt,  Kind::Le,  Kind::Gt,   Kind::Ge,  Kind::Select, Kind::If,
-                                     Kind::Neg, Kind::Not, Kind::Cast, Kind::Loop};
+// Load/Store/PtrToInt/Ptr-comparisons (below) are appended identically to
+// both INT_KINDS and FLOAT_KINDS: a buffer of T is equally meaningful (and
+// equally safe, given generatePtrNode's bounded construction) regardless of
+// T's domain.
+inline constexpr Kind INT_KINDS[] = {
+    Kind::Add,      Kind::Sub,   Kind::Mul,   Kind::Div,   Kind::Mod,   Kind::And,   Kind::Or,   Kind::Xor,
+    Kind::Shl,      Kind::Shr,   Kind::Eq,    Kind::Ne,    Kind::Lt,    Kind::Le,    Kind::Gt,   Kind::Ge,
+    Kind::Select,   Kind::If,    Kind::Neg,   Kind::Not,   Kind::Cast,  Kind::Loop,  Kind::Load, Kind::Store,
+    Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe, Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
 
-inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,    Kind::Sub, Kind::Mul, Kind::Div,  Kind::Eq,
-                                       Kind::Ne,     Kind::Lt,  Kind::Le,  Kind::Gt,   Kind::Ge,
-                                       Kind::Select, Kind::If,  Kind::Neg, Kind::Cast, Kind::Loop};
+inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,   Kind::Eq,     Kind::Ne,
+                                       Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,    Kind::Select, Kind::If,
+                                       Kind::Neg,   Kind::Cast,  Kind::Loop,  Kind::Load,  Kind::Store,  Kind::PtrToInt,
+                                       Kind::PtrEq, Kind::PtrNe, Kind::PtrLt, Kind::PtrLe, Kind::PtrGt,  Kind::PtrGe};
 
 inline int arity(Kind k) {
 	switch (k) {
@@ -90,10 +136,15 @@ inline int arity(Kind k) {
 	case Kind::Param:
 	case Kind::LoopIndex:
 	case Kind::LoopAcc:
+	case Kind::PtrBase:
 		return 0;
 	case Kind::Neg:
 	case Kind::Not:
 	case Kind::Cast:
+	case Kind::Load:
+	case Kind::PtrToInt:
+	case Kind::PtrAdd:
+	case Kind::PtrSub:
 		return 1;
 	case Kind::Select:
 	case Kind::If:
@@ -102,6 +153,45 @@ inline int arity(Kind k) {
 	default:
 		return 2;
 	}
+}
+
+/// True for the six pointer-domain comparison kinds (both kids are
+/// pointer-domain nodes, unlike Eq..Ge whose kids are value-domain).
+inline bool isPtrCompare(Kind k) {
+	return k >= Kind::PtrEq && k <= Kind::PtrGe;
+}
+
+template <typename T>
+int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth);
+
+/// Build a bounded pointer-domain expression: either the raw base pointer, or
+/// a single-hop offset from it (`Kind::PtrAdd`/`Kind::PtrSub`) computed from a
+/// value-domain offset expression. Deliberately never nests (a PtrAdd's own
+/// child is always a value-domain node, never another pointer-domain node),
+/// so every pointer this can produce is directly `base + clampBufferIndex(x)`
+/// or `end - clampBufferIndex(x)` -- always an in-bounds index into the
+/// shared buffer, with no need to reason about compounding offsets across
+/// hops. `depth`/`budget`/`loopDepth` are threaded through exactly like
+/// generateNode's, so the shared node budget still bounds total tree size.
+template <typename T>
+int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth) {
+	const uint8_t sel = reader.byte();
+	const bool leaf = depth <= 0 || budget <= 1 || reader.exhausted() || (sel & 0x1) == 0;
+
+	Node node;
+	if (leaf) {
+		node.kind = Kind::PtrBase;
+		const int idx = static_cast<int>(ast.nodes.size());
+		ast.nodes.push_back(node);
+		return idx;
+	}
+
+	node.kind = (sel & 0x2) ? Kind::PtrAdd : Kind::PtrSub;
+	--budget;
+	node.kid[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+	const int idx = static_cast<int>(ast.nodes.size());
+	ast.nodes.push_back(node);
+	return idx;
 }
 
 /// `loopDepth` counts how many Loop bodies the recursion is currently
@@ -161,6 +251,14 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
 		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
 		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
+	} else if (node.kind == Kind::Load || node.kind == Kind::PtrToInt) {
+		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth);
+	} else if (node.kind == Kind::Store) {
+		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+	} else if (isPtrCompare(node.kind)) {
+		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[1] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth);
 	} else {
 		for (int i = 0; i < childCount; ++i) {
 			kids[i] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
@@ -188,6 +286,14 @@ inline constexpr int MAX_NODES = 64;
 /// many times the compiled loop executes it -- so this only bounds oracle
 /// interpretation cost (which multiplies with loop nesting).
 inline constexpr int LOOP_MAX_TRIPS = 8;
+
+/// Number of `T` elements in the shared buffer every generated program is
+/// handed a pointer to (see Kind::PtrBase). Every pointer-domain node
+/// (generatePtrNode) is constructed so it always lands in [0, BUFFER_ELEMS),
+/// so Load/Store/PtrToInt/Ptr-comparisons never read or write out of bounds --
+/// small enough to keep the oracle/traced buffers cheap, large enough to make
+/// pointer differences/comparisons non-trivial.
+inline constexpr int BUFFER_ELEMS = 8;
 
 /// Build a random, always-valid AST of type T from the reader. Never returns
 /// an empty tree: an empty buffer yields a single Const(0) leaf.
@@ -305,6 +411,72 @@ void print(const Ast& ast, int idx, std::string& out) {
 		out += ", body=";
 		print<T>(ast, n.kid[2], out);
 		out += ")";
+		return;
+	case Kind::Load:
+		out += "*(";
+		print<T>(ast, n.kid[0], out);
+		out += ")";
+		return;
+	case Kind::Store:
+		out += "(*(";
+		print<T>(ast, n.kid[0], out);
+		out += ") = ";
+		print<T>(ast, n.kid[1], out);
+		out += ")";
+		return;
+	case Kind::PtrToInt:
+		out += "(uintptr_t)(";
+		print<T>(ast, n.kid[0], out);
+		out += ")";
+		return;
+	case Kind::PtrEq:
+	case Kind::PtrNe:
+	case Kind::PtrLt:
+	case Kind::PtrLe:
+	case Kind::PtrGt:
+	case Kind::PtrGe: {
+		const char* sym = "?";
+		switch (n.kind) {
+		case Kind::PtrEq:
+			sym = "==";
+			break;
+		case Kind::PtrNe:
+			sym = "!=";
+			break;
+		case Kind::PtrLt:
+			sym = "<";
+			break;
+		case Kind::PtrLe:
+			sym = "<=";
+			break;
+		case Kind::PtrGt:
+			sym = ">";
+			break;
+		default:
+			sym = ">=";
+			break;
+		}
+		out += "((";
+		print<T>(ast, n.kid[0], out);
+		out += " ";
+		out += sym;
+		out += " ";
+		print<T>(ast, n.kid[1], out);
+		out += ") ? 1 : 0)";
+		return;
+	}
+	case Kind::PtrBase:
+		out += "mem";
+		return;
+	case Kind::PtrAdd:
+		out += "(mem + idx(";
+		print<T>(ast, n.kid[0], out);
+		out += "))";
+		return;
+	case Kind::PtrSub:
+		out += "(mem_end - idx(";
+		print<T>(ast, n.kid[0], out);
+		out += "))";
 		return;
 	default:
 		break;

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -141,6 +141,23 @@ int clampTripCount(T raw) {
 	return static_cast<int>(u % static_cast<uint64_t>(LOOP_MAX_TRIPS + 1));
 }
 
+/// Reduce a raw pointer-offset value of type T to a defined index in
+/// [0, BUFFER_ELEMS), via the identical reinterpret-then-modulo recipe as
+/// clampTripCount, just against BUFFER_ELEMS instead of LOOP_MAX_TRIPS + 1.
+/// Shared verbatim (mod constant aside) with clampBufferIndexTraced in
+/// EvalNautilus.hpp so a pointer built from the same raw offset always lands
+/// on the same buffer slot on both the native and traced sides.
+template <typename T>
+int clampBufferIndex(T raw) {
+	uint64_t u;
+	if constexpr (std::is_floating_point_v<T>) {
+		u = clampFloatToInt<T, uint64_t>(raw);
+	} else {
+		u = static_cast<uint64_t>(static_cast<std::make_unsigned_t<T>>(raw));
+	}
+	return static_cast<int>(u % static_cast<uint64_t>(BUFFER_ELEMS));
+}
+
 /// Mutable per-evaluation scratch state, separate from the read-only kernel
 /// `args`: the stack of enclosing Loop frames, innermost last. LoopIndex /
 /// LoopAcc always read `loopStack.back()` -- nesting is plain shadowing, the
@@ -151,10 +168,53 @@ struct LoopFrame {
 	T acc;
 };
 
+/// The shared buffer every generated program's pointer-domain nodes index
+/// into (see Kind::PtrBase in Ast.hpp). A raw, non-owning pointer: the
+/// harness owns the storage and resets its contents between the native-oracle
+/// run and each backend run so Store side effects from one run never leak
+/// into the next.
 template <typename T>
 struct EvalContext {
 	std::vector<LoopFrame<T>> loopStack;
+	std::array<T, BUFFER_ELEMS>* memory = nullptr;
 };
+
+template <typename T>
+T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx);
+template <typename T>
+T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx);
+
+/// Dispatches to whichever of evalNativeInt/evalNativeFloat matches T's
+/// domain. Used by the memory-domain helpers below (evalNativePtr, and the
+/// Load/Store cases inside evalNativeInt/evalNativeFloat) since they are
+/// shared between both domains and need to evaluate value-domain
+/// subexpressions (offsets, stored values) generated in that same domain.
+template <typename T>
+T evalNativeValue(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return evalNativeFloat<T>(ast, idx, args, ctx);
+	} else {
+		return evalNativeInt<T>(ast, idx, args, ctx);
+	}
+}
+
+/// Evaluate a pointer-domain node (Kind::PtrBase/PtrAdd/PtrSub, see Ast.hpp)
+/// to a buffer index. Always in [0, BUFFER_ELEMS) by construction --
+/// generatePtrNode never nests, so there is no "current pointer" state to
+/// track, just a single offset off of index 0 or BUFFER_ELEMS - 1.
+template <typename T>
+int evalNativePtr(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
+	const Node& n = ast.nodes[idx];
+	switch (n.kind) {
+	case Kind::PtrAdd:
+		return clampBufferIndex<T>(evalNativeValue<T>(ast, n.kid[0], args, ctx));
+	case Kind::PtrSub:
+		return (BUFFER_ELEMS - 1) - clampBufferIndex<T>(evalNativeValue<T>(ast, n.kid[0], args, ctx));
+	case Kind::PtrBase:
+	default:
+		return 0;
+	}
+}
 
 template <typename T>
 T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
@@ -169,8 +229,18 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
 	case Kind::Select: {
+		// Both branches are evaluated unconditionally, matching the traced
+		// kernel's `select(cond, t, f)` (a data mux, not real branching -- see
+		// EvalNautilus.hpp). This must hold even though a plain C++ ternary
+		// would short-circuit: now that Store can appear inside t/f, only
+		// evaluating one side here would silently skip the other's memory
+		// side effect while the traced kernel still performs it, breaking
+		// oracle/traced parity for any program that stores inside a Select
+		// branch.
 		const T c = evalNativeInt<T>(ast, n.kid[0], args, ctx);
-		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args, ctx) : evalNativeInt<T>(ast, n.kid[2], args, ctx);
+		const T t = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+		const T f = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+		return c != T(0) ? t : f;
 	}
 	case Kind::If: {
 		const T c = evalNativeInt<T>(ast, n.kid[0], args, ctx);
@@ -202,6 +272,51 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		return static_cast<T>(~evalNativeInt<T>(ast, n.kid[0], args, ctx));
 	case Kind::Cast:
 		return castThrough<T>(evalNativeInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
+	case Kind::Load: {
+		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		return (*ctx.memory)[static_cast<size_t>(i)];
+	}
+	case Kind::Store: {
+		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		const T v = evalNativeValue<T>(ast, n.kid[1], args, ctx);
+		(*ctx.memory)[static_cast<size_t>(i)] = v;
+		return v;
+	}
+	case Kind::PtrToInt: {
+		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		return static_cast<T>(reinterpret_cast<uintptr_t>(&(*ctx.memory)[static_cast<size_t>(i)]));
+	}
+	case Kind::PtrEq:
+	case Kind::PtrNe:
+	case Kind::PtrLt:
+	case Kind::PtrLe:
+	case Kind::PtrGt:
+	case Kind::PtrGe: {
+		const int a = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		const int b = evalNativePtr<T>(ast, n.kid[1], args, ctx);
+		bool r = false;
+		switch (n.kind) {
+		case Kind::PtrEq:
+			r = (a == b);
+			break;
+		case Kind::PtrNe:
+			r = (a != b);
+			break;
+		case Kind::PtrLt:
+			r = (a < b);
+			break;
+		case Kind::PtrLe:
+			r = (a <= b);
+			break;
+		case Kind::PtrGt:
+			r = (a > b);
+			break;
+		default:
+			r = (a >= b);
+			break;
+		}
+		return r ? T(1) : T(0);
+	}
 	default:
 		break;
 	}
@@ -271,8 +386,13 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
 	case Kind::Select: {
+		// See the identical comment in evalNativeInt's Select case: both
+		// branches must be evaluated unconditionally to match the traced
+		// kernel's data-mux `select`, now that Store can live inside them.
 		const T c = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
-		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args, ctx) : evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+		const T t = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
+		const T f = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+		return c != T(0) ? t : f;
 	}
 	case Kind::If: {
 		const T c = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
@@ -294,6 +414,51 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		return static_cast<T>(-evalNativeFloat<T>(ast, n.kid[0], args, ctx));
 	case Kind::Cast:
 		return castThrough<T>(evalNativeFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
+	case Kind::Load: {
+		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		return (*ctx.memory)[static_cast<size_t>(i)];
+	}
+	case Kind::Store: {
+		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		const T v = evalNativeValue<T>(ast, n.kid[1], args, ctx);
+		(*ctx.memory)[static_cast<size_t>(i)] = v;
+		return v;
+	}
+	case Kind::PtrToInt: {
+		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		return static_cast<T>(reinterpret_cast<uintptr_t>(&(*ctx.memory)[static_cast<size_t>(i)]));
+	}
+	case Kind::PtrEq:
+	case Kind::PtrNe:
+	case Kind::PtrLt:
+	case Kind::PtrLe:
+	case Kind::PtrGt:
+	case Kind::PtrGe: {
+		const int a = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		const int b = evalNativePtr<T>(ast, n.kid[1], args, ctx);
+		bool r = false;
+		switch (n.kind) {
+		case Kind::PtrEq:
+			r = (a == b);
+			break;
+		case Kind::PtrNe:
+			r = (a != b);
+			break;
+		case Kind::PtrLt:
+			r = (a < b);
+			break;
+		case Kind::PtrLe:
+			r = (a <= b);
+			break;
+		case Kind::PtrGt:
+			r = (a > b);
+			break;
+		default:
+			r = (a >= b);
+			break;
+		}
+		return r ? T(1) : T(0);
+	}
 	default:
 		break;
 	}
@@ -329,8 +494,9 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 } // namespace detail
 
 template <typename T>
-T evalNative(const Ast& ast, const std::array<T, NUM_PARAMS>& args) {
+T evalNative(const Ast& ast, const std::array<T, NUM_PARAMS>& args, std::array<T, BUFFER_ELEMS>& memory) {
 	detail::EvalContext<T> ctx;
+	ctx.memory = &memory;
 	if constexpr (std::is_floating_point_v<T>) {
 		return detail::evalNativeFloat<T>(ast, ast.root, args, ctx);
 	} else {

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <nautilus/select.hpp>
 #include <nautilus/val.hpp>
+#include <nautilus/val_ptr.hpp>
 #include <type_traits>
 #include <vector>
 
@@ -111,8 +112,26 @@ val<int32_t> clampTripCountTraced(TracedValue<T> raw) {
 	return static_cast<val<int32_t>>(trips);
 }
 
+/// Traced mirror of EvalNative.hpp's clampBufferIndex: same recipe as
+/// clampTripCountTraced, just against BUFFER_ELEMS instead of
+/// LOOP_MAX_TRIPS + 1, so a pointer built from the same raw offset lands on
+/// the same buffer slot as the native oracle.
+template <typename T>
+val<int32_t> clampBufferIndexTraced(TracedValue<T> raw) {
+	TracedValue<uint64_t> u(uint64_t(0));
+	if constexpr (std::is_floating_point_v<T>) {
+		u = clampFloatToIntTraced<T, uint64_t>(raw);
+	} else {
+		u = static_cast<TracedValue<uint64_t>>(static_cast<TracedValue<std::make_unsigned_t<T>>>(raw));
+	}
+	TracedValue<uint64_t> index = u % TracedValue<uint64_t>(uint64_t(BUFFER_ELEMS));
+	return static_cast<val<int32_t>>(index);
+}
+
 /// Mutable per-evaluation scratch state mirroring EvalNative.hpp's
-/// EvalContext: the stack of enclosing traced Loop frames, innermost last.
+/// EvalContext: the stack of enclosing traced Loop frames (innermost last),
+/// plus the base/one-past-last pointer into the shared buffer that every
+/// pointer-domain node (Kind::PtrBase/PtrAdd/PtrSub) is built from.
 template <typename T>
 struct TracedLoopFrame {
 	TracedValue<T> index;
@@ -122,7 +141,48 @@ struct TracedLoopFrame {
 template <typename T>
 struct TracedEvalContext {
 	std::vector<TracedLoopFrame<T>> loopStack;
+	val<T*> basePtr;
+	val<T*> lastPtr; // basePtr + (BUFFER_ELEMS - 1), precomputed once
 };
+
+template <typename T>
+TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx);
+template <typename T>
+TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx);
+
+/// Dispatches to whichever of evalNautilusInt/evalNautilusFloat matches T's
+/// domain -- the traced mirror of EvalNative.hpp's evalNativeValue, needed
+/// for the same reason (evalNautilusPtr and the Load/Store cases below are
+/// shared between both domains).
+template <typename T>
+TracedValue<T> evalNautilusValue(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return evalNautilusFloat<T>(ast, idx, args, ctx);
+	} else {
+		return evalNautilusInt<T>(ast, idx, args, ctx);
+	}
+}
+
+/// Traced mirror of EvalNative.hpp's evalNativePtr: evaluates a
+/// pointer-domain node to a real val<T*>, using the exact same
+/// operator+/operator- val<T*> arithmetic under test.
+template <typename T>
+val<T*> evalNautilusPtr(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
+	const Node& n = ast.nodes[idx];
+	switch (n.kind) {
+	case Kind::PtrAdd: {
+		val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusValue<T>(ast, n.kid[0], args, ctx));
+		return ctx.basePtr + off;
+	}
+	case Kind::PtrSub: {
+		val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusValue<T>(ast, n.kid[0], args, ctx));
+		return ctx.lastPtr - off;
+	}
+	case Kind::PtrBase:
+	default:
+		return ctx.basePtr;
+	}
+}
 
 template <typename T>
 TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
@@ -169,6 +229,50 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		return ~evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 	case Kind::Cast:
 		return castThroughTraced<T>(evalNautilusInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
+	case Kind::Load: {
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> v = *p;
+		return v;
+	}
+	case Kind::Store: {
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> v = evalNautilusValue<T>(ast, n.kid[1], args, ctx);
+		*p = v;
+		return v;
+	}
+	case Kind::PtrToInt:
+		return static_cast<TracedValue<T>>(evalNautilusPtr<T>(ast, n.kid[0], args, ctx));
+	case Kind::PtrEq:
+	case Kind::PtrNe:
+	case Kind::PtrLt:
+	case Kind::PtrLe:
+	case Kind::PtrGt:
+	case Kind::PtrGe: {
+		val<T*> a = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		val<T*> b = evalNautilusPtr<T>(ast, n.kid[1], args, ctx);
+		val<bool> cmp(false);
+		switch (n.kind) {
+		case Kind::PtrEq:
+			cmp = (a == b);
+			break;
+		case Kind::PtrNe:
+			cmp = (a != b);
+			break;
+		case Kind::PtrLt:
+			cmp = (a < b);
+			break;
+		case Kind::PtrLe:
+			cmp = (a <= b);
+			break;
+		case Kind::PtrGt:
+			cmp = (a > b);
+			break;
+		default:
+			cmp = (a >= b);
+			break;
+		}
+		return select(cmp, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
 	default:
 		break;
 	}
@@ -254,6 +358,50 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		return -evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
 	case Kind::Cast:
 		return castThroughTraced<T>(evalNautilusFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
+	case Kind::Load: {
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> v = *p;
+		return v;
+	}
+	case Kind::Store: {
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> v = evalNautilusValue<T>(ast, n.kid[1], args, ctx);
+		*p = v;
+		return v;
+	}
+	case Kind::PtrToInt:
+		return static_cast<TracedValue<T>>(evalNautilusPtr<T>(ast, n.kid[0], args, ctx));
+	case Kind::PtrEq:
+	case Kind::PtrNe:
+	case Kind::PtrLt:
+	case Kind::PtrLe:
+	case Kind::PtrGt:
+	case Kind::PtrGe: {
+		val<T*> a = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		val<T*> b = evalNautilusPtr<T>(ast, n.kid[1], args, ctx);
+		val<bool> cmp(false);
+		switch (n.kind) {
+		case Kind::PtrEq:
+			cmp = (a == b);
+			break;
+		case Kind::PtrNe:
+			cmp = (a != b);
+			break;
+		case Kind::PtrLt:
+			cmp = (a < b);
+			break;
+		case Kind::PtrLe:
+			cmp = (a <= b);
+			break;
+		case Kind::PtrGt:
+			cmp = (a > b);
+			break;
+		default:
+			cmp = (a >= b);
+			break;
+		}
+		return select(cmp, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
 	default:
 		break;
 	}
@@ -289,8 +437,10 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 } // namespace detail
 
 template <typename T>
-TracedValue<T> evalNautilus(const Ast& ast, const TracedArgs<T>& args) {
+TracedValue<T> evalNautilus(const Ast& ast, val<T*> basePtr, const TracedArgs<T>& args) {
 	detail::TracedEvalContext<T> ctx;
+	ctx.basePtr = basePtr;
+	ctx.lastPtr = basePtr + static_cast<int32_t>(BUFFER_ELEMS - 1);
 	if constexpr (std::is_floating_point_v<T>) {
 		return detail::evalNautilusFloat<T>(ast, ast.root, args, ctx);
 	} else {

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -21,8 +21,11 @@ static_assert(NUM_PARAMS == 3, "The harness wires exactly three same-typed param
 
 // registerFunction expects the traced (val<>) return type in the signature; the
 // resulting CompiledFunction is then callable with -- and returns -- raw scalars.
+// The leading val<T*> is the shared BUFFER_ELEMS-element buffer every
+// generated program's pointer-domain nodes (Kind::PtrBase et al., see
+// Ast.hpp) index into.
 template <typename T>
-using KernelSignature = val<T>(val<T>, val<T>, val<T>);
+using KernelSignature = val<T>(val<T*>, val<T>, val<T>, val<T>);
 
 /// Backends compiled into this build, mirroring testing::availableBackends().
 /// The interpreter is always present and acts as an extra differential peer.
@@ -63,6 +66,7 @@ struct Finding {
 	std::string typeName;
 	std::string program;
 	std::vector<std::string> args;
+	std::vector<std::string> memory; // shared buffer's initial contents (see Kind::PtrBase, Ast.hpp)
 	std::string expected = "";
 	std::string got = "";
 	bool exception = false;
@@ -70,12 +74,21 @@ struct Finding {
 	bool hasParam = false;
 };
 
+inline void printMemory(const std::vector<std::string>& memory) {
+	std::fprintf(stderr, "memory   : [");
+	for (size_t i = 0; i < memory.size(); ++i) {
+		std::fprintf(stderr, "%s%s", i == 0 ? "" : ", ", memory[i].c_str());
+	}
+	std::fprintf(stderr, "]\n");
+}
+
 inline void printFinding(const Finding& f) {
 	if (f.exception) {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: EXCEPTION ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
 		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
+		printMemory(f.memory);
 		std::fprintf(stderr, "what()   : %s\n", f.what.c_str());
 		std::fprintf(stderr, "=================================================\n");
 	} else {
@@ -84,6 +97,7 @@ inline void printFinding(const Finding& f) {
 		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
 		std::fprintf(stderr, "args     : p0=%s p1=%s p2=%s\n", f.args[0].c_str(), f.args[1].c_str(), f.args[2].c_str());
+		printMemory(f.memory);
 		std::fprintf(stderr, "expected : %s (native oracle)\n", f.expected.c_str());
 		std::fprintf(stderr, "got      : %s\n", f.got.c_str());
 		std::fprintf(stderr, "================================================\n");
@@ -117,30 +131,49 @@ std::vector<Finding> checkOneTyped(ByteReader& reader) {
 		args[i] = reader.consume<T>();
 	}
 
-	const T expected = evalNative<T>(ast, args);
+	// Initial contents of the shared buffer every pointer-domain node indexes
+	// into (see Kind::PtrBase, Ast.hpp). `memory` is declared once and reused
+	// -- reset to `initialMemory` before every run below -- rather than
+	// freshly constructed per run, so its address stays identical across the
+	// native oracle and every backend; that's what makes Kind::PtrToInt's
+	// pointer->integer cast comparable at all (it embeds a real address).
+	std::array<T, BUFFER_ELEMS> initialMemory {};
+	for (int i = 0; i < BUFFER_ELEMS; ++i) {
+		initialMemory[i] = reader.consume<T>();
+	}
+	std::array<T, BUFFER_ELEMS> memory = initialMemory;
+
+	const T expected = evalNative<T>(ast, args, memory);
 	const std::string program = toString<T>(ast);
 	std::vector<std::string> argStrs;
 	argStrs.reserve(NUM_PARAMS);
 	for (T a : args) {
 		argStrs.push_back(formatValue<T>(a));
 	}
+	std::vector<std::string> memoryStrs;
+	memoryStrs.reserve(BUFFER_ELEMS);
+	for (T v : initialMemory) {
+		memoryStrs.push_back(formatValue<T>(v));
+	}
 
 	std::vector<Finding> findings;
 	for (const auto& backend : configs()) {
 		try {
 			auto engine = makeEngine(backend);
-			std::function<KernelSignature<T>> kernel = [&ast](val<T> a, val<T> b, val<T> c) {
+			std::function<KernelSignature<T>> kernel = [&ast](val<T*> mem, val<T> a, val<T> b, val<T> c) {
 				const TracedArgs<T> traced {a, b, c};
-				return evalNautilus<T>(ast, traced);
+				return evalNautilus<T>(ast, mem, traced);
 			};
 			auto compiled = engine.registerFunction(kernel);
-			const T got = compiled(args[0], args[1], args[2]);
+			memory = initialMemory;
+			const T got = compiled(memory.data(), args[0], args[1], args[2]);
 			if (!valuesEqual<T>(got, expected)) {
-				findings.push_back({backend, typeSuffix<T>(), program, argStrs, formatValue<T>(expected),
+				findings.push_back({backend, typeSuffix<T>(), program, argStrs, memoryStrs, formatValue<T>(expected),
 				                    formatValue<T>(got), false, "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back({backend, typeSuffix<T>(), program, argStrs, "", "", true, e.what(), hasParam});
+			findings.push_back(
+			    {backend, typeSuffix<T>(), program, argStrs, memoryStrs, "", "", true, e.what(), hasParam});
 		}
 	}
 	return findings;

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -79,6 +79,56 @@ mirroring how the original `uint64_t`-only fuzzer worked.
   compiled loop executes it at runtime, so this doesn't blow up compile
   time.
 
+## Memory and pointer domain
+
+Every generated program is additionally handed a pointer (`val<T*>`) to a
+shared, `BUFFER_ELEMS`-element buffer of `T` (`Ast.hpp`), so `val<T*>`
+arithmetic, comparisons, casts, and loads/stores are fuzzed identically to
+the rest of the value domain -- following the same well-defined-by-construction
+principle as everything else here.
+
+* **`Load`/`Store`**: `kid[0]` (both) is a *pointer-domain* node (see below),
+  `kid[1]` (`Store` only) is a value-domain node. `Load` yields `*ptr`; `Store`
+  writes through the pointer and yields the stored value, i.e. the value of
+  the C++ assignment expression `*ptr = v`.
+* **`PtrToInt`**: `(T)(uintptr_t)ptr`, the same pointer -> arithmetic
+  conversion `base_ptr_val` already exposes (`val_ptr.hpp`). Because the
+  harness reuses one buffer object -- reset, not reallocated, between the
+  native-oracle run and every backend run (see below) -- its address is
+  identical across every leg of the differential check, so this is directly
+  comparable rather than merely "equivalent."
+* **`PtrEq`/`PtrNe`/`PtrLt`/`PtrLe`/`PtrGt`/`PtrGe`**: both kids are
+  pointer-domain nodes; yields 0/1 as `T`, the same convention as the
+  value-domain comparisons.
+* **Pointer-domain nodes** (`PtrBase`/`PtrAdd`/`PtrSub`, `generatePtrNode` in
+  `Ast.hpp`): never chosen as the AST root or by the value-domain generator
+  directly -- only ever a kid of one of the nodes above. Deliberately never
+  nest (`PtrAdd`'s own child is always a *value*-domain offset expression,
+  never another pointer-domain node), so every pointer this can produce is
+  directly `base + clampBufferIndex(x)` or `end - clampBufferIndex(x)` for
+  some single offset expression `x` -- always an in-bounds buffer index by
+  construction, with no need to reason about compounding offsets across
+  hops. `clampBufferIndex`/`clampBufferIndexTraced` reduce the raw offset the
+  same reinterpret-to-unsigned-then-modulo way as `Loop`'s trip count, just
+  modulo `BUFFER_ELEMS` -- exercising real `val<T*>::operator+`/`operator-`
+  (scaled by `sizeof(T)`) while staying safe regardless of what value the
+  offset expression evaluates to.
+* **Buffer lifecycle**: the harness declares the buffer once per
+  `checkOneTyped<T>` call and resets its contents (not its storage) to the
+  same initial values before the native-oracle run and before each backend
+  run, so Store side effects from one run never leak into the next, while
+  `PtrToInt` still observes one stable address throughout.
+* **`Select` and memory side effects**: `Select`'s traced form
+  (`select(cond, t, f)`) is a data mux -- both `t` and `f` are always
+  evaluated/lowered, unlike a real C++ ternary or `If`. Once `Store` could
+  appear inside a `Select` branch, the native oracle's original ternary
+  short-circuit (evaluating only the taken branch) would silently skip a
+  memory write that the traced kernel still performs. The oracle's `Select`
+  case now evaluates both branches unconditionally, matching the traced
+  kernel exactly; `If` needed no change since its native/traced forms
+  already evaluate the else-branch unconditionally and the then-branch only
+  when taken (see the `Kind::If` comment in `EvalNative.hpp`).
+
 ## Soundness model
 
 Within the integer domain, unsigned arithmetic uses plain operators (defined

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -38,13 +38,16 @@ std::vector<uint8_t> readFile(const char* path) {
 }
 
 std::vector<uint8_t> randomBuffer() {
-	// 160, not the original 96/128: a type-select byte, a Cast target-type
-	// byte (now drawn from all ten types instead of one domain's eight/two),
-	// and Loop/LoopIndex/LoopAcc kind-selection plus loopDepth-gated leaf
-	// selection all now compete for the same fixed budget, so a larger
-	// buffer keeps tree richness -- and the odds of generating a nontrivial
-	// or nested Loop -- comparable to before.
-	const size_t len = nextRand() % 160;
+	// 256, not the original 96/128/160: on top of the type-select byte, the
+	// Cast target-type byte, and Loop/LoopIndex/LoopAcc kind-selection, the
+	// memory domain (Load/Store/PtrToInt/Ptr-comparisons, each drawing a
+	// pointer-domain subexpression) now consumes its own kind-selection
+	// bytes, and after AST generation every input additionally pays for
+	// BUFFER_ELEMS*sizeof(T) bytes of initial buffer contents (up to 8*8=64
+	// bytes for i64/f64) on top of the three existing NUM_PARAMS args. A
+	// larger buffer keeps tree richness -- and the odds of generating a
+	// nontrivial Load/Store/pointer comparison -- comparable to before.
+	const size_t len = nextRand() % 256;
 	std::vector<uint8_t> buf(len);
 	for (size_t i = 0; i < len; ++i) {
 		buf[i] = static_cast<uint8_t>(nextRand());


### PR DESCRIPTION
## Summary

The differential AST fuzzer (`nautilus/test/fuzz/`) generated well-defined
scalar-only programs across ten `TypeId` domains, but had no coverage for
`val<T*>` at all — no pointer arithmetic, no comparisons, no load/store. This
extends it to fuzz `val<T*>` following C++ pointer semantics, alongside the
existing scalar domain:

- Every generated program is now additionally handed a `val<T*>` into a
  shared, fixed-size (`BUFFER_ELEMS = 8`) buffer of `T`.
- New AST node kinds: `Load`/`Store` (memory access, `Store` yields the
  stored value like a C++ assignment expression), `PtrToInt` (the existing
  pointer→arithmetic conversion in `val_ptr.hpp`), and `PtrEq/Ne/Lt/Le/Gt/Ge`
  (pointer comparisons).
- New pointer-domain node kinds (`PtrBase`/`PtrAdd`/`PtrSub`,
  `generatePtrNode` in `Ast.hpp`): deliberately never nest, so every pointer
  produced is always `base + clampBufferIndex(x)` or
  `end - clampBufferIndex(x)` for a single offset expression `x` — always an
  in-bounds buffer index by construction (same "well-defined by construction"
  approach the rest of this fuzzer already uses for divisors, shifts, casts,
  and loop trip counts).
- The harness reuses one buffer object per differential check (reset, not
  reallocated, between the native-oracle run and each backend run), so
  `PtrToInt`'s pointer→integer cast is directly comparable (same address on
  every leg) rather than merely equivalent.
- Fixed the native oracle's `Select` case (int and float) to evaluate both
  branches unconditionally, matching the traced kernel's `select()` data-mux
  semantics exactly. This was previously a plain ternary (only evaluates the
  taken branch), which was harmless with no side effects in the tree, but
  would now silently skip a `Store`'s memory write on the untaken branch.

See the new "Memory and pointer domain" section in `test/fuzz/README.md` for
the full design rationale.

## Testing

Built `nautilus-fuzz-replay` locally (interpreter + cpp + bc backends; MLIR
wasn't available in this environment) and ran:

- The built-in 2000-iteration smoke corpus — all backends agreed.
- `--survey 5000` (and a smaller earlier `--survey 3000`) — 0 findings across
  ~10,000 total differential runs exercising the new pointer/memory domain.

`./format.sh` passes for all touched files (pre-existing GPU-plugin
formatting issues elsewhere in the tree are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194HaK58n8JdCVSijBQF5tE

---
_Generated by [Claude Code](https://claude.ai/code/session_0194HaK58n8JdCVSijBQF5tE)_