### PR TITLE
Fix AsmJit merged-value corruption from block-arg identifier collision (#321)

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -174,6 +174,18 @@ void AsmJitLoweringProvider::LoweringContext::emitMove(const AsmReg& dst, const 
 	}
 }
 
+// See the header for the rationale (issue #321). When the identifier is
+// already bound it is a downstream merge-block parameter register; copy the
+// result into it rather than dropping the definition.
+void AsmJitLoweringProvider::LoweringContext::bindResult(const ir::OperationIdentifier& id, const AsmReg& reg,
+                                                         RegisterFrame& frame) {
+	if (frame.contains(id)) {
+		emitMove(frame.getValue(id), reg);
+	} else {
+		frame.setValue(id, reg);
+	}
+}
+
 // ── Two-pass compilation ──────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDump) {
@@ -323,13 +335,13 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::b);
 	cc.mov(toGp(reg), static_cast<int64_t>(op->getValue() ? 1 : 0));
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(op->getStamp());
 	cc.mov(toGp(reg), op->getValue());
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
@@ -350,13 +362,13 @@ void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOper
 		cc.mov(tempGp, bits);
 		cc.fmov(vecReg, tempGp);
 	}
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::ptr);
 	cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getValue()));
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 // ── Arithmetic ────────────────────────────────────────────────────────────────
@@ -370,7 +382,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 	} else {
 		cc.add(toGp(result), toGp(left), toGp(right));
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, RegisterFrame& frame) {
@@ -382,7 +394,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, Reg
 	} else {
 		cc.sub(toGp(result), toGp(left), toGp(right));
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, RegisterFrame& frame) {
@@ -394,7 +406,7 @@ void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, Reg
 	} else {
 		cc.mul(toGp(result), toGp(left), toGp(right));
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, RegisterFrame& frame) {
@@ -408,7 +420,7 @@ void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, Reg
 	} else {
 		cc.sdiv(toGp(result), toGp(left), toGp(right));
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, RegisterFrame& frame) {
@@ -424,7 +436,7 @@ void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, Reg
 	}
 	// msub dst, quotient, right, left → dst = left - quotient * right
 	cc.msub(toGp(result), quotient, toGp(right), toGp(left));
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Logical / compare ─────────────────────────────────────────────────────────
@@ -528,7 +540,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 		}
 	}
 	cc.cset(resultGp, Imm(condCode));
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, RegisterFrame& frame) {
@@ -536,7 +548,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, Reg
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 	cc.and_(toGp(result), left, right);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, RegisterFrame& frame) {
@@ -544,21 +556,21 @@ void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, Regis
 	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 	cc.orr(toGp(result), left, right);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, RegisterFrame& frame) {
 	auto input = toGp(frame.getValue(op->getInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 	cc.eor(toGp(result), input, Imm(1));
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	cc.mvn(toGp(result), toGp(src));
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Binary bit operations ─────────────────────────────────────────────────────
@@ -574,7 +586,7 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 	} else {
 		cc.asr(toGp(result), left, right);
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
@@ -592,7 +604,7 @@ void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOper
 		cc.eor(toGp(result), left, right);
 		break;
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Control flow ──────────────────────────────────────────────────────────────
@@ -687,7 +699,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* o
 		cc.csel(toGp(result), toGp(trueVal), toGp(falseVal), Imm(static_cast<uint32_t>(CC::kNE)));
 	}
 
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Memory ────────────────────────────────────────────────────────────────────
@@ -732,7 +744,7 @@ void AsmJitLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* op, R
 			break;
 		}
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* op, RegisterFrame& frame) {
@@ -771,7 +783,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* o
 	// pointer register.
 	auto index = op->getIndex();
 	assert(index < functionAllocaSlots_.size() && "AllocaOperation index out of range for function");
-	frame.setValue(op->getIdentifier(), functionAllocaSlots_[index]);
+	bindResult(op->getIdentifier(), functionAllocaSlots_[index], frame);
 }
 
 // ── External function calls ───────────────────────────────────────────────────
@@ -824,7 +836,7 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 			invokeNode->setRet(0, toVec(result));
 		else
 			invokeNode->setRet(0, toGp(result));
-		frame.setValue(op->getIdentifier(), result);
+		bindResult(op->getIdentifier(), result, frame);
 	}
 }
 
@@ -855,7 +867,7 @@ void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCall
 			invokeNode->setRet(0, toVec(result));
 		else
 			invokeNode->setRet(0, toGp(result));
-		frame.setValue(op->getIdentifier(), result);
+		bindResult(op->getIdentifier(), result, frame);
 	}
 }
 
@@ -868,7 +880,7 @@ void AsmJitLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::Functio
 	} else {
 		cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getFunctionPtr()));
 	}
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 // ── Type conversion ───────────────────────────────────────────────────────────
@@ -975,7 +987,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 		// Float → float: f32↔f64.
 		cc.fcvt(toVec(result), toVec(src));
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 } // namespace nautilus::compiler::asmjit

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
@@ -108,6 +108,21 @@ private:
 		::asmjit::Label getOrCreateLabel(ir::BlockIdentifier blockId);
 		void emitMove(const AsmReg& dst, const AsmReg& src);
 
+		// Bind an operation's freshly computed result to its SSA identifier.
+		// For a normal (single) definition this just records the register.
+		// But a value's identifier can coincide with a downstream merge
+		// block's parameter whose register was already allocated by an
+		// earlier-emitted predecessor edge -- Nautilus SSA reuses an incoming
+		// value's name for the block parameter, and the diamond/loop CFG can
+		// emit that predecessor before this definition. In that case the
+		// identifier is already bound to the parameter register, and this
+		// definition is the value flowing in along *this* edge, so its result
+		// must be copied into the parameter register. Frame::setValue is
+		// emplace-only and would silently ignore the rebind, orphaning the
+		// computed value and leaving the merge parameter uninitialised along
+		// this path (issue #321).
+		void bindResult(const ir::OperationIdentifier& id, const AsmReg& reg, RegisterFrame& frame);
+
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);
 		void processBlockInvocation(const ir::BasicBlockInvocation& bi, RegisterFrame& frame);
 

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -210,6 +210,18 @@ void AsmJitLoweringProvider::LoweringContext::emitMove(const AsmReg& dst, const 
 	}
 }
 
+// See the header for the rationale (issue #321). When the identifier is
+// already bound it is a downstream merge-block parameter register; copy the
+// result into it rather than dropping the definition.
+void AsmJitLoweringProvider::LoweringContext::bindResult(const ir::OperationIdentifier& id, const AsmReg& reg,
+                                                         RegisterFrame& frame) {
+	if (frame.contains(id)) {
+		emitMove(frame.getValue(id), reg);
+	} else {
+		frame.setValue(id, reg);
+	}
+}
+
 // ── Two-pass compilation ──────────────────────────────────────────────────────
 //
 // Pass 1: call cc.newFunc() for every FunctionOperation, storing each FuncNode*.
@@ -378,13 +390,13 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::b);
 	cc.mov(toGp(reg), static_cast<int64_t>(op->getValue() ? 1 : 0));
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(op->getStamp());
 	cc.mov(toGp(reg), op->getValue());
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
@@ -405,13 +417,13 @@ void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOper
 		cc.mov(tempGp, bits);
 		cc.movq(xmmReg, tempGp);
 	}
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
 	auto reg = allocReg(Type::ptr);
 	cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getValue()));
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 // ── Arithmetic ────────────────────────────────────────────────────────────────
@@ -437,7 +449,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 		// (see narrowToStamp's doc comment).
 		narrowToStamp(gDst, op->getStamp());
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, RegisterFrame& frame) {
@@ -457,7 +469,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, Reg
 		cc.sub(gDst, toGp(right));
 		narrowToStamp(gDst, op->getStamp());
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, RegisterFrame& frame) {
@@ -477,7 +489,7 @@ void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, Reg
 		cc.imul(gDst, toGp(right));
 		narrowToStamp(gDst, op->getStamp());
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, RegisterFrame& frame) {
@@ -506,7 +518,7 @@ void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, Reg
 		}
 		cc.mov(toGp(result), quot);
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, RegisterFrame& frame) {
@@ -524,7 +536,7 @@ void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, Reg
 		cc.idiv(rem, quot, toGp(right));
 	}
 	cc.mov(toGp(result), rem);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Logical / compare ─────────────────────────────────────────────────────────
@@ -650,7 +662,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 	}
 	// Zero-extend the 8-bit result into the full 64-bit virtual register.
 	cc.movzx(toGp(result).r32(), resultGp);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, RegisterFrame& frame) {
@@ -659,7 +671,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, Reg
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), left);
 	cc.and_(toGp(result), right);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, RegisterFrame& frame) {
@@ -668,7 +680,7 @@ void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, Regis
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), left);
 	cc.or_(toGp(result), right);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, RegisterFrame& frame) {
@@ -677,7 +689,7 @@ void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, Reg
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), input);
 	cc.xor_(toGp(result), 1);
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
@@ -692,7 +704,7 @@ void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* o
 	// flips its replicated extension consistently) but is wrong for unsigned
 	// stamps, whose invariant is a zero-extended (not flipped) upper half.
 	narrowToStamp(gDst, op->getStamp());
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Binary bit operations ─────────────────────────────────────────────────────
@@ -721,7 +733,7 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 	// positions that change the narrow-width result's own sign, so this is
 	// needed for all three shift forms.
 	narrowToStamp(gDst, op->getStamp());
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
@@ -740,7 +752,7 @@ void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOper
 		cc.xor_(toGp(result), right);
 		break;
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Control flow ──────────────────────────────────────────────────────────────
@@ -819,7 +831,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* o
 	emitMove(result, falseVal);
 	cc.bind(donePath);
 
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 // ── Memory ────────────────────────────────────────────────────────────────────
@@ -864,7 +876,7 @@ void AsmJitLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* op, R
 			break;
 		}
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* op, RegisterFrame& frame) {
@@ -907,7 +919,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* o
 	// pointer register.
 	auto index = op->getIndex();
 	assert(index < functionAllocaSlots_.size() && "AllocaOperation index out of range for function");
-	frame.setValue(op->getIdentifier(), functionAllocaSlots_[index]);
+	bindResult(op->getIdentifier(), functionAllocaSlots_[index], frame);
 }
 
 // ── External function calls ───────────────────────────────────────────────────
@@ -955,7 +967,7 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 			invokeNode->setRet(0, toXmm(result));
 		else
 			invokeNode->setRet(0, toGp(result));
-		frame.setValue(op->getIdentifier(), result);
+		bindResult(op->getIdentifier(), result, frame);
 	}
 }
 
@@ -988,7 +1000,7 @@ void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCall
 			invokeNode->setRet(0, toXmm(result));
 		else
 			invokeNode->setRet(0, toGp(result));
-		frame.setValue(op->getIdentifier(), result);
+		bindResult(op->getIdentifier(), result, frame);
 	}
 }
 
@@ -1003,7 +1015,7 @@ void AsmJitLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::Functio
 		// External function: embed the raw pointer as a compile-time constant.
 		cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getFunctionPtr()));
 	}
-	frame.setValue(op->getIdentifier(), reg);
+	bindResult(op->getIdentifier(), reg, frame);
 }
 
 // ── Type conversion ───────────────────────────────────────────────────────────
@@ -1114,7 +1126,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 		else
 			cc.cvtsd2ss(xDst, xSrc);
 	}
-	frame.setValue(op->getIdentifier(), result);
+	bindResult(op->getIdentifier(), result, frame);
 }
 
 } // namespace nautilus::compiler::asmjit

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -121,6 +121,21 @@ private:
 		::asmjit::Label getOrCreateLabel(ir::BlockIdentifier blockId);
 		void emitMove(const AsmReg& dst, const AsmReg& src);
 
+		// Bind an operation's freshly computed result to its SSA identifier.
+		// For a normal (single) definition this just records the register.
+		// But a value's identifier can coincide with a downstream merge
+		// block's parameter whose register was already allocated by an
+		// earlier-emitted predecessor edge -- Nautilus SSA reuses an incoming
+		// value's name for the block parameter, and the diamond/loop CFG can
+		// emit that predecessor before this definition. In that case the
+		// identifier is already bound to the parameter register, and this
+		// definition is the value flowing in along *this* edge, so its result
+		// must be copied into the parameter register. Frame::setValue is
+		// emplace-only and would silently ignore the rebind, orphaning the
+		// computed value and leaving the merge parameter uninitialised along
+		// this path (issue #321).
+		void bindResult(const ir::OperationIdentifier& id, const AsmReg& reg, RegisterFrame& frame);
+
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);
 		void processBlockInvocation(const ir::BasicBlockInvocation& bi, RegisterFrame& frame);
 

--- a/nautilus/test/common/SelectOperations.hpp
+++ b/nautilus/test/common/SelectOperations.hpp
@@ -81,4 +81,22 @@ val<int32_t> selectPointerAndDeref(val<bool> condition, val<int32_t*> ptr1, val<
 	return *selected;
 }
 
+// Regression (issue #321): a zero-trip Loop nested inside a never-taken If
+// branch, whose result is merged after the If and fed into a Select. The
+// merge block's parameters reuse the SSA identifiers that the else-arm block
+// also defines; the AsmJit backend used to emit the never-taken arm's merge
+// block before the else arm and then silently drop the else arm's
+// definitions, so the merged value was left uninitialised on the taken path.
+val<float> zeroTripLoopInUntakenIfMerge(val<float> p) {
+	val<float> result = 0.0f;
+	if (p != 0.0f) { // never taken when p == 0
+		val<float> acc = 0.0f;
+		for (val<int32_t> i = 0; i < val<int32_t>(0); i = i + 1) { // zero-trip loop
+			acc = 0.0f;
+		}
+		result = acc;
+	}
+	return select(result != 0.0f, val<float>(1.0f), val<float>(0.0f));
+}
+
 } // namespace nautilus::engine

--- a/nautilus/test/execution-tests/SelectExecutionTest.cpp
+++ b/nautilus/test/execution-tests/SelectExecutionTest.cpp
@@ -116,6 +116,18 @@ void selectTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(true, &a, &b) == 42);
 		REQUIRE(f(false, &a, &b) == 100);
 	}
+
+	// Regression for issue #321: a zero-trip loop inside a never-taken if,
+	// merged after the if and consumed by a select. The runtime result is
+	// always 0.0f (the loop never runs, so result stays 0.0f and the select
+	// picks its false value). The AsmJit backend previously returned garbage
+	// for the p == 0 case.
+	SECTION("zeroTripLoopInUntakenIfMerge") {
+		auto f = engine.registerFunction(zeroTripLoopInUntakenIfMerge);
+		REQUIRE(f(0.0f) == 0.0f); // if not taken
+		REQUIRE(f(1.0f) == 0.0f); // if taken, but loop is zero-trip -> still 0.0f
+		REQUIRE(f(-3.5f) == 0.0f);
+	}
 }
 
 TEST_CASE("Select Interpreter Test") {


### PR DESCRIPTION
## Summary

Fixes #321. A zero-trip `Loop` nested inside a never-taken `If` branch caused the AsmJit backend to produce a wrong result for a value merged after the `If`. The interpreter, cpp, and bc backends all agreed with the native C++ oracle; only `asmjit` disagreed.

Minimal repro (from the issue) now returns `0` on `asmjit`, matching the other backends:

```cpp
val<float> repro(val<float> p2) {
    val<float> result = 0.0f;
    if (p2 != 0.0f) {                                   // never taken when p2 == 0
        val<float> acc = 0.0f;
        for (val<int32_t> i = 0; i < val<int32_t>(0); i = i + 1) { acc = 0.0f; } // zero-trip
        result = acc;
    }
    return select(result != 0.0f, val<float>(1.0f), val<float>(0.0f));
}
```

## Root cause

Nautilus SSA reuses an incoming value's identifier as the name of a merge block's parameter. As a result, a merge block can share SSA identifiers with a predecessor block that *also defines* those identifiers. In this program, the else arm (`B2`) defines constants `$16/$17/$18`, and the post-`If` merge block `B6` takes parameters named `$16/$17/$18`.

The AsmJit lowering walks the diamond CFG depth-first and emits the entire true subtree first — reaching `B6` (via the loop-exit block `B4`) before the else arm `B2`. That first edge allocates fresh registers for `B6`'s parameters. When `B2`'s constant visitors then run, `Frame::setValue` is emplace-only (no overwrite), so the rebind is silently ignored: the freshly computed constants are orphaned, and `B2` reads the still-uninitialised merge-parameter registers. This was visible in the generated code, which copied the merge-parameter registers into themselves instead of the computed constants.

Removing the loop made the result correct because the merge/register layout no longer collided in this order — matching the issue's observation.

## Fix

Route every operation-result binding through a new `bindResult()` helper:

- if the identifier is **not** yet bound → record it (previous behaviour);
- if it **is** already bound (a merge-block parameter allocated by an earlier-emitted predecessor edge) → copy the result into that register instead of dropping it.

This makes a value definition that coincides with a downstream merge parameter land in the parameter's register regardless of the order the diamond arms are emitted, which is exactly the phi-copy semantics the merge needs. Normal single-definition values are unaffected (the identifier is never pre-bound for them).

Applied to both the x64 (`X64LoweringProvider`) and A64 (`A64LoweringProvider`) backends, since they share the `LoweringContext` model and the same latent bug.

## Testing

- Added a differential regression test `zeroTripLoopInUntakenIfMerge` (in `SelectOperations.hpp` / `SelectExecutionTest.cpp`), run across every backend and tracing mode plus the interpreter.
- Full `nautilus-execution-tests` suite passes (11521 assertions, 45 passed / 2 skipped).
- Fuzzer: `nautilus-fuzz-replay --survey 5000` reports **0 findings** (previously 1 in the `asmjit|f32|has-param` bucket); the deterministic built-in corpus (2000 inputs) agrees across all backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa92XLC6uXfH29iABeVgd3)_