### PR TITLE
Extend differential fuzzer (logical ops, invoke(), static loops) and fix 4 miscompiles it found

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -135,6 +135,32 @@ bool AsmJitLoweringProvider::LoweringContext::isUnsignedType(Type t) {
 	return t == Type::ui8 || t == Type::ui16 || t == Type::ui32 || t == Type::ui64 || t == Type::b || t == Type::ptr;
 }
 
+void AsmJitLoweringProvider::LoweringContext::narrowToStamp(Gp reg, Type stamp) {
+	switch (stamp) {
+	case Type::i8:
+		cc.sxtb(reg.x(), reg.w());
+		break;
+	case Type::b:
+	case Type::ui8:
+		cc.uxtb(reg.w(), reg.w());
+		break;
+	case Type::i16:
+		cc.sxth(reg.x(), reg.w());
+		break;
+	case Type::ui16:
+		cc.uxth(reg.w(), reg.w());
+		break;
+	case Type::i32:
+		cc.sxtw(reg.x(), reg.w());
+		break;
+	case Type::ui32:
+		cc.mov(reg.w(), reg.w()); // zero-extends upper 32 bits
+		break;
+	default:
+		break; // i64, ui64, ptr -- already full-width, no narrowing needed.
+	}
+}
+
 // ── Register allocation ───────────────────────────────────────────────────────
 
 AsmJitLoweringProvider::AsmReg AsmJitLoweringProvider::LoweringContext::allocReg(Type t) {
@@ -381,6 +407,11 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 		cc.fadd(toVec(result), toVec(left), toVec(right));
 	} else {
 		cc.add(toGp(result), toGp(left), toGp(right));
+		// An add that overflows the narrow stamp's width still produces a
+		// "correct" 64-bit sum; re-extend per the result type so its
+		// sign/zero-extension matches the wrapped-around narrow-width value
+		// (see narrowToStamp's doc comment).
+		narrowToStamp(toGp(result), op->getStamp());
 	}
 	bindResult(op->getIdentifier(), result, frame);
 }
@@ -393,6 +424,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, Reg
 		cc.fsub(toVec(result), toVec(left), toVec(right));
 	} else {
 		cc.sub(toGp(result), toGp(left), toGp(right));
+		narrowToStamp(toGp(result), op->getStamp());
 	}
 	bindResult(op->getIdentifier(), result, frame);
 }
@@ -405,6 +437,7 @@ void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, Reg
 		cc.fmul(toVec(result), toVec(left), toVec(right));
 	} else {
 		cc.mul(toGp(result), toGp(left), toGp(right));
+		narrowToStamp(toGp(result), op->getStamp());
 	}
 	bindResult(op->getIdentifier(), result, frame);
 }
@@ -570,6 +603,11 @@ void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* o
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	cc.mvn(toGp(result), toGp(src));
+	// mvn flips the full 64-bit register, including the extension padding.
+	// That happens to stay correct for signed stamps (flipping a sign bit
+	// flips its replicated extension consistently) but is wrong for unsigned
+	// stamps, whose invariant is a zero-extended (not flipped) upper half.
+	narrowToStamp(toGp(result), op->getStamp());
 	bindResult(op->getIdentifier(), result, frame);
 }
 
@@ -586,6 +624,15 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 	} else {
 		cc.asr(toGp(result), left, right);
 	}
+	// Shifting the full 64-bit register (rather than just the narrow stamp's
+	// width) can leave the extension padding inconsistent with the
+	// narrow-width result -- e.g. a left shift that overflows the stamp's
+	// width still computes a "correct" 64-bit shift, whose sign-extension no
+	// longer matches the wrapped-around narrow-width value. asr already
+	// shifts in the sign bit, but a shift can still move that bit into
+	// positions that change the narrow-width result's own sign, so this is
+	// needed for all three shift forms.
+	narrowToStamp(toGp(result), op->getStamp());
 	bindResult(op->getIdentifier(), result, frame);
 }
 
@@ -655,26 +702,9 @@ void AsmJitLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* o
 			cc.ret(toVec(retReg));
 		} else {
 			auto gp = toGp(retReg);
-			// Ensure sub-32-bit return values are properly narrowed so the
-			// caller sees a clean W0 value that matches the ABI contract.
-			auto retType = op->getReturnValue()->getStamp();
-			switch (retType) {
-			case Type::i8:
-				cc.sxtb(gp.x(), gp.w());
-				break;
-			case Type::b:
-			case Type::ui8:
-				cc.uxtb(gp.w(), gp.w());
-				break;
-			case Type::i16:
-				cc.sxth(gp.x(), gp.w());
-				break;
-			case Type::ui16:
-				cc.uxth(gp.w(), gp.w());
-				break;
-			default:
-				break;
-			}
+			// Ensure narrow return values are properly extended so the caller
+			// sees a clean W0/X0 value that matches the ABI contract.
+			narrowToStamp(gp, op->getReturnValue()->getStamp());
 			cc.ret(gp);
 		}
 	} else {

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -862,10 +862,16 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 
 	if (op->getStamp() != Type::v) {
 		auto result = allocReg(op->getStamp());
-		if (std::holds_alternative<Vec>(result))
+		if (std::holds_alternative<Vec>(result)) {
 			invokeNode->setRet(0, toVec(result));
-		else
+		} else {
 			invokeNode->setRet(0, toGp(result));
+			// The ABI leaves the upper bits of a narrow integer return value
+			// unspecified (the callee only guarantees the stamp's own width),
+			// so re-establish the extension invariant before anything reads
+			// the full X register.
+			narrowToStamp(toGp(result), op->getStamp());
+		}
 		bindResult(op->getIdentifier(), result, frame);
 	}
 }
@@ -893,10 +899,14 @@ void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCall
 
 	if (op->getStamp() != Type::v) {
 		auto result = allocReg(op->getStamp());
-		if (std::holds_alternative<Vec>(result))
+		if (std::holds_alternative<Vec>(result)) {
 			invokeNode->setRet(0, toVec(result));
-		else
+		} else {
 			invokeNode->setRet(0, toGp(result));
+			// See visitProxyCall: narrow integer returns arrive with
+			// unspecified upper bits and must be re-extended.
+			narrowToStamp(toGp(result), op->getStamp());
+		}
 		bindResult(op->getIdentifier(), result, frame);
 	}
 }

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
@@ -100,6 +100,17 @@ private:
 		static bool isFloatType(Type t);
 		static bool isUnsignedType(Type t);
 
+		// Re-establish the register invariant for narrow integer stamps: every
+		// value register holds its narrow value sign-extended (signed stamps) or
+		// zero-extended (unsigned stamps) to the full 64 bits. Entry arguments
+		// and casts establish it; any op whose 64-bit result can exceed the
+		// stamp's width (add/sub/mul wraparound, left shift, bitwise not) must
+		// call this afterwards, because downstream consumers (cmp, udiv/sdiv,
+		// msub, ucvtf/scvtf) operate on the full X register and silently
+		// mis-evaluate a non-canonical value. Mirrors X64LoweringProvider's
+		// narrowToStamp.
+		void narrowToStamp(::asmjit::a64::Gp reg, Type stamp);
+
 		// All integer types are mapped to 64-bit GP (X); floats to Vec (S/D).
 		AsmReg allocReg(Type t);
 		static ::asmjit::a64::Gp toGp(const AsmReg& r);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -963,10 +963,16 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 
 	if (op->getStamp() != Type::v) {
 		auto result = allocReg(op->getStamp());
-		if (std::holds_alternative<Xmm>(result))
+		if (std::holds_alternative<Xmm>(result)) {
 			invokeNode->setRet(0, toXmm(result));
-		else
+		} else {
 			invokeNode->setRet(0, toGp(result));
+			// The ABI leaves the upper bits of a narrow integer return value
+			// unspecified (the callee only guarantees the stamp's own width),
+			// so re-establish the extension invariant before anything reads
+			// the full 64-bit register.
+			narrowToStamp(toGp(result), op->getStamp());
+		}
 		bindResult(op->getIdentifier(), result, frame);
 	}
 }
@@ -996,10 +1002,14 @@ void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCall
 
 	if (op->getStamp() != Type::v) {
 		auto result = allocReg(op->getStamp());
-		if (std::holds_alternative<Xmm>(result))
+		if (std::holds_alternative<Xmm>(result)) {
 			invokeNode->setRet(0, toXmm(result));
-		else
+		} else {
 			invokeNode->setRet(0, toGp(result));
+			// See visitProxyCall: narrow integer returns arrive with
+			// unspecified upper bits and must be re-extended.
+			narrowToStamp(toGp(result), op->getStamp());
+		}
 		bindResult(op->getIdentifier(), result, frame);
 	}
 }

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -1371,7 +1371,10 @@ void BCLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* c
 	allocateRegister(defaultRegister);
 	defaultRegisterFile[defaultRegister] = (int64_t) constPtr->getValue();
 
-	auto targetRegister = registerProvider.allocRegister();
+	// getResultRegister (not a plain allocRegister) so a definition whose SSA
+	// name doubles as an already-bound merge-block parameter writes into that
+	// parameter's register; setValue is emplace-only and keeps the binding.
+	auto targetRegister = getResultRegister(constPtr, frame);
 	frame.setValue(constPtr->getIdentifier(), targetRegister);
 	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
 	program.blocks[block].code.emplace_back(oc);
@@ -1383,7 +1386,7 @@ void BCLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOper
 	allocateRegister(defaultRegister);
 	defaultRegisterFile[defaultRegister] = constInt->getValue();
 
-	auto targetRegister = registerProvider.allocRegister();
+	auto targetRegister = getResultRegister(constInt, frame);
 	frame.setValue(constInt->getIdentifier(), targetRegister);
 	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
 	program.blocks[block].code.emplace_back(oc);
@@ -1394,7 +1397,7 @@ void BCLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* c
 	auto defaultRegister = registerProvider.allocPinnedRegister();
 	allocateRegister(defaultRegister);
 	defaultRegisterFile[defaultRegister] = constInt->getValue();
-	auto targetRegister = registerProvider.allocRegister();
+	auto targetRegister = getResultRegister(constInt, frame);
 	frame.setValue(constInt->getIdentifier(), targetRegister);
 	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
 	program.blocks[block].code.emplace_back(oc);
@@ -1414,7 +1417,7 @@ void BCLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperatio
 		*floatReg = floatValue;
 	}
 
-	auto targetRegister = registerProvider.allocRegister();
+	auto targetRegister = getResultRegister(constInt, frame);
 	frame.setValue(constInt->getIdentifier(), targetRegister);
 	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
 	program.blocks[block].code.emplace_back(oc);
@@ -2122,44 +2125,20 @@ void BCLoweringProvider::LoweringContext::visitCast(ir::CastOperation* castOp, s
 	program.blocks[block].code.emplace_back(oc);
 }
 
-short BCLoweringProvider::LoweringContext::getResultRegister(ir::Operation*, RegisterFrame&) {
-	// auto optResultIdentifier = opt->getIdentifier();
-
-	// if the result value of opt is directly passed to an block argument, then we
-	// can directly write the value to the correct target register.
-
-	/*
-	if (opt->getUsages().size() == 1) {
-	    auto *usage = opt->getUsages()[0];
-	    if (usage->getOperationType() ==
-	ir::Operation::OperationType::BlockInvocation) { auto bi = dynamic_cast<const
-	ir::BasicBlockInvocation *>(usage); auto blockInputArguments =
-	bi->getArguments(); auto blockTargetArguments =
-	bi->getBlock()->getArguments();
-
-	        std::vector<uint64_t> matchingArguments;
-
-	        for (uint64_t i = 0; i < blockInputArguments.size(); i++) {
-	            auto blockArgument = blockInputArguments[i]->getIdentifier();
-	            if (blockArgument == optResultIdentifier) {
-	                matchingArguments.emplace_back(i);
-	            }
-	        }
-
-	        if (matchingArguments.size() == 1) {
-	            auto blockTargetArgumentIdentifier =
-	blockTargetArguments[matchingArguments[0]]->getIdentifier(); if
-	(!frame.contains(blockTargetArgumentIdentifier)) { auto resultReg =
-	registerProvider.allocRegister();
-	                frame.setValue(blockTargetArgumentIdentifier, resultReg);
-	                return resultReg;
-	            } else {
-	                return frame.getValue(blockTargetArgumentIdentifier);
-	            }
-	        }
-	    }
+short BCLoweringProvider::LoweringContext::getResultRegister(ir::Operation* opt, RegisterFrame& frame) {
+	// When the identifier is already bound, this definition's SSA name doubles
+	// as a downstream merge-block parameter whose register was already chosen
+	// by an earlier-emitted predecessor edge (Nautilus SSA reuses an incoming
+	// value's name for the block parameter, and the diamond/loop CFG can emit
+	// that predecessor's invocation before this definition -- issue #321, the
+	// same collision AsmJitLoweringProvider::bindResult handles). The
+	// visitors' subsequent frame.setValue is emplace-only, so allocating a
+	// fresh register here would leave the merge parameter reading a register
+	// this definition never writes. Return the bound register so the op
+	// writes straight into it.
+	if (frame.contains(opt->getIdentifier())) {
+		return frame.getValue(opt->getIdentifier());
 	}
-	 */
 	return registerProvider.allocRegister();
 }
 
@@ -2299,15 +2278,26 @@ void BCLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* selec
 	program.blocks[block].code.emplace_back(oc);
 }
 
-void BCLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* allocaOp, short /*block*/,
+void BCLoweringProvider::LoweringContext::visitAlloca(ir::AllocaOperation* allocaOp, short block,
                                                       RegisterFrame& frame) {
 	// The slot register and its backing buffer were created in the
 	// function prologue from FunctionOperation::getAllocaSpecs().  Every
 	// per-use AllocaOperation just rebinds its identifier to the
-	// already-pinned register.
+	// already-pinned register -- unless the identifier is already bound as a
+	// downstream merge-block parameter (see getResultRegister), in which case
+	// the slot pointer must be copied into the parameter's register instead,
+	// since setValue's emplace would silently keep the old binding.
 	auto index = allocaOp->getIndex();
 	assert(index < functionAllocaSlots.size() && "AllocaOperation index out of range for function");
-	frame.setValue(allocaOp->getIdentifier(), functionAllocaSlots[index]);
+	auto slotRegister = functionAllocaSlots[index];
+	if (frame.contains(allocaOp->getIdentifier())) {
+		auto target = frame.getValue(allocaOp->getIdentifier());
+		if (target != slotRegister) {
+			program.blocks[block].code.emplace_back(OpCode {ByteCode::REG_MOV, slotRegister, -1, target});
+		}
+	} else {
+		frame.setValue(allocaOp->getIdentifier(), slotRegister);
+	}
 }
 
 void BCLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::FunctionAddressOfOperation* funcAddrOp,
@@ -2323,7 +2313,7 @@ void BCLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::FunctionAdd
 		defaultRegisterFile[defaultRegister] = (int64_t) funcAddrOp->getFunctionPtr();
 	}
 
-	auto targetRegister = registerProvider.allocRegister();
+	auto targetRegister = getResultRegister(funcAddrOp, frame);
 	frame.setValue(funcAddrOp->getIdentifier(), targetRegister);
 	OpCode oc = {ByteCode::REG_MOV, defaultRegister, -1, targetRegister};
 	program.blocks[block].code.emplace_back(oc);

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -397,6 +397,7 @@ void setFuncAttributes(mlir::func::FuncOp funcOp, const FunctionAttributes& fnAt
 mlir::FlatSymbolRefAttr MLIRLoweringProvider::insertExternalFunction(const std::string& name, void* functionPtr,
                                                                      const mlir::Type& resultType,
                                                                      const std::vector<mlir::Type>& argTypes,
+                                                                     const std::vector<Type>& argStamps,
                                                                      const FunctionAttributes& fnAttrs) {
 	// The InsertionGuard saves the current insertion point (IP) and restores it
 	// after scope is left.
@@ -429,6 +430,31 @@ mlir::FlatSymbolRefAttr MLIRLoweringProvider::insertExternalFunction(const std::
 
 	// Mark as private (will be converted to external linkage during lowering if needed)
 	funcOp.setPrivate();
+
+	// Sub-32-bit integer arguments must carry an explicit extension attribute:
+	// several C ABIs (Darwin AArch64, x86-64 SysV) require the *caller* to
+	// sign/zero-extend them, and the natively compiled callee assumes that
+	// happened. Without the attribute LLVM emits the call with whatever the
+	// register's upper bits held (e.g. bits of a truncated pointer), and the
+	// callee mis-reads the argument. The *result* deliberately gets no such
+	// attribute: not every ABI guarantees the callee extends a narrow return
+	// (AAPCS64 does not), and an unattributed narrow result is always safe --
+	// LLVM re-extends it itself before any wider use.
+	for (size_t i = 0; i < argStamps.size() && i < argTypes.size(); ++i) {
+		switch (argStamps[i]) {
+		case Type::i8:
+		case Type::i16:
+			funcOp.setArgAttr(static_cast<unsigned>(i), "llvm.signext", mlir::UnitAttr::get(context));
+			break;
+		case Type::b:
+		case Type::ui8:
+		case Type::ui16:
+			funcOp.setArgAttr(static_cast<unsigned>(i), "llvm.zeroext", mlir::UnitAttr::get(context));
+			break;
+		default:
+			break;
+		}
+	}
 
 	// Set function attributes
 	setFuncAttributes(funcOp, fnAttrs);
@@ -896,8 +922,14 @@ void MLIRLoweringProvider::visitProxyCall(ir::ProxyCallOperation* proxyCallOp, V
 	}
 
 	// Function doesn't exist yet - create external function declaration using func dialect
+	std::vector<Type> argStamps;
+	argStamps.reserve(proxyCallOp->getInputArguments().size());
+	for (const auto& arg : proxyCallOp->getInputArguments()) {
+		argStamps.push_back(arg->getStamp());
+	}
 	insertExternalFunction(functionName, proxyCallOp->getFunctionPtr(), getMLIRType(proxyCallOp->getStamp()),
-	                       getMLIRType(proxyCallOp->getInputArguments()), proxyCallOp->getFunctionAttributes());
+	                       getMLIRType(proxyCallOp->getInputArguments()), argStamps,
+	                       proxyCallOp->getFunctionAttributes());
 
 	// Now lookup the function we just created and call it using func::CallOp
 	auto func = theModule.lookupSymbol<mlir::func::FuncOp>(functionName);

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -204,12 +204,17 @@ private:
 	 * @param name: Function name.
 	 * @param numResultBits: Number of bits of returned Integer.
 	 * @param argTypes: Argument types of function.
+	 * @param argStamps: The Nautilus IR types of the arguments, used to attach
+	 *        the ABI-mandated llvm.signext/llvm.zeroext attribute to narrow
+	 *        integer arguments (MLIR types are signless, so the signedness
+	 *        must travel separately).
 	 * @param fnAttrs: Information on attributes, such as 'memory' (access)
 	 * @return FlatSymbolRefAttr: Reference to function used in CallOps.
 	 */
 	::mlir::FlatSymbolRefAttr insertExternalFunction(const std::string& name, void* functionPtr,
 	                                                 const ::mlir::Type& resultType,
 	                                                 const std::vector<::mlir::Type>& argTypes,
+	                                                 const std::vector<Type>& argStamps,
 	                                                 const FunctionAttributes& fnAttrs);
 
 	/**

--- a/nautilus/test/common/ControlFlowFunctions.hpp
+++ b/nautilus/test/common/ControlFlowFunctions.hpp
@@ -318,4 +318,25 @@ val<int32_t> withBranchProbability(val<int32_t> value) {
 	}
 }
 
+// Regression (differential fuzzer): a zero-trip loop inside an if-arm, merged
+// after the if, then combined with a constant. The merge block's parameter
+// reuses the SSA identifier that the untaken arm re-defines (the constant is
+// traced once per path), and the taken arm's edge is emitted first, so it
+// binds that identifier before the other arm's definition runs. The BC
+// backend's emplace-only frame binding then silently dropped the later
+// definition: the constant was written to a fresh register nobody read, the
+// merge parameter's register stayed zero-initialised, and the final addition
+// returned the merged value unmodified.
+val<uint64_t> zeroTripLoopMergeThenAddConstant(val<uint64_t> c, val<uint64_t> p) {
+	val<uint64_t> result = p;
+	if (c != val<uint64_t>(static_cast<uint64_t>(0))) {
+		val<uint64_t> acc = static_cast<uint64_t>(0);
+		for (val<int32_t> i = 0; i < val<int32_t>(0); i = i + 1) {
+			acc = acc + val<uint64_t>(static_cast<uint64_t>(1));
+		}
+		result = acc;
+	}
+	return result + val<uint64_t>(static_cast<uint64_t>(119));
+}
+
 } // namespace nautilus::engine

--- a/nautilus/test/common/ExpressionFunctions.hpp
+++ b/nautilus/test/common/ExpressionFunctions.hpp
@@ -212,7 +212,9 @@ val<int32_t> constructComplexReturnObject(val<int32_t> a, val<int32_t> b) {
 
 val<int32_t> constructComplexReturnObject2(val<int32_t> a, val<int32_t> b) {
 	val<int32_t> t = 0;
-	{ t = constructComplexReturnObject(a, b); }
+	{
+		t = constructComplexReturnObject(a, b);
+	}
 	return t + 42;
 }
 
@@ -261,6 +263,21 @@ val<int32_t> prefixIncrementReturnValue(val<int32_t> x) {
 val<int32_t> prefixDecrementReturnValue(val<int32_t> x) {
 	// --x should return x after decrement, so (--x) + 1 = x
 	return (--x) + 1;
+}
+
+// Regression (differential fuzzer): a narrow unsigned subtraction that wraps
+// around feeds an unsigned comparison. Backends that keep narrow integers in
+// full-width registers must re-normalize (zero-extend) the wrapped result
+// before the compare; the AsmJit A64 backend used to skip that, so the
+// comparison saw the un-wrapped 64-bit difference and answered with the
+// opposite result for wrapped values.
+val<uint32_t> u32WrapSubThenCompare(val<uint32_t> x, val<uint32_t> y) {
+	val<uint32_t> wrapped = x - val<uint32_t>(4279714710u); // wraps for x < 4279714710
+	val<uint32_t> result = 0u;
+	if (wrapped <= y) {
+		result = 1u;
+	}
+	return result;
 }
 
 } // namespace nautilus::engine

--- a/nautilus/test/common/RunctimeCallFunctions.hpp
+++ b/nautilus/test/common/RunctimeCallFunctions.hpp
@@ -228,4 +228,20 @@ val<int16_t> i16NarrowCallReturnCompare(val<int16_t> x, val<int16_t> y) {
 	return result;
 }
 
+int16_t minI16(int16_t x, int16_t y) {
+	return x < y ? x : y;
+}
+
+// Regression (differential fuzzer): sub-32-bit integer *arguments* of a proxy
+// call must be extended by the caller on several C ABIs (Darwin AArch64,
+// x86-64 SysV) -- the natively compiled callee assumes that happened. The
+// MLIR backend used to declare external callees without llvm.signext /
+// llvm.zeroext argument attributes, so an i16 argument whose truncation LLVM
+// folded away (here: from a wider value with live upper bits) reached the
+// callee with garbage in the upper register bits and compared wrongly.
+val<int16_t> i16NarrowCallArgCompare(val<int64_t> x, val<int16_t> y) {
+	val<int16_t> truncated = static_cast<val<int16_t>>(x);
+	return invoke(minI16, truncated, y);
+}
+
 } // namespace nautilus::engine

--- a/nautilus/test/common/RunctimeCallFunctions.hpp
+++ b/nautilus/test/common/RunctimeCallFunctions.hpp
@@ -207,4 +207,25 @@ val<int32_t> incrementFuncCallFiveTimesWithRef(val<bool> isFirstCall) {
 	return invoke(funcAttr, countFuncCall, nautilus::val<bool>(false));
 }
 
+int16_t mixI16(int16_t x, int16_t y) {
+	// int promotion makes x * 3 + y well-defined; the cast wraps it back to
+	// 16 bits, so the interesting outputs are ones whose 32-bit intermediate
+	// (e.g. 25158 * 3 - 24951 = 50523) differs from the wrapped i16 result.
+	return static_cast<int16_t>(x * 3 + y);
+}
+
+// Regression (differential fuzzer): the ABI leaves the upper bits of a narrow
+// integer return value unspecified, so a backend keeping integers in
+// full-width registers must re-extend a call's narrow result before using it.
+// The AsmJit backends used to skip that, so a negative i16 return whose raw
+// register bits were a positive 32-bit intermediate compared as positive.
+val<int16_t> i16NarrowCallReturnCompare(val<int16_t> x, val<int16_t> y) {
+	val<int16_t> mixed = invoke(mixI16, x, y);
+	val<int16_t> result = 0;
+	if (mixed < val<int16_t>(int16_t(0))) {
+		result = 1;
+	}
+	return result;
+}
+
 } // namespace nautilus::engine

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -952,6 +952,19 @@ void functionCallExecutionTest(engine::NautilusEngine& engine) {
 		// -100 * 3 + 5 = -295, negative without wrapping.
 		REQUIRE(f(int16_t(-100), int16_t(5)) == 1);
 	}
+	// Regression (differential fuzzer): narrow i16 *argument* of a proxy call
+	// truncated from a wider value with live upper bits; see
+	// i16NarrowCallArgCompare in RunctimeCallFunctions.hpp.
+	SECTION("i16NarrowCallArgCompare") {
+		auto f = engine.registerFunction(i16NarrowCallArgCompare);
+		// 65537 truncates to 1; a caller that skips the extension hands the
+		// callee 65537, which is no longer < 5.
+		REQUIRE(f(int64_t(65537), int16_t(5)) == 1);
+		// 0xFFFE0003 truncates to 3.
+		REQUIRE(f(int64_t(0xFFFE0003), int16_t(7)) == 3);
+		// Negative wide value truncating to a negative narrow one.
+		REQUIRE(f(int64_t(-65538), int16_t(5)) == -2);
+	}
 }
 
 void nautilusFunctionExecutionTest(engine::NautilusEngine& engine) {

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -371,6 +371,19 @@ void expressionTests(engine::NautilusEngine& engine) {
 		REQUIRE(f(5) == 5);
 		REQUIRE(f(0) == 0);
 	}
+	// Regression (differential fuzzer): wrapped u32 subtraction feeding an
+	// unsigned compare; see u32WrapSubThenCompare in ExpressionFunctions.hpp.
+	SECTION("u32WrapSubThenCompare") {
+		auto f = engine.registerFunction(u32WrapSubThenCompare);
+		// Wrapped: 159212978 - 4279714710 = 174465564 (mod 2^32) <= 882064733.
+		REQUIRE(f(159212978u, 882064733u) == 1u);
+		// Not wrapped: 4279714711 - 4279714710 = 1.
+		REQUIRE(f(4279714711u, 0u) == 0u);
+		REQUIRE(f(4279714711u, 1u) == 1u);
+		// Wrapped from zero: 0 - 4279714710 = 15252586 (mod 2^32).
+		REQUIRE(f(0u, 15252585u) == 0u);
+		REQUIRE(f(0u, 15252586u) == 1u);
+	}
 }
 
 void controlFlowTest(engine::NautilusEngine& engine) {

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -940,6 +940,18 @@ void functionCallExecutionTest(engine::NautilusEngine& engine) {
 			REQUIRE(f(true) == 5);
 		}
 	}
+	// Regression (differential fuzzer): narrow i16 return value of a proxy
+	// call feeding a signed comparison; see i16NarrowCallReturnCompare in
+	// RunctimeCallFunctions.hpp.
+	SECTION("i16NarrowCallReturnCompare") {
+		auto f = engine.registerFunction(i16NarrowCallReturnCompare);
+		// 25158 * 3 - 24951 = 50523 -> wraps to -15013 < 0.
+		REQUIRE(f(int16_t(25158), int16_t(-24951)) == 1);
+		// 100 * 3 + 5 = 305, no wrap, not negative.
+		REQUIRE(f(int16_t(100), int16_t(5)) == 0);
+		// -100 * 3 + 5 = -295, negative without wrapping.
+		REQUIRE(f(int16_t(-100), int16_t(5)) == 1);
+	}
 }
 
 void nautilusFunctionExecutionTest(engine::NautilusEngine& engine) {

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -388,6 +388,15 @@ void expressionTests(engine::NautilusEngine& engine) {
 
 void controlFlowTest(engine::NautilusEngine& engine) {
 
+	// Regression (differential fuzzer): see zeroTripLoopMergeThenAddConstant
+	// in ControlFlowFunctions.hpp.
+	SECTION("zeroTripLoopMergeThenAddConstant") {
+		auto f = engine.registerFunction(zeroTripLoopMergeThenAddConstant);
+		REQUIRE(f(uint64_t(0), uint64_t(0)) == 119);
+		REQUIRE(f(uint64_t(0), uint64_t(23)) == 142);
+		REQUIRE(f(uint64_t(1), uint64_t(23)) == 119); // then-arm: zero-trip loop leaves acc == 0
+	}
+
 	SECTION("chainedIf100") {
 		auto f = engine.registerFunction(chainedIf100);
 		REQUIRE(f(42) == 42);

--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -72,9 +72,18 @@ enum class Kind : uint8_t {
 	// to the current iteration inside body. Lowered to a real traced `for`
 	// loop on the Nautilus side, exercising loop-lowering (not unrolling).
 	Loop,
-	// Leaves, only legal while generating inside a Loop body: current
-	// iteration index / accumulator of the innermost enclosing Loop. No imm
-	// payload -- nesting uses simple shadowing (innermost wins).
+	// Trace-time unrolled fold: imm = trip count (already in
+	// [0, LOOP_MAX_TRIPS], fixed at generation time), kid[0] = init,
+	// kid[1] = body. Same LoopIndex/LoopAcc binding as Loop, but the loop
+	// control is a plain C++ `for` over a static_val<int64_t> counter, so
+	// the tracer unrolls the body once per trip (each iteration sees its
+	// index as a *constant*) -- exercising static_val's snapshot-hash
+	// machinery and trace-time unrolling instead of loop lowering.
+	StaticLoop,
+	// Leaves, only legal while generating inside a Loop/StaticLoop body:
+	// current iteration index / accumulator of the innermost enclosing
+	// loop. No imm payload -- nesting uses simple shadowing (innermost
+	// wins).
 	LoopIndex,
 	LoopAcc,
 	// --- Memory / pointer domain -------------------------------------------
@@ -130,24 +139,46 @@ struct Ast {
 	int root = -1;
 };
 
+/// Depth / node budget bounds. Kept small so each program compiles quickly
+/// (this is a soundness fuzzer, not a throughput one) and generation always
+/// terminates even on huge inputs.
+inline constexpr int MAX_DEPTH = 6;
+inline constexpr int MAX_NODES = 64;
+
+/// Upper bound on a Loop node's trip count (inclusive), enforced identically
+/// by EvalNative.hpp and EvalNautilus.hpp (and used directly as the bound of
+/// StaticLoop's generation-time constant trip count). Compile cost is
+/// governed by AST node count for Loop (its body is traced once regardless
+/// of how many times the compiled loop executes it), but multiplies trace
+/// size for StaticLoop, whose body is unrolled at trace time.
+inline constexpr int LOOP_MAX_TRIPS = 8;
+
+/// Number of `T` elements in the shared buffer every generated program is
+/// handed a pointer to (see Kind::PtrBase). Every pointer-domain node
+/// (generatePtrNode) is constructed so it always lands in [0, BUFFER_ELEMS),
+/// so Load/Store/PtrToInt/Ptr-comparisons never read or write out of bounds --
+/// small enough to keep the oracle/traced buffers cheap, large enough to make
+/// pointer differences/comparisons non-trivial.
+inline constexpr int BUFFER_ELEMS = 8;
+
 namespace detail {
 
 // Load/Store/PtrToInt/Ptr-comparisons (below) are appended identically to
 // both INT_KINDS and FLOAT_KINDS: a buffer of T is equally meaningful (and
 // equally safe, given generatePtrNode's bounded construction) regardless of
 // T's domain.
-inline constexpr Kind INT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,   Kind::Mod,      Kind::And,
-                                     Kind::Or,    Kind::Xor,   Kind::Shl,   Kind::Shr,   Kind::Eq,       Kind::Ne,
-                                     Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,    Kind::Select,   Kind::If,
-                                     Kind::Neg,   Kind::Not,   Kind::LAnd,  Kind::LOr,   Kind::LNot,     Kind::Call,
-                                     Kind::Cast,  Kind::Loop,  Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq,
-                                     Kind::PtrNe, Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
+inline constexpr Kind INT_KINDS[] = {
+    Kind::Add,    Kind::Sub,   Kind::Mul,        Kind::Div,  Kind::Mod,   Kind::And,      Kind::Or,    Kind::Xor,
+    Kind::Shl,    Kind::Shr,   Kind::Eq,         Kind::Ne,   Kind::Lt,    Kind::Le,       Kind::Gt,    Kind::Ge,
+    Kind::Select, Kind::If,    Kind::Neg,        Kind::Not,  Kind::LAnd,  Kind::LOr,      Kind::LNot,  Kind::Call,
+    Kind::Cast,   Kind::Loop,  Kind::StaticLoop, Kind::Load, Kind::Store, Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe,
+    Kind::PtrLt,  Kind::PtrLe, Kind::PtrGt,      Kind::PtrGe};
 
-inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,      Kind::Eq,     Kind::Ne,
-                                       Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,       Kind::Select, Kind::If,
-                                       Kind::Neg,   Kind::LAnd,  Kind::LOr,   Kind::LNot,     Kind::Call,   Kind::Cast,
-                                       Kind::Loop,  Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq,  Kind::PtrNe,
-                                       Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
+inline constexpr Kind FLOAT_KINDS[] = {
+    Kind::Add,   Kind::Sub,   Kind::Mul,    Kind::Div,        Kind::Eq,   Kind::Ne,    Kind::Lt,       Kind::Le,
+    Kind::Gt,    Kind::Ge,    Kind::Select, Kind::If,         Kind::Neg,  Kind::LAnd,  Kind::LOr,      Kind::LNot,
+    Kind::Call,  Kind::Cast,  Kind::Loop,   Kind::StaticLoop, Kind::Load, Kind::Store, Kind::PtrToInt, Kind::PtrEq,
+    Kind::PtrNe, Kind::PtrLt, Kind::PtrLe,  Kind::PtrGt,      Kind::PtrGe};
 
 inline int arity(Kind k) {
 	switch (k) {
@@ -273,6 +304,12 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
 		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
 		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
+	} else if (node.kind == Kind::StaticLoop) {
+		// Trip count is a generation-time constant (imm), not an expression:
+		// a trace-time loop cannot depend on runtime data by definition.
+		node.imm = reader.byte() % (LOOP_MAX_TRIPS + 1);
+		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
 	} else if (node.kind == Kind::Load || node.kind == Kind::PtrToInt) {
 		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth);
 	} else if (node.kind == Kind::Store) {
@@ -295,27 +332,6 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 }
 
 } // namespace detail
-
-/// Depth / node budget bounds. Kept small so each program compiles quickly
-/// (this is a soundness fuzzer, not a throughput one) and generation always
-/// terminates even on huge inputs.
-inline constexpr int MAX_DEPTH = 6;
-inline constexpr int MAX_NODES = 64;
-
-/// Upper bound on a Loop node's trip count (inclusive), enforced identically
-/// by EvalNative.hpp and EvalNautilus.hpp. Compile cost is governed by AST
-/// node count, not trip count -- the body is traced once regardless of how
-/// many times the compiled loop executes it -- so this only bounds oracle
-/// interpretation cost (which multiplies with loop nesting).
-inline constexpr int LOOP_MAX_TRIPS = 8;
-
-/// Number of `T` elements in the shared buffer every generated program is
-/// handed a pointer to (see Kind::PtrBase). Every pointer-domain node
-/// (generatePtrNode) is constructed so it always lands in [0, BUFFER_ELEMS),
-/// so Load/Store/PtrToInt/Ptr-comparisons never read or write out of bounds --
-/// small enough to keep the oracle/traced buffers cheap, large enough to make
-/// pointer differences/comparisons non-trivial.
-inline constexpr int BUFFER_ELEMS = 8;
 
 /// Build a random, always-valid AST of type T from the reader. Never returns
 /// an empty tree: an empty buffer yields a single Const(0) leaf.
@@ -455,6 +471,13 @@ void print(const Ast& ast, int idx, std::string& out) {
 		print<T>(ast, n.kid[1], out);
 		out += ", body=";
 		print<T>(ast, n.kid[2], out);
+		out += ")";
+		return;
+	case Kind::StaticLoop:
+		out += "sloop(trips=" + std::to_string(n.imm) + ", init=";
+		print<T>(ast, n.kid[0], out);
+		out += ", body=";
+		print<T>(ast, n.kid[1], out);
 		out += ")";
 		return;
 	case Kind::Load:

--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ByteReader.hpp"
+#include "Callees.hpp"
 #include "Types.hpp"
 #include <cstdint>
 #include <string>
@@ -49,6 +50,13 @@ enum class Kind : uint8_t {
 	LAnd,
 	LOr,
 	LNot,
+	// Call: a real nautilus::invoke() of a pure native helper (Callees.hpp),
+	// imm selects which one (modulo NUM_CALLEES). Both kids are value-domain
+	// operands passed as val<T>; the result is the helper's T return value.
+	// The native oracle calls the identical instantiation directly, so the
+	// differential surface is exactly the backend's ProxyCall lowering
+	// (argument/return marshalling and narrow-integer ABI extension).
+	Call,
 	// Cast: round-trips the single child through another type, i.e. (T)(To)x.
 	// imm holds the target TypeId, drawn from any of the ten types -- this
 	// can cross the int/float domain boundary (the output type is always T,
@@ -128,18 +136,18 @@ namespace detail {
 // both INT_KINDS and FLOAT_KINDS: a buffer of T is equally meaningful (and
 // equally safe, given generatePtrNode's bounded construction) regardless of
 // T's domain.
-inline constexpr Kind INT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,      Kind::Mod,    Kind::And,
-                                     Kind::Or,    Kind::Xor,   Kind::Shl,   Kind::Shr,      Kind::Eq,     Kind::Ne,
-                                     Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,       Kind::Select, Kind::If,
-                                     Kind::Neg,   Kind::Not,   Kind::LAnd,  Kind::LOr,      Kind::LNot,   Kind::Cast,
-                                     Kind::Loop,  Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq,  Kind::PtrNe,
-                                     Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
+inline constexpr Kind INT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,   Kind::Mod,      Kind::And,
+                                     Kind::Or,    Kind::Xor,   Kind::Shl,   Kind::Shr,   Kind::Eq,       Kind::Ne,
+                                     Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,    Kind::Select,   Kind::If,
+                                     Kind::Neg,   Kind::Not,   Kind::LAnd,  Kind::LOr,   Kind::LNot,     Kind::Call,
+                                     Kind::Cast,  Kind::Loop,  Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq,
+                                     Kind::PtrNe, Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
 
-inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,      Kind::Div,   Kind::Eq,     Kind::Ne,
-                                       Kind::Lt,    Kind::Le,    Kind::Gt,       Kind::Ge,    Kind::Select, Kind::If,
-                                       Kind::Neg,   Kind::LAnd,  Kind::LOr,      Kind::LNot,  Kind::Cast,   Kind::Loop,
-                                       Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe,  Kind::PtrLt,
-                                       Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
+inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,      Kind::Eq,     Kind::Ne,
+                                       Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,       Kind::Select, Kind::If,
+                                       Kind::Neg,   Kind::LAnd,  Kind::LOr,   Kind::LNot,     Kind::Call,   Kind::Cast,
+                                       Kind::Loop,  Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq,  Kind::PtrNe,
+                                       Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
 
 inline int arity(Kind k) {
 	switch (k) {
@@ -250,6 +258,8 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 		// boundary (see the Kind::Cast comment for why this stays sound).
 		constexpr uint32_t typeCount = sizeof(ALL_TYPES) / sizeof(ALL_TYPES[0]);
 		node.imm = static_cast<uint64_t>(ALL_TYPES[reader.byte() % typeCount]);
+	} else if (node.kind == Kind::Call) {
+		node.imm = reader.byte() % NUM_CALLEES;
 	}
 
 	const int childCount = arity(node.kind);
@@ -402,6 +412,14 @@ void print(const Ast& ast, int idx, std::string& out) {
 		out += " ";
 		print<T>(ast, n.kid[1], out);
 		out += " != 0) ? 1 : 0)";
+		return;
+	case Kind::Call:
+		out += calleeName(n.imm);
+		out += "(";
+		print<T>(ast, n.kid[0], out);
+		out += ", ";
+		print<T>(ast, n.kid[1], out);
+		out += ")";
 		return;
 	case Kind::Cast: {
 		const TypeId target = static_cast<TypeId>(n.imm);

--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -40,6 +40,15 @@ enum class Kind : uint8_t {
 	// Unary
 	Neg, // integer and float domains: -x
 	Not, // integer domain only: ~x
+	// Logical ops on val<bool>: each operand is first turned into a bool via
+	// `!= 0`, the bools are combined with the real val<bool> operator
+	// (&&/||/!), and the result is selected back to 0/1 as T -- the same 0/1
+	// convention as the comparisons above. Both operands are always evaluated
+	// (they are value-domain subtrees evaluated *before* the bool op), so even
+	// a short-circuiting && lowering cannot skip a Store side effect.
+	LAnd,
+	LOr,
+	LNot,
 	// Cast: round-trips the single child through another type, i.e. (T)(To)x.
 	// imm holds the target TypeId, drawn from any of the ten types -- this
 	// can cross the int/float domain boundary (the output type is always T,
@@ -119,16 +128,18 @@ namespace detail {
 // both INT_KINDS and FLOAT_KINDS: a buffer of T is equally meaningful (and
 // equally safe, given generatePtrNode's bounded construction) regardless of
 // T's domain.
-inline constexpr Kind INT_KINDS[] = {
-    Kind::Add,      Kind::Sub,   Kind::Mul,   Kind::Div,   Kind::Mod,   Kind::And,   Kind::Or,   Kind::Xor,
-    Kind::Shl,      Kind::Shr,   Kind::Eq,    Kind::Ne,    Kind::Lt,    Kind::Le,    Kind::Gt,   Kind::Ge,
-    Kind::Select,   Kind::If,    Kind::Neg,   Kind::Not,   Kind::Cast,  Kind::Loop,  Kind::Load, Kind::Store,
-    Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe, Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
+inline constexpr Kind INT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,      Kind::Mod,    Kind::And,
+                                     Kind::Or,    Kind::Xor,   Kind::Shl,   Kind::Shr,      Kind::Eq,     Kind::Ne,
+                                     Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,       Kind::Select, Kind::If,
+                                     Kind::Neg,   Kind::Not,   Kind::LAnd,  Kind::LOr,      Kind::LNot,   Kind::Cast,
+                                     Kind::Loop,  Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq,  Kind::PtrNe,
+                                     Kind::PtrLt, Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
 
-inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,   Kind::Div,   Kind::Eq,     Kind::Ne,
-                                       Kind::Lt,    Kind::Le,    Kind::Gt,    Kind::Ge,    Kind::Select, Kind::If,
-                                       Kind::Neg,   Kind::Cast,  Kind::Loop,  Kind::Load,  Kind::Store,  Kind::PtrToInt,
-                                       Kind::PtrEq, Kind::PtrNe, Kind::PtrLt, Kind::PtrLe, Kind::PtrGt,  Kind::PtrGe};
+inline constexpr Kind FLOAT_KINDS[] = {Kind::Add,   Kind::Sub,   Kind::Mul,      Kind::Div,   Kind::Eq,     Kind::Ne,
+                                       Kind::Lt,    Kind::Le,    Kind::Gt,       Kind::Ge,    Kind::Select, Kind::If,
+                                       Kind::Neg,   Kind::LAnd,  Kind::LOr,      Kind::LNot,  Kind::Cast,   Kind::Loop,
+                                       Kind::Load,  Kind::Store, Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe,  Kind::PtrLt,
+                                       Kind::PtrLe, Kind::PtrGt, Kind::PtrGe};
 
 inline int arity(Kind k) {
 	switch (k) {
@@ -140,6 +151,7 @@ inline int arity(Kind k) {
 		return 0;
 	case Kind::Neg:
 	case Kind::Not:
+	case Kind::LNot:
 	case Kind::Cast:
 	case Kind::Load:
 	case Kind::PtrToInt:
@@ -375,6 +387,21 @@ void print(const Ast& ast, int idx, std::string& out) {
 		out += "(~";
 		print<T>(ast, n.kid[0], out);
 		out += ")";
+		return;
+	case Kind::LNot:
+		out += "(!(";
+		print<T>(ast, n.kid[0], out);
+		out += " != 0) ? 1 : 0)";
+		return;
+	case Kind::LAnd:
+	case Kind::LOr:
+		out += "((";
+		print<T>(ast, n.kid[0], out);
+		out += " != 0 ";
+		out += (n.kind == Kind::LAnd) ? "&&" : "||";
+		out += " ";
+		print<T>(ast, n.kid[1], out);
+		out += " != 0) ? 1 : 0)";
 		return;
 	case Kind::Cast: {
 		const TypeId target = static_cast<TypeId>(n.imm);

--- a/nautilus/test/fuzz/Callees.hpp
+++ b/nautilus/test/fuzz/Callees.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace nautilus::fuzz {
+
+/// Number of native helper functions a Kind::Call node can target (its imm
+/// is drawn modulo this).
+inline constexpr int NUM_CALLEES = 2;
+
+/// Pure native helpers exposed to generated programs through Kind::Call.
+/// The native oracle calls them directly; the traced kernel calls the exact
+/// same instantiation through nautilus::invoke(). Because both legs execute
+/// the identical native code, the differential surface is exclusively the
+/// backend's call lowering: argument/return marshalling, narrow-integer ABI
+/// extension, float register passing. Every helper must be fully defined for
+/// all inputs (unsigned-wraparound arithmetic; IEEE 754 for floats).
+template <typename T>
+T calleeMix(T a, T b) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return a * T(0.5) + b;
+	} else {
+		using U = std::make_unsigned_t<T>;
+		return static_cast<T>(static_cast<U>(static_cast<U>(a) * U(3)) + static_cast<U>(b));
+	}
+}
+
+template <typename T>
+T calleeMin(T a, T b) {
+	// NaN-safe by identity: `NaN < b` is false, so b is returned. Both the
+	// oracle and the compiled kernel run this same code, so the results match
+	// by construction whatever the operands are.
+	return a < b ? a : b;
+}
+
+inline const char* calleeName(uint64_t imm) {
+	return imm % NUM_CALLEES == 0 ? "mix" : "min";
+}
+
+} // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -261,6 +261,16 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		}
 		return acc;
 	}
+	case Kind::StaticLoop: {
+		const int trips = static_cast<int>(n.imm);
+		T acc = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		for (int i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
 	case Kind::Neg: {
 		const T v = evalNativeInt<T>(ast, n.kid[0], args, ctx);
 		if constexpr (std::is_signed_v<T>) {
@@ -418,6 +428,16 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		for (int i = 0; i < trips; ++i) {
 			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
 			acc = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
+	case Kind::StaticLoop: {
+		const int trips = static_cast<int>(n.imm);
+		T acc = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		for (int i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Ast.hpp"
+#include "Callees.hpp"
 #include "Types.hpp"
 #include <array>
 #include <cmath>
@@ -364,6 +365,9 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		return (l != T(0)) && (r != T(0)) ? T(1) : T(0);
 	case Kind::LOr:
 		return (l != T(0)) || (r != T(0)) ? T(1) : T(0);
+	case Kind::Call:
+		// Direct call of the same instantiation the traced kernel invoke()s.
+		return n.imm % NUM_CALLEES == 0 ? calleeMix<T>(l, r) : calleeMin<T>(l, r);
 	case Kind::Eq:
 		return l == r ? T(1) : T(0);
 	case Kind::Ne:
@@ -490,6 +494,9 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		return (l != T(0)) && (r != T(0)) ? T(1) : T(0);
 	case Kind::LOr:
 		return (l != T(0)) || (r != T(0)) ? T(1) : T(0);
+	case Kind::Call:
+		// Direct call of the same instantiation the traced kernel invoke()s.
+		return n.imm % NUM_CALLEES == 0 ? calleeMix<T>(l, r) : calleeMin<T>(l, r);
 	case Kind::Eq:
 		return l == r ? T(1) : T(0);
 	case Kind::Ne:

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -270,6 +270,8 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 	}
 	case Kind::Not:
 		return static_cast<T>(~evalNativeInt<T>(ast, n.kid[0], args, ctx));
+	case Kind::LNot:
+		return evalNativeInt<T>(ast, n.kid[0], args, ctx) == T(0) ? T(1) : T(0);
 	case Kind::Cast:
 		return castThrough<T>(evalNativeInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	case Kind::Load: {
@@ -356,6 +358,12 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		return static_cast<T>(l << (r & T(sizeof(T) * 8 - 1)));
 	case Kind::Shr:
 		return static_cast<T>(l >> (r & T(sizeof(T) * 8 - 1)));
+	// LAnd/LOr sit in this binary tail so l and r are both already evaluated
+	// unconditionally -- deliberate, see the Kind::LAnd comment in Ast.hpp.
+	case Kind::LAnd:
+		return (l != T(0)) && (r != T(0)) ? T(1) : T(0);
+	case Kind::LOr:
+		return (l != T(0)) || (r != T(0)) ? T(1) : T(0);
 	case Kind::Eq:
 		return l == r ? T(1) : T(0);
 	case Kind::Ne:
@@ -412,6 +420,8 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 	}
 	case Kind::Neg:
 		return static_cast<T>(-evalNativeFloat<T>(ast, n.kid[0], args, ctx));
+	case Kind::LNot:
+		return evalNativeFloat<T>(ast, n.kid[0], args, ctx) == T(0) ? T(1) : T(0);
 	case Kind::Cast:
 		return castThrough<T>(evalNativeFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	case Kind::Load: {
@@ -474,6 +484,12 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		return static_cast<T>(l * r);
 	case Kind::Div:
 		return static_cast<T>(l / r); // well-defined IEEE 754: produces +-inf / NaN for r == 0
+	// LAnd/LOr sit in this binary tail so l and r are both already evaluated
+	// unconditionally -- deliberate, see the Kind::LAnd comment in Ast.hpp.
+	case Kind::LAnd:
+		return (l != T(0)) && (r != T(0)) ? T(1) : T(0);
+	case Kind::LOr:
+		return (l != T(0)) || (r != T(0)) ? T(1) : T(0);
 	case Kind::Eq:
 		return l == r ? T(1) : T(0);
 	case Kind::Ne:

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -227,6 +227,10 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		return -evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 	case Kind::Not:
 		return ~evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+	case Kind::LNot: {
+		val<bool> b = evalNautilusInt<T>(ast, n.kid[0], args, ctx) != TracedValue<T>(T(0));
+		return select(!b, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
 	case Kind::Cast:
 		return castThroughTraced<T>(evalNautilusInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	case Kind::Load: {
@@ -300,6 +304,19 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		return l << (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
 	case Kind::Shr:
 		return l >> (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
+	case Kind::LAnd: {
+		// Real val<bool> conjunction under test. l and r are both already
+		// evaluated (side-effect parity with the native oracle regardless of
+		// whether && lowers short-circuiting), only the bool combine varies.
+		val<bool> lb = l != TracedValue<T>(T(0));
+		val<bool> rb = r != TracedValue<T>(T(0));
+		return select(lb && rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
+	case Kind::LOr: {
+		val<bool> lb = l != TracedValue<T>(T(0));
+		val<bool> rb = r != TracedValue<T>(T(0));
+		return select(lb || rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
 	case Kind::Eq:
 		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Ne:
@@ -356,6 +373,10 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 	}
 	case Kind::Neg:
 		return -evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+	case Kind::LNot: {
+		val<bool> b = evalNautilusFloat<T>(ast, n.kid[0], args, ctx) != TracedValue<T>(T(0));
+		return select(!b, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
 	case Kind::Cast:
 		return castThroughTraced<T>(evalNautilusFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	case Kind::Load: {
@@ -417,6 +438,17 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		return l * r;
 	case Kind::Div:
 		return l / r; // well-defined IEEE 754: produces +-inf / NaN for r == 0
+	case Kind::LAnd: {
+		// See the Kind::LAnd comment in evalNautilusInt.
+		val<bool> lb = l != TracedValue<T>(T(0));
+		val<bool> rb = r != TracedValue<T>(T(0));
+		return select(lb && rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
+	case Kind::LOr: {
+		val<bool> lb = l != TracedValue<T>(T(0));
+		val<bool> rb = r != TracedValue<T>(T(0));
+		return select(lb || rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
+	}
 	case Kind::Eq:
 		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Ne:

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <nautilus/function.hpp>
 #include <nautilus/select.hpp>
+#include <nautilus/static.hpp>
 #include <nautilus/val.hpp>
 #include <nautilus/val_ptr.hpp>
 #include <type_traits>
@@ -225,6 +226,20 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		}
 		return acc;
 	}
+	case Kind::StaticLoop: {
+		// Plain C++ loop control over a static_val counter: the tracer
+		// unrolls the body, one copy per trip, each seeing its index as a
+		// constant (the static_val makes every iteration's snapshot hash
+		// unique -- the same pattern as test/common/StaticLoopFunctions.hpp).
+		const int64_t trips = static_cast<int64_t>(n.imm);
+		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		for (static_val<int64_t> i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc});
+			acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
 	case Kind::Neg:
 		return -evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 	case Kind::Not:
@@ -373,6 +388,17 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		for (val<int32_t> i = 0; i < trips; i = i + 1) {
 			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
 			acc = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
+	case Kind::StaticLoop: {
+		// See the Kind::StaticLoop comment in evalNautilusInt.
+		const int64_t trips = static_cast<int64_t>(n.imm);
+		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		for (static_val<int64_t> i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc});
+			acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "Ast.hpp"
+#include "Callees.hpp"
 #include "Types.hpp"
 #include <array>
 #include <limits>
+#include <nautilus/function.hpp>
 #include <nautilus/select.hpp>
 #include <nautilus/val.hpp>
 #include <nautilus/val_ptr.hpp>
@@ -317,6 +319,10 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		val<bool> rb = r != TracedValue<T>(T(0));
 		return select(lb || rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	}
+	case Kind::Call:
+		// Real nautilus::invoke() of the same instantiation the native oracle
+		// calls directly -- the backend's ProxyCall lowering is under test.
+		return n.imm % NUM_CALLEES == 0 ? invoke(&calleeMix<T>, l, r) : invoke(&calleeMin<T>, l, r);
 	case Kind::Eq:
 		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Ne:
@@ -449,6 +455,9 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		val<bool> rb = r != TracedValue<T>(T(0));
 		return select(lb || rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	}
+	case Kind::Call:
+		// See the Kind::Call comment in evalNautilusInt.
+		return n.imm % NUM_CALLEES == 0 ? invoke(&calleeMix<T>, l, r) : invoke(&calleeMin<T>, l, r);
 	case Kind::Eq:
 		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	case Kind::Ne:

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -54,6 +54,13 @@ inline engine::NautilusEngine makeEngine(const std::string& backend) {
 	} else {
 		options.setOption("engine.backend", backend);
 	}
+	// Triage aid: NAUTILUS_FUZZ_DUMP=1 dumps every compilation stage to the
+	// console while replaying a saved finding, so the IR a mismatching
+	// backend actually saw can be inspected without editing the harness.
+	if (std::getenv("NAUTILUS_FUZZ_DUMP") != nullptr) {
+		options.setOption("dump.all", true);
+		options.setOption("dump.console", true);
+	}
 	return engine::NautilusEngine(options);
 }
 

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -300,6 +300,22 @@ replayable and inspectable. Pinned by `i16NarrowCallArgCompare` in
 `test/common/RunctimeCallFunctions.hpp` (the truncation-folding shape LLVM
 optimizes into the failing form deterministically).
 
+A larger survey with the `StaticLoop` extension then hit the BC backend's
+variant of the issue #321 merged-value bug -- now fixed: the merge block's
+parameter reuses the SSA identifier that one arm re-defines, the other arm's
+earlier-emitted edge binds that identifier to a fresh register first, and the
+BC translator's emplace-only `Frame::setValue` silently dropped the later
+definition -- so a constant folded after the merge read a register nobody
+ever wrote (zero), e.g. `if(...) - 5808310683196811127` returned the merged
+value unmodified. The AsmJit backends got `bindResult` for this in #322; the
+BC translator now routes result registers through `getResultRegister`, which
+returns the already-bound merge-parameter register so definitions write
+straight into it. Minimized with plain input-file truncation + byte zeroing
+(the saved `fuzz-finding-<n>.bin` shrank from 234 bytes to a 3-block
+program); pinned by `zeroTripLoopMergeThenAddConstant` in
+`test/common/ControlFlowFunctions.hpp`, verified to fail on the pre-fix
+translator.
+
 (An early investigation of this bug also observed every compiling backend
 segfaulting on the same minimal kernel; that turned out to be an artifact of
 the ad hoc standalone reproduction harness's own call-stack depth tripping

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -65,6 +65,13 @@ mirroring how the original `uint64_t`-only fuzzer worked.
   execute the same native code and the differential surface is exclusively
   the backend's call lowering: argument/return marshalling, narrow-integer
   ABI extension, float register passing.
+* **`StaticLoop`** (both domains): the trace-time counterpart of `Loop`. The
+  trip count is a generation-time constant (imm, in `[0, LOOP_MAX_TRIPS]`),
+  and the loop control is a plain C++ `for` over a `static_val<int64_t>`
+  counter -- the tracer unrolls the body once per trip, each iteration
+  seeing its `LoopIndex` as a constant, exercising `static_val`'s
+  snapshot-hash machinery and trace-time unrolling instead of loop
+  lowering (the `static-loop-tests` feature).
 * **`Cast` across the int/float domain boundary**: `(T)(To)v` still always
   produces a `T` result, exactly like a same-domain cast -- only the
   intermediate type's domain changes. Whichever leg of the round trip is

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -278,6 +278,21 @@ back with its positive 32-bit intermediate still in the register, and the
 next comparison answered for that instead. Pinned by
 `i16NarrowCallReturnCompare` in `test/common/RunctimeCallFunctions.hpp`.
 
+The same `Call` extension then caught the argument-direction twin of that
+bug in the **MLIR backend** -- now fixed: `insertExternalFunction` declared
+external callees without `llvm.signext`/`llvm.zeroext` argument attributes,
+but several C ABIs (Darwin AArch64, x86-64 SysV) require the *caller* to
+extend sub-32-bit integer arguments, and the natively compiled callee
+assumes it happened. LLVM, seeing no attribute, folded the truncation away
+and passed an `i16` argument with live upper register bits (in the fuzzed
+case, bits of a `PtrToInt`-derived address -- which also made the mismatch
+address-dependent and only reproducible ~5 out of 6 runs). Survey mode's
+saved `fuzz-finding-<n>.bin` inputs plus `NAUTILUS_FUZZ_DUMP=1` were added
+during this hunt precisely to make such address-dependent findings
+replayable and inspectable. Pinned by `i16NarrowCallArgCompare` in
+`test/common/RunctimeCallFunctions.hpp` (the truncation-folding shape LLVM
+optimizes into the failing form deterministically).
+
 (An early investigation of this bug also observed every compiling backend
 segfaulting on the same minimal kernel; that turned out to be an artifact of
 the ad hoc standalone reproduction harness's own call-stack depth tripping

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -269,6 +269,15 @@ narrow-width wraparound. Fixed by mirroring the x64 provider's
 returns); pinned by `u32WrapSubThenCompare` in
 `test/common/ExpressionFunctions.hpp`.
 
+The `Call` extension immediately surfaced the same invariant's fourth hole,
+in **both** AsmJit providers -- now fixed: narrow integer return values of
+`ProxyCall`/`IndirectCall` were bound without re-extension, but the ABI
+(AAPCS64 and SysV alike) leaves the upper bits of a sub-register-width
+return unspecified. An `i16` helper returning a wrapped-negative value came
+back with its positive 32-bit intermediate still in the register, and the
+next comparison answered for that instead. Pinned by
+`i16NarrowCallReturnCompare` in `test/common/RunctimeCallFunctions.hpp`.
+
 (An early investigation of this bug also observed every compiling backend
 segfaulting on the same minimal kernel; that turned out to be an artifact of
 the ad hoc standalone reproduction harness's own call-stack depth tripping

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -46,13 +46,19 @@ constants, parameters) is generated and evaluated entirely in that one type,
 mirroring how the original `uint64_t`-only fuzzer worked.
 
 * **Integer domain** (8 widths/signs): arithmetic (`+ - * / %`), bitwise
-  (`& | ^ << >> ~`), unary negate, comparisons, `Select`/`If`, `Loop`, and
-  `Cast` (round-trips the value through another type, e.g. `(T)(To)v`,
-  exercising sign/zero-extension/truncation codegen *and* int<->float
-  boundary conversion).
+  (`& | ^ << >> ~`), unary negate, comparisons, logical ops, `Select`/`If`,
+  `Loop`, and `Cast` (round-trips the value through another type, e.g.
+  `(T)(To)v`, exercising sign/zero-extension/truncation codegen *and*
+  int<->float boundary conversion).
 * **Float domain** (`float`, `double`): arithmetic (`+ - * /`), unary
-  negate, comparisons, `Select`/`If`, `Loop`, and `Cast` (round-trips through
-  another integer *or* float type).
+  negate, comparisons, logical ops, `Select`/`If`, `Loop`, and `Cast`
+  (round-trips through another integer *or* float type).
+* **Logical ops** (`LAnd`/`LOr`/`LNot`, both domains): each operand becomes a
+  `val<bool>` via `!= 0`, the bools are combined with the real
+  `val<bool>` `&&`/`||`/`!` operator under test, and the result is selected
+  back to 0/1 as `T` (the comparisons' convention). Operands are evaluated
+  *before* the bool op on both sides, so even a short-circuiting `&&`
+  lowering (`ENABLE_SHORT_CIRCUIT_BOOL`) cannot skip a `Store` side effect.
 * **`Cast` across the int/float domain boundary**: `(T)(To)v` still always
   produces a `T` result, exactly like a same-domain cast -- only the
   intermediate type's domain changes. Whichever leg of the round trip is

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -248,6 +248,21 @@ more common. `Loop` merely made this easy to *stumble into* via survey
 `0.0` for the same reason); the minimal repro above proves the bug itself
 predated and was independent of `Loop`/`Cast`.
 
+Running the harness with the AsmJit backend enabled on ARM (it is off in the
+default CI configuration) surfaced a third bug -- now fixed: the A64 lowering
+kept every integer in a 64-bit register and re-established the "narrow values
+stay sign/zero-extended to 64 bits" invariant only at function entry and
+casts, never after arithmetic. A u32 subtraction that wraps (e.g. `p0 -
+4279714710u`) left the un-wrapped negative difference in the full X register,
+and the next 64-bit `cmp` answered for that value instead of the wrapped
+32-bit one -- so `asmjit|u8/u16/u32` (and the signed narrow widths, via left
+shift and multiply overflow) could disagree with every other backend on any
+comparison, division, modulo, right shift, or int->float conversion fed by
+narrow-width wraparound. Fixed by mirroring the x64 provider's
+`narrowToStamp` re-normalization after add/sub/mul/shift/bitwise-not (and at
+returns); pinned by `u32WrapSubThenCompare` in
+`test/common/ExpressionFunctions.hpp`.
+
 (An early investigation of this bug also observed every compiling backend
 segfaulting on the same minimal kernel; that turned out to be an artifact of
 the ad hoc standalone reproduction harness's own call-stack depth tripping

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -59,6 +59,12 @@ mirroring how the original `uint64_t`-only fuzzer worked.
   back to 0/1 as `T` (the comparisons' convention). Operands are evaluated
   *before* the bool op on both sides, so even a short-circuiting `&&`
   lowering (`ENABLE_SHORT_CIRCUIT_BOOL`) cannot skip a `Store` side effect.
+* **Runtime calls** (`Call`, both domains): a real `nautilus::invoke()` of a
+  pure native helper (`Callees.hpp`, selected by the node's imm). The native
+  oracle calls the *identical instantiation* directly, so the two legs
+  execute the same native code and the differential surface is exclusively
+  the backend's call lowering: argument/return marshalling, narrow-integer
+  ABI extension, float register passing.
 * **`Cast` across the int/float domain boundary**: `(T)(To)v` still always
   produces a `T` result, exactly like a same-domain cast -- only the
   intermediate type's domain changes. Whichever leg of the round trip is

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -73,10 +73,16 @@ int builtinCorpus() {
 // Used to see whether distinct bug classes exist (e.g. a mismatch involving a
 // runtime parameter would point to a codegen bug rather than constant
 // folding; the type breaks out e.g. an i8-only bug from an f64-only one).
+// Each bucket's first input is also saved to fuzz-finding-<n>.bin in the
+// working directory so it can be replayed (`nautilus-fuzz-replay <file>`)
+// and minimized -- essential when a finding depends on the runtime buffer
+// address (Kind::PtrToInt) and is therefore not reproducible from the
+// printed program text alone.
 int survey(int iterations) {
 	std::map<std::string, nautilus::fuzz::Finding> buckets;
 	std::map<std::string, int> counts;
 	int totalFindings = 0;
+	int savedInputs = 0;
 
 	for (int it = 0; it < iterations; ++it) {
 		const std::vector<uint8_t> buf = randomBuffer();
@@ -87,6 +93,11 @@ int survey(int iterations) {
 			counts[key]++;
 			if (!buckets.count(key)) {
 				buckets.emplace(key, f);
+				char name[64];
+				std::snprintf(name, sizeof(name), "fuzz-finding-%d.bin", savedInputs++);
+				std::ofstream out(name, std::ios::binary);
+				out.write(reinterpret_cast<const char*>(buf.data()), static_cast<std::streamsize>(buf.size()));
+				std::printf("  [%s] input saved to %s\n", key.c_str(), name);
 			}
 		}
 		if ((it + 1) % 500 == 0) {


### PR DESCRIPTION
## Summary

Extends the differential AST fuzzer to cover a wider range of Nautilus features, and fixes the four real miscompiles the new coverage surfaced. Alternates extension → finding → fix, so each fix commit cites the coverage that caught it; every bug is pinned by a deterministic regression test in the regular suite.

### Fuzzer extensions

- **`val<bool>` logical operators** (`LAnd`/`LOr`/`LNot`): operands become `val<bool>` via `!= 0`, are combined with the real `&&`/`||`/`!` operator, and select back to the comparisons' 0/1-as-T convention. Operands are evaluated before the bool op on both the oracle and traced sides, so a short-circuiting lowering can't cause a Store side-effect divergence.
- **`invoke()` runtime calls** (`Call`, `Callees.hpp`): a real `nautilus::invoke()` of a pure native helper; the oracle calls the identical instantiation directly, so the differential surface is exclusively the backend's call lowering (arg/return marshalling, narrow-int ABI).
- **Trace-time static loops** (`StaticLoop`): constant trip count, plain C++ `for` over a `static_val<int64_t>` counter — exercising `static_val`'s snapshot-hash machinery and trace-time unrolling instead of loop lowering.
- **Triage infra**: survey mode saves each bucket's first input to `fuzz-finding-<n>.bin` (essential for address-dependent findings via `PtrToInt`), and `NAUTILUS_FUZZ_DUMP=1` dumps all compilation stages during replay.

### Miscompiles found & fixed

1. **AsmJit A64: narrow-int results not re-normalized after arithmetic** — wrapped u32 sub/add/mul left stale high bits in the 64-bit register; downstream full-width consumers (cmp, udiv, msub, ucvtf) mis-evaluated. Added `narrowToStamp` after every width-breaking op + returns, mirroring the x64 provider. Pinned: `u32WrapSubThenCompare`.
2. **AsmJit x64+A64: narrow call returns bound without re-extension** — the ABI leaves upper bits of a sub-register-width return unspecified; a wrapped-negative i16 return compared as its positive 32-bit intermediate. Pinned: `i16NarrowCallReturnCompare`.
3. **MLIR: external callee declarations missing `llvm.signext`/`llvm.zeroext` argument attributes** — Darwin AArch64 / x86-64 SysV require the *caller* to extend sub-32-bit integer args; LLVM folded the truncation away and passed live upper register bits, which the natively compiled callee misread (found as an address-dependent i16 mismatch). Results deliberately stay unattributed (AAPCS64 Linux callees don't extend returns; LLVM re-extends unattributed results itself). Pinned: `i16NarrowCallArgCompare`.
4. **BC: merged-value corruption from block-arg identifier collision** — the bytecode variant of #321/#322: the emplace-only frame binding silently dropped an if-arm's re-definition of a merge-parameter identifier, so a constant combined after the merge read a never-written register. `getResultRegister` now returns the pre-bound merge-parameter register so definitions write straight into it (const/alloca/function-address visitors included). Pinned: `zeroTripLoopMergeThenAddConstant`, verified to fail on the pre-fix translator.

Bugs 1–3 are one invariant violated in three places: narrow integers must stay sign/zero-extended in full-width registers, including across ABI boundaries.

## Test plan

- Differential surveys after each change; final sweep: **4000-input survey + 2000-input built-in corpus across interpreter + MLIR + C++ + BC + AsmJit, 0 findings** (macOS arm64).
- Full ctest suite: **209/209 pass**, including the five new regression sections (which run on every backend × trace mode).
- MLIR fix verified at the LLVM IR level (declarations now carry `signext`/`zeroext`); the BC regression test was empirically confirmed to fail before the fix and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqJnkqf1anJVXDRq4LPsej