### PR TITLE
AsmJit x86-64 backend: branch fusion, immediate folding, and lowering optimizations

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -43,6 +43,7 @@ See [engine.md](engine.md) for how to create modules and override options per mo
 | asmjit.enableIntrinsics=[true,false]        | true     | Module  | Registers the AsmJit intrinsic plugins for this compilation.                                                                                          |
 | asmjit.enablePostRAPeephole=[true,false]    | true     | Module  | Enables post-register-allocation peephole optimizations in the AsmJit backend.                                                                        |
 | asmjit.enableBranchFusion=[true,false]      | true     | Module  | Fuses a compare into the conditional branch that is its only consumer (cmp+jcc instead of cmp+setcc+movzx+test+jz) in the AsmJit x86-64 backend.      |
+| asmjit.enableConstFolding=[true,false]      | true     | Module  | Defers integer/bool/ptr constants in the AsmJit x86-64 backend; consumers fold them as immediate operands (add/sub/cmp/shift/imul/and/or/xor) or rematerialise per use. |
 
 > **Note:** The JIT event listeners registered via `Options::addMLIRJitEventListener` are an engine-scoped resource
 > (their lifetime is tied to the engine) and are inherited by every module.

--- a/docs/options.md
+++ b/docs/options.md
@@ -44,6 +44,7 @@ See [engine.md](engine.md) for how to create modules and override options per mo
 | asmjit.enablePostRAPeephole=[true,false]    | true     | Module  | Enables post-register-allocation peephole optimizations in the AsmJit backend.                                                                        |
 | asmjit.enableBranchFusion=[true,false]      | true     | Module  | Fuses a compare into the conditional branch that is its only consumer (cmp+jcc instead of cmp+setcc+movzx+test+jz) in the AsmJit x86-64 backend.      |
 | asmjit.enableConstFolding=[true,false]      | true     | Module  | Defers integer/bool/ptr constants in the AsmJit x86-64 backend; consumers fold them as immediate operands (add/sub/cmp/shift/imul/and/or/xor) or rematerialise per use. |
+| asmjit.enableSelectCmov=[true,false]        | true     | Module  | Lowers integer selects branch-free via cmov in the AsmJit x86-64 backend (mirrors the A64 backend's csel).                                            |
 
 > **Note:** The JIT event listeners registered via `Options::addMLIRJitEventListener` are an engine-scoped resource
 > (their lifetime is tied to the engine) and are inherited by every module.

--- a/docs/options.md
+++ b/docs/options.md
@@ -42,6 +42,7 @@ See [engine.md](engine.md) for how to create modules and override options per mo
 | bc.registerAllocator=[true,false]           | true     | Module  | Enables the linear register allocator in the bytecode backend.                                                                                        |
 | asmjit.enableIntrinsics=[true,false]        | true     | Module  | Registers the AsmJit intrinsic plugins for this compilation.                                                                                          |
 | asmjit.enablePostRAPeephole=[true,false]    | true     | Module  | Enables post-register-allocation peephole optimizations in the AsmJit backend.                                                                        |
+| asmjit.enableBranchFusion=[true,false]      | true     | Module  | Fuses a compare into the conditional branch that is its only consumer (cmp+jcc instead of cmp+setcc+movzx+test+jz) in the AsmJit x86-64 backend.      |
 
 > **Note:** The JIT event listeners registered via `Options::addMLIRJitEventListener` are an engine-scoped resource
 > (their lifetime is tied to the engine) and are inherited by every module.

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -258,7 +258,8 @@ int64_t canonicalizeToStamp(int64_t value, Type stamp) {
 }
 } // anonymous namespace
 
-std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstValue(const ir::Operation* in) {
+std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstValue(const ir::Operation* in,
+                                                                                   RegisterFrame& frame) {
 	if (const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(in)) {
 		return canonicalizeToStamp(constInt->getValue(), constInt->getStamp());
 	}
@@ -277,9 +278,21 @@ std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstVal
 		const Type srcType = cast->getInput()->getStamp();
 		const Type dstType = cast->getStamp();
 		if (!isFloatType(srcType) && !isFloatType(dstType)) {
-			if (const auto inner = foldableConstValue(cast->getInput())) {
+			if (const auto inner = foldableConstValue(cast->getInput(), frame)) {
 				return canonicalizeToStamp(*inner, dstType);
 			}
+		}
+		return std::nullopt;
+	}
+	// Stale input pointer (see the header comment): the constant-folding IR
+	// pass rewires only binary/if/return/invocation consumers, so this input
+	// edge can still point at the operation a constant replaced. When the
+	// identifier is unbound and resolves to a deferred constant definition,
+	// that constant carries the identifier's value.
+	if (!frame.contains(in->getIdentifier())) {
+		const auto it = deferredConsts_.find(in->getIdentifier());
+		if (it != deferredConsts_.end() && it->second != in) {
+			return foldableConstValue(it->second, frame);
 		}
 	}
 	return std::nullopt;
@@ -292,7 +305,7 @@ Gp AsmJitLoweringProvider::LoweringContext::gpOperand(const ir::Operation* in, R
 	// paths (issue #321), while an SSA input edge to a constant operation
 	// always means that constant.
 	if (enableConstFolding_) {
-		if (const auto value = foldableConstValue(in)) {
+		if (const auto value = foldableConstValue(in, frame)) {
 			auto reg = cc.newInt64();
 			cc.mov(reg, *value);
 			return reg;
@@ -303,18 +316,18 @@ Gp AsmJitLoweringProvider::LoweringContext::gpOperand(const ir::Operation* in, R
 
 AsmJitLoweringProvider::AsmReg AsmJitLoweringProvider::LoweringContext::regOperand(const ir::Operation* in,
                                                                                    RegisterFrame& frame) {
-	if (enableConstFolding_ && foldableConstValue(in).has_value()) {
+	if (enableConstFolding_ && foldableConstValue(in, frame).has_value()) {
 		return AsmReg(gpOperand(in, frame));
 	}
 	return frame.getValue(in->getIdentifier());
 }
 
 std::optional<int32_t> AsmJitLoweringProvider::LoweringContext::imm32Operand(const ir::Operation* in,
-                                                                             RegisterFrame& /*frame*/) {
+                                                                             RegisterFrame& frame) {
 	if (!enableConstFolding_) {
 		return std::nullopt;
 	}
-	const auto value = foldableConstValue(in);
+	const auto value = foldableConstValue(in, frame);
 	if (!value.has_value() || *value < INT32_MIN || *value > INT32_MAX) {
 		return std::nullopt;
 	}
@@ -324,7 +337,7 @@ std::optional<int32_t> AsmJitLoweringProvider::LoweringContext::imm32Operand(con
 void AsmJitLoweringProvider::LoweringContext::emitMoveFromOperand(const AsmReg& dst, const ir::Operation* src,
                                                                   RegisterFrame& frame) {
 	if (enableConstFolding_) {
-		if (const auto value = foldableConstValue(src)) {
+		if (const auto value = foldableConstValue(src, frame)) {
 			cc.mov(toGp(dst), *value);
 			return;
 		}
@@ -372,6 +385,7 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 		blockLabels.clear();
 		processedBlocks.clear();
 		functionAllocaSlots_.clear();
+		deferredConsts_.clear();
 
 		// Static usage counts feed the compare→branch fusion decision; only
 		// pay for the walk when the fusion is enabled.
@@ -537,7 +551,7 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 		SourceValue source;
 		// Constant sources are recovered from the operation itself (see
 		// gpOperand for why a frame binding must not shadow a constant).
-		const auto value = enableConstFolding_ ? foldableConstValue(srcArgs[i]) : std::optional<int64_t> {};
+		const auto value = enableConstFolding_ ? foldableConstValue(srcArgs[i], frame) : std::optional<int64_t> {};
 		if (value.has_value()) {
 			source.imm = *value;
 		} else {
@@ -608,6 +622,7 @@ void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBoolean
 	// A bound identifier doubles as a merge-block parameter register (issue
 	// #321) that must be written, so those keep the materialising path.
 	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
+		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto reg = allocReg(Type::b);
@@ -617,6 +632,7 @@ void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBoolean
 
 void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
 	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
+		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto reg = allocReg(op->getStamp());
@@ -641,6 +657,7 @@ void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOper
 
 void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
 	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
+		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto reg = allocReg(Type::ptr);
@@ -1450,7 +1467,8 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 	// foldableConstValue); emit nothing and let consumers fold or
 	// rematerialise the pre-computed value. Bound identifiers double as
 	// merge-block parameters and must still be written (issue #321).
-	if (enableConstFolding_ && !frame.contains(op->getIdentifier()) && foldableConstValue(op).has_value()) {
+	if (enableConstFolding_ && !frame.contains(op->getIdentifier()) && foldableConstValue(op, frame).has_value()) {
+		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto src = regOperand(op->getInput(), frame);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -102,6 +102,7 @@ AsmJitLoweringProvider::LoweringContext::LoweringContext(std::shared_ptr<ir::IRG
 	}
 	enableBranchFusion_ = options.getOptionOrDefault<bool>("asmjit.enableBranchFusion", true);
 	enableConstFolding_ = options.getOptionOrDefault<bool>("asmjit.enableConstFolding", true);
+	enableSelectCmov_ = options.getOptionOrDefault<bool>("asmjit.enableSelectCmov", true);
 }
 
 // ── Type helpers ──────────────────────────────────────────────────────────────
@@ -555,25 +556,48 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 		}
 	}
 
-	// Copy each source to a fresh temp register first (parallel-copy semantics
-	// avoids clobbering when src and dst registers overlap). Deferred
-	// constants materialise straight into the temp.
-	std::vector<AsmReg> temps;
-	temps.reserve(srcArgs.size());
-	for (size_t i = 0; i < srcArgs.size(); i++) {
-		auto temp = allocReg(dstArgs[i]->getStamp());
-		if (sources[i].reg.has_value()) {
-			emitMove(temp, *sources[i].reg);
-		} else {
-			cc.mov(toGp(temp), sources[i].imm);
-		}
-		temps.push_back(temp);
+	// Parallel-copy semantics: a destination write must not clobber a source
+	// that a later copy still reads. Only a register source that is itself
+	// one of the destination registers needs to detour through a temp; a
+	// self-move (src == dst) needs no code at all, and everything else can
+	// be written directly (immediates and temps can never alias a source).
+	const auto vregId = [](const AsmReg& r) {
+		return std::visit([](const auto& reg) { return reg.id(); }, r);
+	};
+	std::unordered_set<uint32_t> dstIds;
+	for (size_t i = 0; i < dstArgs.size(); i++) {
+		dstIds.insert(vregId(frame.getValue(dstArgs[i]->getIdentifier())));
 	}
 
-	// Then write temps into the destination registers.
+	// Phase 1: detour hazardous register sources through fresh temps.
+	std::vector<std::optional<AsmReg>> temps(srcArgs.size());
+	for (size_t i = 0; i < srcArgs.size(); i++) {
+		if (!sources[i].reg.has_value()) {
+			continue; // immediate -- written directly in phase 2
+		}
+		const auto srcId = vregId(*sources[i].reg);
+		if (srcId == vregId(frame.getValue(dstArgs[i]->getIdentifier()))) {
+			continue; // self-move -- no code needed
+		}
+		if (dstIds.count(srcId) != 0) {
+			auto temp = allocReg(dstArgs[i]->getStamp());
+			emitMove(temp, *sources[i].reg);
+			temps[i] = temp;
+		}
+	}
+
+	// Phase 2: write the destinations.
 	for (size_t i = 0; i < srcArgs.size(); i++) {
 		auto dst = frame.getValue(dstArgs[i]->getIdentifier());
-		emitMove(dst, temps[i]);
+		if (temps[i].has_value()) {
+			emitMove(dst, *temps[i]);
+		} else if (sources[i].reg.has_value()) {
+			if (vregId(*sources[i].reg) != vregId(dst)) {
+				emitMove(dst, *sources[i].reg);
+			}
+		} else {
+			cc.mov(toGp(dst), sources[i].imm);
+		}
 	}
 }
 
@@ -601,22 +625,16 @@ void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperatio
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOperation* op, RegisterFrame& frame) {
+	// One RIP-relative load from the local constant pool instead of a GP
+	// temp plus movd/movq round-trip through the integer register file.
 	auto reg = allocReg(op->getStamp());
 	auto xmmReg = toXmm(reg);
 	if (op->getStamp() == Type::f32) {
-		float val = static_cast<float>(op->getValue());
-		uint32_t bits = 0;
-		memcpy(&bits, &val, sizeof(bits));
-		auto tempGp = cc.newUInt32();
-		cc.mov(tempGp, bits);
-		cc.movd(xmmReg, tempGp);
+		auto mem = cc.newFloatConst(ConstPoolScope::kLocal, static_cast<float>(op->getValue()));
+		cc.movss(xmmReg, mem);
 	} else {
-		double val = op->getValue();
-		uint64_t bits = 0;
-		memcpy(&bits, &val, sizeof(bits));
-		auto tempGp = cc.newUInt64();
-		cc.mov(tempGp, bits);
-		cc.movq(xmmReg, tempGp);
+		auto mem = cc.newDoubleConst(ConstPoolScope::kLocal, op->getValue());
+		cc.movsd(xmmReg, mem);
 	}
 	bindResult(op->getIdentifier(), reg, frame);
 }
@@ -1183,16 +1201,28 @@ void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* o
 	auto condGp = gpOperand(op->getCondition(), frame);
 	auto result = allocReg(op->getStamp());
 
-	auto falsePath = cc.newLabel();
-	auto donePath = cc.newLabel();
+	if (enableSelectCmov_ && !isFloatType(op->getStamp())) {
+		// Branch-free data mux: both values are already unconditionally
+		// computed (select is not lazy), so a cmov replaces the two-way
+		// branch and its misprediction risk. The operand movs do not touch
+		// EFLAGS, so the test's flags survive until the cmov. A64 lowers
+		// select the same way via csel.
+		auto falseGp = gpOperand(op->getFalseValue(), frame);
+		emitMoveFromOperand(result, op->getTrueValue(), frame);
+		cc.test(condGp, condGp);
+		cc.cmovz(toGp(result), falseGp);
+	} else {
+		auto falsePath = cc.newLabel();
+		auto donePath = cc.newLabel();
 
-	cc.test(condGp, condGp);
-	cc.jz(falsePath);
-	emitMoveFromOperand(result, op->getTrueValue(), frame);
-	cc.jmp(donePath);
-	cc.bind(falsePath);
-	emitMoveFromOperand(result, op->getFalseValue(), frame);
-	cc.bind(donePath);
+		cc.test(condGp, condGp);
+		cc.jz(falsePath);
+		emitMoveFromOperand(result, op->getTrueValue(), frame);
+		cc.jmp(donePath);
+		cc.bind(falsePath);
+		emitMoveFromOperand(result, op->getFalseValue(), frame);
+		cc.bind(donePath);
+	}
 
 	bindResult(op->getIdentifier(), result, frame);
 }

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -2,6 +2,7 @@
 #include "nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp"
 #include "nautilus/CompilationStatistics.hpp"
 #include "nautilus/compiler/DumpHandler.hpp"
+#include "nautilus/compiler/ir/Usages.hpp"
 #include "nautilus/exceptions/NotImplementedException.hpp"
 #include <cassert>
 #include <cstring>
@@ -90,7 +91,7 @@ AsmJitLoweringProvider::LoweringContext::LoweringContext(std::shared_ptr<ir::IRG
                                                          const engine::Options& options,
                                                          CompilationStatistics* statistics,
                                                          const AsmJitIntrinsicManager& intrinsicManager)
-    : cc(&code), ir(std::move(ir)), intrinsicManager_(intrinsicManager) {
+    : cc(&code), ir(std::move(ir)), intrinsicManager_(intrinsicManager), statistics_(statistics) {
 	// Register the optional post-RA peephole pass. It appends to the
 	// Compiler's pass list *after* X86RAPass (which was installed during
 	// `cc(&code)` via x86::Compiler::onAttach), so it sees physical-register
@@ -99,6 +100,7 @@ AsmJitLoweringProvider::LoweringContext::LoweringContext(std::shared_ptr<ir::IRG
 	if (options.getOptionOrDefault<bool>("asmjit.enablePostRAPeephole", true)) {
 		cc.addPassT<X64PostRAPeepholePass>(statistics);
 	}
+	enableBranchFusion_ = options.getOptionOrDefault<bool>("asmjit.enableBranchFusion", true);
 }
 
 // ── Type helpers ──────────────────────────────────────────────────────────────
@@ -263,6 +265,11 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 		processedBlocks.clear();
 		functionAllocaSlots_.clear();
 
+		// Static usage counts feed the compare→branch fusion decision; only
+		// pay for the walk when the fusion is enabled.
+		usageCounts_ = enableBranchFusion_ ? ir::countUsages(&funcBlock)
+		                                   : std::unordered_map<ir::OperationIdentifier, uint32_t> {};
+
 		// Materialise the function's alloca table into one stack slot per
 		// entry, captured in a pointer register.  visitAlloca() then just
 		// looks the slot up by index.  Doing this here (rather than per
@@ -317,6 +324,13 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 		cc.endFunc();
 	}
 
+	// Publish the lowering counters into the pipeline-wide statistics sink,
+	// mirroring the `asmjit.peephole.*` namespace: keys are present exactly
+	// when the corresponding optimization is enabled.
+	if (statistics_ != nullptr && enableBranchFusion_) {
+		statistics_->add("asmjit.lowering.fusedBranches", fusedBranches_);
+	}
+
 	// Format the builder node list before finalize(): at this point the IR still carries
 	// virtual registers, which is the representation users want to inspect as "asmjit IR".
 	if (asmjitIRDump != nullptr) {
@@ -340,9 +354,50 @@ void AsmJitLoweringProvider::LoweringContext::processBlock(const ir::BasicBlock*
 	// Bind the pre-created label for this block.
 	cc.bind(getOrCreateLabel(id));
 
-	for (auto* op : block->getOperations()) {
-		dispatch(op, frame);
+	// visitIf consumes a pending fused compare before recursing back here.
+	assert(pendingFusedCompare_ == nullptr && "fused compare leaked across blocks");
+
+	const auto& ops = block->getOperations();
+	for (size_t i = 0; i < ops.size(); i++) {
+		// Compare→branch fusion handshake: when the compare's flags can be
+		// consumed directly by the IfOperation that follows it, skip the
+		// compare's own lowering and let visitIf emit a fused cmp+jcc.
+		// Adjacency guarantees no instruction between cmp and jcc can
+		// clobber EFLAGS or retarget an operand register.
+		if (enableBranchFusion_ && i + 1 < ops.size()) {
+			if (auto* cmp = ir::dyn_cast<ir::CompareOperation>(ops[i])) {
+				if (isFusibleCompare(cmp, ops[i + 1], frame)) {
+					pendingFusedCompare_ = cmp;
+					continue;
+				}
+			}
+		}
+		dispatch(ops[i], frame);
 	}
+}
+
+bool AsmJitLoweringProvider::LoweringContext::isFusibleCompare(const ir::CompareOperation* cmp,
+                                                               const ir::Operation* next, RegisterFrame& frame) {
+	const auto* ifOp = ir::dyn_cast<ir::IfOperation>(next);
+	if (ifOp == nullptr || ifOp->getValue() != cmp) {
+		return false;
+	}
+	// Float EQ/NE needs the parity flag on top of the primary condition
+	// (see visitCompare); fusing those requires a two-jump sequence, so the
+	// first version keeps float compares on the materialising path.
+	if (isFloatType(cmp->getLeftInput()->getStamp())) {
+		return false;
+	}
+	// The if must be the sole consumer; any other use still needs the
+	// materialised boolean.
+	const auto it = usageCounts_.find(cmp->getIdentifier());
+	if (it == usageCounts_.end() || it->second != 1) {
+		return false;
+	}
+	// If the identifier is already bound it doubles as a downstream merge
+	// block's parameter register (issue #321); that register must be written,
+	// so the compare cannot skip materialisation.
+	return !frame.contains(cmp->getIdentifier());
 }
 
 // ── Block-argument passing ────────────────────────────────────────────────────
@@ -758,13 +813,25 @@ void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOper
 // ── Control flow ──────────────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitIf(ir::IfOperation* op, RegisterFrame& frame) {
-	auto condGp = toGp(frame.getValue(op->getValue()->getIdentifier()));
 	auto trueLabel = getOrCreateLabel(op->getTrueBlockInvocation().getBlock()->getIdentifier());
 	auto falseLabel = getOrCreateLabel(op->getFalseBlockInvocation().getBlock()->getIdentifier());
 
 	auto elsePath = cc.newLabel();
-	cc.test(condGp, condGp);
-	cc.jz(elsePath);
+	if (pendingFusedCompare_ != nullptr) {
+		// processBlock proved this compare's only consumer is this if and
+		// skipped its lowering; emit the compare and the negated conditional
+		// jump in one fused step. The block-argument copies below sit after
+		// the jcc, so they cannot disturb the flags.
+		assert(op->getValue() == pendingFusedCompare_ && "pending fused compare does not feed this if");
+		const auto* cmp = pendingFusedCompare_;
+		pendingFusedCompare_ = nullptr;
+		emitFusedCompareBranch(cmp, elsePath, frame);
+		fusedBranches_++;
+	} else {
+		auto condGp = toGp(frame.getValue(op->getValue()->getIdentifier()));
+		cc.test(condGp, condGp);
+		cc.jz(elsePath);
+	}
 
 	// True branch: copy arguments then jump.
 	processBlockInvocation(op->getTrueBlockInvocation(), frame);
@@ -788,6 +855,80 @@ void AsmJitLoweringProvider::LoweringContext::visitIf(ir::IfOperation* op, Regis
 	cc.jmp(falseLabel);
 
 	processBlock(op->getFalseBlockInvocation().getBlock(), frame);
+}
+
+// Fused replacement for visitCompare + the test/jz in visitIf: emits the
+// compare and jumps to @p falseTarget when the condition is false. Mirrors
+// visitCompare's integer paths (the float path is excluded by
+// isFusibleCompare); the condition codes are the negation of the setcc the
+// unfused lowering would have used.
+void AsmJitLoweringProvider::LoweringContext::emitFusedCompareBranch(const ir::CompareOperation* cmp, Label falseTarget,
+                                                                     RegisterFrame& frame) {
+	auto left = toGp(frame.getValue(cmp->getLeftInput()->getIdentifier()));
+
+	if (cmp->getLeftInput()->getStamp() == Type::ptr && isInteger(cmp->getRightInput()->getStamp())) {
+		// Null-pointer check (see visitCompare): only EQ/NE are meaningful.
+		cc.test(left, left);
+		if (cmp->getComparator() == ir::CompareOperation::EQ) {
+			cc.jnz(falseTarget);
+		} else {
+			cc.jz(falseTarget);
+		}
+		return;
+	}
+
+	// Keep visitCompare's `cmp x, 0` → `test x, x` peephole.
+	const auto* rightConst = ir::dyn_cast<ir::ConstIntOperation>(cmp->getRightInput());
+	if (rightConst != nullptr && rightConst->getValue() == 0) {
+		cc.test(left, left);
+	} else {
+		auto right = toGp(frame.getValue(cmp->getRightInput()->getIdentifier()));
+		cc.cmp(left, right);
+	}
+
+	if (isUnsignedType(cmp->getLeftInput()->getStamp())) {
+		switch (cmp->getComparator()) {
+		case ir::CompareOperation::EQ:
+			cc.jne(falseTarget);
+			break;
+		case ir::CompareOperation::NE:
+			cc.je(falseTarget);
+			break;
+		case ir::CompareOperation::LT:
+			cc.jae(falseTarget);
+			break;
+		case ir::CompareOperation::LE:
+			cc.ja(falseTarget);
+			break;
+		case ir::CompareOperation::GT:
+			cc.jbe(falseTarget);
+			break;
+		case ir::CompareOperation::GE:
+			cc.jb(falseTarget);
+			break;
+		}
+	} else {
+		switch (cmp->getComparator()) {
+		case ir::CompareOperation::EQ:
+			cc.jne(falseTarget);
+			break;
+		case ir::CompareOperation::NE:
+			cc.je(falseTarget);
+			break;
+		case ir::CompareOperation::LT:
+			cc.jge(falseTarget);
+			break;
+		case ir::CompareOperation::LE:
+			cc.jg(falseTarget);
+			break;
+		case ir::CompareOperation::GT:
+			cc.jle(falseTarget);
+			break;
+		case ir::CompareOperation::GE:
+			cc.jl(falseTarget);
+			break;
+		}
+	}
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* op, RegisterFrame& frame) {

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -101,6 +101,7 @@ AsmJitLoweringProvider::LoweringContext::LoweringContext(std::shared_ptr<ir::IRG
 		cc.addPassT<X64PostRAPeepholePass>(statistics);
 	}
 	enableBranchFusion_ = options.getOptionOrDefault<bool>("asmjit.enableBranchFusion", true);
+	enableConstFolding_ = options.getOptionOrDefault<bool>("asmjit.enableConstFolding", true);
 }
 
 // ── Type helpers ──────────────────────────────────────────────────────────────
@@ -224,6 +225,112 @@ void AsmJitLoweringProvider::LoweringContext::bindResult(const ir::OperationIden
 	}
 }
 
+// ── Deferred-constant operand helpers ─────────────────────────────────────────
+// With `asmjit.enableConstFolding` on, visitConstInt/Boolean/Ptr emit nothing;
+// consumers recover the value from the input operation itself and either fold
+// it as an immediate or rematerialise it. Values are canonicalised to the same
+// 64-bit register pattern the eager materialisation would have produced, so
+// the register-content invariant (sign/zero-extension per stamp) is identical
+// on both paths.
+
+namespace {
+// Truncate @p value to @p stamp's width and re-extend per its signedness --
+// the canonical 64-bit register pattern the materialising lowering produces.
+int64_t canonicalizeToStamp(int64_t value, Type stamp) {
+	switch (stamp) {
+	case Type::i8:
+		return static_cast<int64_t>(static_cast<int8_t>(value));
+	case Type::i16:
+		return static_cast<int64_t>(static_cast<int16_t>(value));
+	case Type::i32:
+		return static_cast<int64_t>(static_cast<int32_t>(value));
+	case Type::b:
+	case Type::ui8:
+		return static_cast<int64_t>(static_cast<uint8_t>(value));
+	case Type::ui16:
+		return static_cast<int64_t>(static_cast<uint16_t>(value));
+	case Type::ui32:
+		return static_cast<int64_t>(static_cast<uint32_t>(value));
+	default:
+		return value; // i64/ui64/ptr -- full width already.
+	}
+}
+} // anonymous namespace
+
+std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstValue(const ir::Operation* in) {
+	if (const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(in)) {
+		return canonicalizeToStamp(constInt->getValue(), constInt->getStamp());
+	}
+	if (const auto* constBool = ir::dyn_cast<ir::ConstBooleanOperation>(in)) {
+		return constBool->getValue() ? 1 : 0;
+	}
+	if (const auto* constPtr = ir::dyn_cast<ir::ConstPtrOperation>(in)) {
+		return static_cast<int64_t>(reinterpret_cast<uint64_t>(constPtr->getValue()));
+	}
+	// Traced constants typically reach their consumer through an integer
+	// cast ("$3 = 7 :i32; $4 = $3 cast_to i64"). An integer→integer cast of
+	// a constant chain is itself a compile-time constant: re-canonicalising
+	// the inner value per the destination stamp is exactly visitCast's
+	// extend-then-narrow semantics.
+	if (const auto* cast = ir::dyn_cast<ir::CastOperation>(in)) {
+		const Type srcType = cast->getInput()->getStamp();
+		const Type dstType = cast->getStamp();
+		if (!isFloatType(srcType) && !isFloatType(dstType)) {
+			if (const auto inner = foldableConstValue(cast->getInput())) {
+				return canonicalizeToStamp(*inner, dstType);
+			}
+		}
+	}
+	return std::nullopt;
+}
+
+Gp AsmJitLoweringProvider::LoweringContext::gpOperand(const ir::Operation* in, RegisterFrame& frame) {
+	// A constant operand is recovered from the operation itself, IGNORING any
+	// frame binding: the constant's identifier can be shadowed by a
+	// merge-block parameter register that carries a different value on other
+	// paths (issue #321), while an SSA input edge to a constant operation
+	// always means that constant.
+	if (enableConstFolding_) {
+		if (const auto value = foldableConstValue(in)) {
+			auto reg = cc.newInt64();
+			cc.mov(reg, *value);
+			return reg;
+		}
+	}
+	return toGp(frame.getValue(in->getIdentifier()));
+}
+
+AsmJitLoweringProvider::AsmReg AsmJitLoweringProvider::LoweringContext::regOperand(const ir::Operation* in,
+                                                                                   RegisterFrame& frame) {
+	if (enableConstFolding_ && foldableConstValue(in).has_value()) {
+		return AsmReg(gpOperand(in, frame));
+	}
+	return frame.getValue(in->getIdentifier());
+}
+
+std::optional<int32_t> AsmJitLoweringProvider::LoweringContext::imm32Operand(const ir::Operation* in,
+                                                                             RegisterFrame& /*frame*/) {
+	if (!enableConstFolding_) {
+		return std::nullopt;
+	}
+	const auto value = foldableConstValue(in);
+	if (!value.has_value() || *value < INT32_MIN || *value > INT32_MAX) {
+		return std::nullopt;
+	}
+	return static_cast<int32_t>(*value);
+}
+
+void AsmJitLoweringProvider::LoweringContext::emitMoveFromOperand(const AsmReg& dst, const ir::Operation* src,
+                                                                  RegisterFrame& frame) {
+	if (enableConstFolding_) {
+		if (const auto value = foldableConstValue(src)) {
+			cc.mov(toGp(dst), *value);
+			return;
+		}
+	}
+	emitMove(dst, frame.getValue(src->getIdentifier()));
+}
+
 // ── Two-pass compilation ──────────────────────────────────────────────────────
 //
 // Pass 1: call cc.newFunc() for every FunctionOperation, storing each FuncNode*.
@@ -330,6 +437,9 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 	if (statistics_ != nullptr && enableBranchFusion_) {
 		statistics_->add("asmjit.lowering.fusedBranches", fusedBranches_);
 	}
+	if (statistics_ != nullptr && enableConstFolding_) {
+		statistics_->add("asmjit.lowering.foldedImmediates", foldedImmediates_);
+	}
 
 	// Format the builder node list before finalize(): at this point the IR still carries
 	// virtual registers, which is the representation users want to inspect as "asmjit IR".
@@ -412,6 +522,29 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 	if (srcArgs.empty())
 		return;
 
+	// Snapshot the source operands BEFORE binding destination registers: a
+	// source identifier can coincide with a destination parameter identifier
+	// (issue #321), and allocating the destination first would shadow a
+	// deferred-constant source behind the fresh (uninitialised) register.
+	struct SourceValue {
+		std::optional<AsmReg> reg; // bound register, or
+		int64_t imm = 0;           // deferred-constant pattern
+	};
+	std::vector<SourceValue> sources;
+	sources.reserve(srcArgs.size());
+	for (size_t i = 0; i < srcArgs.size(); i++) {
+		SourceValue source;
+		// Constant sources are recovered from the operation itself (see
+		// gpOperand for why a frame binding must not shadow a constant).
+		const auto value = enableConstFolding_ ? foldableConstValue(srcArgs[i]) : std::optional<int64_t> {};
+		if (value.has_value()) {
+			source.imm = *value;
+		} else {
+			source.reg = frame.getValue(srcArgs[i]->getIdentifier());
+		}
+		sources.push_back(source);
+	}
+
 	// Ensure every destination block-argument has a virtual register.
 	// If the identifier was already assigned (e.g. it matches a predecessor's
 	// SSA value), reuse that register; otherwise allocate a fresh one now.
@@ -423,13 +556,17 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 	}
 
 	// Copy each source to a fresh temp register first (parallel-copy semantics
-	// avoids clobbering when src and dst registers overlap).
+	// avoids clobbering when src and dst registers overlap). Deferred
+	// constants materialise straight into the temp.
 	std::vector<AsmReg> temps;
 	temps.reserve(srcArgs.size());
 	for (size_t i = 0; i < srcArgs.size(); i++) {
-		auto src = frame.getValue(srcArgs[i]->getIdentifier());
 		auto temp = allocReg(dstArgs[i]->getStamp());
-		emitMove(temp, src);
+		if (sources[i].reg.has_value()) {
+			emitMove(temp, *sources[i].reg);
+		} else {
+			cc.mov(toGp(temp), sources[i].imm);
+		}
 		temps.push_back(temp);
 	}
 
@@ -443,12 +580,21 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame) {
+	// Deferred (see the operand helpers): consumers fold or rematerialise.
+	// A bound identifier doubles as a merge-block parameter register (issue
+	// #321) that must be written, so those keep the materialising path.
+	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
+		return;
+	}
 	auto reg = allocReg(Type::b);
 	cc.mov(toGp(reg), static_cast<int64_t>(op->getValue() ? 1 : 0));
 	bindResult(op->getIdentifier(), reg, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
+	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
+		return;
+	}
 	auto reg = allocReg(op->getStamp());
 	cc.mov(toGp(reg), op->getValue());
 	bindResult(op->getIdentifier(), reg, frame);
@@ -476,6 +622,9 @@ void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOper
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
+	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
+		return;
+	}
 	auto reg = allocReg(Type::ptr);
 	cc.mov(toGp(reg), reinterpret_cast<uint64_t>(op->getValue()));
 	bindResult(op->getIdentifier(), reg, frame);
@@ -484,10 +633,10 @@ void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperatio
 // ── Arithmetic ────────────────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, RegisterFrame& frame) {
-	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
-	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	if (isFloatType(op->getStamp())) {
+		auto left = frame.getValue(op->getLeftInput()->getIdentifier());
+		auto right = frame.getValue(op->getRightInput()->getIdentifier());
 		auto xDst = toXmm(result);
 		cc.movaps(xDst, toXmm(left));
 		if (op->getStamp() == Type::f32)
@@ -496,8 +645,25 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 			cc.addsd(xDst, toXmm(right));
 	} else {
 		auto gDst = toGp(result);
-		cc.mov(gDst, toGp(left));
-		cc.add(gDst, toGp(right));
+		// Fold a small-constant operand into the add's immediate form
+		// (add is commutative, so either side qualifies).
+		const auto rightImm = imm32Operand(op->getRightInput(), frame);
+		std::optional<int32_t> leftImm;
+		if (!rightImm.has_value()) {
+			leftImm = imm32Operand(op->getLeftInput(), frame);
+		}
+		if (rightImm.has_value()) {
+			cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
+			cc.add(gDst, *rightImm);
+			foldedImmediates_++;
+		} else if (leftImm.has_value()) {
+			cc.mov(gDst, gpOperand(op->getRightInput(), frame));
+			cc.add(gDst, *leftImm);
+			foldedImmediates_++;
+		} else {
+			cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
+			cc.add(gDst, gpOperand(op->getRightInput(), frame));
+		}
 		// An add that overflows the narrow stamp's width still produces a
 		// "correct" 64-bit sum; re-extend per the result type so its
 		// sign/zero-extension matches the wrapped-around narrow-width value
@@ -508,10 +674,10 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, RegisterFrame& frame) {
-	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
-	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	if (isFloatType(op->getStamp())) {
+		auto left = frame.getValue(op->getLeftInput()->getIdentifier());
+		auto right = frame.getValue(op->getRightInput()->getIdentifier());
 		auto xDst = toXmm(result);
 		cc.movaps(xDst, toXmm(left));
 		if (op->getStamp() == Type::f32)
@@ -520,18 +686,23 @@ void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, Reg
 			cc.subsd(xDst, toXmm(right));
 	} else {
 		auto gDst = toGp(result);
-		cc.mov(gDst, toGp(left));
-		cc.sub(gDst, toGp(right));
+		cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
+		if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+			cc.sub(gDst, *rightImm);
+			foldedImmediates_++;
+		} else {
+			cc.sub(gDst, gpOperand(op->getRightInput(), frame));
+		}
 		narrowToStamp(gDst, op->getStamp());
 	}
 	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, RegisterFrame& frame) {
-	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
-	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	if (isFloatType(op->getStamp())) {
+		auto left = frame.getValue(op->getLeftInput()->getIdentifier());
+		auto right = frame.getValue(op->getRightInput()->getIdentifier());
 		auto xDst = toXmm(result);
 		cc.movaps(xDst, toXmm(left));
 		if (op->getStamp() == Type::f32)
@@ -540,18 +711,33 @@ void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, Reg
 			cc.mulsd(xDst, toXmm(right));
 	} else {
 		auto gDst = toGp(result);
-		cc.mov(gDst, toGp(left));
-		cc.imul(gDst, toGp(right));
+		// Fold a small-constant operand via the three-operand imul form
+		// (commutative, so either side qualifies).
+		const auto rightImm = imm32Operand(op->getRightInput(), frame);
+		std::optional<int32_t> leftImm;
+		if (!rightImm.has_value()) {
+			leftImm = imm32Operand(op->getLeftInput(), frame);
+		}
+		if (rightImm.has_value()) {
+			cc.imul(gDst, gpOperand(op->getLeftInput(), frame), *rightImm);
+			foldedImmediates_++;
+		} else if (leftImm.has_value()) {
+			cc.imul(gDst, gpOperand(op->getRightInput(), frame), *leftImm);
+			foldedImmediates_++;
+		} else {
+			cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
+			cc.imul(gDst, gpOperand(op->getRightInput(), frame));
+		}
 		narrowToStamp(gDst, op->getStamp());
 	}
 	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, RegisterFrame& frame) {
-	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
-	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	if (isFloatType(op->getStamp())) {
+		auto left = frame.getValue(op->getLeftInput()->getIdentifier());
+		auto right = frame.getValue(op->getRightInput()->getIdentifier());
 		auto xDst = toXmm(result);
 		cc.movaps(xDst, toXmm(left));
 		if (op->getStamp() == Type::f32)
@@ -563,13 +749,13 @@ void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, Reg
 		// AsmJit Compiler handles the rax/rdx hardware constraint automatically.
 		auto quot = cc.newInt64();
 		auto rem = cc.newInt64();
-		cc.mov(quot, toGp(left));
+		cc.mov(quot, gpOperand(op->getLeftInput(), frame));
 		if (isUnsignedType(op->getStamp())) {
 			cc.xor_(rem, rem);
-			cc.div(rem, quot, toGp(right));
+			cc.div(rem, quot, gpOperand(op->getRightInput(), frame));
 		} else {
 			cc.cqo(rem, quot);
-			cc.idiv(rem, quot, toGp(right));
+			cc.idiv(rem, quot, gpOperand(op->getRightInput(), frame));
 		}
 		cc.mov(toGp(result), quot);
 	}
@@ -577,18 +763,16 @@ void AsmJitLoweringProvider::LoweringContext::visitDiv(ir::DivOperation* op, Reg
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, RegisterFrame& frame) {
-	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
-	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	auto quot = cc.newInt64();
 	auto rem = cc.newInt64();
-	cc.mov(quot, toGp(left));
+	cc.mov(quot, gpOperand(op->getLeftInput(), frame));
 	if (isUnsignedType(op->getStamp())) {
 		cc.xor_(rem, rem);
-		cc.div(rem, quot, toGp(right));
+		cc.div(rem, quot, gpOperand(op->getRightInput(), frame));
 	} else {
 		cc.cqo(rem, quot);
-		cc.idiv(rem, quot, toGp(right));
+		cc.idiv(rem, quot, gpOperand(op->getRightInput(), frame));
 	}
 	cc.mov(toGp(result), rem);
 	bindResult(op->getIdentifier(), result, frame);
@@ -597,14 +781,14 @@ void AsmJitLoweringProvider::LoweringContext::visitMod(ir::ModOperation* op, Reg
 // ── Logical / compare ─────────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation* op, RegisterFrame& frame) {
-	auto left = frame.getValue(op->getLeftInput()->getIdentifier());
-	auto right = frame.getValue(op->getRightInput()->getIdentifier());
 	auto result = allocReg(Type::b);
 	auto resultGp = toGp(result).r8();
 	const bool leftIsFloat = isFloatType(op->getLeftInput()->getStamp());
 	const bool leftIsUnsigned = isUnsignedType(op->getLeftInput()->getStamp());
 
 	if (leftIsFloat) {
+		auto left = frame.getValue(op->getLeftInput()->getIdentifier());
+		auto right = frame.getValue(op->getRightInput()->getIdentifier());
 		const bool isF32 = op->getLeftInput()->getStamp() == Type::f32;
 		auto ucomi = [&](Xmm a, Xmm b) {
 			if (isF32)
@@ -655,21 +839,26 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 		}
 	} else if (op->getLeftInput()->getStamp() == Type::ptr && isInteger(op->getRightInput()->getStamp())) {
 		// Null-pointer check: compare pointer against zero.
-		cc.test(toGp(left), toGp(left));
+		auto left = gpOperand(op->getLeftInput(), frame);
+		cc.test(left, left);
 		if (op->getComparator() == ir::CompareOperation::EQ)
 			cc.sete(resultGp);
 		else
 			cc.setne(resultGp);
 	} else {
+		auto left = gpOperand(op->getLeftInput(), frame);
 		// Peephole: `cmp x, 0` → `test x, x` when the right operand is the
 		// integer constant zero. Same flag output for ZF/SF/CF/OF and all
 		// consumers here read only via setcc/jcc — two bytes shorter and
 		// breaks no dependency.
 		const auto* rightConst = ir::dyn_cast<ir::ConstIntOperation>(op->getRightInput());
 		if (rightConst != nullptr && rightConst->getValue() == 0) {
-			cc.test(toGp(left), toGp(left));
+			cc.test(left, left);
+		} else if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+			cc.cmp(left, *rightImm);
+			foldedImmediates_++;
 		} else {
-			cc.cmp(toGp(left), toGp(right));
+			cc.cmp(left, gpOperand(op->getRightInput(), frame));
 		}
 		if (leftIsUnsigned) {
 			switch (op->getComparator()) {
@@ -721,26 +910,32 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, RegisterFrame& frame) {
-	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
-	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
-	cc.mov(toGp(result), left);
-	cc.and_(toGp(result), right);
+	cc.mov(toGp(result), gpOperand(op->getLeftInput(), frame));
+	if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+		cc.and_(toGp(result), *rightImm);
+		foldedImmediates_++;
+	} else {
+		cc.and_(toGp(result), gpOperand(op->getRightInput(), frame));
+	}
 	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, RegisterFrame& frame) {
-	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
-	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
-	cc.mov(toGp(result), left);
-	cc.or_(toGp(result), right);
+	cc.mov(toGp(result), gpOperand(op->getLeftInput(), frame));
+	if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+		cc.or_(toGp(result), *rightImm);
+		foldedImmediates_++;
+	} else {
+		cc.or_(toGp(result), gpOperand(op->getRightInput(), frame));
+	}
 	bindResult(op->getIdentifier(), result, frame);
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, RegisterFrame& frame) {
 	// NotOperation is logical NOT on a boolean: result = input XOR 1.
-	auto input = toGp(frame.getValue(op->getInput()->getIdentifier()));
+	auto input = gpOperand(op->getInput(), frame);
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), input);
 	cc.xor_(toGp(result), 1);
@@ -749,10 +944,9 @@ void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, Reg
 
 void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
 	// NegateOperation is bitwise NOT (~x): result = input XOR all-ones.
-	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
 	auto gDst = toGp(result);
-	cc.mov(gDst, toGp(src));
+	cc.mov(gDst, gpOperand(op->getInput(), frame));
 	cc.not_(gDst);
 	// not_ flips the full 64-bit register, including the extension padding.
 	// That happens to stay correct for signed stamps (flipping a sign bit
@@ -765,19 +959,33 @@ void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* o
 // ── Binary bit operations ─────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op, RegisterFrame& frame) {
-	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
-	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
 	auto gDst = toGp(result);
-	cc.mov(gDst, left);
-	// The shift count operand must be the CL register; AsmJit's Compiler
-	// handles that constraint when a GP register is given as the count.
-	if (op->getType() == ir::ShiftOperation::LS) {
-		cc.shl(gDst, right.r8());
-	} else if (isUnsignedType(op->getStamp())) {
-		cc.shr(gDst, right.r8());
+	cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
+	// A constant count uses the immediate shift form. The hardware masks the
+	// count mod 64 for 64-bit shifts, exactly like the CL-register form, so
+	// masking here preserves the register-form semantics.
+	if (const auto countImm = imm32Operand(op->getRightInput(), frame)) {
+		const uint32_t count = static_cast<uint32_t>(*countImm) & 63u;
+		if (op->getType() == ir::ShiftOperation::LS) {
+			cc.shl(gDst, count);
+		} else if (isUnsignedType(op->getStamp())) {
+			cc.shr(gDst, count);
+		} else {
+			cc.sar(gDst, count);
+		}
+		foldedImmediates_++;
 	} else {
-		cc.sar(gDst, right.r8());
+		auto right = gpOperand(op->getRightInput(), frame);
+		// The shift count operand must be the CL register; AsmJit's Compiler
+		// handles that constraint when a GP register is given as the count.
+		if (op->getType() == ir::ShiftOperation::LS) {
+			cc.shl(gDst, right.r8());
+		} else if (isUnsignedType(op->getStamp())) {
+			cc.shr(gDst, right.r8());
+		} else {
+			cc.sar(gDst, right.r8());
+		}
 	}
 	// Shifting the full 64-bit register (rather than just the narrow stamp's
 	// width) can leave the extension padding inconsistent with the
@@ -792,20 +1000,34 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
-	auto left = toGp(frame.getValue(op->getLeftInput()->getIdentifier()));
-	auto right = toGp(frame.getValue(op->getRightInput()->getIdentifier()));
 	auto result = allocReg(op->getStamp());
-	cc.mov(toGp(result), left);
-	switch (op->getType()) {
-	case ir::BinaryCompOperation::BAND:
-		cc.and_(toGp(result), right);
-		break;
-	case ir::BinaryCompOperation::BOR:
-		cc.or_(toGp(result), right);
-		break;
-	case ir::BinaryCompOperation::XOR:
-		cc.xor_(toGp(result), right);
-		break;
+	cc.mov(toGp(result), gpOperand(op->getLeftInput(), frame));
+	if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+		switch (op->getType()) {
+		case ir::BinaryCompOperation::BAND:
+			cc.and_(toGp(result), *rightImm);
+			break;
+		case ir::BinaryCompOperation::BOR:
+			cc.or_(toGp(result), *rightImm);
+			break;
+		case ir::BinaryCompOperation::XOR:
+			cc.xor_(toGp(result), *rightImm);
+			break;
+		}
+		foldedImmediates_++;
+	} else {
+		auto right = gpOperand(op->getRightInput(), frame);
+		switch (op->getType()) {
+		case ir::BinaryCompOperation::BAND:
+			cc.and_(toGp(result), right);
+			break;
+		case ir::BinaryCompOperation::BOR:
+			cc.or_(toGp(result), right);
+			break;
+		case ir::BinaryCompOperation::XOR:
+			cc.xor_(toGp(result), right);
+			break;
+		}
 	}
 	bindResult(op->getIdentifier(), result, frame);
 }
@@ -828,7 +1050,7 @@ void AsmJitLoweringProvider::LoweringContext::visitIf(ir::IfOperation* op, Regis
 		emitFusedCompareBranch(cmp, elsePath, frame);
 		fusedBranches_++;
 	} else {
-		auto condGp = toGp(frame.getValue(op->getValue()->getIdentifier()));
+		auto condGp = gpOperand(op->getValue(), frame);
 		cc.test(condGp, condGp);
 		cc.jz(elsePath);
 	}
@@ -864,7 +1086,7 @@ void AsmJitLoweringProvider::LoweringContext::visitIf(ir::IfOperation* op, Regis
 // unfused lowering would have used.
 void AsmJitLoweringProvider::LoweringContext::emitFusedCompareBranch(const ir::CompareOperation* cmp, Label falseTarget,
                                                                      RegisterFrame& frame) {
-	auto left = toGp(frame.getValue(cmp->getLeftInput()->getIdentifier()));
+	auto left = gpOperand(cmp->getLeftInput(), frame);
 
 	if (cmp->getLeftInput()->getStamp() == Type::ptr && isInteger(cmp->getRightInput()->getStamp())) {
 		// Null-pointer check (see visitCompare): only EQ/NE are meaningful.
@@ -881,9 +1103,11 @@ void AsmJitLoweringProvider::LoweringContext::emitFusedCompareBranch(const ir::C
 	const auto* rightConst = ir::dyn_cast<ir::ConstIntOperation>(cmp->getRightInput());
 	if (rightConst != nullptr && rightConst->getValue() == 0) {
 		cc.test(left, left);
+	} else if (const auto rightImm = imm32Operand(cmp->getRightInput(), frame)) {
+		cc.cmp(left, *rightImm);
+		foldedImmediates_++;
 	} else {
-		auto right = toGp(frame.getValue(cmp->getRightInput()->getIdentifier()));
-		cc.cmp(left, right);
+		cc.cmp(left, gpOperand(cmp->getRightInput(), frame));
 	}
 
 	if (isUnsignedType(cmp->getLeftInput()->getStamp())) {
@@ -940,7 +1164,7 @@ void AsmJitLoweringProvider::LoweringContext::visitBranch(ir::BranchOperation* o
 
 void AsmJitLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* op, RegisterFrame& frame) {
 	if (op->hasReturnValue()) {
-		auto retReg = frame.getValue(op->getReturnValue()->getIdentifier());
+		auto retReg = regOperand(op->getReturnValue(), frame);
 		if (std::holds_alternative<Xmm>(retReg)) {
 			cc.ret(toXmm(retReg));
 		} else {
@@ -956,9 +1180,7 @@ void AsmJitLoweringProvider::LoweringContext::visitReturn(ir::ReturnOperation* o
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* op, RegisterFrame& frame) {
-	auto condGp = toGp(frame.getValue(op->getCondition()->getIdentifier()));
-	auto trueVal = frame.getValue(op->getTrueValue()->getIdentifier());
-	auto falseVal = frame.getValue(op->getFalseValue()->getIdentifier());
+	auto condGp = gpOperand(op->getCondition(), frame);
 	auto result = allocReg(op->getStamp());
 
 	auto falsePath = cc.newLabel();
@@ -966,10 +1188,10 @@ void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* o
 
 	cc.test(condGp, condGp);
 	cc.jz(falsePath);
-	emitMove(result, trueVal);
+	emitMoveFromOperand(result, op->getTrueValue(), frame);
 	cc.jmp(donePath);
 	cc.bind(falsePath);
-	emitMove(result, falseVal);
+	emitMoveFromOperand(result, op->getFalseValue(), frame);
 	cc.bind(donePath);
 
 	bindResult(op->getIdentifier(), result, frame);
@@ -978,7 +1200,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSelect(ir::SelectOperation* o
 // ── Memory ────────────────────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* op, RegisterFrame& frame) {
-	auto addrGp = toGp(frame.getValue(op->getAddress()->getIdentifier()));
+	auto addrGp = gpOperand(op->getAddress(), frame);
 	auto result = allocReg(op->getStamp());
 
 	if (op->getStamp() == Type::f32) {
@@ -1021,8 +1243,8 @@ void AsmJitLoweringProvider::LoweringContext::visitLoad(ir::LoadOperation* op, R
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitStore(ir::StoreOperation* op, RegisterFrame& frame) {
-	auto addrGp = toGp(frame.getValue(op->getAddress()->getIdentifier()));
-	auto valReg = frame.getValue(op->getValue()->getIdentifier());
+	auto addrGp = gpOperand(op->getAddress(), frame);
+	auto valReg = regOperand(op->getValue(), frame);
 
 	if (op->getValue()->getStamp() == Type::f32) {
 		cc.movss(x86::dword_ptr(addrGp), toXmm(valReg));
@@ -1071,6 +1293,13 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 	// (e.g. emit `paddd xmm0, xmm1` for vector_add_i32x4_impl). The handler
 	// is expected to bind the result identifier into the frame itself.
 	if (auto intrinsic = intrinsicManager_.getIntrinsic(op->getFunctionPtr())) {
+		// Intrinsic handlers read argument registers straight from the frame,
+		// so materialise-and-bind any deferred constant argument first.
+		for (auto* arg : op->getInputArguments()) {
+			if (!frame.contains(arg->getIdentifier())) {
+				frame.setValue(arg->getIdentifier(), regOperand(arg, frame));
+			}
+		}
 		IntrinsicCallContext ctx {cc, op, frame};
 		if ((*intrinsic)(ctx)) {
 			return;
@@ -1084,6 +1313,15 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 		sig.addArg(getTypeId(arg->getStamp()));
 	}
 
+	// Resolve argument registers BEFORE emitting the InvokeNode: a deferred
+	// constant rematerialises with a `mov reg, imm`, which must precede the
+	// call in the instruction stream.
+	std::vector<AsmReg> argRegs;
+	argRegs.reserve(op->getInputArguments().size());
+	for (auto* arg : op->getInputArguments()) {
+		argRegs.push_back(regOperand(arg, frame));
+	}
+
 	InvokeNode* invokeNode = nullptr;
 	auto it = funcNodes_.find(op->getFunctionName());
 	if (it != funcNodes_.end()) {
@@ -1094,12 +1332,11 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 		cc.invoke(&invokeNode, reinterpret_cast<uint64_t>(op->getFunctionPtr()), sig);
 	}
 
-	for (size_t i = 0; i < op->getInputArguments().size(); i++) {
-		auto argReg = frame.getValue(op->getInputArguments()[i]->getIdentifier());
-		if (std::holds_alternative<Xmm>(argReg))
-			invokeNode->setArg(i, toXmm(argReg));
+	for (size_t i = 0; i < argRegs.size(); i++) {
+		if (std::holds_alternative<Xmm>(argRegs[i]))
+			invokeNode->setArg(i, toXmm(argRegs[i]));
 		else
-			invokeNode->setArg(i, toGp(argReg));
+			invokeNode->setArg(i, toGp(argRegs[i]));
 	}
 
 	if (op->getStamp() != Type::v) {
@@ -1127,18 +1364,25 @@ void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCall
 	}
 
 	// The function pointer is a runtime GP register value.
-	auto fnPtrGp = toGp(frame.getValue(op->getFunctionPtrOperand()->getIdentifier()));
+	auto fnPtrGp = gpOperand(op->getFunctionPtrOperand(), frame);
+
+	// Resolve argument registers BEFORE emitting the InvokeNode (see
+	// visitProxyCall): rematerialisation movs must precede the call.
+	const auto inputArgs = op->getInputArguments();
+	std::vector<AsmReg> argRegs;
+	argRegs.reserve(inputArgs.size());
+	for (auto* arg : inputArgs) {
+		argRegs.push_back(regOperand(arg, frame));
+	}
 
 	InvokeNode* invokeNode = nullptr;
 	cc.invoke(&invokeNode, fnPtrGp, sig);
 
-	const auto inputArgs = op->getInputArguments();
-	for (size_t i = 0; i < inputArgs.size(); i++) {
-		auto argReg = frame.getValue(inputArgs[i]->getIdentifier());
-		if (std::holds_alternative<Xmm>(argReg))
-			invokeNode->setArg(i, toXmm(argReg));
+	for (size_t i = 0; i < argRegs.size(); i++) {
+		if (std::holds_alternative<Xmm>(argRegs[i]))
+			invokeNode->setArg(i, toXmm(argRegs[i]));
 		else
-			invokeNode->setArg(i, toGp(argReg));
+			invokeNode->setArg(i, toGp(argRegs[i]));
 	}
 
 	if (op->getStamp() != Type::v) {
@@ -1172,7 +1416,14 @@ void AsmJitLoweringProvider::LoweringContext::visitFunctionAddressOf(ir::Functio
 // ── Type conversion ───────────────────────────────────────────────────────────
 
 void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, RegisterFrame& frame) {
-	auto src = frame.getValue(op->getInput()->getIdentifier());
+	// An integer cast of a constant chain is itself a deferred constant (see
+	// foldableConstValue); emit nothing and let consumers fold or
+	// rematerialise the pre-computed value. Bound identifiers double as
+	// merge-block parameters and must still be written (issue #321).
+	if (enableConstFolding_ && !frame.contains(op->getIdentifier()) && foldableConstValue(op).has_value()) {
+		return;
+	}
+	auto src = regOperand(op->getInput(), frame);
 	const Type srcType = op->getInput()->getStamp();
 	const Type dstType = op->getStamp();
 	auto result = allocReg(dstType);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -11,6 +11,7 @@
 #include "nautilus/compiler/ir/blocks/BasicBlockInvocation.hpp"
 #include "nautilus/options.hpp"
 #include <asmjit/x86.h>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -101,9 +102,15 @@ private:
 		const ir::CompareOperation* pendingFusedCompare_ = nullptr;
 		/// Gates the compare→branch fusion (option `asmjit.enableBranchFusion`).
 		bool enableBranchFusion_ = true;
+		/// Gates constant deferral + immediate folding (option
+		/// `asmjit.enableConstFolding`). When on, integer/bool/ptr constants
+		/// are not materialised at their definition; consumers either fold
+		/// them as immediate operands or rematerialise them per use.
+		bool enableConstFolding_ = true;
 		/// Statistics sink shared with the rest of the pipeline; may be null.
 		CompilationStatistics* statistics_ = nullptr;
 		int64_t fusedBranches_ = 0;
+		int64_t foldedImmediates_ = 0;
 		/// Pointer registers for the current function's alloca slots, indexed
 		/// by AllocaOperation::getIndex(). Materialised once in the function
 		/// prologue from FunctionOperation::getAllocaSpecs(); cleared per
@@ -134,6 +141,24 @@ private:
 
 		::asmjit::Label getOrCreateLabel(ir::BlockIdentifier blockId);
 		void emitMove(const AsmReg& dst, const AsmReg& src);
+
+		// The canonical 64-bit register pattern of an integer-like constant
+		// operation (sign-extended for signed stamps, zero-extended for
+		// unsigned/bool/ptr), or nullopt when @p in is not such a constant.
+		static std::optional<int64_t> foldableConstValue(const ir::Operation* in);
+		// Fetch @p in's GP register from the frame, or rematerialise a
+		// deferred constant into a fresh register (per use — a shared lazy
+		// binding would not dominate uses in sibling branches).
+		::asmjit::x86::Gp gpOperand(const ir::Operation* in, RegisterFrame& frame);
+		// Like gpOperand but preserves the GP/XMM distinction. Floats are
+		// never deferred, so the rematerialisation path is GP-only.
+		AsmReg regOperand(const ir::Operation* in, RegisterFrame& frame);
+		// The constant's canonical pattern when @p in is a deferred constant
+		// that fits a sign-extended imm32 operand; nullopt otherwise.
+		std::optional<int32_t> imm32Operand(const ir::Operation* in, RegisterFrame& frame);
+		// Move @p src's value into @p dst: a register move when bound, a
+		// direct `mov dst, imm` when @p src is a deferred constant.
+		void emitMoveFromOperand(const AsmReg& dst, const ir::Operation* src, RegisterFrame& frame);
 
 		// Bind an operation's freshly computed result to its SSA identifier.
 		// For a normal (single) definition this just records the register.

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -100,6 +100,10 @@ private:
 		/// compare's own lowering (cmp+setcc+movzx) is skipped and visitIf
 		/// emits a fused cmp+jcc instead.
 		const ir::CompareOperation* pendingFusedCompare_ = nullptr;
+		/// Deferred constant definitions of the current function, keyed by
+		/// identifier. Used to recover a constant through a stale input
+		/// pointer (see foldableConstValue).
+		std::unordered_map<ir::OperationIdentifier, const ir::Operation*> deferredConsts_;
 		/// Gates the compare→branch fusion (option `asmjit.enableBranchFusion`).
 		bool enableBranchFusion_ = true;
 		/// Gates constant deferral + immediate folding (option
@@ -148,7 +152,13 @@ private:
 		// The canonical 64-bit register pattern of an integer-like constant
 		// operation (sign-extended for signed stamps, zero-extended for
 		// unsigned/bool/ptr), or nullopt when @p in is not such a constant.
-		static std::optional<int64_t> foldableConstValue(const ir::Operation* in);
+		// Falls back to the deferred-constant definition recorded for @p in's
+		// identifier: the constant-folding IR pass rewires only some consumer
+		// kinds (binary ops, if, return, invocations), so cast/select/call/
+		// memory operands can still hold a stale pointer to the operation the
+		// constant replaced. Identifier-keyed frame reads used to paper over
+		// that; with deferral the definition must be recovered explicitly.
+		std::optional<int64_t> foldableConstValue(const ir::Operation* in, RegisterFrame& frame);
 		// Fetch @p in's GP register from the frame, or rematerialise a
 		// deferred constant into a fresh register (per use — a shared lazy
 		// binding would not dominate uses in sibling branches).

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -90,6 +90,20 @@ private:
 		std::unordered_map<std::string, ::asmjit::FuncNode*> funcNodes_;
 		std::unordered_map<ir::BlockIdentifier, ::asmjit::Label> blockLabels;
 		std::unordered_set<ir::BlockIdentifier> processedBlocks;
+		/// Static SSA usage counts for the current function (see ir::countUsages).
+		/// Only populated when branch fusion is enabled; used to prove that a
+		/// compare's sole consumer is the IfOperation that follows it.
+		std::unordered_map<ir::OperationIdentifier, uint32_t> usageCounts_;
+		/// Set by processBlock when the next dispatched operation is an
+		/// IfOperation that can consume this compare's EFLAGS directly. The
+		/// compare's own lowering (cmp+setcc+movzx) is skipped and visitIf
+		/// emits a fused cmp+jcc instead.
+		const ir::CompareOperation* pendingFusedCompare_ = nullptr;
+		/// Gates the compare→branch fusion (option `asmjit.enableBranchFusion`).
+		bool enableBranchFusion_ = true;
+		/// Statistics sink shared with the rest of the pipeline; may be null.
+		CompilationStatistics* statistics_ = nullptr;
+		int64_t fusedBranches_ = 0;
 		/// Pointer registers for the current function's alloca slots, indexed
 		/// by AllocaOperation::getIndex(). Materialised once in the function
 		/// prologue from FunctionOperation::getAllocaSpecs(); cleared per
@@ -138,6 +152,14 @@ private:
 
 		void processBlock(const ir::BasicBlock* block, RegisterFrame& frame);
 		void processBlockInvocation(const ir::BasicBlockInvocation& bi, RegisterFrame& frame);
+
+		// True when `cmp` may skip materialising its boolean because the
+		// immediately following IfOperation is its only consumer and can read
+		// the flags directly.
+		bool isFusibleCompare(const ir::CompareOperation* cmp, const ir::Operation* next, RegisterFrame& frame);
+		// Emit the compare and the negated conditional jump to @p falseTarget
+		// in place of the unfused cmp+setcc+movzx / test+jz sequence.
+		void emitFusedCompareBranch(const ir::CompareOperation* cmp, ::asmjit::Label falseTarget, RegisterFrame& frame);
 
 		// Per-operation hooks invoked by OperationDispatcher::dispatch.
 		void visitConstBoolean(ir::ConstBooleanOperation* op, RegisterFrame& frame);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -107,6 +107,9 @@ private:
 		/// are not materialised at their definition; consumers either fold
 		/// them as immediate operands or rematerialise them per use.
 		bool enableConstFolding_ = true;
+		/// Gates the branch-free select lowering via cmov (option
+		/// `asmjit.enableSelectCmov`).
+		bool enableSelectCmov_ = true;
 		/// Statistics sink shared with the rest of the pipeline; may be null.
 		CompilationStatistics* statistics_ = nullptr;
 		int64_t fusedBranches_ = 0;

--- a/nautilus/src/nautilus/compiler/ir/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/ir/CMakeLists.txt
@@ -5,4 +5,4 @@ add_subdirectory(passes)
 add_subdirectory(util)
 #add_subdirectory(Types)
 
-add_source_files(nautilus IRGraph.cpp)
+add_source_files(nautilus IRGraph.cpp Usages.cpp)

--- a/nautilus/src/nautilus/compiler/ir/Usages.cpp
+++ b/nautilus/src/nautilus/compiler/ir/Usages.cpp
@@ -1,0 +1,59 @@
+
+#include "nautilus/compiler/ir/Usages.hpp"
+#include "nautilus/compiler/ir/operations/BranchOperation.hpp"
+#include "nautilus/compiler/ir/operations/IfOperation.hpp"
+#include <unordered_set>
+#include <vector>
+
+namespace nautilus::compiler::ir {
+
+std::unordered_map<OperationIdentifier, uint32_t> countUsages(const BasicBlock* entryBlock) {
+	std::unordered_map<OperationIdentifier, uint32_t> usageCounts;
+	std::unordered_set<BlockIdentifier> visited;
+	std::vector<const BasicBlock*> worklist;
+	worklist.push_back(entryBlock);
+	visited.insert(entryBlock->getIdentifier());
+
+	auto countInput = [&usageCounts](const Operation* input) {
+		if (input != nullptr) {
+			usageCounts[input->getIdentifier()]++;
+		}
+	};
+
+	while (!worklist.empty()) {
+		const auto* block = worklist.back();
+		worklist.pop_back();
+		for (auto* opt : block->getOperations()) {
+			for (auto* input : opt->getInputs()) {
+				countInput(input);
+			}
+			if (auto* ifOp = dyn_cast<IfOperation>(opt)) {
+				for (auto* input : ifOp->getTrueBlockInvocation().getInputs()) {
+					countInput(input);
+				}
+				for (auto* input : ifOp->getFalseBlockInvocation().getInputs()) {
+					countInput(input);
+				}
+				auto* trueBlk = ifOp->getTrueBlockInvocation().getBlock();
+				auto* falseBlk = ifOp->getFalseBlockInvocation().getBlock();
+				if (trueBlk != nullptr && visited.insert(trueBlk->getIdentifier()).second) {
+					worklist.push_back(trueBlk);
+				}
+				if (falseBlk != nullptr && visited.insert(falseBlk->getIdentifier()).second) {
+					worklist.push_back(falseBlk);
+				}
+			} else if (auto* brOp = dyn_cast<BranchOperation>(opt)) {
+				for (auto* input : brOp->getNextBlockInvocation().getInputs()) {
+					countInput(input);
+				}
+				auto* next = brOp->getNextBlockInvocation().getBlock();
+				if (next != nullptr && visited.insert(next->getIdentifier()).second) {
+					worklist.push_back(next);
+				}
+			}
+		}
+	}
+	return usageCounts;
+}
+
+} // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/Usages.hpp
+++ b/nautilus/src/nautilus/compiler/ir/Usages.hpp
@@ -1,0 +1,27 @@
+
+#pragma once
+
+#include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
+#include "nautilus/compiler/ir/operations/Operation.hpp"
+#include <cstdint>
+#include <unordered_map>
+
+namespace nautilus::compiler::ir {
+
+/**
+ * @brief Counts one use per static SSA reference for every operation
+ * reachable from @p entryBlock.
+ *
+ * Walks every reachable block and accumulates one use per static reference.
+ * Operation::getInputs() gives the SSA operand span uniformly — the only
+ * values that live outside that span are the arguments attached to the
+ * BasicBlockInvocations embedded in IfOperation/BranchOperation terminators,
+ * which are visited explicitly.
+ *
+ * Backends use the result to decide whether a value's materialisation can be
+ * folded into its sole consumer (e.g. fusing a compare into the conditional
+ * branch that reads it).
+ */
+std::unordered_map<OperationIdentifier, uint32_t> countUsages(const BasicBlock* entryBlock);
+
+} // namespace nautilus::compiler::ir

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -212,6 +212,26 @@ TEST_CASE("Execution Benchmark") {
 			    });
 		}
 	}
+
+	// AsmJit-only A/B benchmark for constant deferral + immediate folding
+	// (asmjit.enableConstFolding). Most visible where loop bodies contain
+	// constant operands (i = i + 1, cmp i, n).
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (bool fold : {false, true}) {
+			std::string tag = fold ? "constFold" : "noConstFold";
+			Catch::Benchmark::Benchmark("exec_asmjit_" + name + "_" + tag)
+			    .operator=([&func, fold](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("asmjit"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("asmjit.enableConstFolding", fold);
+				    func(meter, op);
+			    });
+		}
+	}
 #endif
 }
 

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -190,6 +190,29 @@ TEST_CASE("Execution Benchmark") {
 		}
 	}
 #endif
+
+#ifdef ENABLE_ASMJIT_BACKEND
+	// AsmJit-only A/B benchmark for the compare→branch fusion in the lowering
+	// (asmjit.enableBranchFusion). Most visible on branch-heavy loops
+	// (fibonacci), where fusion removes the setcc+movzx+test round-trip per
+	// iteration.
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (bool fusion : {false, true}) {
+			std::string tag = fusion ? "branchFusion" : "noBranchFusion";
+			Catch::Benchmark::Benchmark("exec_asmjit_" + name + "_" + tag)
+			    .operator=([&func, fusion](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("asmjit"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("asmjit.enableBranchFusion", fusion);
+				    func(meter, op);
+			    });
+		}
+	}
+#endif
 }
 
 } // namespace nautilus::engine

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -232,6 +232,27 @@ TEST_CASE("Execution Benchmark") {
 			    });
 		}
 	}
+
+	// AsmJit-only comparison of the lowering baseline against all lowering
+	// optimizations stacked (branch fusion + const folding + select cmov).
+	for (auto& test : benchmarks) {
+		auto func = std::get<1>(test);
+		auto name = std::get<0>(test);
+		for (bool allOpts : {false, true}) {
+			std::string tag = allOpts ? "allOpts" : "baseline";
+			Catch::Benchmark::Benchmark("exec_asmjit_" + name + "_" + tag)
+			    .operator=([&func, allOpts](Catch::Benchmark::Chronometer meter) {
+				    auto op = engine::Options();
+				    op.setOption("mlir.eager_compilation", true);
+				    op.setOption("engine.backend", std::string("asmjit"));
+				    op.setOption("engine.traceMode", "lazyTracing");
+				    op.setOption("asmjit.enableBranchFusion", allOpts);
+				    op.setOption("asmjit.enableConstFolding", allOpts);
+				    op.setOption("asmjit.enableSelectCmov", allOpts);
+				    func(meter, op);
+			    });
+		}
+	}
 #endif
 }
 

--- a/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
+++ b/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
@@ -1,0 +1,228 @@
+
+#include "ExecutionTest.hpp"
+#include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include <catch2/catch_all.hpp>
+
+// Tests for the optional instruction-selection optimizations in the AsmJit
+// lowering (asmjit.enableBranchFusion, ...). forEachBackend only exercises
+// the default (all optimizations on), so this test pins two things:
+//   1. Integration probe: for workloads that provably contain the target
+//      patterns, `fn.getStatistics()` exposes non-zero counters under the
+//      `asmjit.lowering.*` namespace, proving the optimization actually fires
+//      through the Engine path.
+//   2. Differential correctness: compiling the same function with each
+//      optimization enabled vs. disabled must produce identical results for
+//      every input we probe. This is the safety net against the optimized
+//      lowering paths silently diverging from the reference paths.
+
+namespace nautilus::engine {
+
+#ifdef ENABLE_ASMJIT_BACKEND
+#ifdef ENABLE_TRACING
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+
+namespace {
+
+// Loop whose header compare feeds only the loop branch — the canonical
+// branch-fusion candidate (mirrors the fibonacci benchmark kernel).
+val<int32_t> fibLike(val<int32_t> n) {
+	val<int32_t> a = 0, b = 1, c = 0;
+	for (val<int32_t> i = 2; i <= n; i = i + 1) {
+		c = a + b;
+		a = b;
+		b = c;
+	}
+	return b;
+}
+
+// Signed and unsigned comparators across both if-arms; every comparator kind
+// must pick the correctly negated jcc when fused.
+val<int32_t> compareLadder(val<int32_t> x, val<uint32_t> u) {
+	val<int32_t> r = 0;
+	if (x < 10) {
+		r = r + 1;
+	}
+	if (x <= -3) {
+		r = r + 2;
+	}
+	if (x > 100) {
+		r = r + 4;
+	}
+	if (x >= 0) {
+		r = r + 8;
+	}
+	if (x == 42) {
+		r = r + 16;
+	}
+	if (x != 7) {
+		r = r + 32;
+	}
+	if (u < val<uint32_t>(5u)) {
+		r = r + 64;
+	}
+	if (u >= val<uint32_t>(0x80000000u)) {
+		r = r + 128;
+	}
+	return r;
+}
+
+// The compare's boolean is consumed by two separate branches, so fusion
+// must NOT fire and the materialised boolean must still be produced.
+val<int32_t> compareWithTwoUses(val<int32_t> x, val<int32_t> y) {
+	val<bool> c = x < y;
+	val<int32_t> r = 0;
+	if (c) {
+		r = 10;
+	}
+	if (c) {
+		r = r + 1;
+	}
+	return r;
+}
+
+// Regression pin (differential fuzzer, see test/fuzz/README.md): a wrapped
+// narrow unsigned subtraction feeding an unsigned compare — the compare must
+// see the re-normalised (zero-extended) value even on the fused path.
+val<uint32_t> u32WrapSubCompare(val<uint32_t> x, val<uint32_t> y) {
+	val<uint32_t> wrapped = x - val<uint32_t>(4279714710u);
+	val<uint32_t> result = 0u;
+	if (wrapped <= y) {
+		result = 1u;
+	}
+	return result;
+}
+
+// Regression pin (issue #321 shape): merge-block parameter reusing an SSA
+// identifier that one arm re-defines. Guards the isFusibleCompare bail-out
+// for identifiers that double as merge parameters.
+val<uint64_t> zeroTripMergeAddConstant(val<uint64_t> c, val<uint64_t> p) {
+	val<uint64_t> result = p;
+	if (c != val<uint64_t>(static_cast<uint64_t>(0))) {
+		val<uint64_t> acc = static_cast<uint64_t>(0);
+		for (val<int32_t> i = 0; i < val<int32_t>(0); i = i + 1) {
+			acc = acc + val<uint64_t>(static_cast<uint64_t>(1));
+		}
+		result = acc;
+	}
+	return result + val<uint64_t>(static_cast<uint64_t>(119));
+}
+
+// Float compares must stay on the unfused path (parity-flag handling); this
+// pins that they still work while fusion handles the surrounding loop.
+val<int32_t> floatThreshold(val<double> x) {
+	val<int32_t> n = 0;
+	for (val<int32_t> i = 0; i < 4; i = i + 1) {
+		if (x > 1.5) {
+			n = n + 1;
+		}
+		x = x + 1.0;
+	}
+	return n;
+}
+
+engine::NautilusEngine makeAsmJitEngine(bool enableBranchFusion) {
+	return nautilus::testing::makeEngine("asmjit", [enableBranchFusion](engine::Options& opts) {
+		opts.setOption("asmjit.enableBranchFusion", enableBranchFusion);
+		opts.setOption("engine.traceMode", "lazyTracing");
+		// Force the legacy (non-tiered) path so stats land on the same
+		// executable we query here (see PostRAPeepholeTest for details).
+		opts.setOption("engine.compilationStrategy", std::string("legacy"));
+	});
+}
+
+int64_t getCounter(const std::shared_ptr<const compiler::CompilationStatistics>& stats, const std::string& key) {
+	REQUIRE(stats != nullptr);
+	const auto* value = stats->find(key);
+	if (value == nullptr) {
+		return 0;
+	}
+	REQUIRE(std::holds_alternative<int64_t>(*value));
+	return std::get<int64_t>(*value);
+}
+
+} // namespace
+
+TEST_CASE("AsmJit branch fusion: publishes counters via CompilationStatistics") {
+	auto engine = makeAsmJitEngine(true);
+	auto fn = engine.registerFunction(fibLike);
+	REQUIRE(fn(10) == 55);
+	auto stats = fn.getStatistics();
+	REQUIRE(stats != nullptr);
+	// The loop-header compare feeds only the loop branch, so at least one
+	// compare must have been fused.
+	REQUIRE(getCounter(stats, "asmjit.lowering.fusedBranches") >= 1);
+}
+
+TEST_CASE("AsmJit branch fusion: disabling suppresses counter emission") {
+	auto engine = makeAsmJitEngine(false);
+	auto fn = engine.registerFunction(fibLike);
+	REQUIRE(fn(10) == 55);
+	auto stats = fn.getStatistics();
+	REQUIRE(stats != nullptr);
+	REQUIRE(stats->find("asmjit.lowering.fusedBranches") == nullptr);
+}
+
+TEST_CASE("AsmJit branch fusion: differential correctness across inputs") {
+	auto fibOn = makeAsmJitEngine(true).registerFunction(fibLike);
+	auto fibOff = makeAsmJitEngine(false).registerFunction(fibLike);
+	for (int32_t n : {0, 1, 2, 3, 10, 30, 1000}) {
+		INFO("fibLike differential n=" << n);
+		REQUIRE(fibOn(n) == fibOff(n));
+	}
+
+	auto ladderOn = makeAsmJitEngine(true).registerFunction(compareLadder);
+	auto ladderOff = makeAsmJitEngine(false).registerFunction(compareLadder);
+	for (int32_t x : {-100, -3, -1, 0, 7, 10, 42, 100, 101, INT32_MIN, INT32_MAX}) {
+		for (uint32_t u : {0u, 4u, 5u, 0x7FFFFFFFu, 0x80000000u, 0xFFFFFFFFu}) {
+			INFO("compareLadder differential x=" << x << " u=" << u);
+			REQUIRE(ladderOn(x, u) == ladderOff(x, u));
+		}
+	}
+
+	auto twoUsesOn = makeAsmJitEngine(true).registerFunction(compareWithTwoUses);
+	auto twoUsesOff = makeAsmJitEngine(false).registerFunction(compareWithTwoUses);
+	for (int32_t x : {-5, 0, 3}) {
+		for (int32_t y : {-5, 0, 3}) {
+			INFO("compareWithTwoUses differential x=" << x << " y=" << y);
+			REQUIRE(twoUsesOn(x, y) == twoUsesOff(x, y));
+		}
+	}
+}
+
+TEST_CASE("AsmJit branch fusion: pinned fuzzer regressions stay correct") {
+	auto wrapOn = makeAsmJitEngine(true).registerFunction(u32WrapSubCompare);
+	auto wrapOff = makeAsmJitEngine(false).registerFunction(u32WrapSubCompare);
+	for (uint32_t x : {0u, 1u, 4279714709u, 4279714710u, 4279714711u, 0xFFFFFFFFu}) {
+		for (uint32_t y : {0u, 15252586u, 0xFFFFFFFFu}) {
+			INFO("u32WrapSubCompare differential x=" << x << " y=" << y);
+			REQUIRE(wrapOn(x, y) == wrapOff(x, y));
+		}
+	}
+
+	auto mergeOn = makeAsmJitEngine(true).registerFunction(zeroTripMergeAddConstant);
+	auto mergeOff = makeAsmJitEngine(false).registerFunction(zeroTripMergeAddConstant);
+	for (uint64_t c : {uint64_t(0), uint64_t(1), uint64_t(42)}) {
+		for (uint64_t p : {uint64_t(0), uint64_t(7), uint64_t(1) << 60}) {
+			INFO("zeroTripMergeAddConstant differential c=" << c << " p=" << p);
+			REQUIRE(mergeOn(c, p) == mergeOff(c, p));
+			REQUIRE(mergeOn(c, p) == (c != 0 ? uint64_t(119) : p + 119));
+		}
+	}
+}
+
+TEST_CASE("AsmJit branch fusion: float compares keep the unfused path") {
+	auto fnOn = makeAsmJitEngine(true).registerFunction(floatThreshold);
+	auto fnOff = makeAsmJitEngine(false).registerFunction(floatThreshold);
+	for (double x : {-2.0, 0.0, 1.5, 1.6, 100.0}) {
+		INFO("floatThreshold differential x=" << x);
+		REQUIRE(fnOn(x) == fnOff(x));
+	}
+}
+
+#endif // !__aarch64__ && !_M_ARM64
+#endif // ENABLE_TRACING
+#endif // ENABLE_ASMJIT_BACKEND
+
+} // namespace nautilus::engine

--- a/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
+++ b/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
@@ -122,9 +122,59 @@ val<int32_t> floatThreshold(val<double> x) {
 	return n;
 }
 
-engine::NautilusEngine makeAsmJitEngine(bool enableBranchFusion) {
-	return nautilus::testing::makeEngine("asmjit", [enableBranchFusion](engine::Options& opts) {
+// Constant-heavy arithmetic mixing every foldable immediate site (add, sub,
+// imul, shift, and/or/xor, compare) across signed and unsigned widths,
+// including a constant outside the sign-extended imm32 range that must be
+// rematerialised instead of folded.
+val<int64_t> constArithMix(val<int64_t> x, val<uint32_t> u) {
+	val<int64_t> a = x + 7;
+	val<int64_t> b = a - 100;
+	val<int64_t> c = b * 3;
+	val<int64_t> d = c ^ 0x55;
+	val<int64_t> e = d & 0x0F0F;
+	val<int64_t> f = e | 0x11;
+	val<int64_t> g = f << 3;
+	val<int64_t> h = g >> 2;
+	val<int64_t> big = x + 0x123456789LL; // does not fit imm32 -> rematerialised
+	val<uint32_t> uw = u * 5u + 4279714710u;
+	val<int64_t> r = h + big + static_cast<val<int64_t>>(uw);
+	if (r > -1000000) {
+		r = r + 1;
+	}
+	return r;
+}
+
+// A constant LEFT operand of a fused compare (the static-loop iteration
+// shape): the fused branch lowering must rematerialise the deferred constant
+// instead of reading it through the frame.
+val<int32_t> constLeftCompare(val<int32_t> t) {
+	val<int32_t> r = 0;
+	if (val<int32_t>(6) > t) {
+		r = r + 1;
+	}
+	if (val<int32_t>(-3) <= t) {
+		r = r + 2;
+	}
+	return r;
+}
+
+// Narrow-width wrap-around with constant operands: the folded immediate must
+// produce the same canonically extended register pattern as the
+// materialise-then-operate path.
+val<int32_t> i8ConstWrap(val<int8_t> x) {
+	val<int8_t> y = x + (int8_t) 100; // wraps for x > 27
+	val<int8_t> z = y - (int8_t) 5;
+	val<int32_t> r = 0;
+	if (z < (int8_t) 0) {
+		r = 1;
+	}
+	return r + static_cast<val<int32_t>>(z);
+}
+
+engine::NautilusEngine makeAsmJitEngine(bool enableBranchFusion, bool enableConstFolding = true) {
+	return nautilus::testing::makeEngine("asmjit", [enableBranchFusion, enableConstFolding](engine::Options& opts) {
 		opts.setOption("asmjit.enableBranchFusion", enableBranchFusion);
+		opts.setOption("asmjit.enableConstFolding", enableConstFolding);
 		opts.setOption("engine.traceMode", "lazyTracing");
 		// Force the legacy (non-tiered) path so stats land on the same
 		// executable we query here (see PostRAPeepholeTest for details).
@@ -218,6 +268,77 @@ TEST_CASE("AsmJit branch fusion: float compares keep the unfused path") {
 	for (double x : {-2.0, 0.0, 1.5, 1.6, 100.0}) {
 		INFO("floatThreshold differential x=" << x);
 		REQUIRE(fnOn(x) == fnOff(x));
+	}
+}
+
+TEST_CASE("AsmJit const folding: publishes counters via CompilationStatistics") {
+	auto engine = makeAsmJitEngine(true, true);
+	auto fn = engine.registerFunction(constArithMix);
+	fn(1, 1u);
+	auto stats = fn.getStatistics();
+	REQUIRE(stats != nullptr);
+	REQUIRE(getCounter(stats, "asmjit.lowering.foldedImmediates") >= 5);
+
+	auto off = makeAsmJitEngine(true, false);
+	auto fnOff = off.registerFunction(constArithMix);
+	fnOff(1, 1u);
+	auto statsOff = fnOff.getStatistics();
+	REQUIRE(statsOff != nullptr);
+	REQUIRE(statsOff->find("asmjit.lowering.foldedImmediates") == nullptr);
+}
+
+TEST_CASE("AsmJit const folding: differential correctness across inputs") {
+	auto mixOn = makeAsmJitEngine(true, true).registerFunction(constArithMix);
+	auto mixOff = makeAsmJitEngine(true, false).registerFunction(constArithMix);
+	for (int64_t x : {int64_t(-1000000), int64_t(-1), int64_t(0), int64_t(1), int64_t(12345), INT64_MAX / 2}) {
+		for (uint32_t u : {0u, 1u, 858993459u, 0xFFFFFFFFu}) {
+			INFO("constArithMix differential x=" << x << " u=" << u);
+			REQUIRE(mixOn(x, u) == mixOff(x, u));
+		}
+	}
+
+	auto wrapOn = makeAsmJitEngine(true, true).registerFunction(i8ConstWrap);
+	auto wrapOff = makeAsmJitEngine(true, false).registerFunction(i8ConstWrap);
+	for (int32_t x = -128; x <= 127; x++) {
+		INFO("i8ConstWrap differential x=" << x);
+		REQUIRE(wrapOn(static_cast<int8_t>(x)) == wrapOff(static_cast<int8_t>(x)));
+	}
+
+	auto leftOn = makeAsmJitEngine(true, true).registerFunction(constLeftCompare);
+	auto leftOff = makeAsmJitEngine(true, false).registerFunction(constLeftCompare);
+	for (int32_t t : {-100, -3, -2, 0, 5, 6, 7, 100}) {
+		INFO("constLeftCompare differential t=" << t);
+		REQUIRE(leftOn(t) == leftOff(t));
+		REQUIRE(leftOn(t) == ((6 > t ? 1 : 0) + (-3 <= t ? 2 : 0)));
+	}
+
+	// Both optimizations off vs both on -- the full-stack differential.
+	auto allOn = makeAsmJitEngine(true, true).registerFunction(fibLike);
+	auto allOff = makeAsmJitEngine(false, false).registerFunction(fibLike);
+	for (int32_t n : {0, 1, 2, 10, 1000}) {
+		INFO("fibLike all-opts differential n=" << n);
+		REQUIRE(allOn(n) == allOff(n));
+	}
+}
+
+TEST_CASE("AsmJit const folding: pinned fuzzer regressions stay correct") {
+	auto wrapOn = makeAsmJitEngine(true, true).registerFunction(u32WrapSubCompare);
+	auto wrapOff = makeAsmJitEngine(true, false).registerFunction(u32WrapSubCompare);
+	for (uint32_t x : {0u, 1u, 4279714709u, 4279714710u, 4279714711u, 0xFFFFFFFFu}) {
+		for (uint32_t y : {0u, 15252586u, 0xFFFFFFFFu}) {
+			INFO("u32WrapSubCompare const-fold differential x=" << x << " y=" << y);
+			REQUIRE(wrapOn(x, y) == wrapOff(x, y));
+		}
+	}
+
+	auto mergeOn = makeAsmJitEngine(true, true).registerFunction(zeroTripMergeAddConstant);
+	auto mergeOff = makeAsmJitEngine(true, false).registerFunction(zeroTripMergeAddConstant);
+	for (uint64_t c : {uint64_t(0), uint64_t(1), uint64_t(42)}) {
+		for (uint64_t p : {uint64_t(0), uint64_t(7), uint64_t(1) << 60}) {
+			INFO("zeroTripMergeAddConstant const-fold differential c=" << c << " p=" << p);
+			REQUIRE(mergeOn(c, p) == mergeOff(c, p));
+			REQUIRE(mergeOn(c, p) == (c != 0 ? uint64_t(119) : p + 119));
+		}
 	}
 }
 

--- a/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
+++ b/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
@@ -159,6 +159,16 @@ val<int32_t> constLeftCompare(val<int32_t> t) {
 	return r;
 }
 
+// Regression (differential fuzzer): a BAND of two constants folds to a
+// constant in the IR pass, but the cast consuming it keeps a stale pointer
+// to the replaced operation (the pass rewires only binary/if/return/
+// invocation inputs). The lowering must recover the constant by identifier
+// from the deferred-constant registry instead of throwing.
+val<int32_t> foldedConstShiftCount(val<int32_t> x) {
+	val<uint8_t> shift = val<uint8_t>((uint8_t) 202) & val<uint8_t>((uint8_t) 7);
+	return x >> shift;
+}
+
 // Narrow-width wrap-around with constant operands: the folded immediate must
 // produce the same canonically extended register pattern as the
 // materialise-then-operate path.
@@ -326,6 +336,14 @@ TEST_CASE("AsmJit const folding: differential correctness across inputs") {
 		INFO("constLeftCompare differential t=" << t);
 		REQUIRE(leftOn(t) == leftOff(t));
 		REQUIRE(leftOn(t) == ((6 > t ? 1 : 0) + (-3 <= t ? 2 : 0)));
+	}
+
+	auto staleOn = makeAsmJitEngine(true, true).registerFunction(foldedConstShiftCount);
+	auto staleOff = makeAsmJitEngine(true, false).registerFunction(foldedConstShiftCount);
+	for (int32_t x : {-1024, -1, 0, 1, 12345, INT32_MAX}) {
+		INFO("foldedConstShiftCount differential x=" << x);
+		REQUIRE(staleOn(x) == staleOff(x));
+		REQUIRE(staleOn(x) == (x >> 2));
 	}
 
 	// Both optimizations off vs both on -- the full-stack differential.

--- a/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
+++ b/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
@@ -2,6 +2,7 @@
 #include "ExecutionTest.hpp"
 #include "nautilus/CompilationStatistics.hpp"
 #include "nautilus/Engine.hpp"
+#include "nautilus/select.hpp"
 #include "nautilus/val.hpp"
 #include <catch2/catch_all.hpp>
 
@@ -171,15 +172,30 @@ val<int32_t> i8ConstWrap(val<int8_t> x) {
 	return r + static_cast<val<int32_t>>(z);
 }
 
-engine::NautilusEngine makeAsmJitEngine(bool enableBranchFusion, bool enableConstFolding = true) {
-	return nautilus::testing::makeEngine("asmjit", [enableBranchFusion, enableConstFolding](engine::Options& opts) {
-		opts.setOption("asmjit.enableBranchFusion", enableBranchFusion);
-		opts.setOption("asmjit.enableConstFolding", enableConstFolding);
-		opts.setOption("engine.traceMode", "lazyTracing");
-		// Force the legacy (non-tiered) path so stats land on the same
-		// executable we query here (see PostRAPeepholeTest for details).
-		opts.setOption("engine.compilationStrategy", std::string("legacy"));
-	});
+// Integer and float selects: the integer ones take the cmov path, the float
+// one must stay on the branchy path.
+val<int64_t> selectMix(val<int64_t> x, val<int64_t> y) {
+	val<int64_t> lo = select(x < y, x, y);
+	val<int64_t> hi = select(x < y, y, x);
+	return hi - lo + select(x == y, val<int64_t>(100), val<int64_t>(0));
+}
+
+val<double> selectFloatKernel(val<bool> c, val<double> a, val<double> b) {
+	return select(c, a, b);
+}
+
+engine::NautilusEngine makeAsmJitEngine(bool enableBranchFusion, bool enableConstFolding = true,
+                                        bool enableSelectCmov = true) {
+	return nautilus::testing::makeEngine(
+	    "asmjit", [enableBranchFusion, enableConstFolding, enableSelectCmov](engine::Options& opts) {
+		    opts.setOption("asmjit.enableBranchFusion", enableBranchFusion);
+		    opts.setOption("asmjit.enableConstFolding", enableConstFolding);
+		    opts.setOption("asmjit.enableSelectCmov", enableSelectCmov);
+		    opts.setOption("engine.traceMode", "lazyTracing");
+		    // Force the legacy (non-tiered) path so stats land on the same
+		    // executable we query here (see PostRAPeepholeTest for details).
+		    opts.setOption("engine.compilationStrategy", std::string("legacy"));
+	    });
 }
 
 int64_t getCounter(const std::shared_ptr<const compiler::CompilationStatistics>& stats, const std::string& key) {
@@ -339,6 +355,27 @@ TEST_CASE("AsmJit const folding: pinned fuzzer regressions stay correct") {
 			REQUIRE(mergeOn(c, p) == mergeOff(c, p));
 			REQUIRE(mergeOn(c, p) == (c != 0 ? uint64_t(119) : p + 119));
 		}
+	}
+}
+
+TEST_CASE("AsmJit select cmov: differential correctness across inputs") {
+	auto mixOn = makeAsmJitEngine(true, true, true).registerFunction(selectMix);
+	auto mixOff = makeAsmJitEngine(true, true, false).registerFunction(selectMix);
+	for (int64_t x : {int64_t(-100), int64_t(-1), int64_t(0), int64_t(1), int64_t(42), INT64_MAX / 2}) {
+		for (int64_t y : {int64_t(-100), int64_t(0), int64_t(42), int64_t(7000)}) {
+			INFO("selectMix differential x=" << x << " y=" << y);
+			REQUIRE(mixOn(x, y) == mixOff(x, y));
+			const int64_t expected = std::abs(x - y) + (x == y ? 100 : 0);
+			REQUIRE(mixOn(x, y) == expected);
+		}
+	}
+
+	auto fOn = makeAsmJitEngine(true, true, true).registerFunction(selectFloatKernel);
+	auto fOff = makeAsmJitEngine(true, true, false).registerFunction(selectFloatKernel);
+	for (bool c : {false, true}) {
+		INFO("selectFloatKernel differential c=" << c);
+		REQUIRE(fOn(c, 1.5, -2.5) == fOff(c, 1.5, -2.5));
+		REQUIRE(fOn(c, 1.5, -2.5) == (c ? 1.5 : -2.5));
 	}
 }
 

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -2,6 +2,7 @@ include(CTest)
 include(Catch)
 set(NAUTILUS_EXECUTION_TEST_SOURCES
         ExecutionTest.cpp
+        AsmJitLoweringModeTest.cpp
         BCDispatchModeTest.cpp
         BCRegisterCoalescingTest.cpp
         BoolExecutionTest.cpp


### PR DESCRIPTION
## Summary

Instruction-selection optimizations for the AsmJit x86-64 lowering, targeting the hot-loop patterns in the execution benchmarks (`exec_asmjit_{add,fibonacci,sum}`) and the `comp_asmjit_*` compilation-time rows:

1. **Compare→branch fusion** (`asmjit.enableBranchFusion`, default on) — a compare whose only consumer is the immediately following `IfOperation` now emits a single `cmp+jcc` instead of `cmp+setcc+movzx` followed by `test+jz`. The single-consumer proof reuses the BC backend's static usage-count walk, extracted into a shared `ir::countUsages` helper. Statistics counter: `asmjit.lowering.fusedBranches`.
2. **Constant deferral + immediate folding** (`asmjit.enableConstFolding`, default on) — integer/bool/ptr constants (including the `cast_to` chains the tracer wraps them in) are no longer materialised at their definition. Consumers fold them into immediate forms (`add/sub/imul/cmp/and/or/xor` and immediate shift counts) when the canonical value fits a sign-extended imm32, and rematerialise per use otherwise; dead constants vanish entirely. Constant operands are always recovered from the operation itself, never through the frame, so a merge-block parameter binding that shares the constant's SSA identifier (the issue #321 shape) cannot shadow it. Statistics counter: `asmjit.lowering.foldedImmediates`.
3. **Smarter block-argument parallel copies** — self-moves emit nothing, only sources that alias a destination register detour through a temp, and deferred constants are written as `mov dst, imm` — roughly halving the moves on loop back edges.
4. **Branch-free selects** (`asmjit.enableSelectCmov`, default on) — integer selects lower to `test+cmov` (mirroring the A64 backend's `csel`); float selects keep the branchy path.
5. **Float constants via ConstPool** — one RIP-relative `movss/movsd` from the local constant pool instead of a GP temp plus `movd/movq`.

All options follow the existing `asmjit.enablePostRAPeephole` pattern so each optimization can be A/B benchmarked and disabled independently; `docs/options.md` documents the new flags.

## Benchmark results

Measured by the CI benchmark workflow on this PR (`25009156` vs `main`/`6c74bdd`):

| Benchmark | main | this PR | speedup |
|---|---|---|---|
| `exec_asmjit_fibonacci` | 21.74 µs | 14.38 µs | **1.51×** |
| `exec_asmjit_sum` (10 MiB i32 reduction) | 5.27 ms | 2.81 ms | **1.88×** |
| `exec_asmjit_add` | 3.57 ns | 3.60 ns | 1.00× (call-overhead bound) |

`comp_asmjit_*` compilation times did not regress. New A/B rows in `ExecutionBenchmark.cpp` (`exec_asmjit_*_{branchFusion,noBranchFusion}`, `_{constFold,noConstFold}`) give per-optimization attribution inside one binary, mirroring the BC backend's pattern.

## Correctness notes

- Fusion requires adjacency (compare directly before the `if`), so no EFLAGS-liveness reasoning is needed — nothing can clobber the flags between `cmp` and `jcc`.
- Deferred constants are canonicalised (sign/zero-extended per stamp) to exactly the 64-bit register pattern the eager materialisation produces, so the register-content invariant is identical on both paths.
- Call lowering resolves argument registers before emitting the `InvokeNode`, so rematerialisation `mov`s precede the call; intrinsic handlers read the frame directly, so deferred constant arguments are materialised-and-bound before dispatching to them.
- The differential fuzzer's smoke corpus caught one real bug in the deferral design before merge: `ConstantFoldingAndCopyPropagationPass` rewires only binary/if/return/invocation consumer inputs when folding, so cast/select/call/memory operands can hold a **stale pointer** to the operation a constant replaced — identifier-keyed frame reads papered over this before deferral. Fixed by recording deferred constant definitions per function and letting `foldableConstValue` fall back to that registry by identifier; pinned by a regression kernel in `AsmJitLoweringModeTest.cpp`. The underlying IR-pass wart is tracked in #327.
- The scoped-out redundant-narrowing elimination (per-op `movsx/movzx` after narrow arithmetic) is intentionally not touched — fuzzing previously found several correctness bugs in exactly that invariant (`test/fuzz/README.md`).

## Testing

- New `AsmJitLoweringModeTest.cpp` (modeled on `PostRAPeepholeTest.cpp`): statistics integration probes plus differential on/off correctness across all comparator kinds, narrow-width wrap-around, imm32 range boundaries, constant-left fused compares, selects, the stale-pointer fold shape, and the pinned fuzzer regressions (`u32WrapSubThenCompare`, `zeroTripLoopMergeThenAddConstant` shapes).
- Full `ctest` suite passes (209 tests) with the optimizations on by default, so every `forEachBackend` test exercises the new codegen.
- `nautilus-fuzz-replay` smoke corpus: 2000/2000 programs agree across all backends + interpreter. A 5000-input `--survey` run reports one asmjit disagreement — `(f32)(huge u64)` saturating to 2^63 via `cvttss2si` in the float→u64 cast — which **reproduces identically on unmodified `main`** (pre-existing, unrelated to this PR; tracked in #328).
- A64 backend is untouched; the shared `ir::countUsages` helper is placed so the A64 ports are a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTeVc9UNPZPDezpVKZgi

---
_Generated by [Claude Code](https://claude.ai/code/session_014svTeVc9UNPZPDezpVKZgi)_