### PR TITLE
Rewire all consumer input edges in constant folding pass (#327)

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -258,8 +258,7 @@ int64_t canonicalizeToStamp(int64_t value, Type stamp) {
 }
 } // anonymous namespace
 
-std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstValue(const ir::Operation* in,
-                                                                                   RegisterFrame& frame) {
+std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstValue(const ir::Operation* in) {
 	if (const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(in)) {
 		return canonicalizeToStamp(constInt->getValue(), constInt->getStamp());
 	}
@@ -278,21 +277,9 @@ std::optional<int64_t> AsmJitLoweringProvider::LoweringContext::foldableConstVal
 		const Type srcType = cast->getInput()->getStamp();
 		const Type dstType = cast->getStamp();
 		if (!isFloatType(srcType) && !isFloatType(dstType)) {
-			if (const auto inner = foldableConstValue(cast->getInput(), frame)) {
+			if (const auto inner = foldableConstValue(cast->getInput())) {
 				return canonicalizeToStamp(*inner, dstType);
 			}
-		}
-		return std::nullopt;
-	}
-	// Stale input pointer (see the header comment): the constant-folding IR
-	// pass rewires only binary/if/return/invocation consumers, so this input
-	// edge can still point at the operation a constant replaced. When the
-	// identifier is unbound and resolves to a deferred constant definition,
-	// that constant carries the identifier's value.
-	if (!frame.contains(in->getIdentifier())) {
-		const auto it = deferredConsts_.find(in->getIdentifier());
-		if (it != deferredConsts_.end() && it->second != in) {
-			return foldableConstValue(it->second, frame);
 		}
 	}
 	return std::nullopt;
@@ -305,7 +292,7 @@ Gp AsmJitLoweringProvider::LoweringContext::gpOperand(const ir::Operation* in, R
 	// paths (issue #321), while an SSA input edge to a constant operation
 	// always means that constant.
 	if (enableConstFolding_) {
-		if (const auto value = foldableConstValue(in, frame)) {
+		if (const auto value = foldableConstValue(in)) {
 			auto reg = cc.newInt64();
 			cc.mov(reg, *value);
 			return reg;
@@ -316,18 +303,17 @@ Gp AsmJitLoweringProvider::LoweringContext::gpOperand(const ir::Operation* in, R
 
 AsmJitLoweringProvider::AsmReg AsmJitLoweringProvider::LoweringContext::regOperand(const ir::Operation* in,
                                                                                    RegisterFrame& frame) {
-	if (enableConstFolding_ && foldableConstValue(in, frame).has_value()) {
+	if (enableConstFolding_ && foldableConstValue(in).has_value()) {
 		return AsmReg(gpOperand(in, frame));
 	}
 	return frame.getValue(in->getIdentifier());
 }
 
-std::optional<int32_t> AsmJitLoweringProvider::LoweringContext::imm32Operand(const ir::Operation* in,
-                                                                             RegisterFrame& frame) {
+std::optional<int32_t> AsmJitLoweringProvider::LoweringContext::imm32Operand(const ir::Operation* in) {
 	if (!enableConstFolding_) {
 		return std::nullopt;
 	}
-	const auto value = foldableConstValue(in, frame);
+	const auto value = foldableConstValue(in);
 	if (!value.has_value() || *value < INT32_MIN || *value > INT32_MAX) {
 		return std::nullopt;
 	}
@@ -337,7 +323,7 @@ std::optional<int32_t> AsmJitLoweringProvider::LoweringContext::imm32Operand(con
 void AsmJitLoweringProvider::LoweringContext::emitMoveFromOperand(const AsmReg& dst, const ir::Operation* src,
                                                                   RegisterFrame& frame) {
 	if (enableConstFolding_) {
-		if (const auto value = foldableConstValue(src, frame)) {
+		if (const auto value = foldableConstValue(src)) {
 			cc.mov(toGp(dst), *value);
 			return;
 		}
@@ -385,7 +371,6 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 		blockLabels.clear();
 		processedBlocks.clear();
 		functionAllocaSlots_.clear();
-		deferredConsts_.clear();
 
 		// Static usage counts feed the compare→branch fusion decision; only
 		// pay for the walk when the fusion is enabled.
@@ -551,7 +536,7 @@ void AsmJitLoweringProvider::LoweringContext::processBlockInvocation(const ir::B
 		SourceValue source;
 		// Constant sources are recovered from the operation itself (see
 		// gpOperand for why a frame binding must not shadow a constant).
-		const auto value = enableConstFolding_ ? foldableConstValue(srcArgs[i], frame) : std::optional<int64_t> {};
+		const auto value = enableConstFolding_ ? foldableConstValue(srcArgs[i]) : std::optional<int64_t> {};
 		if (value.has_value()) {
 			source.imm = *value;
 		} else {
@@ -622,7 +607,6 @@ void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBoolean
 	// A bound identifier doubles as a merge-block parameter register (issue
 	// #321) that must be written, so those keep the materialising path.
 	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
-		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto reg = allocReg(Type::b);
@@ -632,7 +616,6 @@ void AsmJitLoweringProvider::LoweringContext::visitConstBoolean(ir::ConstBoolean
 
 void AsmJitLoweringProvider::LoweringContext::visitConstInt(ir::ConstIntOperation* op, RegisterFrame& frame) {
 	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
-		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto reg = allocReg(op->getStamp());
@@ -657,7 +640,6 @@ void AsmJitLoweringProvider::LoweringContext::visitConstFloat(ir::ConstFloatOper
 
 void AsmJitLoweringProvider::LoweringContext::visitConstPtr(ir::ConstPtrOperation* op, RegisterFrame& frame) {
 	if (enableConstFolding_ && !frame.contains(op->getIdentifier())) {
-		deferredConsts_[op->getIdentifier()] = op;
 		return;
 	}
 	auto reg = allocReg(Type::ptr);
@@ -682,10 +664,10 @@ void AsmJitLoweringProvider::LoweringContext::visitAdd(ir::AddOperation* op, Reg
 		auto gDst = toGp(result);
 		// Fold a small-constant operand into the add's immediate form
 		// (add is commutative, so either side qualifies).
-		const auto rightImm = imm32Operand(op->getRightInput(), frame);
+		const auto rightImm = imm32Operand(op->getRightInput());
 		std::optional<int32_t> leftImm;
 		if (!rightImm.has_value()) {
-			leftImm = imm32Operand(op->getLeftInput(), frame);
+			leftImm = imm32Operand(op->getLeftInput());
 		}
 		if (rightImm.has_value()) {
 			cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
@@ -722,7 +704,7 @@ void AsmJitLoweringProvider::LoweringContext::visitSub(ir::SubOperation* op, Reg
 	} else {
 		auto gDst = toGp(result);
 		cc.mov(gDst, gpOperand(op->getLeftInput(), frame));
-		if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+		if (const auto rightImm = imm32Operand(op->getRightInput())) {
 			cc.sub(gDst, *rightImm);
 			foldedImmediates_++;
 		} else {
@@ -748,10 +730,10 @@ void AsmJitLoweringProvider::LoweringContext::visitMul(ir::MulOperation* op, Reg
 		auto gDst = toGp(result);
 		// Fold a small-constant operand via the three-operand imul form
 		// (commutative, so either side qualifies).
-		const auto rightImm = imm32Operand(op->getRightInput(), frame);
+		const auto rightImm = imm32Operand(op->getRightInput());
 		std::optional<int32_t> leftImm;
 		if (!rightImm.has_value()) {
-			leftImm = imm32Operand(op->getLeftInput(), frame);
+			leftImm = imm32Operand(op->getLeftInput());
 		}
 		if (rightImm.has_value()) {
 			cc.imul(gDst, gpOperand(op->getLeftInput(), frame), *rightImm);
@@ -889,7 +871,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 		const auto* rightConst = ir::dyn_cast<ir::ConstIntOperation>(op->getRightInput());
 		if (rightConst != nullptr && rightConst->getValue() == 0) {
 			cc.test(left, left);
-		} else if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+		} else if (const auto rightImm = imm32Operand(op->getRightInput())) {
 			cc.cmp(left, *rightImm);
 			foldedImmediates_++;
 		} else {
@@ -947,7 +929,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation*
 void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, RegisterFrame& frame) {
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), gpOperand(op->getLeftInput(), frame));
-	if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+	if (const auto rightImm = imm32Operand(op->getRightInput())) {
 		cc.and_(toGp(result), *rightImm);
 		foldedImmediates_++;
 	} else {
@@ -959,7 +941,7 @@ void AsmJitLoweringProvider::LoweringContext::visitAnd(ir::AndOperation* op, Reg
 void AsmJitLoweringProvider::LoweringContext::visitOr(ir::OrOperation* op, RegisterFrame& frame) {
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), gpOperand(op->getLeftInput(), frame));
-	if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+	if (const auto rightImm = imm32Operand(op->getRightInput())) {
 		cc.or_(toGp(result), *rightImm);
 		foldedImmediates_++;
 	} else {
@@ -1000,7 +982,7 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 	// A constant count uses the immediate shift form. The hardware masks the
 	// count mod 64 for 64-bit shifts, exactly like the CL-register form, so
 	// masking here preserves the register-form semantics.
-	if (const auto countImm = imm32Operand(op->getRightInput(), frame)) {
+	if (const auto countImm = imm32Operand(op->getRightInput())) {
 		const uint32_t count = static_cast<uint32_t>(*countImm) & 63u;
 		if (op->getType() == ir::ShiftOperation::LS) {
 			cc.shl(gDst, count);
@@ -1037,7 +1019,7 @@ void AsmJitLoweringProvider::LoweringContext::visitShift(ir::ShiftOperation* op,
 void AsmJitLoweringProvider::LoweringContext::visitBinaryComp(ir::BinaryCompOperation* op, RegisterFrame& frame) {
 	auto result = allocReg(op->getStamp());
 	cc.mov(toGp(result), gpOperand(op->getLeftInput(), frame));
-	if (const auto rightImm = imm32Operand(op->getRightInput(), frame)) {
+	if (const auto rightImm = imm32Operand(op->getRightInput())) {
 		switch (op->getType()) {
 		case ir::BinaryCompOperation::BAND:
 			cc.and_(toGp(result), *rightImm);
@@ -1138,7 +1120,7 @@ void AsmJitLoweringProvider::LoweringContext::emitFusedCompareBranch(const ir::C
 	const auto* rightConst = ir::dyn_cast<ir::ConstIntOperation>(cmp->getRightInput());
 	if (rightConst != nullptr && rightConst->getValue() == 0) {
 		cc.test(left, left);
-	} else if (const auto rightImm = imm32Operand(cmp->getRightInput(), frame)) {
+	} else if (const auto rightImm = imm32Operand(cmp->getRightInput())) {
 		cc.cmp(left, *rightImm);
 		foldedImmediates_++;
 	} else {
@@ -1467,8 +1449,7 @@ void AsmJitLoweringProvider::LoweringContext::visitCast(ir::CastOperation* op, R
 	// foldableConstValue); emit nothing and let consumers fold or
 	// rematerialise the pre-computed value. Bound identifiers double as
 	// merge-block parameters and must still be written (issue #321).
-	if (enableConstFolding_ && !frame.contains(op->getIdentifier()) && foldableConstValue(op, frame).has_value()) {
-		deferredConsts_[op->getIdentifier()] = op;
+	if (enableConstFolding_ && !frame.contains(op->getIdentifier()) && foldableConstValue(op).has_value()) {
 		return;
 	}
 	auto src = regOperand(op->getInput(), frame);

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -100,10 +100,6 @@ private:
 		/// compare's own lowering (cmp+setcc+movzx) is skipped and visitIf
 		/// emits a fused cmp+jcc instead.
 		const ir::CompareOperation* pendingFusedCompare_ = nullptr;
-		/// Deferred constant definitions of the current function, keyed by
-		/// identifier. Used to recover a constant through a stale input
-		/// pointer (see foldableConstValue).
-		std::unordered_map<ir::OperationIdentifier, const ir::Operation*> deferredConsts_;
 		/// Gates the compare→branch fusion (option `asmjit.enableBranchFusion`).
 		bool enableBranchFusion_ = true;
 		/// Gates constant deferral + immediate folding (option
@@ -151,14 +147,11 @@ private:
 
 		// The canonical 64-bit register pattern of an integer-like constant
 		// operation (sign-extended for signed stamps, zero-extended for
-		// unsigned/bool/ptr), or nullopt when @p in is not such a constant.
-		// Falls back to the deferred-constant definition recorded for @p in's
-		// identifier: the constant-folding IR pass rewires only some consumer
-		// kinds (binary ops, if, return, invocations), so cast/select/call/
-		// memory operands can still hold a stale pointer to the operation the
-		// constant replaced. Identifier-keyed frame reads used to paper over
-		// that; with deferral the definition must be recovered explicitly.
-		std::optional<int64_t> foldableConstValue(const ir::Operation* in, RegisterFrame& frame);
+		// unsigned/bool/ptr) or of an integer cast of a constant chain, or
+		// nullopt when @p in is not such a constant. The constant-folding IR
+		// pass guarantees pointer-consistent input edges (issue #327), so the
+		// definition is always recovered from the operation pointer itself.
+		std::optional<int64_t> foldableConstValue(const ir::Operation* in);
 		// Fetch @p in's GP register from the frame, or rematerialise a
 		// deferred constant into a fresh register (per use — a shared lazy
 		// binding would not dominate uses in sibling branches).
@@ -168,7 +161,7 @@ private:
 		AsmReg regOperand(const ir::Operation* in, RegisterFrame& frame);
 		// The constant's canonical pattern when @p in is a deferred constant
 		// that fits a sign-extended imm32 operand; nullopt otherwise.
-		std::optional<int32_t> imm32Operand(const ir::Operation* in, RegisterFrame& frame);
+		std::optional<int32_t> imm32Operand(const ir::Operation* in);
 		// Move @p src's value into @p dst: a register move when bound, a
 		// direct `mov dst, imm` when @p src is a deferred constant.
 		void emitMoveFromOperand(const AsmReg& dst, const ir::Operation* src, RegisterFrame& frame);

--- a/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/Operation.hpp
@@ -147,6 +147,12 @@ public:
 		return inputs;
 	}
 
+	/// Replaces the SSA input at @p index. Lets IR passes rewire value edges
+	/// generically across every operation kind instead of via per-kind setters.
+	void setInput(std::size_t index, Operation* newInput) noexcept {
+		inputs[index] = newInput;
+	}
+
 	void setSourceTag(const tracing::Tag* tag) const noexcept {
 		sourceTag = tag;
 	}

--- a/nautilus/src/nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.cpp
@@ -13,12 +13,10 @@
 #include "nautilus/compiler/ir/operations/ConstFloatOperation.hpp"
 #include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
 #include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/operations/IfOperation.hpp"
 #include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
 #include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
 #include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
-#include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
 #include "nautilus/compiler/ir/util/ControlFlowUtil.hpp"
 #include <cstdint>
 #include <unordered_map>
@@ -351,16 +349,15 @@ Operation* tryFold(common::Arena& arena, Operation* op) {
 	}
 }
 
-/// Rewires one invocation's arguments so that every entry matching a key in
-/// @p replacements is swapped for the corresponding value. Takes a snapshot
-/// before mutating because `replaceArgument` walks the same arguments span.
-void propagateInInvocation(BasicBlockInvocation& inv, const std::unordered_map<Operation*, Operation*>& replacements) {
-	const auto args = inv.getArguments();
-	std::vector<Operation*> snapshot(args.begin(), args.end());
-	for (auto* arg : snapshot) {
-		auto it = replacements.find(arg);
-		if (it != replacements.end()) {
-			inv.replaceArgument(arg, it->second);
+/// Rewires every SSA input edge of @p op that matches a key in
+/// @p replacements. All operation kinds store their operands in the base
+/// Operation::inputs span (block-invocation arguments included), so this
+/// covers binary/cast/select/unary/load/store/call/if/return uniformly.
+void replaceInputs(Operation& op, const std::unordered_map<Operation*, Operation*>& replacements) {
+	const auto ins = op.getInputs();
+	for (size_t i = 0; i < ins.size(); ++i) {
+		if (auto it = replacements.find(ins[i]); it != replacements.end()) {
+			op.setInput(i, it->second);
 		}
 	}
 }
@@ -368,29 +365,12 @@ void propagateInInvocation(BasicBlockInvocation& inv, const std::unordered_map<O
 void propagateReplacements(FunctionOperation& fn, const std::unordered_map<Operation*, Operation*>& replacements) {
 	for (auto* block : fn.getBasicBlocks()) {
 		for (auto* op : block->getOperations()) {
-			if (auto* bin = dyn_cast<BinaryOperation>(op)) {
-				if (auto it = replacements.find(bin->getLeftInput()); it != replacements.end()) {
-					bin->setLeftInput(it->second);
-				}
-				if (auto it = replacements.find(bin->getRightInput()); it != replacements.end()) {
-					bin->setRightInput(it->second);
-				}
-			}
-			if (auto* ifOp = dyn_cast<IfOperation>(op)) {
-				if (auto it = replacements.find(ifOp->getBooleanValue()); it != replacements.end()) {
-					ifOp->setBooleanValue(it->second);
-				}
-			}
-			if (auto* retOp = dyn_cast<ReturnOperation>(op)) {
-				if (retOp->hasReturnValue()) {
-					if (auto it = replacements.find(retOp->getReturnValue()); it != replacements.end()) {
-						retOp->setReturnValue(it->second);
-					}
-				}
-			}
+			replaceInputs(*op, replacements);
+			// Invocation argument lists are embedded sub-objects of the
+			// terminator, not block operations, so they need their own walk.
 			for (auto* inv : getSuccessorInvocations(*op)) {
 				if (inv != nullptr) {
-					propagateInInvocation(*inv, replacements);
+					replaceInputs(*inv, replacements);
 				}
 			}
 		}

--- a/nautilus/src/nautilus/compiler/ir/passes/IRVerifier.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/IRVerifier.cpp
@@ -46,6 +46,36 @@ void verifyFunction(VerificationResult& r, const FunctionOperation& fn) {
 		ownedBlocks.insert(block);
 	}
 
+	// Every operation defined in this function: block operations plus block
+	// arguments. Input edges are checked against this set below — a pointer
+	// to anything else is stale, e.g. an operation a pass replaced and
+	// removed without rewiring its consumers (issue #327).
+	std::unordered_set<const Operation*> definedOps;
+	for (const auto* block : blocks) {
+		if (block == nullptr) {
+			continue;
+		}
+		for (const auto* op : block->getOperations()) {
+			definedOps.insert(op);
+		}
+		for (const auto* arg : block->getArguments()) {
+			definedOps.insert(arg);
+		}
+	}
+	const auto checkInputs = [&](const BasicBlock* block, const Operation* op, const char* what) {
+		for (const auto* input : op->getInputs()) {
+			if (input == nullptr) {
+				addError(r, &fn, block, fmt::format("{} {} has a null input", what, op->getIdentifier().toString()));
+				continue;
+			}
+			if (!definedOps.contains(input)) {
+				addError(r, &fn, block,
+				         fmt::format("{} {} input {} points at an operation not defined in function {}", what,
+				                     op->getIdentifier().toString(), input->getIdentifier().toString(), fn.getName()));
+			}
+		}
+	};
+
 	for (const auto* block : blocks) {
 		if (block == nullptr) {
 			continue;
@@ -65,6 +95,7 @@ void verifyFunction(VerificationResult& r, const FunctionOperation& fn) {
 			if (isTerminatorOp(op->getOperationType())) {
 				addError(r, &fn, block, fmt::format("terminator op at index {} but block length is {}", i, ops.size()));
 			}
+			checkInputs(block, op, "operation");
 		}
 		auto* terminator = ops.back();
 		if (terminator == nullptr) {
@@ -75,10 +106,12 @@ void verifyFunction(VerificationResult& r, const FunctionOperation& fn) {
 			addError(r, &fn, block, "block's last operation is not a terminator");
 			continue;
 		}
+		checkInputs(block, terminator, "terminator");
 
 		// Every outgoing invocation's target must be non-null and owned by
 		// this function. And the target must list this block as a predecessor.
 		for (auto* inv : getSuccessorInvocations(*terminator)) {
+			checkInputs(block, inv, "terminator invocation");
 			const auto* target = inv->getBlock();
 			if (target == nullptr) {
 				addError(r, &fn, block, "terminator invocation targets null block");

--- a/nautilus/src/nautilus/compiler/ir/passes/IRVerifier.hpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/IRVerifier.hpp
@@ -37,6 +37,9 @@ struct VerificationResult {
  *    terminators.
  *  - Every `BasicBlockInvocation` in a terminator targets a non-null
  *    block that is owned by the same function.
+ *  - Every operation input and invocation argument points at an operation
+ *    defined in the same function (a block operation or a block argument) —
+ *    no stale pointers to operations a pass replaced and removed (#327).
  *  - Every block listed as a target also lists the source block in its
  *    predecessor set (requires `rebuildPredecessorLists` to have run, or
  *    the wiring invariant to have been maintained by passes).

--- a/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
+++ b/nautilus/test/execution-tests/AsmJitLoweringModeTest.cpp
@@ -159,11 +159,11 @@ val<int32_t> constLeftCompare(val<int32_t> t) {
 	return r;
 }
 
-// Regression (differential fuzzer): a BAND of two constants folds to a
-// constant in the IR pass, but the cast consuming it keeps a stale pointer
-// to the replaced operation (the pass rewires only binary/if/return/
-// invocation inputs). The lowering must recover the constant by identifier
-// from the deferred-constant registry instead of throwing.
+// Regression (differential fuzzer, issue #327): a BAND of two constants
+// folds to a constant in the IR pass, and the cast consuming it must be
+// rewired to the replacement — a stale pointer to the dead BAND used to
+// make the lowering throw. Pins the pass-level fix end-to-end through the
+// backend's pointer-based constant recovery.
 val<int32_t> foldedConstShiftCount(val<int32_t> x) {
 	val<uint8_t> shift = val<uint8_t>((uint8_t) 202) & val<uint8_t>((uint8_t) 7);
 	return x >> shift;

--- a/nautilus/test/ir-pass-tests/ConstantFoldingAndCopyPropagationTest.cpp
+++ b/nautilus/test/ir-pass-tests/ConstantFoldingAndCopyPropagationTest.cpp
@@ -4,18 +4,26 @@
 #include "nautilus/compiler/ir/operations/ArithmeticOperations/DivOperation.hpp"
 #include "nautilus/compiler/ir/operations/ArithmeticOperations/ModOperation.hpp"
 #include "nautilus/compiler/ir/operations/ArithmeticOperations/MulOperation.hpp"
+#include "nautilus/compiler/ir/operations/BinaryOperations/BinaryCompOperation.hpp"
 #include "nautilus/compiler/ir/operations/BinaryOperations/ShiftOperation.hpp"
 #include "nautilus/compiler/ir/operations/BranchOperation.hpp"
+#include "nautilus/compiler/ir/operations/CastOperation.hpp"
 #include "nautilus/compiler/ir/operations/ConstBooleanOperation.hpp"
 #include "nautilus/compiler/ir/operations/ConstIntOperation.hpp"
 #include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
 #include "nautilus/compiler/ir/operations/LogicalOperations/AndOperation.hpp"
 #include "nautilus/compiler/ir/operations/LogicalOperations/CompareOperation.hpp"
+#include "nautilus/compiler/ir/operations/LogicalOperations/NotOperation.hpp"
+#include "nautilus/compiler/ir/operations/LogicalOperations/OrOperation.hpp"
+#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
 #include "nautilus/compiler/ir/operations/ReturnOperation.hpp"
+#include "nautilus/compiler/ir/operations/SelectOperation.hpp"
+#include "nautilus/compiler/ir/operations/StoreOperation.hpp"
 #include "nautilus/compiler/ir/passes/ConstantFoldingAndCopyPropagationPass.hpp"
 #include "nautilus/compiler/ir/passes/IRPassManager.hpp"
 #include "nautilus/options.hpp"
 #include <catch2/catch_all.hpp>
+#include <span>
 
 namespace nautilus::testing {
 
@@ -61,6 +69,10 @@ BasicBlock* entryBlock(IRGraph& ir) {
 
 void runPass(IRGraph& ir) {
 	engine::Options opts;
+	// Enforce pointer-consistent IR after the pass (issue #327): the verifier
+	// fails any input edge still pointing at a replaced, removed operation.
+	opts.setOption("ir.verifyAfterEachPass", true);
+	opts.setOption("ir.failOnVerifyError", true);
 	compiler::ir::IRPassManager mgr(opts);
 	mgr.addPass(std::make_unique<compiler::ir::ConstantFoldingAndCopyPropagationPass>());
 	mgr.run(ir);
@@ -400,6 +412,131 @@ TEST_CASE("ConstantFolding: boolean And folds") {
 	auto* folded = compiler::ir::dyn_cast<compiler::ir::ConstBooleanOperation>(ops[2]);
 	REQUIRE(folded != nullptr);
 	REQUIRE(folded->getValue() == false);
+}
+
+// Regression tests for issue #327: propagateReplacements must rewire EVERY
+// consumer kind's input pointer, not just binary/if/return/invocation inputs.
+// Each test folds an operation and asserts that the consumer's input edge is
+// the replacement constant itself (a stale pointer to the removed operation
+// would fail the dyn_cast and, since #327, IR verification). Found while
+// developing the AsmJit constant-deferral optimization (PR #326), whose
+// pointer-based operand recovery crashed on the stale edges.
+
+TEST_CASE("ConstantFolding: cast consumer is rewired to the folded constant (#327)") {
+	auto ir = std::make_shared<IRGraph>("cf-cast-consumer");
+	auto& arena = ir->getArena();
+	auto* entry = arena.create<BasicBlock>(arena, BlockIdentifier {0}, std::vector<BasicBlockArgument*> {});
+	// The issue's repro shape: `202u8 & 7u8` folds to 2, and the cast that
+	// widens the shift amount to i32 must consume the folded constant.
+	auto* c202 =
+	    entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {1}, int64_t {202}, Type::ui8);
+	auto* c7 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {2}, int64_t {7}, Type::ui8);
+	auto* band = entry->addOperation<compiler::ir::BinaryCompOperation>(OperationIdentifier {3}, c202, c7,
+	                                                                    compiler::ir::BinaryCompOperation::BAND);
+	auto* castOp = entry->addOperation<compiler::ir::CastOperation>(OperationIdentifier {4}, band, Type::i32);
+	entry->addOperation<compiler::ir::ReturnOperation>(castOp);
+	wrapInGraph(ir, entry);
+
+	runPass(*ir);
+
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::BinaryComp) == 0);
+	auto* folded = compiler::ir::dyn_cast<compiler::ir::ConstIntOperation>(castOp->getInput());
+	REQUIRE(folded != nullptr);
+	REQUIRE(folded->getValue() == 2);
+	REQUIRE(folded->getStamp() == Type::ui8);
+}
+
+TEST_CASE("ConstantFolding: select consumer is rewired on all three slots (#327)") {
+	auto ir = std::make_shared<IRGraph>("cf-select-consumer");
+	auto& arena = ir->getArena();
+	auto* entry = arena.create<BasicBlock>(arena, BlockIdentifier {0}, std::vector<BasicBlockArgument*> {});
+	auto* cT = entry->addOperation<compiler::ir::ConstBooleanOperation>(OperationIdentifier {1}, true);
+	auto* cF = entry->addOperation<compiler::ir::ConstBooleanOperation>(OperationIdentifier {2}, false);
+	auto* cond = entry->addOperation<compiler::ir::AndOperation>(OperationIdentifier {3}, cT, cF);
+	auto* c5 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {4}, int64_t {5}, Type::i32);
+	auto* c3 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {5}, int64_t {3}, Type::i32);
+	auto* tv = entry->addOperation<compiler::ir::AddOperation>(OperationIdentifier {6}, c5, c3);
+	auto* fv = entry->addOperation<compiler::ir::MulOperation>(OperationIdentifier {7}, c5, c3);
+	auto* sel = entry->addOperation<compiler::ir::SelectOperation>(OperationIdentifier {8}, cond, tv, fv, Type::i32);
+	entry->addOperation<compiler::ir::ReturnOperation>(sel);
+	wrapInGraph(ir, entry);
+
+	runPass(*ir);
+
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::AndOp) == 0);
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::AddOp) == 0);
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::MulOp) == 0);
+	auto* foldedCond = compiler::ir::dyn_cast<compiler::ir::ConstBooleanOperation>(sel->getCondition());
+	REQUIRE(foldedCond != nullptr);
+	REQUIRE(foldedCond->getValue() == false);
+	auto* foldedTrue = compiler::ir::dyn_cast<compiler::ir::ConstIntOperation>(sel->getTrueValue());
+	REQUIRE(foldedTrue != nullptr);
+	REQUIRE(foldedTrue->getValue() == 8);
+	auto* foldedFalse = compiler::ir::dyn_cast<compiler::ir::ConstIntOperation>(sel->getFalseValue());
+	REQUIRE(foldedFalse != nullptr);
+	REQUIRE(foldedFalse->getValue() == 15);
+}
+
+TEST_CASE("ConstantFolding: unary not consumer is rewired (#327)") {
+	auto ir = std::make_shared<IRGraph>("cf-not-consumer");
+	auto& arena = ir->getArena();
+	auto* entry = arena.create<BasicBlock>(arena, BlockIdentifier {0}, std::vector<BasicBlockArgument*> {});
+	auto* cT = entry->addOperation<compiler::ir::ConstBooleanOperation>(OperationIdentifier {1}, true);
+	auto* cF = entry->addOperation<compiler::ir::ConstBooleanOperation>(OperationIdentifier {2}, false);
+	auto* orOp = entry->addOperation<compiler::ir::OrOperation>(OperationIdentifier {3}, cT, cF);
+	auto* notOp = entry->addOperation<compiler::ir::NotOperation>(OperationIdentifier {4}, orOp);
+	entry->addOperation<compiler::ir::ReturnOperation>(notOp);
+	wrapInGraph(ir, entry, Type::b);
+
+	runPass(*ir);
+
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::OrOp) == 0);
+	auto* folded = compiler::ir::dyn_cast<compiler::ir::ConstBooleanOperation>(notOp->getInput());
+	REQUIRE(folded != nullptr);
+	REQUIRE(folded->getValue() == true);
+}
+
+TEST_CASE("ConstantFolding: store value consumer is rewired (#327)") {
+	auto ir = std::make_shared<IRGraph>("cf-store-consumer");
+	auto& arena = ir->getArena();
+	auto* ptrArg = arena.create<BasicBlockArgument>(OperationIdentifier {10}, Type::ptr);
+	auto* entry = arena.create<BasicBlock>(arena, BlockIdentifier {0}, std::vector<BasicBlockArgument*> {ptrArg});
+	auto* c5 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {1}, int64_t {5}, Type::i32);
+	auto* c3 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {2}, int64_t {3}, Type::i32);
+	auto* add = entry->addOperation<compiler::ir::AddOperation>(OperationIdentifier {3}, c5, c3);
+	auto* store = entry->addOperation<compiler::ir::StoreOperation>(add, ptrArg);
+	entry->addOperation<compiler::ir::ReturnOperation>();
+	wrapInGraph(ir, entry, Type::v);
+
+	runPass(*ir);
+
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::AddOp) == 0);
+	auto* folded = compiler::ir::dyn_cast<compiler::ir::ConstIntOperation>(store->getValue());
+	REQUIRE(folded != nullptr);
+	REQUIRE(folded->getValue() == 8);
+	REQUIRE(store->getAddress() == ptrArg);
+}
+
+TEST_CASE("ConstantFolding: proxy call argument is rewired (#327)") {
+	auto ir = std::make_shared<IRGraph>("cf-call-consumer");
+	auto& arena = ir->getArena();
+	auto* entry = arena.create<BasicBlock>(arena, BlockIdentifier {0}, std::vector<BasicBlockArgument*> {});
+	auto* c5 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {1}, int64_t {5}, Type::i32);
+	auto* c3 = entry->addOperation<compiler::ir::ConstIntOperation>(OperationIdentifier {2}, int64_t {3}, Type::i32);
+	auto* add = entry->addOperation<compiler::ir::AddOperation>(OperationIdentifier {3}, c5, c3);
+	Operation* callArgs[] = {add};
+	auto* call = entry->addOperation<compiler::ir::ProxyCallOperation>(
+	    OperationIdentifier {4}, std::span<Operation* const> {callArgs, 1}, Type::i32);
+	entry->addOperation<compiler::ir::ReturnOperation>(call);
+	wrapInGraph(ir, entry);
+
+	runPass(*ir);
+
+	REQUIRE(countOpsOfType(*ir, Operation::OperationType::AddOp) == 0);
+	REQUIRE(call->getInputArguments().size() == 1);
+	auto* folded = compiler::ir::dyn_cast<compiler::ir::ConstIntOperation>(call->getInputArguments()[0]);
+	REQUIRE(folded != nullptr);
+	REQUIRE(folded->getValue() == 8);
 }
 
 } // namespace nautilus::testing

--- a/nautilus/test/ir-pass-tests/IRVerifierTest.cpp
+++ b/nautilus/test/ir-pass-tests/IRVerifierTest.cpp
@@ -50,4 +50,34 @@ TEST_CASE("IRVerifier: chain-of-empty fixture is well-formed") {
 	REQUIRE(result.ok());
 }
 
+TEST_CASE("IRVerifier: input pointing at an operation outside the function is flagged (#327)") {
+	auto ir = std::make_shared<compiler::ir::IRGraph>("stale-input-test");
+	auto& arena = ir->getArena();
+	auto* entry = arena.create<compiler::ir::BasicBlock>(arena, compiler::ir::BlockIdentifier {0},
+	                                                     std::vector<compiler::ir::BasicBlockArgument*> {});
+	// A constant that lives in the arena but in no block's operation list —
+	// the shape a pass leaves behind when it removes an operation without
+	// rewiring its consumers (a stale input edge).
+	auto* detached =
+	    arena.create<compiler::ir::ConstIntOperation>(arena, compiler::ir::OperationIdentifier {1}, 7, Type::i32);
+	entry->addOperation<compiler::ir::ReturnOperation>(detached);
+
+	auto* fn =
+	    arena.create<compiler::ir::FunctionOperation>("execute", std::vector<compiler::ir::BasicBlock*> {entry},
+	                                                  std::vector<Type> {}, std::vector<std::string> {}, Type::i32);
+	ir->addFunctionOperation(fn);
+
+	compiler::ir::rebuildPredecessorLists(*ir);
+	auto result = compiler::ir::IRVerifier::verify(*ir);
+	REQUIRE_FALSE(result.ok());
+	bool found = false;
+	for (const auto& err : result.errors) {
+		if (err.message.find("not defined in function") != std::string::npos) {
+			found = true;
+			break;
+		}
+	}
+	REQUIRE(found);
+}
+
 } // namespace nautilus::testing


### PR DESCRIPTION
Fixes #327.

## Problem

`ConstantFoldingAndCopyPropagationPass::propagateReplacements` rewired only four consumer kinds after replacing an operation with a folded constant: `BinaryOperation` left/right inputs, `IfOperation`'s boolean, `ReturnOperation`'s value, and `BasicBlockInvocation` argument lists. Every other consumer — `CastOperation`, `SelectOperation`, `NotOperation`/`NegateOperation`, `LoadOperation`/`StoreOperation`, `ProxyCallOperation`/`IndirectCallOperation` — kept a stale `Operation*` input pointing at the dead, replaced operation. The bug was latent on `main` but broke the AsmJit constant-deferral optimization (#326), which had to work around it with a per-function `deferredConsts_` registry.

## Fix

**Generic rewiring.** Every operation kind stores its operands in the base `Operation::inputs` span — block-invocation arguments included (they are documented as real SSA value edges precisely so generic passes see them). `propagateReplacements` now does a single kind-agnostic walk: for each operation in each block, remap every `getInputs()` slot through the replacement map (via a new `Operation::setInput(index, op)` mutator), plus the same remap on each terminator's successor invocations (embedded sub-objects, not block operations). This is the same traversal shape `StrengthReductionPass::countConsumers` already uses read-only. The per-kind cases and the snapshot-based `propagateInInvocation` helper are deleted.

**Invariant pinned in the verifier.** `IRVerifier` gains an operand-definedness check: every operation input and invocation argument must point at an operation defined in the same function (a block operation or a block argument). A stale edge to a replaced-and-removed operation now fails verification under the existing opt-in flags (`ir.verifyAfterEachPass`, `ir.failOnVerifyError`), so no default-path cost.

**AsmJit workaround removed.** With pointer-consistent IR guaranteed, the `deferredConsts_` registry and the stale-pointer fallback in `foldableConstValue` are gone; constants are recovered purely from the operation pointer. `foldableConstValue`/`imm32Operand` drop their now-unused `RegisterFrame&` parameter. Constant deferral itself (skip materialisation of unbound constants, consumers fold or rematerialise) is unchanged.

## Tests

- New pass tests assert pointer identity of the consumer's input edge after folding, for each previously-unwired kind: cast (the issue's repro shape, `202u8 & 7u8` feeding a `cast_to i32`), select (all three slots), unary not, store value, and proxy-call argument.
- The constant-folding pass test helper now runs with `ir.verifyAfterEachPass` + `ir.failOnVerifyError`, so all existing and new pass tests enforce pointer-consistency.
- New `IRVerifier` test: an input pointing at an operation outside the function is flagged.
- The `foldedConstShiftCount` differential kernel in `AsmJitLoweringModeTest` keeps pinning the shape end-to-end through the backend, now exercising the pass-level fix instead of the removed registry.

All 207 tests pass locally (clang-18, Debug, MLIR backend off; CI covers the full matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c6CRUkpioCDkV12XASKmy

---
_Generated by [Claude Code](https://claude.ai/code/session_012c6CRUkpioCDkV12XASKmy)_