### PR TITLE
Fix float→uint64 cast overflow in AsmJit x64 backend

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -1501,14 +1501,51 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 	} else if (srcIsFloat && !dstIsFloat) {
 		// Float → integer: truncate toward zero, then narrow to the destination
 		// width so the value is defined by its low dstWidth bits (see the
-		// integer→integer path above). Mirrors A64LoweringProvider::visitCast.
+		// integer→integer path above). Mirrors A64LoweringProvider::visitCast
+		// (which uses fcvtzu/fcvtzs and needs no ui64 special case).
 		auto gDst = toGp(result);
 		auto xSrc = toXmm(src);
-		if (srcType == Type::f32)
-			cc.cvttss2si(gDst.r64(), xSrc);
-		else
-			cc.cvttsd2si(gDst.r64(), xSrc);
-		narrowToStamp(gDst, dstType);
+		if (dstType == Type::ui64) {
+			// cvttss2si/cvttsd2si is signed; inputs in [2^63, 2^64) would
+			// overflow to the indefinite value 2^63 (issue #328). Standard
+			// unsigned sequence: below 2^63 convert directly; otherwise
+			// subtract 2^63 in the float domain (exact, 2^63 is representable
+			// in f32 and f64), convert, and set bit 63 back. Narrower unsigned
+			// destinations fit the signed conversion and need no special case.
+			Label big = cc.newLabel();
+			Label done = cc.newLabel();
+			if (srcType == Type::f32) {
+				auto threshold = cc.newFloatConst(ConstPoolScope::kLocal, 9223372036854775808.0f);
+				cc.ucomiss(xSrc, threshold);
+				cc.jae(big);
+				cc.cvttss2si(gDst.r64(), xSrc);
+				cc.jmp(done);
+				cc.bind(big);
+				auto xAdj = cc.newXmmSs();
+				cc.movss(xAdj, xSrc);
+				cc.subss(xAdj, threshold);
+				cc.cvttss2si(gDst.r64(), xAdj);
+			} else {
+				auto threshold = cc.newDoubleConst(ConstPoolScope::kLocal, 9223372036854775808.0);
+				cc.ucomisd(xSrc, threshold);
+				cc.jae(big);
+				cc.cvttsd2si(gDst.r64(), xSrc);
+				cc.jmp(done);
+				cc.bind(big);
+				auto xAdj = cc.newXmmSd();
+				cc.movsd(xAdj, xSrc);
+				cc.subsd(xAdj, threshold);
+				cc.cvttsd2si(gDst.r64(), xAdj);
+			}
+			cc.btc(gDst.r64(), 63);
+			cc.bind(done);
+		} else {
+			if (srcType == Type::f32)
+				cc.cvttss2si(gDst.r64(), xSrc);
+			else
+				cc.cvttsd2si(gDst.r64(), xSrc);
+			narrowToStamp(gDst, dstType);
+		}
 	} else if (!srcIsFloat && dstIsFloat) {
 		// Integer → float.
 		auto gSrc = toGp(src);

--- a/nautilus/test/execution-tests/CastExecutionTest.cpp
+++ b/nautilus/test/execution-tests/CastExecutionTest.cpp
@@ -183,11 +183,39 @@ void narrowCastSignTest(engine::NautilusEngine& engine) {
 	checkNarrowCastSign<int64_t, int8_t>(engine, "i64_to_i8", {0, 127, 128, 255, 256});
 }
 
+// Regression for the AsmJit x64 float→uint64 lowering (issue #328). The
+// backend emitted the signed cvttss2si/cvttsd2si for every integer
+// destination, so inputs in [2^63, 2^64) overflowed to the "integer
+// indefinite" value 2^63 instead of converting. All inputs stay below 2^64:
+// converting larger values to uint64_t is undefined behavior, so the native
+// reference would be undefined too.
+template <typename In>
+void checkFloatToUi64(engine::NautilusEngine& engine, std::string name, std::initializer_list<In> inputs) {
+	DYNAMIC_SECTION(name) {
+		auto f = engine.registerFunction(staticCastExpression<In, uint64_t>);
+		for (In in : inputs) {
+			REQUIRE(f(in) == static_cast<uint64_t>(in));
+		}
+	}
+}
+
+void floatToUnsignedCastTest(engine::NautilusEngine& engine) {
+	// Values straddling the 2^63 boundary where the signed conversion overflows.
+	checkFloatToUi64<float>(engine, "f32_to_ui64",
+	                        {0.0f, 1.5f, 4294967296.0f /*2^32*/, 4611686018427387904.0f /*2^62*/,
+	                         9223372036854775808.0f /*2^63*/, 16500484545456129080.0f /*issue #328 fuzz value*/,
+	                         18446742974197923840.0f /*largest f32 < 2^64*/});
+	checkFloatToUi64<double>(engine, "f64_to_ui64",
+	                         {0.0, 1.5, 4294967296.0, 4611686018427387904.0, 9223372036854775808.0,
+	                          16500484545456129080.0, 18446744073709549568.0 /*largest f64 < 2^64*/});
+}
+
 TEST_CASE("Cast Interpreter Test") {
 	auto engine = nautilus::testing::makeEngine("interpreter");
 	castTest(engine);
 	ptrCastTest(engine);
 	narrowCastSignTest(engine);
+	floatToUnsignedCastTest(engine);
 }
 
 #ifdef ENABLE_TRACING
@@ -201,6 +229,11 @@ TEST_CASE("Pointer Cast Compiler Test") {
 
 TEST_CASE("Narrowing Cast Sign Compiler Test") {
 	nautilus::testing::forEachBackendWithTraceMode([](engine::NautilusEngine& engine) { narrowCastSignTest(engine); });
+}
+
+TEST_CASE("Float To Unsigned Cast Compiler Test") {
+	nautilus::testing::forEachBackendWithTraceMode(
+	    [](engine::NautilusEngine& engine) { floatToUnsignedCastTest(engine); });
 }
 #endif
 } // namespace nautilus::engine


### PR DESCRIPTION
Fixes #328.

## Problem

`X64LoweringProvider::visitCast`'s float→integer path always emitted the signed truncating conversion (`cvttss2si`/`cvttsd2si` into a 64-bit GP register) for every integer destination, including `ui64`. For float inputs in `[2^63, 2^64)` the signed conversion overflows and x86 returns the "integer indefinite" value `0x8000000000000000`, silently miscompiling `(uint64_t)(float)` casts. Found by `nautilus-fuzz-replay --survey`; only the AsmJit x86-64 backend diverged from the native oracle.

## Fix

For `ui64` destinations, emit the standard pre-AVX512 unsigned conversion sequence (what C++ compilers generate):

1. compare the input against `2^63` (`ucomiss`/`ucomisd` against a constant-pool value);
2. below → `cvttss2si`/`cvttsd2si` directly;
3. at/above → copy, subtract `2^63` in the float domain (exact: `2^63` is representable in both f32 and f64), convert signed, then set bit 63 back with `btc`.

Narrower unsigned destinations (`ui8/ui16/ui32`) keep the existing path: their full value range fits the signed 64-bit conversion and `narrowToStamp` re-normalizes. Negative and NaN inputs take the direct path (their conversion to `uint64_t` is UB in C++, matching native codegen behavior). Constant folding is unaffected: `foldableConstValue` only folds int→int casts, so all float→int casts go through this runtime path.

**A64 audited per the issue:** `A64LoweringProvider::visitCast` already emits `fcvtzu` for unsigned destinations and needs no change.

## Regression test

Adds `floatToUnsignedCastTest` in `CastExecutionTest.cpp`: `f32→ui64` and `f64→ui64` casts across the `2^63` boundary (including the fuzz-reported value `16500484545456129080` and the largest representable values below `2^64`), run on the interpreter and — via `forEachBackendWithTraceMode` — every enabled backend in both trace modes, pinning x64 and A64 to the same observable behavior.

## Verification

- Before the fix, the new test fails on asmjit exactly as reported: `got 9223372036854775808 (0x8000000000000000)` for inputs above `2^63`; all other backends pass.
- After the fix, the new test passes on all backends, and the full test suite passes (202/202).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DswLWGsGKZ1E8pvqWn9Ahk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DswLWGsGKZ1E8pvqWn9Ahk)_