### PR TITLE
Extend differential fuzzer to richer control-flow shapes

### DIFF
--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -80,12 +80,39 @@ enum class Kind : uint8_t {
 	// index as a *constant*) -- exercising static_val's snapshot-hash
 	// machinery and trace-time unrolling instead of loop lowering.
 	StaticLoop,
-	// Leaves, only legal while generating inside a Loop/StaticLoop body:
-	// current iteration index / accumulator of the innermost enclosing
-	// loop. No imm payload -- nesting uses simple shadowing (innermost
-	// wins).
+	// Two loop-carried accumulators (the fibonacci shape): kid[0] = count,
+	// kid[1] = initA, kid[2] = bodyA, kid[3] = bodyB. accB starts at the
+	// *raw* (unclamped) count value -- already evaluated, so no extra kid is
+	// needed. Each trip evaluates both bodies against the OLD (A, B, index)
+	// and then commits both -- parallel update semantics, so bodyA = accB /
+	// bodyB = accA generates a genuine register swap on the back edge. The
+	// result is A + B (wrapping for signed ints) after the loop. This is
+	// the sharpest probe for back-edge parallel-copy sequencing and
+	// multi-argument block-invocation passing, where two previous merge
+	// bugs (asmjit #321, the BC collision) lived.
+	Loop2,
+	// Bounded loop with a conditional mid-body early exit: kid[0] = count,
+	// kid[1] = init, kid[2] = body. Each trip: acc = body, then break when
+	// a fixed predicate on acc holds (ints: acc & 1, floats: acc < 0 --
+	// NaN compares false, so it is well-defined). Traced as a real
+	// `if (...) break;` inside the for body, so the loop body's CFG splits
+	// mid-block -- a shape none of the other loop kinds produce.
+	LoopBreak,
+	// Bounded loop whose *header* condition is a conjunction of the counter
+	// bound and a data-dependent predicate on the accumulator:
+	// `i < trips && pred(acc)` (ints: (acc & 3) != 3, floats: acc >= 0 --
+	// NaN exits, well-defined). kid[0] = count, kid[1] = init,
+	// kid[2] = body. Exercises compound val<bool> loop conditions.
+	WhileLoop,
+	// Leaves, only legal while generating inside a loop body: current
+	// iteration index / accumulator(s) of the innermost enclosing loop.
+	// No imm payload -- nesting uses simple shadowing (innermost wins).
+	// LoopAcc2 reads the innermost frame's second accumulator; every
+	// single-accumulator loop kind publishes acc2 == acc, so it is legal
+	// (and identically defined on both sides) inside any loop body.
 	LoopIndex,
 	LoopAcc,
+	LoopAcc2,
 	// --- Memory / pointer domain -------------------------------------------
 	// A generated program owns one shared, fixed-size `T` buffer (BUFFER_ELEMS
 	// elements). kid[0] of Load/Store/PtrToInt and both kids of the Ptr*
@@ -131,7 +158,7 @@ enum class Kind : uint8_t {
 struct Node {
 	Kind kind;
 	uint64_t imm = 0;
-	int kid[3] = {-1, -1, -1};
+	int kid[4] = {-1, -1, -1, -1}; // slot 3 is only used by Kind::Loop2
 };
 
 struct Ast {
@@ -168,17 +195,19 @@ namespace detail {
 // equally safe, given generatePtrNode's bounded construction) regardless of
 // T's domain.
 inline constexpr Kind INT_KINDS[] = {
-    Kind::Add,    Kind::Sub,   Kind::Mul,        Kind::Div,  Kind::Mod,   Kind::And,      Kind::Or,    Kind::Xor,
-    Kind::Shl,    Kind::Shr,   Kind::Eq,         Kind::Ne,   Kind::Lt,    Kind::Le,       Kind::Gt,    Kind::Ge,
-    Kind::Select, Kind::If,    Kind::Neg,        Kind::Not,  Kind::LAnd,  Kind::LOr,      Kind::LNot,  Kind::Call,
-    Kind::Cast,   Kind::Loop,  Kind::StaticLoop, Kind::Load, Kind::Store, Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe,
-    Kind::PtrLt,  Kind::PtrLe, Kind::PtrGt,      Kind::PtrGe};
+    Kind::Add,       Kind::Sub,        Kind::Mul,    Kind::Div,   Kind::Mod,      Kind::And,   Kind::Or,
+    Kind::Xor,       Kind::Shl,        Kind::Shr,    Kind::Eq,    Kind::Ne,       Kind::Lt,    Kind::Le,
+    Kind::Gt,        Kind::Ge,         Kind::Select, Kind::If,    Kind::Neg,      Kind::Not,   Kind::LAnd,
+    Kind::LOr,       Kind::LNot,       Kind::Call,   Kind::Cast,  Kind::Loop,     Kind::Loop2, Kind::LoopBreak,
+    Kind::WhileLoop, Kind::StaticLoop, Kind::Load,   Kind::Store, Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe,
+    Kind::PtrLt,     Kind::PtrLe,      Kind::PtrGt,  Kind::PtrGe};
 
 inline constexpr Kind FLOAT_KINDS[] = {
-    Kind::Add,   Kind::Sub,   Kind::Mul,    Kind::Div,        Kind::Eq,   Kind::Ne,    Kind::Lt,       Kind::Le,
-    Kind::Gt,    Kind::Ge,    Kind::Select, Kind::If,         Kind::Neg,  Kind::LAnd,  Kind::LOr,      Kind::LNot,
-    Kind::Call,  Kind::Cast,  Kind::Loop,   Kind::StaticLoop, Kind::Load, Kind::Store, Kind::PtrToInt, Kind::PtrEq,
-    Kind::PtrNe, Kind::PtrLt, Kind::PtrLe,  Kind::PtrGt,      Kind::PtrGe};
+    Kind::Add,       Kind::Sub,        Kind::Mul,   Kind::Div,    Kind::Eq,       Kind::Ne,    Kind::Lt,
+    Kind::Le,        Kind::Gt,         Kind::Ge,    Kind::Select, Kind::If,       Kind::Neg,   Kind::LAnd,
+    Kind::LOr,       Kind::LNot,       Kind::Call,  Kind::Cast,   Kind::Loop,     Kind::Loop2, Kind::LoopBreak,
+    Kind::WhileLoop, Kind::StaticLoop, Kind::Load,  Kind::Store,  Kind::PtrToInt, Kind::PtrEq, Kind::PtrNe,
+    Kind::PtrLt,     Kind::PtrLe,      Kind::PtrGt, Kind::PtrGe};
 
 inline int arity(Kind k) {
 	switch (k) {
@@ -186,6 +215,7 @@ inline int arity(Kind k) {
 	case Kind::Param:
 	case Kind::LoopIndex:
 	case Kind::LoopAcc:
+	case Kind::LoopAcc2:
 	case Kind::PtrBase:
 		return 0;
 	case Kind::Neg:
@@ -200,7 +230,11 @@ inline int arity(Kind k) {
 	case Kind::Select:
 	case Kind::If:
 	case Kind::Loop:
+	case Kind::LoopBreak:
+	case Kind::WhileLoop:
 		return 3;
+	case Kind::Loop2:
+		return 4;
 	default:
 		return 2;
 	}
@@ -261,8 +295,9 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 	Node node;
 	if (leaf) {
 		if (loopDepth > 0 && (sel & 0x6) == 0x6) {
-			// ~1/4 of in-loop leaves reference the innermost loop's index/acc.
-			node.kind = (sel & 0x1) ? Kind::LoopAcc : Kind::LoopIndex;
+			// ~1/4 of in-loop leaves reference the innermost loop's
+			// index/accumulator(s); LoopAcc2 is acc for the single-acc kinds.
+			node.kind = (sel & 0x1) ? ((sel & 0x8) ? Kind::LoopAcc2 : Kind::LoopAcc) : Kind::LoopIndex;
 		} else if (sel & 0x4) {
 			node.kind = Kind::Param;
 			node.imm = reader.byte() % NUM_PARAMS;
@@ -296,14 +331,19 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 	const int childCount = arity(node.kind);
 	// Children must be generated before the parent is pushed so that parent
 	// indices stay greater than their children (handy for evaluation/printing).
-	int kids[3] = {-1, -1, -1};
-	if (node.kind == Kind::Loop) {
+	int kids[4] = {-1, -1, -1, -1};
+	if (node.kind == Kind::Loop || node.kind == Kind::LoopBreak || node.kind == Kind::WhileLoop) {
 		// count (kid[0]) and init (kid[1]) live in the *outer* scope -- they
 		// must not see this loop's own LoopIndex/LoopAcc. Only the body
 		// (kid[2]) is generated one loop deeper.
 		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
 		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
 		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
+	} else if (node.kind == Kind::Loop2) {
+		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth);
+		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
+		kids[3] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1);
 	} else if (node.kind == Kind::StaticLoop) {
 		// Trip count is a generation-time constant (imm), not an expression:
 		// a trace-time loop cannot depend on runtime data by definition.
@@ -326,6 +366,7 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 	node.kid[0] = kids[0];
 	node.kid[1] = kids[1];
 	node.kid[2] = kids[2];
+	node.kid[3] = kids[3];
 	const int idx = static_cast<int>(ast.nodes.size());
 	ast.nodes.push_back(node);
 	return idx;
@@ -404,6 +445,9 @@ void print(const Ast& ast, int idx, std::string& out) {
 	case Kind::LoopAcc:
 		out += "la";
 		return;
+	case Kind::LoopAcc2:
+		out += "lb";
+		return;
 	case Kind::Neg:
 		out += "(-";
 		print<T>(ast, n.kid[0], out);
@@ -478,6 +522,35 @@ void print(const Ast& ast, int idx, std::string& out) {
 		print<T>(ast, n.kid[0], out);
 		out += ", body=";
 		print<T>(ast, n.kid[1], out);
+		out += ")";
+		return;
+	case Kind::Loop2:
+		out += "loop2(count=";
+		print<T>(ast, n.kid[0], out);
+		out += ", initA=";
+		print<T>(ast, n.kid[1], out);
+		out += ", bodyA=";
+		print<T>(ast, n.kid[2], out);
+		out += ", bodyB=";
+		print<T>(ast, n.kid[3], out);
+		out += ")";
+		return;
+	case Kind::LoopBreak:
+		out += "loopbrk(count=";
+		print<T>(ast, n.kid[0], out);
+		out += ", init=";
+		print<T>(ast, n.kid[1], out);
+		out += ", body=";
+		print<T>(ast, n.kid[2], out);
+		out += ")";
+		return;
+	case Kind::WhileLoop:
+		out += "while(count=";
+		print<T>(ast, n.kid[0], out);
+		out += ", init=";
+		print<T>(ast, n.kid[1], out);
+		out += ", body=";
+		print<T>(ast, n.kid[2], out);
 		out += ")";
 		return;
 	case Kind::Load:

--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -113,6 +113,11 @@ enum class Kind : uint8_t {
 	LoopIndex,
 	LoopAcc,
 	LoopAcc2,
+	// The *enclosing* (one-level-up) loop's iteration index; only legal when
+	// nested at least two loops deep. Values from an outer loop's frame must
+	// survive across the inner loop's back edge as extra block arguments --
+	// a longer live range than anything the innermost-frame leaves produce.
+	LoopIndexOuter,
 	// --- Memory / pointer domain -------------------------------------------
 	// A generated program owns one shared, fixed-size `T` buffer (BUFFER_ELEMS
 	// elements). kid[0] of Load/Store/PtrToInt and both kids of the Ptr*
@@ -216,6 +221,7 @@ inline int arity(Kind k) {
 	case Kind::LoopIndex:
 	case Kind::LoopAcc:
 	case Kind::LoopAcc2:
+	case Kind::LoopIndexOuter:
 	case Kind::PtrBase:
 		return 0;
 	case Kind::Neg:
@@ -298,6 +304,10 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 			// ~1/4 of in-loop leaves reference the innermost loop's
 			// index/accumulator(s); LoopAcc2 is acc for the single-acc kinds.
 			node.kind = (sel & 0x1) ? ((sel & 0x8) ? Kind::LoopAcc2 : Kind::LoopAcc) : Kind::LoopIndex;
+			if (loopDepth > 1 && (sel & 0x18) == 0x10) {
+				// Deeply nested only: read the enclosing loop's index instead.
+				node.kind = Kind::LoopIndexOuter;
+			}
 		} else if (sel & 0x4) {
 			node.kind = Kind::Param;
 			node.imm = reader.byte() % NUM_PARAMS;
@@ -447,6 +457,9 @@ void print(const Ast& ast, int idx, std::string& out) {
 		return;
 	case Kind::LoopAcc2:
 		out += "lb";
+		return;
+	case Kind::LoopIndexOuter:
+		out += "lio";
 		return;
 	case Kind::Neg:
 		out += "(-";

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -261,6 +261,8 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		return ctx.loopStack.back().acc;
 	case Kind::LoopAcc2:
 		return ctx.loopStack.back().acc2;
+	case Kind::LoopIndexOuter:
+		return ctx.loopStack[ctx.loopStack.size() - 2].index;
 	case Kind::Select: {
 		// Both branches are evaluated unconditionally, matching the traced
 		// kernel's `select(cond, t, f)` (a data mux, not real branching -- see
@@ -487,6 +489,8 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		return ctx.loopStack.back().acc;
 	case Kind::LoopAcc2:
 		return ctx.loopStack.back().acc2;
+	case Kind::LoopIndexOuter:
+		return ctx.loopStack[ctx.loopStack.size() - 2].index;
 	case Kind::Select: {
 		// See the identical comment in evalNativeInt's Select case: both
 		// branches must be evaluated unconditionally to match the traced

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -161,13 +161,43 @@ int clampBufferIndex(T raw) {
 
 /// Mutable per-evaluation scratch state, separate from the read-only kernel
 /// `args`: the stack of enclosing Loop frames, innermost last. LoopIndex /
-/// LoopAcc always read `loopStack.back()` -- nesting is plain shadowing, the
-/// generator guarantees the stack is non-empty wherever they appear.
+/// LoopAcc / LoopAcc2 always read `loopStack.back()` -- nesting is plain
+/// shadowing, the generator guarantees the stack is non-empty wherever they
+/// appear. Single-accumulator loop kinds publish acc2 == acc so LoopAcc2 is
+/// well-defined inside any loop body; only Kind::Loop2 carries a distinct
+/// second accumulator.
 template <typename T>
 struct LoopFrame {
 	T index;
 	T acc;
+	T acc2;
 };
+
+/// Fixed early-exit predicate for Kind::LoopBreak, mirrored exactly by
+/// EvalNautilus.hpp's traced twin: break once the accumulator is odd (ints)
+/// or negative (floats; NaN compares false, so it never breaks -- fully
+/// defined either way).
+template <typename T>
+bool breakPredicate(T acc) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return acc < T(0);
+	} else {
+		return (acc & T(1)) != T(0);
+	}
+}
+
+/// Fixed continuation predicate for Kind::WhileLoop's compound header
+/// condition (`i < trips && whilePredicate(acc)`), mirrored exactly by the
+/// traced twin: keep running while the accumulator's low bits aren't all
+/// set (ints) or it is non-negative (floats; NaN exits).
+template <typename T>
+bool whilePredicate(T acc) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return acc >= T(0);
+	} else {
+		return (acc & T(3)) != T(3);
+	}
+}
 
 /// The shared buffer every generated program's pointer-domain nodes index
 /// into (see Kind::PtrBase in Ast.hpp). A raw, non-owning pointer: the
@@ -229,6 +259,8 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		return ctx.loopStack.back().index;
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
+	case Kind::LoopAcc2:
+		return ctx.loopStack.back().acc2;
 	case Kind::Select: {
 		// Both branches are evaluated unconditionally, matching the traced
 		// kernel's `select(cond, t, f)` (a data mux, not real branching -- see
@@ -255,7 +287,7 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		const int trips = clampTripCount<T>(rawCount);
 		T acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
 		for (int i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
 			acc = evalNativeInt<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
@@ -265,8 +297,54 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		const int trips = static_cast<int>(n.imm);
 		T acc = evalNativeInt<T>(ast, n.kid[0], args, ctx);
 		for (int i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
 			acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
+	case Kind::Loop2: {
+		const T rawCount = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T accA = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+		T accB = rawCount;
+		for (int i = 0; i < trips; ++i) {
+			// Parallel update: both bodies see the OLD (index, A, B) frame,
+			// then both commit -- bodyA = lb / bodyB = la is a real swap.
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), accA, accB});
+			const T newA = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+			const T newB = evalNativeInt<T>(ast, n.kid[3], args, ctx);
+			ctx.loopStack.pop_back();
+			accA = newA;
+			accB = newB;
+		}
+		if constexpr (std::is_signed_v<T> && !std::is_floating_point_v<T>) {
+			return wrappingAdd<T>(accA, accB);
+		} else {
+			return static_cast<T>(accA + accB);
+		}
+	}
+	case Kind::LoopBreak: {
+		const T rawCount = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+		for (int i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
+			acc = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+			if (breakPredicate<T>(acc)) {
+				break;
+			}
+		}
+		return acc;
+	}
+	case Kind::WhileLoop: {
+		const T rawCount = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+		for (int i = 0; i < trips && whilePredicate<T>(acc); ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
+			acc = evalNativeInt<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;
@@ -407,6 +485,8 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		return ctx.loopStack.back().index;
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
+	case Kind::LoopAcc2:
+		return ctx.loopStack.back().acc2;
 	case Kind::Select: {
 		// See the identical comment in evalNativeInt's Select case: both
 		// branches must be evaluated unconditionally to match the traced
@@ -426,7 +506,7 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		const int trips = clampTripCount<T>(rawCount);
 		T acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
 		for (int i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
 			acc = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
@@ -436,8 +516,54 @@ T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 		const int trips = static_cast<int>(n.imm);
 		T acc = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
 		for (int i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
 			acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
+	case Kind::Loop2: {
+		const T rawCount = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T accA = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
+		T accB = rawCount;
+		for (int i = 0; i < trips; ++i) {
+			// Parallel update: both bodies see the OLD (index, A, B) frame,
+			// then both commit -- bodyA = lb / bodyB = la is a real swap.
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), accA, accB});
+			const T newA = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+			const T newB = evalNativeFloat<T>(ast, n.kid[3], args, ctx);
+			ctx.loopStack.pop_back();
+			accA = newA;
+			accB = newB;
+		}
+		if constexpr (std::is_signed_v<T> && !std::is_floating_point_v<T>) {
+			return wrappingAdd<T>(accA, accB);
+		} else {
+			return static_cast<T>(accA + accB);
+		}
+	}
+	case Kind::LoopBreak: {
+		const T rawCount = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
+		for (int i = 0; i < trips; ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
+			acc = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+			if (breakPredicate<T>(acc)) {
+				break;
+			}
+		}
+		return acc;
+	}
+	case Kind::WhileLoop: {
+		const T rawCount = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
+		const int trips = clampTripCount<T>(rawCount);
+		T acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
+		for (int i = 0; i < trips && whilePredicate<T>(acc); ++i) {
+			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc, acc});
+			acc = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -222,6 +222,8 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		return ctx.loopStack.back().acc;
 	case Kind::LoopAcc2:
 		return ctx.loopStack.back().acc2;
+	case Kind::LoopIndexOuter:
+		return ctx.loopStack[ctx.loopStack.size() - 2].index;
 	case Kind::Select: {
 		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 		TracedValue<T> t = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
@@ -440,6 +442,8 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		return ctx.loopStack.back().acc;
 	case Kind::LoopAcc2:
 		return ctx.loopStack.back().acc2;
+	case Kind::LoopIndexOuter:
+		return ctx.loopStack[ctx.loopStack.size() - 2].index;
 	case Kind::Select: {
 		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
 		TracedValue<T> t = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -139,7 +139,28 @@ template <typename T>
 struct TracedLoopFrame {
 	TracedValue<T> index;
 	TracedValue<T> acc;
+	TracedValue<T> acc2; // == acc for single-accumulator loop kinds
 };
+
+/// Traced twin of EvalNative.hpp's breakPredicate -- must never drift.
+template <typename T>
+val<bool> breakPredicateTraced(TracedValue<T> acc) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return acc < TracedValue<T>(T(0));
+	} else {
+		return (acc & TracedValue<T>(T(1))) != TracedValue<T>(T(0));
+	}
+}
+
+/// Traced twin of EvalNative.hpp's whilePredicate -- must never drift.
+template <typename T>
+val<bool> whilePredicateTraced(TracedValue<T> acc) {
+	if constexpr (std::is_floating_point_v<T>) {
+		return acc >= TracedValue<T>(T(0));
+	} else {
+		return (acc & TracedValue<T>(T(3))) != TracedValue<T>(T(3));
+	}
+}
 
 template <typename T>
 struct TracedEvalContext {
@@ -199,6 +220,8 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		return ctx.loopStack.back().index;
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
+	case Kind::LoopAcc2:
+		return ctx.loopStack.back().acc2;
 	case Kind::Select: {
 		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 		TracedValue<T> t = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
@@ -220,7 +243,54 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
 		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
 		for (val<int32_t> i = 0; i < trips; i = i + 1) {
-			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc, acc});
+			acc = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
+	case Kind::Loop2: {
+		TracedValue<T> rawCount = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> accA = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> accB = rawCount;
+		for (val<int32_t> i = 0; i < trips; i = i + 1) {
+			// Parallel update mirroring the oracle: both bodies see the OLD
+			// (index, A, B) frame, then both commit -- two loop-carried values
+			// force a genuine parallel copy on the back edge (a swap when
+			// bodyA = lb and bodyB = la, the fibonacci shape).
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), accA, accB});
+			TracedValue<T> newA = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+			TracedValue<T> newB = evalNautilusInt<T>(ast, n.kid[3], args, ctx);
+			ctx.loopStack.pop_back();
+			accA = newA;
+			accB = newB;
+		}
+		return accA + accB;
+	}
+	case Kind::LoopBreak: {
+		TracedValue<T> rawCount = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+		for (val<int32_t> i = 0; i < trips; i = i + 1) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc, acc});
+			acc = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+			// Real traced early exit: the loop body's CFG splits mid-block.
+			if (breakPredicateTraced<T>(acc)) {
+				break;
+			}
+		}
+		return acc;
+	}
+	case Kind::WhileLoop: {
+		TracedValue<T> rawCount = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+		// Compound data-dependent header condition (counter bound && acc
+		// predicate), re-evaluated every iteration like the oracle's.
+		for (val<int32_t> i = 0; i < trips && whilePredicateTraced<T>(acc); i = i + 1) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc, acc});
 			acc = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
@@ -234,7 +304,8 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		const int64_t trips = static_cast<int64_t>(n.imm);
 		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
 		for (static_val<int64_t> i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc});
+			ctx.loopStack.push_back(
+			    TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc, acc});
 			acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
 			ctx.loopStack.pop_back();
 		}
@@ -367,6 +438,8 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		return ctx.loopStack.back().index;
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
+	case Kind::LoopAcc2:
+		return ctx.loopStack.back().acc2;
 	case Kind::Select: {
 		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
 		TracedValue<T> t = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
@@ -386,7 +459,54 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
 		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
 		for (val<int32_t> i = 0; i < trips; i = i + 1) {
-			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc, acc});
+			acc = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+		}
+		return acc;
+	}
+	case Kind::Loop2: {
+		TracedValue<T> rawCount = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> accA = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> accB = rawCount;
+		for (val<int32_t> i = 0; i < trips; i = i + 1) {
+			// Parallel update mirroring the oracle: both bodies see the OLD
+			// (index, A, B) frame, then both commit -- two loop-carried values
+			// force a genuine parallel copy on the back edge (a swap when
+			// bodyA = lb and bodyB = la, the fibonacci shape).
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), accA, accB});
+			TracedValue<T> newA = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
+			TracedValue<T> newB = evalNautilusFloat<T>(ast, n.kid[3], args, ctx);
+			ctx.loopStack.pop_back();
+			accA = newA;
+			accB = newB;
+		}
+		return accA + accB;
+	}
+	case Kind::LoopBreak: {
+		TracedValue<T> rawCount = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
+		for (val<int32_t> i = 0; i < trips; i = i + 1) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc, acc});
+			acc = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
+			ctx.loopStack.pop_back();
+			// Real traced early exit: the loop body's CFG splits mid-block.
+			if (breakPredicateTraced<T>(acc)) {
+				break;
+			}
+		}
+		return acc;
+	}
+	case Kind::WhileLoop: {
+		TracedValue<T> rawCount = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
+		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
+		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
+		// Compound data-dependent header condition (counter bound && acc
+		// predicate), re-evaluated every iteration like the oracle's.
+		for (val<int32_t> i = 0; i < trips && whilePredicateTraced<T>(acc); i = i + 1) {
+			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc, acc});
 			acc = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
@@ -397,7 +517,8 @@ TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& a
 		const int64_t trips = static_cast<int64_t>(n.imm);
 		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
 		for (static_val<int64_t> i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc});
+			ctx.loopStack.push_back(
+			    TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc, acc});
 			acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
 			ctx.loopStack.pop_back();
 		}

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -72,6 +72,26 @@ mirroring how the original `uint64_t`-only fuzzer worked.
   seeing its `LoopIndex` as a constant, exercising `static_val`'s
   snapshot-hash machinery and trace-time unrolling instead of loop
   lowering (the `static-loop-tests` feature).
+* **Richer loop shapes** (both domains):
+  * `Loop2` -- two loop-carried accumulators updated with parallel
+    semantics (both bodies see the old `(index, A, B)` frame, then both
+    commit), so `bodyA = lb` / `bodyB = la` generates a genuine register
+    swap on the back edge: the sharpest probe for parallel-copy sequencing
+    and multi-argument block-invocation passing, where the asmjit #321 and
+    BC merge bugs lived. Bodies can read `LoopAcc` (`la`), `LoopAcc2`
+    (`lb`), `LoopIndex` (`li`); single-accumulator loops publish
+    `acc2 == acc` so `lb` is legal in any loop body.
+  * `LoopBreak` -- a real traced `if (...) break;` mid-body on a fixed
+    accumulator predicate (ints: odd, floats: negative; NaN-safe),
+    splitting the loop body's CFG.
+  * `WhileLoop` -- a compound data-dependent header condition
+    (`i < trips && pred(acc)`, re-evaluated per iteration), exercising
+    `val<bool>` conjunctions in loop headers.
+  * `LoopIndexOuter` (`lio`) -- reads the *enclosing* loop's index from a
+    doubly-nested body, forcing outer-frame values to survive across the
+    inner loop's back edge as extra block arguments.
+  All predicates are fixed and mirrored exactly between `EvalNative.hpp`
+  and `EvalNautilus.hpp`, keeping every program fully defined.
 * **`Cast` across the int/float domain boundary**: `(T)(To)v` still always
   produces a `T` result, exactly like a same-domain cast -- only the
   intermediate type's domain changes. Whichever leg of the round trip is


### PR DESCRIPTION
## Summary

Follow-up to #324 (stacked on that branch): extends the differential fuzzer's control-flow coverage with four new constructs that target the lowering paths where the previous session's merge/parallel-copy bugs lived. No new miscompiles surfaced — the #324 fixes hold under substantially harder control-flow stress, and this coverage now guards them permanently.

- **`Loop2`** — two loop-carried accumulators with parallel update semantics (both bodies see the old `(index, A, B)` frame, then both commit), so `bodyA = lb` / `bodyB = la` generates a genuine register swap on the back edge: the sharpest probe for parallel-copy sequencing and multi-argument block-invocation passing (asmjit #321 / BC-merge territory). `Node` gains a fourth kid slot and a `LoopAcc2` (`lb`) leaf; single-accumulator loops publish `acc2 == acc` so `lb` is legal in any loop body.
- **`LoopBreak`** — a real traced `if (...) break;` mid-body on a fixed accumulator predicate (ints: odd, floats: negative; NaN-safe), splitting the loop body's CFG — a shape no other loop kind produces.
- **`WhileLoop`** — compound data-dependent header condition (`i < trips && pred(acc)`), re-evaluated per iteration, exercising `val<bool>` conjunctions in loop headers.
- **`LoopIndexOuter`** (`lio`) — a doubly-nested body reads the *enclosing* loop's index, forcing outer-frame values to survive across the inner loop's back edge as extra block arguments.

All predicates are fixed and mirrored exactly between the native oracle (`EvalNative.hpp`) and the traced kernel (`EvalNautilus.hpp`), keeping every generated program fully defined by construction.

## Test plan

- Per-extension differential surveys (1500 / 2500 inputs), then a final sweep: **5000-input survey + 2000-input built-in corpus across interpreter + MLIR + C++ + BC + AsmJit — 0 findings** (macOS arm64).
- Full ctest suite: **209/209 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqJnkqf1anJVXDRq4LPsej