### PR TITLE
Add tbc backend: state-of-the-art tail-call-threaded bytecode interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_dependent_option(ENABLE_MLIR_BACKEND "Enable the MLIR compiler backend" ON
 cmake_dependent_option(NAUTILUS_DOWNLOAD_MLIR "Download pre-built MLIR binaries" ON "ENABLE_MLIR_BACKEND;NOT USE_EXTERNAL_MLIR" OFF)
 cmake_dependent_option(ENABLE_C_BACKEND "Enable the C compiler backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_BC_BACKEND "Enable the bytecode interpreter backend" ON "ENABLE_TRACING" OFF)
+cmake_dependent_option(ENABLE_TBC_BACKEND "Enable the threaded bytecode interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_ASMJIT_BACKEND "Enable the asmjit interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_SHORT_CIRCUIT_BOOL "Trace val<bool> && / || with C++ short-circuit semantics (drops the operator overloads so the built-in operators route through val<bool>::operator bool())" OFF "ENABLE_TRACING" OFF)
 
@@ -166,7 +167,7 @@ if (ENABLE_STACKTRACE)
 endif ()
 
 
-if (ENABLE_BC_BACKEND)
+if (ENABLE_BC_BACKEND OR ENABLE_TBC_BACKEND)
     add_subdirectory(${THIRD_PARTY_DIR}/dyncall)
     list(APPEND EXPORT_TARGETS dyncall_s)
 endif ()

--- a/nautilus/include/nautilus/Executable.hpp
+++ b/nautilus/include/nautilus/Executable.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <any>
+#include <cstdint>
+#include <cstring>
 #include <functional>
 #include <map>
 #include <memory>
@@ -30,6 +32,16 @@ public:
 		 * @return result
 		 */
 		virtual std::any invokeGeneric(const std::vector<std::any>& args) = 0;
+
+		/**
+		 * @brief Optional allocation-free fast path: arguments and result as
+		 * raw 64-bit slots (integers zero-extended, bools 0/1, floats and
+		 * pointers bit-exact). Returns false when unsupported, in which case
+		 * the caller falls back to invokeGeneric.
+		 */
+		virtual bool invokeRaw(const uint64_t* /*args*/, size_t /*argCount*/, uint64_t* /*result*/) {
+			return false;
+		}
 
 		void setGeneratedFiles(const std::map<std::string, std::string>& generatedFiles);
 
@@ -73,6 +85,138 @@ public:
 		std::any getGenericArg(T&& val) {
 			return std::any((std::underlying_type_t<std::remove_cvref_t<T>>) val);
 		}
+
+		/// Convert a boxed arithmetic result whose exact C++ type differs from
+		/// R. Backends box per nautilus IR type, but distinct C++ types share
+		/// one IR type (char vs int8_t; long vs long long for i64 depending on
+		/// the platform), so an exact any_cast cannot be relied upon.
+		template <typename T>
+		static T convertBoxedArithmetic(const std::any& res) {
+			if constexpr (std::is_integral_v<T>) {
+				if (const auto* v = std::any_cast<bool>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<char>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<signed char>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<unsigned char>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<short>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<unsigned short>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<int>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<unsigned int>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<long>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<unsigned long>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<long long>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<unsigned long long>(&res)) {
+					return static_cast<T>(*v);
+				}
+			} else {
+				if (const auto* v = std::any_cast<float>(&res)) {
+					return static_cast<T>(*v);
+				}
+				if (const auto* v = std::any_cast<double>(&res)) {
+					return static_cast<T>(*v);
+				}
+			}
+			throw std::bad_any_cast();
+		}
+
+		/// Whether T can travel through the raw 64-bit-slot fast path.
+		template <typename T>
+		static constexpr bool isRawSlotCompatible() {
+			using D = std::remove_cvref_t<T>;
+			return std::is_void_v<D> || std::is_enum_v<D> || std::is_pointer_v<D> || std::is_integral_v<D> ||
+			       std::is_same_v<D, float> || std::is_same_v<D, double>;
+		}
+
+		/// Normalize a value into a raw 64-bit slot (integers zero-extended,
+		/// bools 0/1, floats and pointers bit-exact) — the register-slot
+		/// convention shared by interpreting backends.
+		template <typename T>
+		static uint64_t toRawSlot(T value) {
+			using D = std::remove_cvref_t<T>;
+			if constexpr (std::is_enum_v<D>) {
+				return toRawSlot(static_cast<std::underlying_type_t<D>>(value));
+			} else if constexpr (std::is_pointer_v<D>) {
+				return reinterpret_cast<uint64_t>(value);
+			} else if constexpr (std::is_same_v<D, bool>) {
+				return value ? 1 : 0;
+			} else if constexpr (std::is_integral_v<D>) {
+				return static_cast<uint64_t>(static_cast<std::make_unsigned_t<D>>(value));
+			} else if constexpr (std::is_same_v<D, float>) {
+				uint32_t bits = 0;
+				std::memcpy(&bits, &value, sizeof(bits));
+				return bits;
+			} else {
+				static_assert(std::is_same_v<D, double>);
+				uint64_t bits = 0;
+				std::memcpy(&bits, &value, sizeof(bits));
+				return bits;
+			}
+		}
+
+		/// Read a raw 64-bit result slot as T (the low bits are authoritative
+		/// for narrow types).
+		template <typename T>
+		static T fromRawSlot(uint64_t raw) {
+			if constexpr (std::is_enum_v<T>) {
+				return static_cast<T>(fromRawSlot<std::underlying_type_t<T>>(raw));
+			} else if constexpr (std::is_pointer_v<T>) {
+				return reinterpret_cast<T>(raw);
+			} else if constexpr (std::is_same_v<T, bool>) {
+				return raw != 0;
+			} else if constexpr (std::is_integral_v<T>) {
+				return static_cast<T>(raw);
+			} else if constexpr (std::is_same_v<T, float>) {
+				float value;
+				const auto bits = static_cast<uint32_t>(raw);
+				std::memcpy(&value, &bits, sizeof(value));
+				return value;
+			} else {
+				static_assert(std::is_same_v<T, double>);
+				double value;
+				std::memcpy(&value, &raw, sizeof(value));
+				return value;
+			}
+		}
+
+		/// Unbox a generic invocation result as R. Handles enums (boxed as
+		/// their underlying type), pointers (boxed as void*), and arithmetic
+		/// results boxed as a same-width alias of R.
+		template <typename T>
+		static T castGenericResult(const std::any& res) {
+			if constexpr (std::is_enum_v<T>) {
+				return static_cast<T>(castGenericResult<std::underlying_type_t<T>>(res));
+			} else if constexpr (std::is_pointer_v<T>) {
+				return (T) std::any_cast<void*>(res);
+			} else if constexpr (std::is_arithmetic_v<T>) {
+				if (const T* exact = std::any_cast<T>(&res)) {
+					return *exact;
+				}
+				return convertBoxedArithmetic<T>(res);
+			} else {
+				return std::any_cast<T>(res);
+			}
+		}
 		/**
 		 * @brief Invoke the function with a set of arguments
 		 * @param arguments
@@ -88,16 +232,24 @@ public:
 				}
 			} else {
 				auto& genericFunction = std::get<std::unique_ptr<GenericInvocable>>(func);
+				// Allocation-free fast path: pass arguments as raw 64-bit
+				// slots on the stack. Backends that don't implement invokeRaw
+				// return false and take the boxed route below.
+				if constexpr (isRawSlotCompatible<R>() && (isRawSlotCompatible<Args>() && ...)) {
+					const uint64_t rawArgs[sizeof...(Args) + 1] = {toRawSlot(arguments)...};
+					uint64_t rawResult = 0;
+					if (genericFunction->invokeRaw(rawArgs, sizeof...(Args), &rawResult)) {
+						if constexpr (!std::is_void_v<R>) {
+							return fromRawSlot<R>(rawResult);
+						} else {
+							return;
+						}
+					}
+				}
 				if constexpr (!std::is_void_v<R>) {
 					std::vector<std::any> inputs_ = {getGenericArg(arguments)...};
 					auto res = genericFunction->invokeGeneric(inputs_);
-					if constexpr (std::is_same_v<R, char>) {
-						return std::any_cast<int8_t>(res);
-					} else if constexpr (std::is_pointer_v<R>) {
-						return (R) std::any_cast<void*>(res);
-					} else {
-						return std::any_cast<R>(res);
-					}
+					return castGenericResult<R>(res);
 				} else {
 					std::vector<std::any> inputs_ = {getGenericArg(arguments)...};
 					genericFunction->invokeGeneric(inputs_);

--- a/nautilus/include/nautilus/common/config.h.in
+++ b/nautilus/include/nautilus/common/config.h.in
@@ -3,6 +3,7 @@
 #cmakedefine ENABLE_TRACING
 #cmakedefine ENABLE_LOGGING
 #cmakedefine ENABLE_BC_BACKEND
+#cmakedefine ENABLE_TBC_BACKEND
 #cmakedefine ENABLE_C_BACKEND
 #cmakedefine ENABLE_MLIR_BACKEND
 #cmakedefine ENABLE_ASMJIT_BACKEND

--- a/nautilus/src/nautilus/compiler/backends/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/CMakeLists.txt
@@ -3,6 +3,7 @@ if (ENABLE_TRACING)
     add_subdirectory(bc)
     add_subdirectory(cpp)
     add_subdirectory(mlir)
+    add_subdirectory(tbc)
 endif ()
 
 if (ENABLE_ASMJIT_BACKEND)

--- a/nautilus/src/nautilus/compiler/backends/CompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/CompilationBackend.cpp
@@ -12,6 +12,9 @@
 #ifdef ENABLE_MLIR_BACKEND
 #include "nautilus/compiler/backends/mlir/MLIRCompilationBackend.hpp"
 #endif
+#ifdef ENABLE_TBC_BACKEND
+#include "nautilus/compiler/backends/tbc/TBCBackend.hpp"
+#endif
 #include "nautilus/exceptions/RuntimeException.hpp"
 
 namespace nautilus::compiler {
@@ -26,6 +29,9 @@ CompilationBackendRegistry::CompilationBackendRegistry() {
 #endif
 #ifdef ENABLE_BC_BACKEND
 	items["bc"] = std::make_unique<bc::BCInterpreterBackend>();
+#endif
+#ifdef ENABLE_TBC_BACKEND
+	items["tbc"] = std::make_unique<tbc::TBCBackend>();
 #endif
 #ifdef ENABLE_C_BACKEND
 	items["cpp"] = std::make_unique<cpp::CPPCompilationBackend>();

--- a/nautilus/src/nautilus/compiler/backends/tbc/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/tbc/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+
+if (ENABLE_TBC_BACKEND)
+    # Outgoing external calls are marshaled through dyncall (no dyncallback:
+    # the tbc backend never allocates executable memory).
+    target_link_libraries(nautilus PRIVATE dyncall_s)
+
+    add_source_files(nautilus
+            TBCBackend.cpp
+            TBCCode.cpp
+            TBCExecutable.cpp
+            TBCInterpreter.cpp
+            TBCLoweringProvider.cpp
+            TBCTrampoline.cpp
+    )
+endif ()

--- a/nautilus/src/nautilus/compiler/backends/tbc/README.md
+++ b/nautilus/src/nautilus/compiler/backends/tbc/README.md
@@ -1,0 +1,180 @@
+# TBC — Threaded Bytecode Interpreter Backend
+
+`tbc` is a from-scratch bytecode interpreter backend built for high execution
+performance and portability. It runs on x86-64 and ARM64 (Linux/macOS) and —
+unlike the legacy `bc` backend — **never allocates executable memory**, so it
+also works on platforms that forbid runtime code generation (iOS).
+
+Select it with `options.setOption("engine.backend", "tbc")`. It is built when
+`ENABLE_TBC_BACKEND` is on (default, dependent on `ENABLE_TRACING`).
+
+## Why a second bytecode backend?
+
+The `bc` backend's default configuration dispatches every instruction through
+an indirect function-pointer call, routes *every* call — including
+Nautilus-to-Nautilus calls in the same module — through the dyncall FFI plus a
+dyncallback trampoline into a nested interpreter, copies its whole register
+file on every invocation, and heap-allocates and re-zeroes alloca buffers per
+call. Its fast paths (threaded dispatch, superinstructions, immediates) are
+opt-in. dyncallback also allocates runtime-executable trampolines, which makes
+the backend unusable on iOS.
+
+`tbc` starts from the state of the art instead of retrofitting it:
+
+| | bc (default) | tbc (default) |
+|---|---|---|
+| dispatch | indirect call per op | tail-call threading (`musttail`) / computed goto |
+| code layout | per-block vectors + `std::variant` terminators | one flat stream, fixed 8-byte words |
+| internal calls | dyncall → dyncallback thunk → nested interpreter | native `CALL`/`RET` in the dispatch loop |
+| frames | full register-file copy, heap allocas | contiguous VM stack, in-frame allocas |
+| fusion / immediates | opt-in, threaded mode only | on by default |
+| executable memory | dyncallback trampolines | none |
+
+Measured on the loop kernels of `test/benchmark/ExecutionBenchmark.cpp`
+(Release, x86-64): ~3–4× faster than `bc`'s default *and* best opt-in
+configurations; per-call entry ~1.7× faster.
+
+## Design
+
+### Instruction encoding (`TBCOpcodes.hpp`, `TBCCode.hpp`)
+
+One flat `std::vector<Instr>` per function. `Instr` is a fixed 8-byte word:
+
+```
+struct Instr { uint16_t op, a, b, c; };   // a = dst, b/c = srcs | imm16
+```
+
+- Branch targets are signed 32-bit *relative* instruction offsets packed as
+  `b | c<<16` (`JMP`, `CJMP`) or in the second word of 2-word forms (fused
+  compare-and-branch, `SELECT`), so dispatch needs only the instruction
+  pointer — no code-base register.
+- Opcodes are fully type-monomorphized (no runtime type tags). Numeric
+  families expand over a canonical 10-type order via X-macros; the lowering
+  computes `family base + type index` instead of per-type switches, and
+  static_asserts pin the layout.
+- Every consumer of the opcode list — the `Op` enum, all three dispatch
+  skins, and the disassembler name table — expands the same X-macros, so they
+  cannot drift.
+
+### Dispatch (`TBCInterpreter.cpp`)
+
+Three skins, selected via `tbc.dispatch = auto | tailcall | goto | switch`
+(default `auto` = strongest supported; unavailable requests degrade silently):
+
+1. **Tail-call threading** (Clang, incl. iOS): each opcode is its own handler
+   function with the shared signature
+   `uint64_t(const Instr* ip, uint64_t* fp, VMContext* ctx)`; every handler
+   ends in `[[clang::musttail]] return kDispatchTable[ip->op](ip, fp, ctx)`.
+   The three hot values stay pinned in argument registers, each opcode gets
+   its own BTB-friendly indirect-branch site, and the compiler optimizes each
+   handler in isolation (the wasm3 / upb / CPython 3.14 technique).
+2. **Token-threaded computed goto** (GCC/Clang): `goto *labels[ip->op]`.
+3. **Portable `for(;;) switch`** (any compiler).
+
+### Values and frames
+
+Register slots are untyped 64 bits with the same normalization convention as
+`bc`: bools stored 0/1, narrow integers zero-extended, floats/pointers
+bit-exact. Consumers always read their exact declared width, so upper-bit
+garbage (e.g. from native callers of trampolines) is unobservable.
+
+Frames live on one contiguous per-thread `uint64_t` stack:
+
+```
+base[0..2]                      caller fp, return ip, caller dst register
+fp[0 .. regSlots)               value + constant registers   (fp = base + 3)
+fp[regSlots .. frameSlots-3)    alloca area (16-aligned, zeroed per call)
+```
+
+Frame setup is one bounds check + one `memcpy` of the function's *constant
+image* (constants live in pinned register slots) + alloca pointer fixups.
+The stack is reentrancy-safe: an external call that calls back into TBC code
+simply pushes further frames at `sp`.
+
+### Calls
+
+- **Internal** (`ProxyCall` to a function in the same module): resolved at
+  lowering to a function index; the `CALL` handler pushes a frame, copies the
+  argument registers, and continues in the same dispatch loop. `RET` writes
+  the result into the caller's destination register and pops. Entry frames
+  return to a static `HALT` instruction. No FFI, no C++ recursion.
+- **External** (`invoke`): a single `CALL_EXT` instruction referencing a
+  per-call-site record `{target, argRegs, argTypes, returnType}`; one handler
+  drives the outgoing dyncall VM (arguments + call in one dispatch). Outgoing
+  dyncall builds call frames dynamically without executable memory.
+- **Indirect** (`CALL_IND`): the target register always holds a real native
+  pointer (see trampolines below), so it uses the external path.
+
+### Escaping internal function pointers (`TBCTrampoline.hpp`)
+
+`FunctionAddressOf` of an internal function must produce something native
+code can call (e.g. `invoke(applyFnPtr, nautilusAdd.getFuncPtr(), …)`). `bc`
+fabricates a dyncallback thunk at runtime; `tbc` instead binds one of a fixed
+pool of **pre-compiled template trampolines** — 64 slots × arities 0–8, the
+slot index baked in as a template argument — that forward their integer-class
+arguments into the interpreter. Zero runtime code generation. Float-valued
+signatures throw a clear `NotImplementedException` (no current usage).
+
+### Entry path (`TBCExecutable.cpp`)
+
+`hasInvocableFunctionPtr()` is `false`; callers go through the
+`GenericInvocable` machinery in `include/nautilus/Executable.hpp`. The hot
+route is the allocation-free `invokeRaw` fast path (raw 64-bit slots on the
+stack); the boxed `std::any` route remains as fallback and for exotic types.
+
+### Lowering (`TBCLoweringProvider.cpp`)
+
+Ports the proven structure of `BCLoweringProvider` (block-argument edges as
+parallel copies, per-arm landing pads for `IfOp`, free-list linear register
+allocation with global use counts, merge-parameter register reuse — issue
+#321) and then **flattens** the block-structured code into the final stream:
+jumps to the next block in emission order fall through, and branch offsets
+are patched once all block positions are known.
+
+Optimizations are **on by default** (flags exist only for A/B benchmarking):
+
+- `tbc.superinstructions` — a single-use comparison feeding a conditional
+  branch fuses into one 2-word compare-and-branch instruction.
+- `tbc.immediates` — small constant right operands of i32/i64 add/sub/mul
+  fold into the 16-bit immediate field; small integer constants materialize
+  via `MOV_imm` without occupying a constant slot at all.
+- `tbc.coalescing` — block-edge parallel copies emit the minimum number of
+  MOVs (one temp only for a genuine permutation cycle).
+
+Other options: `tbc.dispatch` (see above), `tbc.stackSizeKb` (default 1024),
+`tbc.registerAllocator` (default true).
+
+## Testing
+
+- The whole execution/val/tracing suite runs on `tbc` via
+  `test/common/ExecutionTest.hpp::availableBackends()`.
+- `test/execution-tests/TBCDispatchModeTest.cpp` pins every dispatch skin ×
+  lowering-option combination against a de-optimized switch reference.
+- The differential fuzz harness (`test/fuzz/Harness.hpp`) includes `tbc`,
+  continuously cross-checking it against the interpreter and all other
+  backends.
+- `test/benchmark/{Execution,Tracing}Benchmark.cpp` include `tbc`.
+
+## Follow-ups / future work
+
+- **`invokeRaw`-style typed entry for tiered compilation**: `tbc` is a
+  natural `engine.tier0.backend`; measure and tune the tier-0 handoff.
+- **`[[clang::preserve_none]]`** on the tail-call handlers (guarded by
+  `__has_attribute`) — CPython measured additional wins from freeing
+  caller-saved registers across handlers.
+- **Memory-offset superinstructions** (`LOAD_off` / `STORE_off`): fuse
+  `add ptr, const` feeding a single-use load/store — the dominant
+  query-compilation access pattern. Needs a small local dataflow check in the
+  flattener.
+- **Dead-MOV elimination after immediate folding**: folding leaves the
+  constant's `MOV_imm` behind when it has no other uses; a cheap liveness
+  pass over the flat stream could drop it.
+- **Zero-dependency typed call thunks**: replace outgoing dyncall with
+  template-instantiated callers selected at lowering time (signatures are
+  statically known). Requires a register-only argument cap and care with the
+  Apple arm64 stack-argument packing rules; would remove the last third-party
+  dependency.
+- **Float-signature trampolines**: extend the escaping-function-pointer pool
+  beyond integer-class signatures if a use case appears.
+- **Instruction-stream prefetch hints / handler layout experiments** once
+  real query workloads are profiled.

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.cpp
@@ -1,0 +1,101 @@
+
+#include "nautilus/compiler/backends/tbc/TBCBackend.hpp"
+#include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/compiler/backends/tbc/TBCExecutable.hpp"
+#include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
+#include "nautilus/compiler/backends/tbc/TBCLoweringProvider.hpp"
+#include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
+#include <chrono>
+
+namespace nautilus::compiler::tbc {
+
+namespace {
+DispatchMode parseDispatchMode(const std::string& name) {
+	if (name == "tailcall") {
+		return DispatchMode::Tailcall;
+	}
+	if (name == "goto") {
+		return DispatchMode::Goto;
+	}
+	if (name == "switch") {
+		return DispatchMode::Switch;
+	}
+	// "auto" (and anything unknown) selects the strongest mode this build
+	// supports: tail-call on Clang, computed goto on GCC, switch otherwise.
+	return bestAvailableDispatchMode();
+}
+
+const char* dispatchModeName(DispatchMode mode) {
+	switch (mode) {
+	case DispatchMode::Tailcall:
+		return "tailcall";
+	case DispatchMode::Goto:
+		return "goto";
+	case DispatchMode::Switch:
+		return "switch";
+	}
+	return "unknown";
+}
+} // namespace
+
+std::unique_ptr<Executable> TBCBackend::compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler,
+                                                const engine::Options& options,
+                                                CompilationStatistics* statistics) const {
+	const auto backendStart = std::chrono::steady_clock::now();
+	const auto& functionOperations = ir->getFunctionOperations();
+
+	// All optimizations default to ON; the options exist for A/B comparisons.
+	TBCLoweringOptions loweringOptions;
+	loweringOptions.enableRegisterAllocator = options.getOptionOrDefault("tbc.registerAllocator", true);
+	loweringOptions.enableRegisterCoalescing = options.getOptionOrDefault("tbc.coalescing", true);
+	loweringOptions.enableSuperinstructions = options.getOptionOrDefault("tbc.superinstructions", true);
+	loweringOptions.enableImmediates = options.getOptionOrDefault("tbc.immediates", true);
+
+	auto program = std::make_shared<TBCProgram>();
+	program->dispatch =
+	    clampDispatchMode(parseDispatchMode(options.getOptionOrDefault<std::string>("tbc.dispatch", "auto")));
+	const auto stackSizeKb = options.getOptionOrDefault("tbc.stackSizeKb", 1024);
+	program->minStackSlots = static_cast<uint64_t>(stackSizeKb) * 1024 / sizeof(uint64_t);
+
+	// The function index and every function's signature must exist before any
+	// lowering runs: calls and FunctionAddressOf between module functions
+	// resolve to interpreter-native targets (or trampolines) regardless of
+	// lowering order.
+	program->functions.resize(functionOperations.size());
+	for (size_t i = 0; i < functionOperations.size(); i++) {
+		const auto& funcOp = functionOperations[i];
+		program->functionIndex[funcOp->getName()] = static_cast<uint32_t>(i);
+		auto& function = program->functions[i];
+		function.name = funcOp->getName();
+		function.returnType = funcOp->getOutputArg();
+		for (const auto* argument : funcOp->getFunctionBasicBlock().getArguments()) {
+			function.argTypes.push_back(argument->getStamp());
+		}
+	}
+
+	int64_t totalInstructions = 0;
+	int64_t maxRegisters = 0;
+	for (size_t i = 0; i < functionOperations.size(); i++) {
+		const auto& funcOp = functionOperations[i];
+		auto& function = program->functions[i];
+		TBCLoweringProvider::lower(funcOp, *program, function, loweringOptions);
+
+		if (funcOp->getName() == "execute") {
+			dumpHandler.dump("after_tbc_generation", "tbc", [&function]() { return function.toString(); });
+		}
+		totalInstructions += static_cast<int64_t>(function.code.size());
+		maxRegisters = std::max<int64_t>(maxRegisters, function.regSlots);
+	}
+
+	if (statistics != nullptr) {
+		statistics->set("tbc.instructions", totalInstructions);
+		statistics->set("tbc.codeSize.bytes", totalInstructions * static_cast<int64_t>(sizeof(Instr)));
+		statistics->set("tbc.registers.max", maxRegisters);
+		statistics->set("tbc.dispatch", std::string(dispatchModeName(program->dispatch)));
+		statistics->recordTimingMs("backend.totalMs", backendStart);
+	}
+
+	return std::make_unique<TBCExecutable>(std::move(program));
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "nautilus/compiler/backends/CompilationBackend.hpp"
+
+namespace nautilus::compiler::tbc {
+
+/**
+ * @brief The TBC (threaded bytecode) backend: a from-scratch, high-performance
+ * bytecode interpreter.
+ *
+ * Compared to the legacy bc backend it uses tail-call (musttail) or
+ * computed-goto dispatch over one flat instruction stream, interpreter-native
+ * calls between module functions (no FFI round trip), a contiguous per-thread
+ * VM stack with in-frame allocas, and default-on compare-and-branch fusion and
+ * immediate folding. It never allocates executable memory, so it runs on
+ * platforms that forbid runtime code generation (iOS).
+ */
+class TBCBackend : public CompilationBackend {
+public:
+	std::unique_ptr<Executable> compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler,
+	                                    const engine::Options& options,
+	                                    CompilationStatistics* statistics = nullptr) const override;
+};
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.cpp
@@ -1,0 +1,104 @@
+
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include "nautilus/compiler/backends/tbc/TBCTrampoline.hpp"
+#include <sstream>
+
+namespace nautilus::compiler::tbc {
+
+TBCProgram::~TBCProgram() {
+	releaseTrampolines(this);
+}
+
+namespace {
+const char* const kOpNames[] = {
+#define TBC_NAME_V(name, fn) #name,
+    TBC_VALUE_OPCODE_LIST(TBC_NAME_V)
+#undef TBC_NAME_V
+#define TBC_NAME_C(name) #name,
+        TBC_CONTROL_SIMPLE_LIST(TBC_NAME_C)
+#undef TBC_NAME_C
+#define TBC_NAME_F(name, ctype, cmp) #name,
+            TBC_CJMP_FUSED_LIST(TBC_NAME_F)
+#undef TBC_NAME_F
+};
+static_assert(sizeof(kOpNames) / sizeof(kOpNames[0]) == kOpCount);
+
+/// Number of instruction words the opcode at `pc` occupies.
+size_t instrWords(Op op) {
+	switch (op) {
+	case Op::SELECT:
+#define TBC_WORDS_F(name, ctype, cmp) case Op::name:
+		TBC_CJMP_FUSED_LIST(TBC_WORDS_F)
+#undef TBC_WORDS_F
+		return 2;
+	default:
+		return 1;
+	}
+}
+
+bool isFusedBranch(Op op) {
+	switch (op) {
+#define TBC_ISF(name, ctype, cmp) case Op::name:
+		TBC_CJMP_FUSED_LIST(TBC_ISF)
+#undef TBC_ISF
+		return true;
+	default:
+		return false;
+	}
+}
+} // namespace
+
+const char* opName(Op op) {
+	const auto idx = opIndex(op);
+	return idx < kOpCount ? kOpNames[idx] : "<invalid>";
+}
+
+std::string TBCFunction::toString() const {
+	std::stringstream ss;
+	ss << "function " << name << " (regs=" << regSlots << ", frameSlots=" << frameSlots
+	   << ", allocaBytes=" << allocaBytes << ")\n";
+	for (size_t pc = 0; pc < code.size();) {
+		const Instr& inst = code[pc];
+		const auto op = static_cast<Op>(inst.op);
+		ss << "  " << pc << ":\t" << opName(op);
+		switch (op) {
+		case Op::JMP:
+			ss << " -> " << static_cast<int64_t>(pc) + packedOffset(inst);
+			break;
+		case Op::CJMP:
+			ss << " r" << inst.a << " -> " << static_cast<int64_t>(pc) + packedOffset(inst);
+			break;
+		case Op::SELECT:
+			ss << " r" << inst.a << " = r" << inst.b << " ? r" << inst.c << " : r" << code[pc + 1].a;
+			break;
+		case Op::RET:
+			if (inst.a != kNoReg) {
+				ss << " r" << inst.a;
+			}
+			break;
+		case Op::CALL:
+			ss << " fn" << inst.b << " site" << inst.c << (inst.a != kNoReg ? " -> r" + std::to_string(inst.a) : "");
+			break;
+		case Op::CALL_EXT:
+			ss << " site" << inst.b << (inst.a != kNoReg ? " -> r" + std::to_string(inst.a) : "");
+			break;
+		case Op::CALL_IND:
+			ss << " [r" << inst.b << "] site" << inst.c
+			   << (inst.a != kNoReg ? " -> r" + std::to_string(inst.a) : "");
+			break;
+		default:
+			if (isFusedBranch(op)) {
+				ss << " r" << inst.a << ", r" << inst.b << " -> "
+				   << static_cast<int64_t>(pc) + packedOffsetLoHi(code[pc + 1]);
+			} else {
+				ss << " r" << inst.a << ", r" << inst.b << ", r" << inst.c;
+			}
+			break;
+		}
+		ss << "\n";
+		pc += instrWords(op);
+	}
+	return ss.str();
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.cpp
@@ -83,8 +83,7 @@ std::string TBCFunction::toString() const {
 			ss << " site" << inst.b << (inst.a != kNoReg ? " -> r" + std::to_string(inst.a) : "");
 			break;
 		case Op::CALL_IND:
-			ss << " [r" << inst.b << "] site" << inst.c
-			   << (inst.a != kNoReg ? " -> r" + std::to_string(inst.a) : "");
+			ss << " [r" << inst.b << "] site" << inst.c << (inst.a != kNoReg ? " -> r" + std::to_string(inst.a) : "");
 			break;
 		default:
 			if (isFusedBranch(op)) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "nautilus/compiler/backends/tbc/TBCOpcodes.hpp"
+#include "nautilus/tracing/Types.hpp"
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace nautilus::compiler::tbc {
+
+/// Register index sentinel: "no register" (void results, unused fields).
+constexpr uint16_t kNoReg = 0xFFFF;
+
+/// One fixed-width instruction word. Fields are opcode-specific; the common
+/// convention for value ops is a=dst, b=src1, c=src2 (or c=imm16). Branch
+/// offsets are signed 32-bit relative instruction counts packed as b|c<<16
+/// (or word1.a|word1.b<<16 for 2-word fused branches).
+struct Instr {
+	uint16_t op;
+	uint16_t a;
+	uint16_t b;
+	uint16_t c;
+};
+
+static_assert(sizeof(Instr) == 8);
+
+constexpr int32_t packedOffset(const Instr& i) {
+	return static_cast<int32_t>(static_cast<uint32_t>(i.b) | (static_cast<uint32_t>(i.c) << 16));
+}
+
+constexpr int32_t packedOffsetLoHi(const Instr& i) {
+	return static_cast<int32_t>(static_cast<uint32_t>(i.a) | (static_cast<uint32_t>(i.b) << 16));
+}
+
+/// Per-call-site record. The instruction stream only carries the record index;
+/// argument registers, types, and the target live here. Used by CALL (internal,
+/// interpreter-native), CALL_EXT (external via dyncall), and CALL_IND (register
+/// target, internal or external).
+struct CallSite {
+	void* target = nullptr;         // external function pointer (CALL_EXT)
+	uint32_t internalFnIdx = ~0u;   // callee index (CALL)
+	Type returnType = Type::v;
+	std::vector<Type> argTypes;     // callee signature, for dyncall marshaling
+	std::vector<uint16_t> argRegs;  // caller registers holding the arguments
+};
+
+/// One lowered function: a flat instruction stream plus its frame metadata.
+/// Frame layout (in 8-byte slots, pushed on the contiguous VM stack):
+///   base[0..2]                     header: caller fp, return ip, caller dst reg
+///   fp[0 .. regSlots)              value + constant registers (fp = base + 3)
+///   fp[regSlots .. frameSlots-3)   alloca area (16-aligned at runtime)
+struct TBCFunction {
+	std::string name;
+	std::vector<Instr> code;
+	/// Initial register contents, memcpy'd into the frame on every call.
+	/// Constant slots hold their values; everything else is zero.
+	std::vector<uint64_t> initImage;
+	uint32_t regSlots = 0;
+	uint32_t frameSlots = 0; // 3 header + regSlots + alloca slots (incl. alignment slack)
+	uint32_t allocaBytes = 0;
+	std::vector<std::pair<uint16_t, uint32_t>> allocaRegs; // register -> byte offset in the alloca area
+	std::vector<uint16_t> argRegs;
+	std::vector<Type> argTypes;
+	Type returnType = Type::v;
+
+	std::string toString() const;
+};
+
+enum class DispatchMode : uint8_t { Tailcall, Goto, Switch };
+
+/// A whole compiled module: all functions plus the program-wide call-site
+/// table. Heap-allocated once and never moved afterwards: escaping internal
+/// function pointers (see TBCTrampoline.hpp) bind trampoline slots to this
+/// object's address, released again by the destructor.
+struct TBCProgram {
+	TBCProgram() = default;
+	TBCProgram(const TBCProgram&) = delete;
+	TBCProgram& operator=(const TBCProgram&) = delete;
+	~TBCProgram();
+
+	std::vector<TBCFunction> functions;
+	std::unordered_map<std::string, uint32_t> functionIndex;
+	std::vector<CallSite> callsites;
+	uint64_t minStackSlots = 0;
+	DispatchMode dispatch = DispatchMode::Switch;
+};
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.hpp
@@ -38,11 +38,11 @@ constexpr int32_t packedOffsetLoHi(const Instr& i) {
 /// interpreter-native), CALL_EXT (external via dyncall), and CALL_IND (register
 /// target, internal or external).
 struct CallSite {
-	void* target = nullptr;         // external function pointer (CALL_EXT)
-	uint32_t internalFnIdx = ~0u;   // callee index (CALL)
+	void* target = nullptr;       // external function pointer (CALL_EXT)
+	uint32_t internalFnIdx = ~0u; // callee index (CALL)
 	Type returnType = Type::v;
-	std::vector<Type> argTypes;     // callee signature, for dyncall marshaling
-	std::vector<uint16_t> argRegs;  // caller registers holding the arguments
+	std::vector<Type> argTypes;    // callee signature, for dyncall marshaling
+	std::vector<uint16_t> argRegs; // caller registers holding the arguments
 };
 
 /// One lowered function: a flat instruction stream plus its frame metadata.

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.cpp
@@ -1,0 +1,176 @@
+
+#include "nautilus/compiler/backends/tbc/TBCExecutable.hpp"
+#include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
+#include <any>
+#include <cstring>
+
+namespace nautilus::compiler::tbc {
+
+namespace {
+
+/// Normalize a C++ value into a 64-bit register slot per the declared IR type
+/// (same convention as the interpreter's writeReg).
+template <class T>
+uint64_t normalizeAs(Type type, T value) {
+	switch (type) {
+	case Type::b:
+		return value != T {} ? 1 : 0;
+	case Type::i8:
+		return static_cast<uint64_t>(static_cast<uint8_t>(static_cast<int8_t>(value)));
+	case Type::ui8:
+		return static_cast<uint64_t>(static_cast<uint8_t>(value));
+	case Type::i16:
+		return static_cast<uint64_t>(static_cast<uint16_t>(static_cast<int16_t>(value)));
+	case Type::ui16:
+		return static_cast<uint64_t>(static_cast<uint16_t>(value));
+	case Type::i32:
+		return static_cast<uint64_t>(static_cast<uint32_t>(static_cast<int32_t>(value)));
+	case Type::ui32:
+		return static_cast<uint64_t>(static_cast<uint32_t>(value));
+	case Type::i64:
+		return static_cast<uint64_t>(static_cast<int64_t>(value));
+	case Type::ui64:
+		return static_cast<uint64_t>(value);
+	case Type::f32: {
+		const auto f = static_cast<float>(value);
+		uint64_t raw = 0;
+		std::memcpy(&raw, &f, sizeof(f));
+		return raw;
+	}
+	case Type::f64: {
+		const auto d = static_cast<double>(value);
+		uint64_t raw = 0;
+		std::memcpy(&raw, &d, sizeof(d));
+		return raw;
+	}
+	default:
+		throw RuntimeException("tbc: unsupported argument type");
+	}
+}
+
+template <class T>
+bool tryDecode(const std::any& value, Type type, uint64_t& out) {
+	if (const T* typed = std::any_cast<T>(&value)) {
+		out = normalizeAs(type, *typed);
+		return true;
+	}
+	return false;
+}
+
+/// Decode a boxed argument (see Executable::Invocable::getGenericArg for how
+/// callers box: fundamentals as-is, pointers as void*, enums as their
+/// underlying type). Distinct C++ types can share one nautilus Type (char vs
+/// int8_t; long vs long long for i64 across platforms), so decoding probes
+/// every fundamental candidate instead of assuming a single boxed type.
+uint64_t decodeArgument(const std::any& value, Type type) {
+	if (type == Type::ptr) {
+		return reinterpret_cast<uint64_t>(std::any_cast<void*>(value));
+	}
+	uint64_t out = 0;
+	if (tryDecode<bool>(value, type, out) || tryDecode<char>(value, type, out) ||
+	    tryDecode<signed char>(value, type, out) || tryDecode<unsigned char>(value, type, out) ||
+	    tryDecode<short>(value, type, out) || tryDecode<unsigned short>(value, type, out) ||
+	    tryDecode<int>(value, type, out) || tryDecode<unsigned int>(value, type, out) ||
+	    tryDecode<long>(value, type, out) || tryDecode<unsigned long>(value, type, out) ||
+	    tryDecode<long long>(value, type, out) || tryDecode<unsigned long long>(value, type, out) ||
+	    tryDecode<float>(value, type, out) || tryDecode<double>(value, type, out)) {
+		return out;
+	}
+	throw RuntimeException("tbc: cannot decode argument of unexpected boxed type");
+}
+
+/// Box a raw 64-bit result slot per the function's IR return type, matching
+/// exactly what Invocable::operator() unboxes.
+std::any boxResult(Type type, uint64_t raw) {
+	switch (type) {
+	case Type::b:
+		return std::any(raw != 0);
+	case Type::i8:
+		return std::any(static_cast<int8_t>(raw));
+	case Type::ui8:
+		return std::any(static_cast<uint8_t>(raw));
+	case Type::i16:
+		return std::any(static_cast<int16_t>(raw));
+	case Type::ui16:
+		return std::any(static_cast<uint16_t>(raw));
+	case Type::i32:
+		return std::any(static_cast<int32_t>(raw));
+	case Type::ui32:
+		return std::any(static_cast<uint32_t>(raw));
+	case Type::i64:
+		return std::any(static_cast<int64_t>(raw));
+	case Type::ui64:
+		return std::any(static_cast<uint64_t>(raw));
+	case Type::f32: {
+		float value;
+		std::memcpy(&value, &raw, sizeof(value));
+		return std::any(value);
+	}
+	case Type::f64: {
+		double value;
+		std::memcpy(&value, &raw, sizeof(value));
+		return std::any(value);
+	}
+	case Type::ptr:
+		return std::any(reinterpret_cast<void*>(raw));
+	case Type::v:
+		return {};
+	}
+	throw RuntimeException("tbc: unsupported return type");
+}
+
+class TBCGenericInvocable final : public Executable::GenericInvocable {
+public:
+	TBCGenericInvocable(std::shared_ptr<TBCProgram> program, uint32_t functionIndex)
+	    : program(std::move(program)), functionIndex(functionIndex) {
+	}
+
+	std::any invokeGeneric(const std::vector<std::any>& args) override {
+		const TBCFunction& function = program->functions[functionIndex];
+		if (args.size() != function.argTypes.size()) {
+			throw RuntimeException("tbc: argument count mismatch");
+		}
+		std::vector<uint64_t> slots(args.size());
+		for (size_t i = 0; i < args.size(); ++i) {
+			slots[i] = decodeArgument(args[i], function.argTypes[i]);
+		}
+		const uint64_t raw = invoke(*program, functionIndex, slots.data(), slots.size());
+		return boxResult(function.returnType, raw);
+	}
+
+	bool invokeRaw(const uint64_t* args, size_t argCount, uint64_t* result) override {
+		if (argCount != program->functions[functionIndex].argTypes.size()) {
+			throw RuntimeException("tbc: argument count mismatch");
+		}
+		*result = invoke(*program, functionIndex, args, argCount);
+		return true;
+	}
+
+private:
+	std::shared_ptr<TBCProgram> program;
+	uint32_t functionIndex;
+};
+
+} // namespace
+
+TBCExecutable::TBCExecutable(std::shared_ptr<TBCProgram> program) : program(std::move(program)) {
+}
+
+void* TBCExecutable::getInvocableFunctionPtr(const std::string&) {
+	throw RuntimeException("tbc: no native function pointers; use the generic invocable");
+}
+
+bool TBCExecutable::hasInvocableFunctionPtr() {
+	return false;
+}
+
+std::unique_ptr<Executable::GenericInvocable> TBCExecutable::getGenericInvocable(const std::string& member) {
+	const auto it = program->functionIndex.find(member);
+	if (it == program->functionIndex.end()) {
+		throw RuntimeException("tbc: unknown function \"" + member + "\"");
+	}
+	return std::make_unique<TBCGenericInvocable>(program, it->second);
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "nautilus/Executable.hpp"
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include <memory>
+
+namespace nautilus::compiler::tbc {
+
+/**
+ * @brief Executable wrapper around a TBCProgram.
+ *
+ * Deliberately exposes NO native function pointer: fabricating one for an
+ * interpreted function requires runtime-generated trampolines (bc uses
+ * dyncallback), which allocate executable memory and are therefore forbidden
+ * on iOS. Callers go through the GenericInvocable path instead, which the
+ * Executable/Module machinery supports transparently.
+ */
+class TBCExecutable : public Executable {
+public:
+	explicit TBCExecutable(std::shared_ptr<TBCProgram> program);
+
+	[[nodiscard]] void* getInvocableFunctionPtr(const std::string& member) override;
+	bool hasInvocableFunctionPtr() override;
+	std::unique_ptr<GenericInvocable> getGenericInvocable(const std::string& member) override;
+
+private:
+	std::shared_ptr<TBCProgram> program;
+};
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCHandlers.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCHandlers.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include <cstring>
+#include <type_traits>
+
+namespace nautilus::compiler::tbc {
+
+// Value-op semantics shared by all three dispatch skins (tail-call, computed
+// goto, switch). Every body is a tiny force-inlinable function
+// `void(const Instr&, uint64_t*)`; the skins add the per-opcode dispatch glue.
+//
+// Register slots are untyped 64 bits. Writers normalize: bools are stored as
+// 0/1, narrow integers are zero-extended, floats/pointers keep their bit
+// pattern (same invariant as the bc backend's writeReg). Readers use the exact
+// IR-typed width, so the low bytes are always authoritative.
+
+template <class T>
+inline T readReg(const uint64_t* fp, uint16_t r) {
+	T value;
+	std::memcpy(&value, &fp[r], sizeof(T));
+	return value;
+}
+
+template <class T>
+inline void writeReg(uint64_t* fp, uint16_t r, T value) {
+	if constexpr (std::is_same_v<T, bool>) {
+		fp[r] = value ? 1u : 0u;
+	} else if constexpr (std::is_integral_v<T>) {
+		fp[r] = static_cast<uint64_t>(static_cast<std::make_unsigned_t<T>>(value));
+	} else {
+		fp[r] = 0;
+		std::memcpy(&fp[r], &value, sizeof(T));
+	}
+}
+
+inline void opNop(const Instr&, uint64_t*) {
+}
+
+inline void opMov(const Instr& i, uint64_t* fp) {
+	fp[i.a] = fp[i.b];
+}
+
+template <class T>
+inline void opMovImm(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(static_cast<int16_t>(i.c)));
+}
+
+template <class T>
+inline void opAdd(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) + readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opSub(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) - readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opMul(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) * readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opDiv(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) / readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opMod(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) % readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opAddImm(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) + static_cast<T>(static_cast<int16_t>(i.c))));
+}
+
+template <class T>
+inline void opSubImm(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) - static_cast<T>(static_cast<int16_t>(i.c))));
+}
+
+template <class T>
+inline void opMulImm(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) * static_cast<T>(static_cast<int16_t>(i.c))));
+}
+
+template <class T>
+inline void opEq(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<T>(fp, i.b) == readReg<T>(fp, i.c));
+}
+
+template <class T>
+inline void opNe(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<T>(fp, i.b) != readReg<T>(fp, i.c));
+}
+
+template <class T>
+inline void opLt(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<T>(fp, i.b) < readReg<T>(fp, i.c));
+}
+
+template <class T>
+inline void opLe(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<T>(fp, i.b) <= readReg<T>(fp, i.c));
+}
+
+template <class T>
+inline void opGt(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<T>(fp, i.b) > readReg<T>(fp, i.c));
+}
+
+template <class T>
+inline void opGe(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<T>(fp, i.b) >= readReg<T>(fp, i.c));
+}
+
+inline void opAnd(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<bool>(fp, i.b) && readReg<bool>(fp, i.c));
+}
+
+inline void opOr(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, readReg<bool>(fp, i.b) || readReg<bool>(fp, i.c));
+}
+
+inline void opNot(const Instr& i, uint64_t* fp) {
+	writeReg<bool>(fp, i.a, !readReg<bool>(fp, i.b));
+}
+
+template <class T>
+inline void opLoad(const Instr& i, uint64_t* fp) {
+	T value;
+	std::memcpy(&value, reinterpret_cast<const void*>(fp[i.b]), sizeof(T));
+	writeReg<T>(fp, i.a, value);
+}
+
+template <class T>
+inline void opStore(const Instr& i, uint64_t* fp) {
+	T value = readReg<T>(fp, i.b);
+	std::memcpy(reinterpret_cast<void*>(fp[i.a]), &value, sizeof(T));
+}
+
+template <class T>
+inline void opBand(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) & readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opBor(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) | readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opBxor(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) ^ readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opShl(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) << readReg<T>(fp, i.c)));
+}
+
+template <class T>
+inline void opShr(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) >> readReg<T>(fp, i.c)));
+}
+
+inline void opBnot(const Instr& i, uint64_t* fp) {
+	writeReg<int64_t>(fp, i.a, ~readReg<int64_t>(fp, i.b));
+}
+
+template <class S, class D>
+inline void opCast(const Instr& i, uint64_t* fp) {
+	writeReg<D>(fp, i.a, static_cast<D>(readReg<S>(fp, i.b)));
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.cpp
@@ -53,8 +53,7 @@ DCCallVM* tlsDyncallVM() {
 /// the dispatch loop and yields the entry result slot.
 constexpr Instr kHalt {opIndex(Op::HALT), 0, 0, 0};
 
-uint64_t* pushFrame(VMContext* ctx, const TBCFunction& fn, uint64_t* callerFp, const Instr* returnIp,
-                    uint16_t dstReg) {
+uint64_t* pushFrame(VMContext* ctx, const TBCFunction& fn, uint64_t* callerFp, const Instr* returnIp, uint16_t dstReg) {
 	uint64_t* base = ctx->sp;
 	if (base + fn.frameSlots > ctx->stackEnd) {
 		throw RuntimeException("tbc: VM stack overflow (increase tbc.stackSizeKb)");
@@ -297,16 +296,16 @@ uint64_t runGoto(const Instr* ip, uint64_t* fp, VMContext* ctx) {
 	TBC_VALUE_OPCODE_LIST(TBC_LBL)
 #undef TBC_LBL
 
-L_SELECT : {
+L_SELECT: {
 	fp[ip->a] = readReg<bool>(fp, ip->b) ? fp[ip->c] : fp[ip[1].a];
 	ip += 2;
 	TBC_NEXT();
 }
-L_JMP : {
+L_JMP: {
 	ip += packedOffset(*ip);
 	TBC_NEXT();
 }
-L_CJMP : {
+L_CJMP: {
 	ip = readReg<bool>(fp, ip->a) ? ip + packedOffset(*ip) : ip + 1;
 	TBC_NEXT();
 }
@@ -317,25 +316,25 @@ L_CJMP : {
 	}
 	TBC_CJMP_FUSED_LIST(TBC_LBL_F)
 #undef TBC_LBL_F
-L_RET : {
+L_RET: {
 	const auto t = doReturn(*ip, fp, ctx);
 	ip = t.ip;
 	fp = t.fp;
 	TBC_NEXT();
 }
-L_CALL : {
+L_CALL: {
 	const auto t = doCall(*ip, ip, fp, ctx);
 	ip = t.ip;
 	fp = t.fp;
 	TBC_NEXT();
 }
-L_CALL_EXT : {
+L_CALL_EXT: {
 	const CallSite& site = ctx->prog->callsites[ip->b];
 	doExtCall(site, site.target, fp, ip->a);
 	++ip;
 	TBC_NEXT();
 }
-L_CALL_IND : {
+L_CALL_IND: {
 	doIndirectCall(*ip, fp, ctx);
 	++ip;
 	TBC_NEXT();
@@ -360,8 +359,7 @@ L_TRAP:
 using Handler = uint64_t (*)(const Instr*, uint64_t*, VMContext*);
 extern const Handler kDispatchTable[kOpCount];
 
-#define TBC_TAIL_NEXT()                                                                                                \
-	[[clang::musttail]] return kDispatchTable[ip->op](ip, fp, ctx)
+#define TBC_TAIL_NEXT() [[clang::musttail]] return kDispatchTable[ip->op](ip, fp, ctx)
 
 #define TBC_TH(name, fn)                                                                                               \
 	static uint64_t th_##name(const Instr* ip, uint64_t* fp, VMContext* ctx) {                                         \

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.cpp
@@ -1,0 +1,514 @@
+
+#include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
+#include "nautilus/compiler/backends/tbc/TBCHandlers.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
+#include <algorithm>
+#include <dyncall.h>
+#include <vector>
+
+// Dispatch capability detection. The tail-call skin needs Clang's guaranteed
+// [[clang::musttail]]; the computed-goto skin needs the GNU labels-as-values
+// extension (GCC and Clang). The switch skin always exists as the portable
+// fallback (e.g. MSVC).
+#if defined(__clang__) && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::musttail)
+#define TBC_HAS_MUSTTAIL 1
+#endif
+#endif
+#if defined(__GNUC__) || defined(__clang__)
+#define TBC_HAS_COMPUTED_GOTO 1
+#endif
+
+namespace nautilus::compiler::tbc {
+
+namespace {
+
+/// Per-thread VM state: one contiguous stack shared by all frames of all
+/// nested invocations on this thread (reentrancy through external calls that
+/// call back into TBC code just pushes further frames at `sp`).
+struct VMContext {
+	std::vector<uint64_t> storage;
+	uint64_t* sp = nullptr;
+	uint64_t* stackEnd = nullptr;
+	const TBCProgram* prog = nullptr;
+};
+
+VMContext& tlsContext() {
+	static thread_local VMContext ctx;
+	return ctx;
+}
+
+DCCallVM* tlsDyncallVM() {
+	struct Holder {
+		DCCallVM* vm = dcNewCallVM(4096);
+		~Holder() {
+			dcFree(vm);
+		}
+	};
+	static thread_local Holder holder;
+	return holder.vm;
+}
+
+/// The single instruction an entry frame "returns" to; its handler terminates
+/// the dispatch loop and yields the entry result slot.
+constexpr Instr kHalt {opIndex(Op::HALT), 0, 0, 0};
+
+uint64_t* pushFrame(VMContext* ctx, const TBCFunction& fn, uint64_t* callerFp, const Instr* returnIp,
+                    uint16_t dstReg) {
+	uint64_t* base = ctx->sp;
+	if (base + fn.frameSlots > ctx->stackEnd) {
+		throw RuntimeException("tbc: VM stack overflow (increase tbc.stackSizeKb)");
+	}
+	ctx->sp = base + fn.frameSlots;
+	base[0] = reinterpret_cast<uint64_t>(callerFp);
+	base[1] = reinterpret_cast<uint64_t>(returnIp);
+	base[2] = dstReg == kNoReg ? ~uint64_t {0} : dstReg;
+	uint64_t* fp = base + 3;
+	std::memcpy(fp, fn.initImage.data(), fn.initImage.size() * sizeof(uint64_t));
+	if (!fn.allocaRegs.empty()) {
+		auto area = reinterpret_cast<uintptr_t>(fp + fn.regSlots);
+		area = (area + 15u) & ~uintptr_t {15};
+		std::memset(reinterpret_cast<void*>(area), 0, fn.allocaBytes);
+		for (const auto& [reg, offset] : fn.allocaRegs) {
+			fp[reg] = static_cast<uint64_t>(area + offset);
+		}
+	}
+	return fp;
+}
+
+/// External call through dyncall: marshal the argument registers per the call
+/// site's signature, call, and write the (re-normalized) result. Outgoing
+/// dyncall builds the call frame dynamically without any runtime code
+/// generation, so this path is iOS-safe (unlike dyncallback thunks).
+void doExtCall(const CallSite& site, void* target, uint64_t* fp, uint16_t dstReg) {
+	DCCallVM* vm = tlsDyncallVM();
+	dcReset(vm);
+	for (size_t i = 0; i < site.argRegs.size(); ++i) {
+		const uint16_t r = site.argRegs[i];
+		switch (site.argTypes[i]) {
+		case Type::b:
+			dcArgBool(vm, readReg<bool>(fp, r));
+			break;
+		case Type::i8:
+		case Type::ui8:
+			dcArgChar(vm, readReg<int8_t>(fp, r));
+			break;
+		case Type::i16:
+		case Type::ui16:
+			dcArgShort(vm, readReg<int16_t>(fp, r));
+			break;
+		case Type::i32:
+		case Type::ui32:
+			dcArgInt(vm, readReg<int32_t>(fp, r));
+			break;
+		case Type::i64:
+		case Type::ui64:
+			dcArgLongLong(vm, readReg<int64_t>(fp, r));
+			break;
+		case Type::f32:
+			dcArgFloat(vm, readReg<float>(fp, r));
+			break;
+		case Type::f64:
+			dcArgDouble(vm, readReg<double>(fp, r));
+			break;
+		case Type::ptr:
+			dcArgPointer(vm, reinterpret_cast<void*>(fp[r]));
+			break;
+		default:
+			throw RuntimeException("tbc: unsupported external call argument type");
+		}
+	}
+	switch (site.returnType) {
+	case Type::v:
+		dcCallVoid(vm, target);
+		return;
+	case Type::b:
+		// Mask to the low byte: callees are only required to set the low byte
+		// of a bool return register (same rationale as bc's Dyncall::callB).
+		writeReg<bool>(fp, dstReg, (dcCallBool(vm, target) & 0xFF) != 0);
+		return;
+	case Type::i8:
+		writeReg<int8_t>(fp, dstReg, dcCallChar(vm, target));
+		return;
+	case Type::ui8:
+		writeReg<uint8_t>(fp, dstReg, static_cast<uint8_t>(dcCallChar(vm, target)));
+		return;
+	case Type::i16:
+		writeReg<int16_t>(fp, dstReg, dcCallShort(vm, target));
+		return;
+	case Type::ui16:
+		writeReg<uint16_t>(fp, dstReg, static_cast<uint16_t>(dcCallShort(vm, target)));
+		return;
+	case Type::i32:
+		writeReg<int32_t>(fp, dstReg, dcCallInt(vm, target));
+		return;
+	case Type::ui32:
+		writeReg<uint32_t>(fp, dstReg, static_cast<uint32_t>(dcCallInt(vm, target)));
+		return;
+	case Type::i64:
+		writeReg<int64_t>(fp, dstReg, dcCallLongLong(vm, target));
+		return;
+	case Type::ui64:
+		writeReg<uint64_t>(fp, dstReg, static_cast<uint64_t>(dcCallLongLong(vm, target)));
+		return;
+	case Type::f32:
+		writeReg<float>(fp, dstReg, dcCallFloat(vm, target));
+		return;
+	case Type::f64:
+		writeReg<double>(fp, dstReg, dcCallDouble(vm, target));
+		return;
+	case Type::ptr:
+		writeReg<uint64_t>(fp, dstReg, reinterpret_cast<uint64_t>(dcCallPointer(vm, target)));
+		return;
+	}
+	throw RuntimeException("tbc: unsupported external call return type");
+}
+
+/// Control transfer produced by call/return helpers, applied by each skin.
+struct Transfer {
+	const Instr* ip;
+	uint64_t* fp;
+};
+
+inline Transfer doReturn(const Instr& inst, uint64_t* fp, VMContext* ctx) {
+	uint64_t* base = fp - 3;
+	auto* callerFp = reinterpret_cast<uint64_t*>(base[0]);
+	const auto* returnIp = reinterpret_cast<const Instr*>(base[1]);
+	const uint64_t dst = base[2];
+	if (dst != ~uint64_t {0}) {
+		callerFp[dst] = inst.a == kNoReg ? 0 : fp[inst.a];
+	}
+	ctx->sp = base;
+	return {returnIp, callerFp};
+}
+
+inline Transfer enterFunction(const TBCFunction& fn, const CallSite& site, const Instr* ip, uint64_t* fp,
+                              VMContext* ctx, uint16_t dstReg) {
+	uint64_t* newFp = pushFrame(ctx, fn, fp, ip + 1, dstReg);
+	for (size_t i = 0; i < site.argRegs.size(); ++i) {
+		newFp[fn.argRegs[i]] = fp[site.argRegs[i]];
+	}
+	return {fn.code.data(), newFp};
+}
+
+inline Transfer doCall(const Instr& inst, const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	const TBCProgram& prog = *ctx->prog;
+	return enterFunction(prog.functions[inst.b], prog.callsites[inst.c], ip, fp, ctx, inst.a);
+}
+
+inline void doIndirectCall(const Instr& inst, uint64_t* fp, VMContext* ctx) {
+	// Indirect targets are always real native pointers: internal functions
+	// hand out pre-compiled trampolines (TBCTrampoline.hpp), so no
+	// internal/external discrimination is needed here.
+	const CallSite& site = ctx->prog->callsites[inst.c];
+	doExtCall(site, reinterpret_cast<void*>(fp[inst.b]), fp, inst.a);
+}
+
+// ── Skin 1: portable for(;;) switch ─────────────────────────────────────────
+
+uint64_t runSwitch(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	for (;;) {
+		const Instr& inst = *ip;
+		switch (static_cast<Op>(inst.op)) {
+#define TBC_CASE(name, fn)                                                                                             \
+	case Op::name:                                                                                                     \
+		(fn)(inst, fp);                                                                                                \
+		++ip;                                                                                                          \
+		break;
+			TBC_VALUE_OPCODE_LIST(TBC_CASE)
+#undef TBC_CASE
+		case Op::SELECT:
+			fp[inst.a] = readReg<bool>(fp, inst.b) ? fp[inst.c] : fp[ip[1].a];
+			ip += 2;
+			break;
+		case Op::JMP:
+			ip += packedOffset(inst);
+			break;
+		case Op::CJMP:
+			ip = readReg<bool>(fp, inst.a) ? ip + packedOffset(inst) : ip + 1;
+			break;
+#define TBC_CASE_F(name, ctype, cmp)                                                                                   \
+	case Op::name:                                                                                                     \
+		ip += (readReg<ctype>(fp, inst.a) cmp readReg<ctype>(fp, inst.b)) ? packedOffsetLoHi(ip[1]) : 2;               \
+		break;
+			TBC_CJMP_FUSED_LIST(TBC_CASE_F)
+#undef TBC_CASE_F
+		case Op::RET: {
+			const auto t = doReturn(inst, fp, ctx);
+			ip = t.ip;
+			fp = t.fp;
+			break;
+		}
+		case Op::CALL: {
+			const auto t = doCall(inst, ip, fp, ctx);
+			ip = t.ip;
+			fp = t.fp;
+			break;
+		}
+		case Op::CALL_EXT: {
+			const CallSite& site = ctx->prog->callsites[inst.b];
+			doExtCall(site, site.target, fp, inst.a);
+			++ip;
+			break;
+		}
+		case Op::CALL_IND:
+			doIndirectCall(inst, fp, ctx);
+			++ip;
+			break;
+		case Op::HALT:
+			return fp[0];
+		default:
+			throw RuntimeException("tbc: invalid opcode in instruction stream");
+		}
+	}
+}
+
+// ── Skin 2: token-threaded computed goto (GCC / Clang) ──────────────────────
+
+#ifdef TBC_HAS_COMPUTED_GOTO
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wgnu-label-as-value"
+#endif
+uint64_t runGoto(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	static const void* const labels[] = {
+#define TBC_LADDR_V(name, fn) &&L_##name,
+	    TBC_VALUE_OPCODE_LIST(TBC_LADDR_V)
+#undef TBC_LADDR_V
+#define TBC_LADDR_C(name) &&L_##name,
+	        TBC_CONTROL_SIMPLE_LIST(TBC_LADDR_C)
+#undef TBC_LADDR_C
+#define TBC_LADDR_F(name, ctype, cmp) &&L_##name,
+	            TBC_CJMP_FUSED_LIST(TBC_LADDR_F)
+#undef TBC_LADDR_F
+	};
+	static_assert(sizeof(labels) / sizeof(labels[0]) == kOpCount);
+
+#define TBC_NEXT() goto* labels[ip->op]
+	TBC_NEXT();
+
+#define TBC_LBL(name, fn)                                                                                              \
+	L_##name : {                                                                                                       \
+		(fn)(*ip, fp);                                                                                                 \
+		++ip;                                                                                                          \
+		TBC_NEXT();                                                                                                    \
+	}
+	TBC_VALUE_OPCODE_LIST(TBC_LBL)
+#undef TBC_LBL
+
+L_SELECT : {
+	fp[ip->a] = readReg<bool>(fp, ip->b) ? fp[ip->c] : fp[ip[1].a];
+	ip += 2;
+	TBC_NEXT();
+}
+L_JMP : {
+	ip += packedOffset(*ip);
+	TBC_NEXT();
+}
+L_CJMP : {
+	ip = readReg<bool>(fp, ip->a) ? ip + packedOffset(*ip) : ip + 1;
+	TBC_NEXT();
+}
+#define TBC_LBL_F(name, ctype, cmp)                                                                                    \
+	L_##name : {                                                                                                       \
+		ip += (readReg<ctype>(fp, ip->a) cmp readReg<ctype>(fp, ip->b)) ? packedOffsetLoHi(ip[1]) : 2;                 \
+		TBC_NEXT();                                                                                                    \
+	}
+	TBC_CJMP_FUSED_LIST(TBC_LBL_F)
+#undef TBC_LBL_F
+L_RET : {
+	const auto t = doReturn(*ip, fp, ctx);
+	ip = t.ip;
+	fp = t.fp;
+	TBC_NEXT();
+}
+L_CALL : {
+	const auto t = doCall(*ip, ip, fp, ctx);
+	ip = t.ip;
+	fp = t.fp;
+	TBC_NEXT();
+}
+L_CALL_EXT : {
+	const CallSite& site = ctx->prog->callsites[ip->b];
+	doExtCall(site, site.target, fp, ip->a);
+	++ip;
+	TBC_NEXT();
+}
+L_CALL_IND : {
+	doIndirectCall(*ip, fp, ctx);
+	++ip;
+	TBC_NEXT();
+}
+L_HALT:
+	return fp[0];
+L_TRAP:
+	throw RuntimeException("tbc: invalid opcode in instruction stream");
+#undef TBC_NEXT
+}
+#pragma GCC diagnostic pop
+#endif // TBC_HAS_COMPUTED_GOTO
+
+// ── Skin 3: tail-call threading (Clang musttail) ────────────────────────────
+//
+// Every opcode gets its own handler function; (ip, fp, ctx) stay pinned in
+// argument registers across the whole execution, and each handler ends in a
+// guaranteed tail call through the dispatch table — one indirect branch per
+// instruction with a distinct, BTB-friendly branch site per opcode.
+
+#ifdef TBC_HAS_MUSTTAIL
+using Handler = uint64_t (*)(const Instr*, uint64_t*, VMContext*);
+extern const Handler kDispatchTable[kOpCount];
+
+#define TBC_TAIL_NEXT()                                                                                                \
+	[[clang::musttail]] return kDispatchTable[ip->op](ip, fp, ctx)
+
+#define TBC_TH(name, fn)                                                                                               \
+	static uint64_t th_##name(const Instr* ip, uint64_t* fp, VMContext* ctx) {                                         \
+		(fn)(*ip, fp);                                                                                                 \
+		++ip;                                                                                                          \
+		TBC_TAIL_NEXT();                                                                                               \
+	}
+TBC_VALUE_OPCODE_LIST(TBC_TH)
+#undef TBC_TH
+
+static uint64_t th_SELECT(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	fp[ip->a] = readReg<bool>(fp, ip->b) ? fp[ip->c] : fp[ip[1].a];
+	ip += 2;
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_JMP(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	ip += packedOffset(*ip);
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_CJMP(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	ip = readReg<bool>(fp, ip->a) ? ip + packedOffset(*ip) : ip + 1;
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_RET(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	const auto t = doReturn(*ip, fp, ctx);
+	ip = t.ip;
+	fp = t.fp;
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_CALL(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	const auto t = doCall(*ip, ip, fp, ctx);
+	ip = t.ip;
+	fp = t.fp;
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_CALL_EXT(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	const CallSite& site = ctx->prog->callsites[ip->b];
+	doExtCall(site, site.target, fp, ip->a);
+	++ip;
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_CALL_IND(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	doIndirectCall(*ip, fp, ctx);
+	++ip;
+	TBC_TAIL_NEXT();
+}
+static uint64_t th_HALT(const Instr*, uint64_t* fp, VMContext*) {
+	return fp[0];
+}
+static uint64_t th_TRAP(const Instr*, uint64_t*, VMContext*) {
+	throw RuntimeException("tbc: invalid opcode in instruction stream");
+}
+#define TBC_TH_F(name, ctype, cmp)                                                                                     \
+	static uint64_t th_##name(const Instr* ip, uint64_t* fp, VMContext* ctx) {                                         \
+		ip += (readReg<ctype>(fp, ip->a) cmp readReg<ctype>(fp, ip->b)) ? packedOffsetLoHi(ip[1]) : 2;                 \
+		TBC_TAIL_NEXT();                                                                                               \
+	}
+TBC_CJMP_FUSED_LIST(TBC_TH_F)
+#undef TBC_TH_F
+#undef TBC_TAIL_NEXT
+
+const Handler kDispatchTable[kOpCount] = {
+#define TBC_TADDR_V(name, fn) th_##name,
+    TBC_VALUE_OPCODE_LIST(TBC_TADDR_V)
+#undef TBC_TADDR_V
+#define TBC_TADDR_C(name) th_##name,
+        TBC_CONTROL_SIMPLE_LIST(TBC_TADDR_C)
+#undef TBC_TADDR_C
+#define TBC_TADDR_F(name, ctype, cmp) th_##name,
+            TBC_CJMP_FUSED_LIST(TBC_TADDR_F)
+#undef TBC_TADDR_F
+};
+
+uint64_t runTailcall(const Instr* ip, uint64_t* fp, VMContext* ctx) {
+	return kDispatchTable[ip->op](ip, fp, ctx);
+}
+#endif // TBC_HAS_MUSTTAIL
+
+} // namespace
+
+DispatchMode bestAvailableDispatchMode() {
+#if defined(TBC_HAS_MUSTTAIL)
+	return DispatchMode::Tailcall;
+#elif defined(TBC_HAS_COMPUTED_GOTO)
+	return DispatchMode::Goto;
+#else
+	return DispatchMode::Switch;
+#endif
+}
+
+DispatchMode clampDispatchMode(DispatchMode requested) {
+	const auto best = bestAvailableDispatchMode();
+	// Modes are ordered strongest-first in the enum; a request the build
+	// cannot execute silently degrades to the best available.
+	return static_cast<uint8_t>(requested) < static_cast<uint8_t>(best) ? best : requested;
+}
+
+uint64_t invoke(const TBCProgram& program, uint32_t functionIndex, const uint64_t* args, size_t argCount) {
+	auto& ctx = tlsContext();
+
+	// Size (or grow) the per-thread stack. Growth is only safe while no frame
+	// is live, because frames hold interior pointers into the storage.
+	constexpr size_t kDefaultStackSlots = 128 * 1024; // 1 MiB
+	const size_t wantSlots = std::max<size_t>(static_cast<size_t>(program.minStackSlots), kDefaultStackSlots);
+	const bool idle = ctx.storage.empty() || ctx.sp == ctx.storage.data();
+	if (idle && ctx.storage.size() < wantSlots) {
+		ctx.storage.assign(wantSlots, 0);
+		ctx.sp = ctx.storage.data();
+		ctx.stackEnd = ctx.storage.data() + ctx.storage.size();
+	}
+
+	const TBCFunction& fn = program.functions[functionIndex];
+
+	// Save/restore around the run so reentrant invocations (an external call
+	// that calls back into another TBC executable) and exceptions leave the
+	// context exactly as they found it.
+	struct Restore {
+		VMContext& ctx;
+		const TBCProgram* prog;
+		uint64_t* sp;
+		~Restore() {
+			ctx.prog = prog;
+			ctx.sp = sp;
+		}
+	} restore {ctx, ctx.prog, ctx.sp};
+	ctx.prog = &program;
+
+	uint64_t resultSlot = 0;
+	uint64_t* fp = pushFrame(&ctx, fn, &resultSlot, &kHalt, 0);
+	const size_t argsToCopy = std::min(argCount, fn.argRegs.size());
+	for (size_t i = 0; i < argsToCopy; ++i) {
+		fp[fn.argRegs[i]] = args[i];
+	}
+	const Instr* ip = fn.code.data();
+
+	switch (program.dispatch) {
+#ifdef TBC_HAS_MUSTTAIL
+	case DispatchMode::Tailcall:
+		return runTailcall(ip, fp, &ctx);
+#endif
+#ifdef TBC_HAS_COMPUTED_GOTO
+	case DispatchMode::Goto:
+		return runGoto(ip, fp, &ctx);
+#endif
+	default:
+		return runSwitch(ip, fp, &ctx);
+	}
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include <cstddef>
+#include <cstdint>
+
+namespace nautilus::compiler::tbc {
+
+/// Best dispatch mode the current compiler can execute (tail-call on Clang,
+/// computed goto on GCC, switch elsewhere).
+DispatchMode bestAvailableDispatchMode();
+
+/// Clamp a requested mode to what the build supports.
+DispatchMode clampDispatchMode(DispatchMode requested);
+
+/// Execute `program.functions[functionIndex]` with the given 64-bit argument
+/// slots (already normalized per the function's argument types) and return the
+/// raw 64-bit result slot (0 for void). Runs on a thread-local contiguous VM
+/// stack; safe for reentrant use (external calls that call back into TBC code).
+/// Throws RuntimeException on VM stack overflow.
+uint64_t invoke(const TBCProgram& program, uint32_t functionIndex, const uint64_t* args, size_t argCount);
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -1,0 +1,971 @@
+
+#include "nautilus/compiler/backends/tbc/TBCLoweringProvider.hpp"
+#include "nautilus/compiler/Frame.hpp"
+#include "nautilus/compiler/backends/tbc/TBCTrampoline.hpp"
+#include "nautilus/compiler/ir/OperationDispatcher.hpp"
+#include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
+#include "nautilus/exceptions/NotImplementedException.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
+#include <cassert>
+#include <cstring>
+#include <span>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace nautilus::compiler::tbc {
+
+namespace {
+
+// Index into the canonical 10-type family order (i8..ui64, f32, f64). Type::b
+// and Type::ptr are mapped by the callers according to each family's rules.
+int numTypeIndex(Type t) {
+	switch (t) {
+	case Type::i8:
+		return 0;
+	case Type::i16:
+		return 1;
+	case Type::i32:
+		return 2;
+	case Type::i64:
+		return 3;
+	case Type::ui8:
+		return 4;
+	case Type::ui16:
+		return 5;
+	case Type::ui32:
+		return 6;
+	case Type::ui64:
+		return 7;
+	case Type::f32:
+		return 8;
+	case Type::f64:
+		return 9;
+	default:
+		return -1;
+	}
+}
+
+// Integer-only families (MOD, bitwise, shifts) share the first 8 entries.
+int intTypeIndex(Type t) {
+	const int idx = numTypeIndex(t);
+	return idx >= 0 && idx <= 7 ? idx : -1;
+}
+
+Op typedOp(Op base, int typeIndex, const char* what) {
+	if (typeIndex < 0) {
+		throw NotImplementedException(std::string("tbc: unsupported type for ") + what);
+	}
+	return static_cast<Op>(opIndex(base) + typeIndex);
+}
+
+/// Map an arithmetic op with a foldable small-constant right operand to its
+/// immediate form (Op::COUNT = not foldable).
+Op immFormOf(Op op) {
+	switch (op) {
+	case Op::ADD_i32:
+		return Op::ADD_imm_i32;
+	case Op::ADD_i64:
+		return Op::ADD_imm_i64;
+	case Op::SUB_i32:
+		return Op::SUB_imm_i32;
+	case Op::SUB_i64:
+		return Op::SUB_imm_i64;
+	case Op::MUL_i32:
+		return Op::MUL_imm_i32;
+	case Op::MUL_i64:
+		return Op::MUL_imm_i64;
+	default:
+		return Op::COUNT;
+	}
+}
+
+/// Map an i32/i64 comparison opcode to the fused compare-and-branch form
+/// (Op::COUNT = not fusable).
+Op fusedFormOf(Op op) {
+	const int rel = opIndex(op) - opIndex(Op::EQ_i8);
+	if (rel < 0 || rel >= 60) {
+		return Op::COUNT;
+	}
+	const int pred = rel / 10;
+	const int typeIdx = rel % 10;
+	if (typeIdx != 2 && typeIdx != 3) { // only i32 / i64
+		return Op::COUNT;
+	}
+	return static_cast<Op>(opIndex(Op::CJMP_EQ_i32) + pred * 2 + (typeIdx == 3 ? 1 : 0));
+}
+
+/// Write a constant into an image slot with the same normalization the
+/// interpreter's writeReg applies (bools 0/1, narrow ints zero-extended,
+/// floats bit-exact).
+uint64_t normalizedConst(Type t, int64_t value) {
+	switch (t) {
+	case Type::b:
+		return value != 0 ? 1 : 0;
+	case Type::i8:
+	case Type::ui8:
+		return static_cast<uint64_t>(static_cast<uint8_t>(value));
+	case Type::i16:
+	case Type::ui16:
+		return static_cast<uint64_t>(static_cast<uint16_t>(value));
+	case Type::i32:
+	case Type::ui32:
+		return static_cast<uint64_t>(static_cast<uint32_t>(value));
+	default:
+		return static_cast<uint64_t>(value);
+	}
+}
+
+struct Terminator {
+	enum Kind : uint8_t { None, Jump, CondJump, Ret } kind = None;
+	uint16_t condReg = kNoReg;
+	int trueBlock = -1;
+	int falseBlock = -1;
+	uint16_t retReg = kNoReg;
+};
+
+struct BlockCode {
+	std::vector<Instr> code;
+	Terminator term;
+	// Set when this block ends in a conditional jump whose condition is a
+	// single-use comparison; the flattener may fuse the trailing compare into
+	// the branch (mirrors bc's fuseCompareIntoBranch).
+	bool fuseCompareIntoBranch = false;
+	// (index into `code`, immediate) pairs recorded for arithmetic ops whose
+	// right operand is a small integer constant (mirrors bc's
+	// foldableImmediates).
+	std::vector<std::pair<uint32_t, int16_t>> foldableImmediates;
+};
+
+using RegisterFrame = Frame<ir::OperationIdentifier, uint16_t>;
+
+class RegisterProvider {
+public:
+	uint16_t allocRegister() {
+		if (!freeList.empty()) {
+			const uint16_t reg = freeList.back();
+			freeList.pop_back();
+			return reg;
+		}
+		return nextRegister();
+	}
+
+	/// Pinned registers hold values pre-initialized in the init image
+	/// (constants, function pointers) or written once in the frame prologue
+	/// (alloca pointers); they must never be reused by another operation.
+	uint16_t allocPinnedRegister() {
+		const uint16_t reg = nextRegister();
+		pinned.insert(reg);
+		return reg;
+	}
+
+	/// Bypass the free list (block-invocation temporaries must not alias
+	/// already-bound target registers that were freed earlier); the slot may
+	/// still be freed later like any other allocation.
+	uint16_t allocFreshRegister() {
+		return nextRegister();
+	}
+
+	void freeRegister(uint16_t reg) {
+		if (pinned.count(reg) > 0) {
+			return;
+		}
+		freeList.push_back(reg);
+	}
+
+	uint32_t getRegisterCount() const {
+		return currentRegister;
+	}
+
+private:
+	uint16_t nextRegister() {
+		if (currentRegister >= kNoReg) {
+			throw RuntimeException("tbc: function requires more than 65534 registers");
+		}
+		return static_cast<uint16_t>(currentRegister++);
+	}
+
+	uint32_t currentRegister = 0;
+	std::vector<uint16_t> freeList;
+	std::unordered_set<uint16_t> pinned;
+};
+
+class LoweringContext : public ir::OperationDispatcher<LoweringContext> {
+public:
+	LoweringContext(const ir::FunctionOperation* func, TBCProgram& program, TBCFunction& out,
+	                const TBCLoweringOptions& options)
+	    : func(func), program(program), out(out), options(options) {
+	}
+
+	void process() {
+		RegisterFrame rootFrame;
+		const auto& functionBasicBlock = func->getFunctionBasicBlock();
+		// argTypes/returnType were pre-filled by the backend (they must be
+		// available before this function is lowered, e.g. for trampolines).
+		for (auto* argument : functionBasicBlock.getArguments()) {
+			const auto argumentRegister = registerProvider.allocRegister();
+			rootFrame.setValue(argument->getIdentifier(), argumentRegister);
+			out.argRegs.emplace_back(argumentRegister);
+			functionArgs.insert(argument->getIdentifier());
+		}
+
+		// Materialize the alloca table: one pinned register per entry, laid
+		// out contiguously (with per-spec alignment) in the frame's alloca
+		// area. The pointers themselves are computed at frame-push time.
+		uint32_t allocaOffset = 0;
+		for (const auto& spec : func->getAllocaSpecs()) {
+			const auto align = static_cast<uint32_t>(spec.align == 0 ? 1 : spec.align);
+			if (align > 16) {
+				throw NotImplementedException("tbc: alloca alignment > 16 is not supported");
+			}
+			allocaOffset = (allocaOffset + align - 1) & ~(align - 1);
+			const auto slotRegister = registerProvider.allocPinnedRegister();
+			out.allocaRegs.emplace_back(slotRegister, allocaOffset);
+			functionAllocaSlots.emplace_back(slotRegister);
+			allocaOffset += static_cast<uint32_t>(spec.size);
+		}
+		out.allocaBytes = allocaOffset;
+
+		if (options.enableRegisterAllocator) {
+			countAllUsages(&functionBasicBlock);
+		}
+		processBlock(&functionBasicBlock, rootFrame);
+
+		finalize();
+	}
+
+private:
+	friend class ir::OperationDispatcher<LoweringContext>;
+
+	const ir::FunctionOperation* func;
+	TBCProgram& program;
+	TBCFunction& out;
+	TBCLoweringOptions options;
+	RegisterProvider registerProvider;
+	std::vector<BlockCode> blocks;
+	std::vector<std::pair<uint16_t, uint64_t>> constInits;
+	std::unordered_map<ir::BlockIdentifier, int> activeBlocks;
+	std::unordered_map<ir::OperationIdentifier, int> usageCounts;
+	std::unordered_set<ir::OperationIdentifier> functionArgs;
+	std::vector<uint16_t> functionAllocaSlots;
+
+	void emit(int block, Op op, uint16_t a, uint16_t b = 0, uint16_t c = 0) {
+		blocks[block].code.push_back(Instr {opIndex(op), a, b, c});
+	}
+
+	int processBlock(const ir::BasicBlock* block, RegisterFrame& frame) {
+		auto entry = activeBlocks.find(block->getIdentifier());
+		if (entry != activeBlocks.end()) {
+			return entry->second;
+		}
+		const int blockIndex = static_cast<int>(blocks.size());
+		activeBlocks.emplace(block->getIdentifier(), blockIndex);
+		blocks.emplace_back();
+		for (auto* opt : block->getOperations()) {
+			this->dispatch(opt, blockIndex, frame);
+		}
+		return blockIndex;
+	}
+
+	// ── Register bookkeeping (ports of the bc allocator helpers) ────────────
+
+	/// When the identifier is already bound, this definition's SSA name doubles
+	/// as a downstream merge-block parameter whose register was chosen by an
+	/// earlier-emitted predecessor edge (issue #321); write straight into it.
+	uint16_t getResultRegister(ir::Operation* opt, RegisterFrame& frame) {
+		if (frame.contains(opt->getIdentifier())) {
+			return frame.getValue(opt->getIdentifier());
+		}
+		return registerProvider.allocRegister();
+	}
+
+	void countAllUsages(const ir::BasicBlock* entryBlock) {
+		std::unordered_set<ir::BlockIdentifier> visited;
+		std::vector<const ir::BasicBlock*> worklist;
+		worklist.push_back(entryBlock);
+		visited.insert(entryBlock->getIdentifier());
+
+		auto countInput = [this](const ir::Operation* input) {
+			if (input != nullptr) {
+				usageCounts[input->getIdentifier()]++;
+			}
+		};
+
+		while (!worklist.empty()) {
+			const auto* block = worklist.back();
+			worklist.pop_back();
+			for (auto* opt : block->getOperations()) {
+				for (auto* input : opt->getInputs()) {
+					countInput(input);
+				}
+				if (auto* ifOp = ir::dyn_cast<ir::IfOperation>(opt)) {
+					for (auto* input : ifOp->getTrueBlockInvocation().getInputs()) {
+						countInput(input);
+					}
+					for (auto* input : ifOp->getFalseBlockInvocation().getInputs()) {
+						countInput(input);
+					}
+					auto* trueBlk = ifOp->getTrueBlockInvocation().getBlock();
+					auto* falseBlk = ifOp->getFalseBlockInvocation().getBlock();
+					if (trueBlk != nullptr && visited.insert(trueBlk->getIdentifier()).second) {
+						worklist.push_back(trueBlk);
+					}
+					if (falseBlk != nullptr && visited.insert(falseBlk->getIdentifier()).second) {
+						worklist.push_back(falseBlk);
+					}
+				} else if (auto* brOp = ir::dyn_cast<ir::BranchOperation>(opt)) {
+					for (auto* input : brOp->getNextBlockInvocation().getInputs()) {
+						countInput(input);
+					}
+					auto* next = brOp->getNextBlockInvocation().getBlock();
+					if (next != nullptr && visited.insert(next->getIdentifier()).second) {
+						worklist.push_back(next);
+					}
+				}
+			}
+		}
+	}
+
+	void useValue(const ir::OperationIdentifier& identifier, RegisterFrame& frame) {
+		if (!options.enableRegisterAllocator) {
+			return;
+		}
+		if (functionArgs.count(identifier) > 0) {
+			return;
+		}
+		auto it = usageCounts.find(identifier);
+		if (it != usageCounts.end() && it->second > 0) {
+			it->second--;
+			if (it->second == 0 && frame.contains(identifier)) {
+				registerProvider.freeRegister(frame.getValue(identifier));
+			}
+		}
+	}
+
+	// ── Constants ────────────────────────────────────────────────────────────
+
+	/// Allocate a pinned register whose slot is pre-set in the init image.
+	uint16_t constSlot(uint64_t rawValue) {
+		const auto reg = registerProvider.allocPinnedRegister();
+		constInits.emplace_back(reg, rawValue);
+		return reg;
+	}
+
+	void materializeConst(ir::Operation* opt, int block, RegisterFrame& frame, Type type, int64_t value) {
+		const auto target = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), target);
+		const int idx = intTypeIndex(type == Type::b ? Type::ui8 : type);
+		if (idx >= 0 && value >= -32768 && value <= 32767) {
+			emit(block, typedOp(Op::MOV_imm_i8, idx, "const"), target, 0, static_cast<uint16_t>(value));
+			return;
+		}
+		emit(block, Op::MOV, target, constSlot(normalizedConst(type, value)));
+	}
+
+	void visitConstInt(ir::ConstIntOperation* constInt, int block, RegisterFrame& frame) {
+		materializeConst(constInt, block, frame, constInt->getStamp(), constInt->getValue());
+	}
+
+	void visitConstBoolean(ir::ConstBooleanOperation* constBool, int block, RegisterFrame& frame) {
+		materializeConst(constBool, block, frame, Type::b, constBool->getValue() ? 1 : 0);
+	}
+
+	void visitConstFloat(ir::ConstFloatOperation* constFloat, int block, RegisterFrame& frame) {
+		uint64_t raw = 0;
+		if (constFloat->getStamp() == Type::f32) {
+			const auto value = static_cast<float>(constFloat->getValue());
+			std::memcpy(&raw, &value, sizeof(value));
+		} else {
+			const auto value = static_cast<double>(constFloat->getValue());
+			std::memcpy(&raw, &value, sizeof(value));
+		}
+		const auto target = getResultRegister(constFloat, frame);
+		frame.setValue(constFloat->getIdentifier(), target);
+		emit(block, Op::MOV, target, constSlot(raw));
+	}
+
+	void visitConstPtr(ir::ConstPtrOperation* constPtr, int block, RegisterFrame& frame) {
+		const auto target = getResultRegister(constPtr, frame);
+		frame.setValue(constPtr->getIdentifier(), target);
+		emit(block, Op::MOV, target, constSlot(reinterpret_cast<uint64_t>(constPtr->getValue())));
+	}
+
+	// ── Arithmetic / logic ───────────────────────────────────────────────────
+
+	/// Record the arithmetic op about to be emitted as immediate-foldable when
+	/// its right operand is an i32/i64 constant fitting 16 bits (port of bc's
+	/// recordFoldableImmediate).
+	void recordFoldableImmediate(int block, ir::Operation* rightInput, Type type) {
+		if (type != Type::i32 && type != Type::i64) {
+			return;
+		}
+		const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(rightInput);
+		if (constInt == nullptr) {
+			return;
+		}
+		const int64_t value = constInt->getValue();
+		if (value < -32768 || value > 32767) {
+			return;
+		}
+		blocks[block].foldableImmediates.emplace_back(static_cast<uint32_t>(blocks[block].code.size()),
+		                                              static_cast<int16_t>(value));
+	}
+
+	template <class OperationType>
+	void lowerBinary(OperationType* opt, int block, RegisterFrame& frame, Op base, int typeIndex, const char* what) {
+		const auto left = frame.getValue(opt->getLeftInput()->getIdentifier());
+		const auto right = frame.getValue(opt->getRightInput()->getIdentifier());
+		useValue(opt->getLeftInput()->getIdentifier(), frame);
+		useValue(opt->getRightInput()->getIdentifier(), frame);
+		const auto result = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), result);
+		emit(block, typedOp(base, typeIndex, what), result, left, right);
+	}
+
+	int arithTypeIndex(Type t) const {
+		// Pointer arithmetic runs as i64, matching bc.
+		return numTypeIndex(t == Type::ptr ? Type::i64 : t);
+	}
+
+	void visitAdd(ir::AddOperation* opt, int block, RegisterFrame& frame) {
+		recordFoldableImmediate(block, opt->getRightInput(), opt->getStamp());
+		lowerBinary(opt, block, frame, Op::ADD_i8, arithTypeIndex(opt->getStamp()), "add");
+	}
+
+	void visitSub(ir::SubOperation* opt, int block, RegisterFrame& frame) {
+		recordFoldableImmediate(block, opt->getRightInput(), opt->getStamp());
+		lowerBinary(opt, block, frame, Op::SUB_i8, arithTypeIndex(opt->getStamp()), "sub");
+	}
+
+	void visitMul(ir::MulOperation* opt, int block, RegisterFrame& frame) {
+		recordFoldableImmediate(block, opt->getRightInput(), opt->getStamp());
+		lowerBinary(opt, block, frame, Op::MUL_i8, arithTypeIndex(opt->getStamp()), "mul");
+	}
+
+	void visitDiv(ir::DivOperation* opt, int block, RegisterFrame& frame) {
+		lowerBinary(opt, block, frame, Op::DIV_i8, arithTypeIndex(opt->getStamp()), "div");
+	}
+
+	void visitMod(ir::ModOperation* opt, int block, RegisterFrame& frame) {
+		lowerBinary(opt, block, frame, Op::MOD_i8, intTypeIndex(opt->getStamp()), "mod");
+	}
+
+	void visitCompare(ir::CompareOperation* opt, int block, RegisterFrame& frame) {
+		auto type = opt->getLeftInput()->getStamp();
+		if (type == Type::ptr) {
+			type = Type::i64; // pointer compares run as i64, matching bc
+		} else if (type == Type::b) {
+			type = Type::ui8; // bool slots are normalized 0/1
+		}
+		const int comparator = static_cast<int>(opt->getComparator());
+		if (comparator < 0 || comparator > 5) {
+			throw NotImplementedException("tbc: unsupported comparator");
+		}
+		const int idx = numTypeIndex(type);
+		if (idx < 0) {
+			throw NotImplementedException("tbc: unsupported compare type");
+		}
+		const auto base = static_cast<Op>(opIndex(Op::EQ_i8) + comparator * 10);
+		lowerBinary(opt, block, frame, base, idx, "compare");
+	}
+
+	void visitAnd(ir::AndOperation* opt, int block, RegisterFrame& frame) {
+		lowerBinary(opt, block, frame, Op::AND_b, 0, "and");
+	}
+
+	void visitOr(ir::OrOperation* opt, int block, RegisterFrame& frame) {
+		lowerBinary(opt, block, frame, Op::OR_b, 0, "or");
+	}
+
+	void visitBinaryComp(ir::BinaryCompOperation* opt, int block, RegisterFrame& frame) {
+		Op base;
+		switch (opt->getType()) {
+		case ir::BinaryCompOperation::BAND:
+			base = Op::BAND_i8;
+			break;
+		case ir::BinaryCompOperation::BOR:
+			base = Op::BOR_i8;
+			break;
+		case ir::BinaryCompOperation::XOR:
+			base = Op::BXOR_i8;
+			break;
+		default:
+			throw NotImplementedException("tbc: unsupported binary op");
+		}
+		lowerBinary(opt, block, frame, base, intTypeIndex(opt->getStamp()), "bitwise");
+	}
+
+	void visitShift(ir::ShiftOperation* opt, int block, RegisterFrame& frame) {
+		const Op base = opt->getType() == ir::ShiftOperation::LS ? Op::SHL_i8 : Op::SHR_i8;
+		lowerBinary(opt, block, frame, base, intTypeIndex(opt->getStamp()), "shift");
+	}
+
+	void visitNot(ir::NotOperation* opt, int block, RegisterFrame& frame) {
+		const auto input = frame.getValue(opt->getInput()->getIdentifier());
+		useValue(opt->getInput()->getIdentifier(), frame);
+		const auto result = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), result);
+		emit(block, Op::NOT_b, result, input);
+	}
+
+	void visitNegate(ir::NegateOperation* opt, int block, RegisterFrame& frame) {
+		const auto input = frame.getValue(opt->getInput()->getIdentifier());
+		useValue(opt->getInput()->getIdentifier(), frame);
+		const auto result = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), result);
+		// Bitwise negation runs on the full 64-bit slot (bc parity: consumers
+		// always read their exact width, so high garbage is unobservable).
+		emit(block, Op::BNOT_i64, result, input);
+	}
+
+	// ── Memory ───────────────────────────────────────────────────────────────
+
+	int memTypeIndex(Type t, const char* what) {
+		if (t == Type::b) {
+			return 10; // the LOAD_b / STORE_b slot directly after the 10-type family
+		}
+		const int idx = numTypeIndex(t == Type::ptr ? Type::i64 : t);
+		if (idx < 0) {
+			throw NotImplementedException(std::string("tbc: unsupported type for ") + what);
+		}
+		return idx;
+	}
+
+	void visitLoad(ir::LoadOperation* opt, int block, RegisterFrame& frame) {
+		const auto address = frame.getValue(opt->getAddress()->getIdentifier());
+		useValue(opt->getAddress()->getIdentifier(), frame);
+		const auto result = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), result);
+		emit(block, typedOp(Op::LOAD_i8, memTypeIndex(opt->getStamp(), "load"), "load"), result, address);
+	}
+
+	void visitStore(ir::StoreOperation* opt, int block, RegisterFrame& frame) {
+		const auto address = frame.getValue(opt->getAddress()->getIdentifier());
+		const auto value = frame.getValue(opt->getValue()->getIdentifier());
+		useValue(opt->getAddress()->getIdentifier(), frame);
+		useValue(opt->getValue()->getIdentifier(), frame);
+		emit(block, typedOp(Op::STORE_i8, memTypeIndex(opt->getValue()->getStamp(), "store"), "store"), address,
+		     value);
+	}
+
+	void visitAlloca(ir::AllocaOperation* opt, int block, RegisterFrame& frame) {
+		// The slot register was pinned in the prologue; the pointer itself is
+		// computed at frame-push time. Rebind the identifier — unless it is
+		// already bound as a downstream merge-block parameter, in which case
+		// copy the pointer into the parameter's register (setValue is
+		// emplace-only and would silently keep the old binding).
+		const auto index = opt->getIndex();
+		assert(index < functionAllocaSlots.size() && "AllocaOperation index out of range for function");
+		const auto slotRegister = functionAllocaSlots[index];
+		if (frame.contains(opt->getIdentifier())) {
+			const auto target = frame.getValue(opt->getIdentifier());
+			if (target != slotRegister) {
+				emit(block, Op::MOV, target, slotRegister);
+			}
+		} else {
+			frame.setValue(opt->getIdentifier(), slotRegister);
+		}
+	}
+
+	void visitCast(ir::CastOperation* opt, int block, RegisterFrame& frame) {
+		const auto input = frame.getValue(opt->getInput()->getIdentifier());
+		useValue(opt->getInput()->getIdentifier(), frame);
+		const auto result = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), result);
+
+		const auto srcType = opt->getInput()->getStamp();
+		const auto dstType = opt->getStamp();
+		// Identity casts (two C++ types mapping to the same nautilus Type,
+		// e.g. size_t and uint64_t on macOS) and ui64 <-> ptr are register
+		// moves. Pointer-valued targets convert as ui64 (bc parity).
+		if (srcType == dstType || (srcType == Type::ui64 && dstType == Type::ptr)) {
+			emit(block, Op::MOV, result, input);
+			return;
+		}
+		const int srcIdx = numTypeIndex(srcType == Type::ptr ? Type::ui64 : srcType);
+		const int dstIdx = numTypeIndex(dstType == Type::ptr ? Type::ui64 : dstType);
+		if (srcIdx < 0 || dstIdx < 0) {
+			throw NotImplementedException("tbc: unsupported cast");
+		}
+		if (srcIdx == dstIdx) {
+			emit(block, Op::MOV, result, input);
+			return;
+		}
+		emit(block, static_cast<Op>(opIndex(Op::CAST_i8_i8) + srcIdx * 10 + dstIdx), result, input);
+	}
+
+	void visitSelect(ir::SelectOperation* opt, int block, RegisterFrame& frame) {
+		const auto condition = frame.getValue(opt->getCondition()->getIdentifier());
+		const auto trueValue = frame.getValue(opt->getTrueValue()->getIdentifier());
+		const auto falseValue = frame.getValue(opt->getFalseValue()->getIdentifier());
+		useValue(opt->getCondition()->getIdentifier(), frame);
+		useValue(opt->getTrueValue()->getIdentifier(), frame);
+		useValue(opt->getFalseValue()->getIdentifier(), frame);
+		const auto result = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), result);
+		// Slots are normalized by their producers, so SELECT is a typeless
+		// 64-bit slot pick: word0 {dst, cond, trueReg}, word1 {falseReg}.
+		emit(block, Op::SELECT, result, condition, trueValue);
+		// Operand word: never dispatched, so it carries TRAP defensively.
+		blocks[block].code.push_back(Instr {opIndex(Op::TRAP), falseValue, 0, 0});
+	}
+
+	// ── Control flow ─────────────────────────────────────────────────────────
+
+	void processInvocation(const ir::BasicBlockInvocation& invocation, int block, RegisterFrame& parentFrame) {
+		// Direct port of bc's block-invocation lowering (see
+		// BCLoweringProvider.cpp for the full rationale): reads strictly
+		// before writes; fresh targets get fresh registers; with coalescing,
+		// already-bound targets are sequenced as a parallel copy.
+		auto blockInputArguments = invocation.getArguments();
+		auto& blockTargetArguments = invocation.getBlock()->getArguments();
+
+		if (!options.enableRegisterAllocator || !options.enableRegisterCoalescing) {
+			std::vector<uint16_t> tempArgs;
+			tempArgs.reserve(blockInputArguments.size());
+			for (auto* input : blockInputArguments) {
+				const auto sourceReg = parentFrame.getValue(input->getIdentifier());
+				const auto tempReg = registerProvider.allocFreshRegister();
+				tempArgs.push_back(tempReg);
+				emit(block, Op::MOV, tempReg, sourceReg);
+				useValue(input->getIdentifier(), parentFrame);
+			}
+			for (std::size_t i = 0; i < blockInputArguments.size(); ++i) {
+				const auto blockTargetArgument = blockTargetArguments[i]->getIdentifier();
+				if (!parentFrame.contains(blockTargetArgument)) {
+					parentFrame.setValue(blockTargetArgument, tempArgs[i]);
+				} else {
+					const auto targetReg = parentFrame.getValue(blockTargetArgument);
+					if (targetReg != tempArgs[i]) {
+						emit(block, Op::MOV, targetReg, tempArgs[i]);
+					}
+					if (options.enableRegisterAllocator) {
+						registerProvider.freeRegister(tempArgs[i]);
+					}
+				}
+			}
+			return;
+		}
+
+		std::vector<std::pair<uint16_t, uint16_t>> boundPairs;
+		std::vector<std::pair<ir::OperationIdentifier, uint16_t>> freshBindings;
+		for (std::size_t i = 0; i < blockInputArguments.size(); ++i) {
+			auto* input = blockInputArguments[i];
+			const auto sourceReg = parentFrame.getValue(input->getIdentifier());
+			const auto blockTargetArgument = blockTargetArguments[i]->getIdentifier();
+			if (!parentFrame.contains(blockTargetArgument)) {
+				const auto freshReg = registerProvider.allocFreshRegister();
+				emit(block, Op::MOV, freshReg, sourceReg);
+				freshBindings.emplace_back(blockTargetArgument, freshReg);
+			} else {
+				const auto targetReg = parentFrame.getValue(blockTargetArgument);
+				if (targetReg != sourceReg) {
+					boundPairs.emplace_back(targetReg, sourceReg);
+				}
+			}
+			useValue(input->getIdentifier(), parentFrame);
+		}
+		for (auto& [identifier, reg] : freshBindings) {
+			parentFrame.setValue(identifier, reg);
+		}
+		emitParallelCopy(block, std::move(boundPairs));
+	}
+
+	/// Classic parallel-copy sequentialization (port of bc's emitParallelCopy):
+	/// emit any move whose destination is no longer needed as a source; break
+	/// genuine cycles by stashing one destination in a fresh temp.
+	void emitParallelCopy(int block, std::vector<std::pair<uint16_t, uint16_t>> pairs) {
+		if (pairs.empty()) {
+			return;
+		}
+		std::unordered_map<uint16_t, int> pendingReads;
+		for (auto& p : pairs) {
+			pendingReads[p.second]++;
+		}
+		std::vector<char> done(pairs.size(), 0);
+		std::vector<uint16_t> cycleTemps;
+		std::size_t remaining = pairs.size();
+		while (remaining > 0) {
+			bool progressed = false;
+			for (std::size_t i = 0; i < pairs.size(); i++) {
+				if (done[i]) {
+					continue;
+				}
+				const auto [dst, src] = pairs[i];
+				if (pendingReads[dst] == 0) {
+					emit(block, Op::MOV, dst, src);
+					done[i] = 1;
+					remaining--;
+					progressed = true;
+					pendingReads[src]--;
+				}
+			}
+			if (progressed || remaining == 0) {
+				continue;
+			}
+			for (std::size_t i = 0; i < pairs.size(); i++) {
+				if (done[i]) {
+					continue;
+				}
+				const uint16_t dst = pairs[i].first;
+				const uint16_t temp = registerProvider.allocFreshRegister();
+				emit(block, Op::MOV, temp, dst);
+				cycleTemps.push_back(temp);
+				for (std::size_t j = 0; j < pairs.size(); j++) {
+					if (!done[j] && pairs[j].second == dst) {
+						pairs[j].second = temp;
+					}
+				}
+				pendingReads[dst] = 0;
+				break;
+			}
+		}
+		for (const uint16_t temp : cycleTemps) {
+			registerProvider.freeRegister(temp);
+		}
+	}
+
+	void visitIf(ir::IfOperation* ifOpt, int block, RegisterFrame& frame) {
+		const auto conditionalReg = frame.getValue(ifOpt->getValue()->getIdentifier());
+
+		// Mark for compare-and-branch fusion when the condition is a
+		// comparison used nowhere but this branch (checked before useValue so
+		// the count still reflects the original number of uses).
+		if (const auto* cmp = ir::dyn_cast<ir::CompareOperation>(ifOpt->getValue())) {
+			const auto it = usageCounts.find(cmp->getIdentifier());
+			if (it != usageCounts.end() && it->second == 1) {
+				blocks[block].fuseCompareIntoBranch = true;
+			}
+		}
+		useValue(ifOpt->getValue()->getIdentifier(), frame);
+
+		// Route each arm through a landing-pad block so the two arms cannot
+		// clobber shared merge-block parameter registers (see bc's visitIf for
+		// the full ordering rationale).
+		const int trueLandingPad = static_cast<int>(blocks.size());
+		blocks.emplace_back();
+		processInvocation(ifOpt->getTrueBlockInvocation(), trueLandingPad, frame);
+		const int trueBlockIndex = processBlock(ifOpt->getTrueBlockInvocation().getBlock(), frame);
+		blocks[trueLandingPad].term = Terminator {Terminator::Jump, kNoReg, trueBlockIndex, -1, kNoReg};
+
+		const int falseLandingPad = static_cast<int>(blocks.size());
+		blocks.emplace_back();
+		processInvocation(ifOpt->getFalseBlockInvocation(), falseLandingPad, frame);
+		const int falseBlockIndex = processBlock(ifOpt->getFalseBlockInvocation().getBlock(), frame);
+		blocks[falseLandingPad].term = Terminator {Terminator::Jump, kNoReg, falseBlockIndex, -1, kNoReg};
+
+		blocks[block].term = Terminator {Terminator::CondJump, conditionalReg, trueLandingPad, falseLandingPad, kNoReg};
+	}
+
+	void visitBranch(ir::BranchOperation* branchOp, int block, RegisterFrame& frame) {
+		processInvocation(branchOp->getNextBlockInvocation(), block, frame);
+		const int blockIndex = processBlock(branchOp->getNextBlockInvocation().getBlock(), frame);
+		blocks[block].term = Terminator {Terminator::Jump, kNoReg, blockIndex, -1, kNoReg};
+	}
+
+	void visitReturn(ir::ReturnOperation* returnOpt, int block, RegisterFrame& frame) {
+		if (returnOpt->hasReturnValue()) {
+			const auto returnReg = frame.getValue(returnOpt->getReturnValue()->getIdentifier());
+			useValue(returnOpt->getReturnValue()->getIdentifier(), frame);
+			blocks[block].term = Terminator {Terminator::Ret, kNoReg, -1, -1, returnReg};
+		} else {
+			blocks[block].term = Terminator {Terminator::Ret, kNoReg, -1, -1, kNoReg};
+		}
+	}
+
+	// ── Calls ────────────────────────────────────────────────────────────────
+
+	uint16_t addCallSite(CallSite&& site) {
+		if (program.callsites.size() >= kNoReg) {
+			throw RuntimeException("tbc: too many call sites in program");
+		}
+		program.callsites.emplace_back(std::move(site));
+		return static_cast<uint16_t>(program.callsites.size() - 1);
+	}
+
+	CallSite buildCallSite(std::span<ir::Operation* const> arguments, Type returnType, RegisterFrame& frame) {
+		CallSite site;
+		site.returnType = returnType;
+		site.argTypes.reserve(arguments.size());
+		site.argRegs.reserve(arguments.size());
+		for (auto* arg : arguments) {
+			site.argTypes.push_back(arg->getStamp());
+			site.argRegs.push_back(frame.getValue(arg->getIdentifier()));
+			useValue(arg->getIdentifier(), frame);
+		}
+		return site;
+	}
+
+	void visitProxyCall(ir::ProxyCallOperation* opt, int block, RegisterFrame& frame) {
+		auto site = buildCallSite(opt->getInputArguments(), opt->getStamp(), frame);
+
+		uint16_t dst = kNoReg;
+		if (opt->getStamp() != Type::v) {
+			dst = getResultRegister(opt, frame);
+			frame.setValue(opt->getIdentifier(), dst);
+		}
+
+		// Calls to functions in the same module run interpreter-native: no FFI,
+		// just a frame push in the shared dispatch loop.
+		const auto it = program.functionIndex.find(opt->getFunctionName());
+		if (it != program.functionIndex.end()) {
+			site.internalFnIdx = it->second;
+			const auto siteIdx = addCallSite(std::move(site));
+			emit(block, Op::CALL, dst, static_cast<uint16_t>(it->second), siteIdx);
+			return;
+		}
+		site.target = opt->getFunctionPtr();
+		const auto siteIdx = addCallSite(std::move(site));
+		emit(block, Op::CALL_EXT, dst, siteIdx);
+	}
+
+	void visitIndirectCall(ir::IndirectCallOperation* opt, int block, RegisterFrame& frame) {
+		auto site = buildCallSite(opt->getInputArguments(), opt->getStamp(), frame);
+		const auto functionReg = frame.getValue(opt->getFunctionPtrOperand()->getIdentifier());
+		useValue(opt->getFunctionPtrOperand()->getIdentifier(), frame);
+
+		uint16_t dst = kNoReg;
+		if (opt->getStamp() != Type::v) {
+			dst = getResultRegister(opt, frame);
+			frame.setValue(opt->getIdentifier(), dst);
+		}
+		const auto siteIdx = addCallSite(std::move(site));
+		emit(block, Op::CALL_IND, dst, functionReg, siteIdx);
+	}
+
+	void visitFunctionAddressOf(ir::FunctionAddressOfOperation* opt, int block, RegisterFrame& frame) {
+		// Internal functions have no machine code; hand out a pre-compiled
+		// trampoline bound to the function, which is a genuine native pointer
+		// usable both by CALL_IND and by external code (no runtime code
+		// generation involved — iOS-safe).
+		uint64_t value;
+		const auto it = program.functionIndex.find(opt->getFunctionName());
+		if (it != program.functionIndex.end()) {
+			value = reinterpret_cast<uint64_t>(acquireTrampoline(&program, it->second));
+		} else {
+			value = reinterpret_cast<uint64_t>(opt->getFunctionPtr());
+		}
+		const auto target = getResultRegister(opt, frame);
+		frame.setValue(opt->getIdentifier(), target);
+		emit(block, Op::MOV, target, constSlot(value));
+	}
+
+	// ── Flattening ───────────────────────────────────────────────────────────
+
+	bool shouldFuse(const BlockCode& blk) const {
+		if (!options.enableSuperinstructions || blk.term.kind != Terminator::CondJump || !blk.fuseCompareIntoBranch ||
+		    blk.code.empty()) {
+			return false;
+		}
+		const Instr& last = blk.code.back();
+		return last.a == blk.term.condReg && fusedFormOf(static_cast<Op>(last.op)) != Op::COUNT;
+	}
+
+	void finalize() {
+		const auto regCount = registerProvider.getRegisterCount();
+		out.regSlots = regCount;
+		out.initImage.assign(regCount, 0);
+		for (const auto& [reg, value] : constInits) {
+			out.initImage[reg] = value;
+		}
+		// +2 slack slots so the alloca area can be 16-aligned at runtime.
+		const uint32_t allocaSlots = out.allocaBytes > 0 ? (out.allocaBytes + 7) / 8 + 2 : 0;
+		out.frameSlots = 3 + regCount + allocaSlots;
+
+		// Fold recorded immediates into the arithmetic ops.
+		if (options.enableImmediates) {
+			for (auto& blk : blocks) {
+				for (const auto& [index, immediate] : blk.foldableImmediates) {
+					Instr& inst = blk.code[index];
+					const Op immOp = immFormOf(static_cast<Op>(inst.op));
+					if (immOp != Op::COUNT) {
+						inst.op = opIndex(immOp);
+						inst.c = static_cast<uint16_t>(immediate);
+					}
+				}
+			}
+		}
+
+		// Flatten the block-structured code into one contiguous stream:
+		// terminators become JMP/CJMP/RET, jumps to the next block in emission
+		// order fall through, and fusable trailing compares merge into 2-word
+		// compare-and-branch instructions. Branch targets are patched once all
+		// block start offsets are known.
+		struct Fixup {
+			uint32_t at;         // instruction word the branch executes from
+			uint32_t offsetWord; // word holding the packed offset
+			bool loHi;           // packed in fields a|b (2-word forms) instead of b|c
+			int targetBlock;
+		};
+		std::vector<uint32_t> blockStart(blocks.size(), 0);
+		std::vector<Fixup> fixups;
+		auto& codeOut = out.code;
+
+		for (std::size_t b = 0; b < blocks.size(); ++b) {
+			blockStart[b] = static_cast<uint32_t>(codeOut.size());
+			auto& blk = blocks[b];
+			const bool fuse = shouldFuse(blk);
+			const std::size_t bodyCount = blk.code.size() - (fuse ? 1 : 0);
+			codeOut.insert(codeOut.end(), blk.code.begin(), blk.code.begin() + static_cast<long>(bodyCount));
+
+			const int next = static_cast<int>(b) + 1;
+			switch (blk.term.kind) {
+			case Terminator::Ret:
+				codeOut.push_back(Instr {opIndex(Op::RET), blk.term.retReg, 0, 0});
+				break;
+			case Terminator::Jump:
+				if (blk.term.trueBlock != next) {
+					const auto at = static_cast<uint32_t>(codeOut.size());
+					codeOut.push_back(Instr {opIndex(Op::JMP), 0, 0, 0});
+					fixups.push_back({at, at, false, blk.term.trueBlock});
+				}
+				break;
+			case Terminator::CondJump: {
+				if (fuse) {
+					const Instr& cmp = blk.code.back();
+					const Op fusedOp = fusedFormOf(static_cast<Op>(cmp.op));
+					const auto at = static_cast<uint32_t>(codeOut.size());
+					codeOut.push_back(Instr {opIndex(fusedOp), cmp.b, cmp.c, 0});
+					codeOut.push_back(Instr {opIndex(Op::TRAP), 0, 0, 0});
+					fixups.push_back({at, at + 1, true, blk.term.trueBlock});
+				} else {
+					const auto at = static_cast<uint32_t>(codeOut.size());
+					codeOut.push_back(Instr {opIndex(Op::CJMP), blk.term.condReg, 0, 0});
+					fixups.push_back({at, at, false, blk.term.trueBlock});
+				}
+				if (blk.term.falseBlock != next) {
+					const auto at = static_cast<uint32_t>(codeOut.size());
+					codeOut.push_back(Instr {opIndex(Op::JMP), 0, 0, 0});
+					fixups.push_back({at, at, false, blk.term.falseBlock});
+				}
+				break;
+			}
+			case Terminator::None:
+				throw RuntimeException("tbc: block without terminator");
+			}
+		}
+
+		for (const auto& fixup : fixups) {
+			const auto offset = static_cast<int32_t>(blockStart[fixup.targetBlock]) - static_cast<int32_t>(fixup.at);
+			const auto packed = static_cast<uint32_t>(offset);
+			Instr& word = codeOut[fixup.offsetWord];
+			if (fixup.loHi) {
+				word.a = static_cast<uint16_t>(packed & 0xFFFF);
+				word.b = static_cast<uint16_t>(packed >> 16);
+			} else {
+				word.b = static_cast<uint16_t>(packed & 0xFFFF);
+				word.c = static_cast<uint16_t>(packed >> 16);
+			}
+		}
+	}
+};
+
+} // namespace
+
+void TBCLoweringProvider::lower(const ir::FunctionOperation* func, TBCProgram& program, TBCFunction& out,
+                                const TBCLoweringOptions& options) {
+	out.name = func->getName();
+	LoweringContext context(func, program, out, options);
+	context.process();
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -543,8 +543,7 @@ private:
 		const auto value = frame.getValue(opt->getValue()->getIdentifier());
 		useValue(opt->getAddress()->getIdentifier(), frame);
 		useValue(opt->getValue()->getIdentifier(), frame);
-		emit(block, typedOp(Op::STORE_i8, memTypeIndex(opt->getValue()->getStamp(), "store"), "store"), address,
-		     value);
+		emit(block, typedOp(Op::STORE_i8, memTypeIndex(opt->getValue()->getStamp(), "store"), "store"), address, value);
 	}
 
 	void visitAlloca(ir::AllocaOperation* opt, int block, RegisterFrame& frame) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include "nautilus/compiler/ir/IRGraph.hpp"
+
+namespace nautilus::compiler::tbc {
+
+/**
+ * @brief Configuration for the TBC lowering.
+ *
+ * Unlike the bc backend, every optimization defaults to ON — the flags exist
+ * for A/B benchmarking and debugging, not for backwards compatibility.
+ *
+ * enableRegisterAllocator: linear register allocation with a free list; when
+ * disabled every SSA value keeps its own register.
+ *
+ * enableRegisterCoalescing: sequence block-invocation arguments targeting
+ * already-bound registers as a parallel copy (minimum number of MOVs, one temp
+ * only for a genuine permutation cycle) instead of staging each argument
+ * through a temp.
+ *
+ * enableSuperinstructions: fuse a single-use comparison feeding a conditional
+ * branch into one 2-word compare-and-branch instruction.
+ *
+ * enableImmediates: fold small constant right operands of i32/i64 add/sub/mul
+ * into the instruction's 16-bit immediate field.
+ */
+struct TBCLoweringOptions {
+	bool enableRegisterAllocator = true;
+	bool enableRegisterCoalescing = true;
+	bool enableSuperinstructions = true;
+	bool enableImmediates = true;
+};
+
+/**
+ * @brief Lowers one IR function to the TBC flat bytecode format.
+ *
+ * `program` must already contain the module-wide function index (so calls to
+ * other functions in the same module become interpreter-native CALLs) and the
+ * pre-sized internal-handle arena; the call-site table is appended to.
+ */
+class TBCLoweringProvider {
+public:
+	static void lower(const ir::FunctionOperation* func, TBCProgram& program, TBCFunction& out,
+	                  const TBCLoweringOptions& options);
+};
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
@@ -21,26 +21,26 @@ namespace nautilus::compiler::tbc {
 // need the name (enum, name table) simply ignore it.
 
 #define TBC_NUM10(X, NAME, FN)                                                                                         \
-	X(NAME##_i8, (FN<int8_t>))                                                                                         \
-	X(NAME##_i16, (FN<int16_t>))                                                                                       \
-	X(NAME##_i32, (FN<int32_t>))                                                                                       \
-	X(NAME##_i64, (FN<int64_t>))                                                                                       \
-	X(NAME##_ui8, (FN<uint8_t>))                                                                                       \
-	X(NAME##_ui16, (FN<uint16_t>))                                                                                     \
-	X(NAME##_ui32, (FN<uint32_t>))                                                                                     \
-	X(NAME##_ui64, (FN<uint64_t>))                                                                                     \
-	X(NAME##_f32, (FN<float>))                                                                                         \
-	X(NAME##_f64, (FN<double>))
+	X(NAME##_i8, (FN<int8_t>) )                                                                                        \
+	X(NAME##_i16, (FN<int16_t>) )                                                                                      \
+	X(NAME##_i32, (FN<int32_t>) )                                                                                      \
+	X(NAME##_i64, (FN<int64_t>) )                                                                                      \
+	X(NAME##_ui8, (FN<uint8_t>) )                                                                                      \
+	X(NAME##_ui16, (FN<uint16_t>) )                                                                                    \
+	X(NAME##_ui32, (FN<uint32_t>) )                                                                                    \
+	X(NAME##_ui64, (FN<uint64_t>) )                                                                                    \
+	X(NAME##_f32, (FN<float>) )                                                                                        \
+	X(NAME##_f64, (FN<double>) )
 
 #define TBC_INT8(X, NAME, FN)                                                                                          \
-	X(NAME##_i8, (FN<int8_t>))                                                                                         \
-	X(NAME##_i16, (FN<int16_t>))                                                                                       \
-	X(NAME##_i32, (FN<int32_t>))                                                                                       \
-	X(NAME##_i64, (FN<int64_t>))                                                                                       \
-	X(NAME##_ui8, (FN<uint8_t>))                                                                                       \
-	X(NAME##_ui16, (FN<uint16_t>))                                                                                     \
-	X(NAME##_ui32, (FN<uint32_t>))                                                                                     \
-	X(NAME##_ui64, (FN<uint64_t>))
+	X(NAME##_i8, (FN<int8_t>) )                                                                                        \
+	X(NAME##_i16, (FN<int16_t>) )                                                                                      \
+	X(NAME##_i32, (FN<int32_t>) )                                                                                      \
+	X(NAME##_i64, (FN<int64_t>) )                                                                                      \
+	X(NAME##_ui8, (FN<uint8_t>) )                                                                                      \
+	X(NAME##_ui16, (FN<uint16_t>) )                                                                                    \
+	X(NAME##_ui32, (FN<uint32_t>) )                                                                                    \
+	X(NAME##_ui64, (FN<uint64_t>) )
 
 // One row of the cast grid: SRC -> each of the 10 numeric types. The full grid
 // is 10x10 in row-major (source-major) order so the lowering can compute
@@ -48,16 +48,16 @@ namespace nautilus::compiler::tbc {
 // keep the index math trivial; the lowering emits MOV for identity casts, so
 // they are never dispatched.
 #define TBC_CAST_ROW(X, S, SN)                                                                                         \
-	X(CAST_##SN##_i8, (opCast<S, int8_t>))                                                                             \
-	X(CAST_##SN##_i16, (opCast<S, int16_t>))                                                                           \
-	X(CAST_##SN##_i32, (opCast<S, int32_t>))                                                                           \
-	X(CAST_##SN##_i64, (opCast<S, int64_t>))                                                                           \
-	X(CAST_##SN##_ui8, (opCast<S, uint8_t>))                                                                           \
-	X(CAST_##SN##_ui16, (opCast<S, uint16_t>))                                                                         \
-	X(CAST_##SN##_ui32, (opCast<S, uint32_t>))                                                                         \
-	X(CAST_##SN##_ui64, (opCast<S, uint64_t>))                                                                         \
-	X(CAST_##SN##_f32, (opCast<S, float>))                                                                             \
-	X(CAST_##SN##_f64, (opCast<S, double>))
+	X(CAST_##SN##_i8, (opCast<S, int8_t>) )                                                                            \
+	X(CAST_##SN##_i16, (opCast<S, int16_t>) )                                                                          \
+	X(CAST_##SN##_i32, (opCast<S, int32_t>) )                                                                          \
+	X(CAST_##SN##_i64, (opCast<S, int64_t>) )                                                                          \
+	X(CAST_##SN##_ui8, (opCast<S, uint8_t>) )                                                                          \
+	X(CAST_##SN##_ui16, (opCast<S, uint16_t>) )                                                                        \
+	X(CAST_##SN##_ui32, (opCast<S, uint32_t>) )                                                                        \
+	X(CAST_##SN##_ui64, (opCast<S, uint64_t>) )                                                                        \
+	X(CAST_##SN##_f32, (opCast<S, float>) )                                                                            \
+	X(CAST_##SN##_f64, (opCast<S, double>) )
 
 #define TBC_CAST_GRID(X)                                                                                               \
 	TBC_CAST_ROW(X, int8_t, i8)                                                                                        \
@@ -75,25 +75,25 @@ namespace nautilus::compiler::tbc {
 // field `c` through the type's normal write semantics. Bool constants use the
 // ui8 form; float/ptr constants always go through the constant image.
 #define TBC_MOVIMM_LIST(X)                                                                                             \
-	X(MOV_imm_i8, (opMovImm<int8_t>))                                                                                  \
-	X(MOV_imm_i16, (opMovImm<int16_t>))                                                                                \
-	X(MOV_imm_i32, (opMovImm<int32_t>))                                                                                \
-	X(MOV_imm_i64, (opMovImm<int64_t>))                                                                                \
-	X(MOV_imm_ui8, (opMovImm<uint8_t>))                                                                                \
-	X(MOV_imm_ui16, (opMovImm<uint16_t>))                                                                              \
-	X(MOV_imm_ui32, (opMovImm<uint32_t>))                                                                              \
-	X(MOV_imm_ui64, (opMovImm<uint64_t>))
+	X(MOV_imm_i8, (opMovImm<int8_t>) )                                                                                 \
+	X(MOV_imm_i16, (opMovImm<int16_t>) )                                                                               \
+	X(MOV_imm_i32, (opMovImm<int32_t>) )                                                                               \
+	X(MOV_imm_i64, (opMovImm<int64_t>) )                                                                               \
+	X(MOV_imm_ui8, (opMovImm<uint8_t>) )                                                                               \
+	X(MOV_imm_ui16, (opMovImm<uint16_t>) )                                                                             \
+	X(MOV_imm_ui32, (opMovImm<uint32_t>) )                                                                             \
+	X(MOV_imm_ui64, (opMovImm<uint64_t>) )
 
 // Immediate-folded arithmetic (default on): right operand is a sign-extended
 // 16-bit immediate in field `c`, replacing one register read + the separate
 // constant materialization on the hot path (dominant loop-increment idiom).
 #define TBC_IMM_ARITH_LIST(X)                                                                                          \
-	X(ADD_imm_i32, (opAddImm<int32_t>))                                                                                \
-	X(ADD_imm_i64, (opAddImm<int64_t>))                                                                                \
-	X(SUB_imm_i32, (opSubImm<int32_t>))                                                                                \
-	X(SUB_imm_i64, (opSubImm<int64_t>))                                                                                \
-	X(MUL_imm_i32, (opMulImm<int32_t>))                                                                                \
-	X(MUL_imm_i64, (opMulImm<int64_t>))
+	X(ADD_imm_i32, (opAddImm<int32_t>) )                                                                               \
+	X(ADD_imm_i64, (opAddImm<int64_t>) )                                                                               \
+	X(SUB_imm_i32, (opSubImm<int32_t>) )                                                                               \
+	X(SUB_imm_i64, (opSubImm<int64_t>) )                                                                               \
+	X(MUL_imm_i32, (opMulImm<int32_t>) )                                                                               \
+	X(MUL_imm_i64, (opMulImm<int64_t>) )
 
 // Every 1-word value opcode: executes its body, then falls through to the next
 // instruction word. Comparison families are contiguous in EQ,NE,LT,LE,GT,GE
@@ -118,9 +118,9 @@ namespace nautilus::compiler::tbc {
 	X(OR_b, (opOr))                                                                                                    \
 	X(NOT_b, (opNot))                                                                                                  \
 	TBC_NUM10(X, LOAD, opLoad)                                                                                         \
-	X(LOAD_b, (opLoad<bool>))                                                                                          \
+	X(LOAD_b, (opLoad<bool>) )                                                                                         \
 	TBC_NUM10(X, STORE, opStore)                                                                                       \
-	X(STORE_b, (opStore<bool>))                                                                                        \
+	X(STORE_b, (opStore<bool>) )                                                                                       \
 	TBC_INT8(X, BAND, opBand)                                                                                          \
 	TBC_INT8(X, BOR, opBor)                                                                                            \
 	TBC_INT8(X, BXOR, opBxor)                                                                                          \
@@ -175,12 +175,12 @@ enum class Op : uint16_t {
 	TBC_VALUE_OPCODE_LIST(TBC_ENUM_V)
 #undef TBC_ENUM_V
 #define TBC_ENUM_C(name) name,
-	TBC_CONTROL_SIMPLE_LIST(TBC_ENUM_C)
+	    TBC_CONTROL_SIMPLE_LIST(TBC_ENUM_C)
 #undef TBC_ENUM_C
 #define TBC_ENUM_F(name, ctype, cmp) name,
-	    TBC_CJMP_FUSED_LIST(TBC_ENUM_F)
+	        TBC_CJMP_FUSED_LIST(TBC_ENUM_F)
 #undef TBC_ENUM_F
-	        COUNT,
+	            COUNT,
 };
 
 constexpr uint16_t opIndex(Op op) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
@@ -1,0 +1,208 @@
+#pragma once
+
+#include <cstdint>
+
+namespace nautilus::compiler::tbc {
+
+// The TBC opcode set is generated from the X-macro lists below. Every consumer
+// (the Op enum, the three dispatch skins, the name table for the disassembler)
+// expands the same lists, so they cannot drift.
+//
+// Numeric families expand over the canonical 10-type order
+//   i8, i16, i32, i64, ui8, ui16, ui32, ui64, f32, f64
+// and the lowering computes `family base + type index` instead of a per-type
+// switch, so this order is load-bearing (see the static_asserts at the bottom).
+// Type::b and Type::ptr are mapped onto this order at lowering time (b -> ui8
+// for compares, ptr -> i64/ui64), mirroring the bc backend's choices.
+//
+// Each entry is X(NAME, (handlerExpression)). The handler expression is a
+// value-op body `void(const Instr&, uint64_t*)` and is parenthesized so
+// template arguments with commas survive macro expansion; consumers that only
+// need the name (enum, name table) simply ignore it.
+
+#define TBC_NUM10(X, NAME, FN)                                                                                         \
+	X(NAME##_i8, (FN<int8_t>))                                                                                         \
+	X(NAME##_i16, (FN<int16_t>))                                                                                       \
+	X(NAME##_i32, (FN<int32_t>))                                                                                       \
+	X(NAME##_i64, (FN<int64_t>))                                                                                       \
+	X(NAME##_ui8, (FN<uint8_t>))                                                                                       \
+	X(NAME##_ui16, (FN<uint16_t>))                                                                                     \
+	X(NAME##_ui32, (FN<uint32_t>))                                                                                     \
+	X(NAME##_ui64, (FN<uint64_t>))                                                                                     \
+	X(NAME##_f32, (FN<float>))                                                                                         \
+	X(NAME##_f64, (FN<double>))
+
+#define TBC_INT8(X, NAME, FN)                                                                                          \
+	X(NAME##_i8, (FN<int8_t>))                                                                                         \
+	X(NAME##_i16, (FN<int16_t>))                                                                                       \
+	X(NAME##_i32, (FN<int32_t>))                                                                                       \
+	X(NAME##_i64, (FN<int64_t>))                                                                                       \
+	X(NAME##_ui8, (FN<uint8_t>))                                                                                       \
+	X(NAME##_ui16, (FN<uint16_t>))                                                                                     \
+	X(NAME##_ui32, (FN<uint32_t>))                                                                                     \
+	X(NAME##_ui64, (FN<uint64_t>))
+
+// One row of the cast grid: SRC -> each of the 10 numeric types. The full grid
+// is 10x10 in row-major (source-major) order so the lowering can compute
+// `CAST_BASE + srcIdx * 10 + dstIdx`. Diagonal (identity) entries exist to
+// keep the index math trivial; the lowering emits MOV for identity casts, so
+// they are never dispatched.
+#define TBC_CAST_ROW(X, S, SN)                                                                                         \
+	X(CAST_##SN##_i8, (opCast<S, int8_t>))                                                                             \
+	X(CAST_##SN##_i16, (opCast<S, int16_t>))                                                                           \
+	X(CAST_##SN##_i32, (opCast<S, int32_t>))                                                                           \
+	X(CAST_##SN##_i64, (opCast<S, int64_t>))                                                                           \
+	X(CAST_##SN##_ui8, (opCast<S, uint8_t>))                                                                           \
+	X(CAST_##SN##_ui16, (opCast<S, uint16_t>))                                                                         \
+	X(CAST_##SN##_ui32, (opCast<S, uint32_t>))                                                                         \
+	X(CAST_##SN##_ui64, (opCast<S, uint64_t>))                                                                         \
+	X(CAST_##SN##_f32, (opCast<S, float>))                                                                             \
+	X(CAST_##SN##_f64, (opCast<S, double>))
+
+#define TBC_CAST_GRID(X)                                                                                               \
+	TBC_CAST_ROW(X, int8_t, i8)                                                                                        \
+	TBC_CAST_ROW(X, int16_t, i16)                                                                                      \
+	TBC_CAST_ROW(X, int32_t, i32)                                                                                      \
+	TBC_CAST_ROW(X, int64_t, i64)                                                                                      \
+	TBC_CAST_ROW(X, uint8_t, ui8)                                                                                      \
+	TBC_CAST_ROW(X, uint16_t, ui16)                                                                                    \
+	TBC_CAST_ROW(X, uint32_t, ui32)                                                                                    \
+	TBC_CAST_ROW(X, uint64_t, ui64)                                                                                    \
+	TBC_CAST_ROW(X, float, f32)                                                                                        \
+	TBC_CAST_ROW(X, double, f64)
+
+// Small-constant materialization: writes the sign-extended 16-bit immediate in
+// field `c` through the type's normal write semantics. Bool constants use the
+// ui8 form; float/ptr constants always go through the constant image.
+#define TBC_MOVIMM_LIST(X)                                                                                             \
+	X(MOV_imm_i8, (opMovImm<int8_t>))                                                                                  \
+	X(MOV_imm_i16, (opMovImm<int16_t>))                                                                                \
+	X(MOV_imm_i32, (opMovImm<int32_t>))                                                                                \
+	X(MOV_imm_i64, (opMovImm<int64_t>))                                                                                \
+	X(MOV_imm_ui8, (opMovImm<uint8_t>))                                                                                \
+	X(MOV_imm_ui16, (opMovImm<uint16_t>))                                                                              \
+	X(MOV_imm_ui32, (opMovImm<uint32_t>))                                                                              \
+	X(MOV_imm_ui64, (opMovImm<uint64_t>))
+
+// Immediate-folded arithmetic (default on): right operand is a sign-extended
+// 16-bit immediate in field `c`, replacing one register read + the separate
+// constant materialization on the hot path (dominant loop-increment idiom).
+#define TBC_IMM_ARITH_LIST(X)                                                                                          \
+	X(ADD_imm_i32, (opAddImm<int32_t>))                                                                                \
+	X(ADD_imm_i64, (opAddImm<int64_t>))                                                                                \
+	X(SUB_imm_i32, (opSubImm<int32_t>))                                                                                \
+	X(SUB_imm_i64, (opSubImm<int64_t>))                                                                                \
+	X(MUL_imm_i32, (opMulImm<int32_t>))                                                                                \
+	X(MUL_imm_i64, (opMulImm<int64_t>))
+
+// Every 1-word value opcode: executes its body, then falls through to the next
+// instruction word. Comparison families are contiguous in EQ,NE,LT,LE,GT,GE
+// order (matching ir::CompareOperation::Comparator) so the lowering computes
+// `EQ_i8 + comparator * 10 + typeIdx`.
+#define TBC_VALUE_OPCODE_LIST(X)                                                                                       \
+	X(NOP, (opNop))                                                                                                    \
+	X(MOV, (opMov))                                                                                                    \
+	TBC_MOVIMM_LIST(X)                                                                                                 \
+	TBC_NUM10(X, ADD, opAdd)                                                                                           \
+	TBC_NUM10(X, SUB, opSub)                                                                                           \
+	TBC_NUM10(X, MUL, opMul)                                                                                           \
+	TBC_NUM10(X, DIV, opDiv)                                                                                           \
+	TBC_INT8(X, MOD, opMod)                                                                                            \
+	TBC_NUM10(X, EQ, opEq)                                                                                             \
+	TBC_NUM10(X, NE, opNe)                                                                                             \
+	TBC_NUM10(X, LT, opLt)                                                                                             \
+	TBC_NUM10(X, LE, opLe)                                                                                             \
+	TBC_NUM10(X, GT, opGt)                                                                                             \
+	TBC_NUM10(X, GE, opGe)                                                                                             \
+	X(AND_b, (opAnd))                                                                                                  \
+	X(OR_b, (opOr))                                                                                                    \
+	X(NOT_b, (opNot))                                                                                                  \
+	TBC_NUM10(X, LOAD, opLoad)                                                                                         \
+	X(LOAD_b, (opLoad<bool>))                                                                                          \
+	TBC_NUM10(X, STORE, opStore)                                                                                       \
+	X(STORE_b, (opStore<bool>))                                                                                        \
+	TBC_INT8(X, BAND, opBand)                                                                                          \
+	TBC_INT8(X, BOR, opBor)                                                                                            \
+	TBC_INT8(X, BXOR, opBxor)                                                                                          \
+	TBC_INT8(X, SHL, opShl)                                                                                            \
+	TBC_INT8(X, SHR, opShr)                                                                                            \
+	X(BNOT_i64, (opBnot))                                                                                              \
+	TBC_CAST_GRID(X)                                                                                                   \
+	TBC_IMM_ARITH_LIST(X)
+
+// Control opcodes with hand-written handlers in every dispatch skin (they
+// modify ip / fp / the VM stack, or consume a second instruction word).
+//   SELECT   a=dst, b=cond, c=trueReg;  word1.a=falseReg          (2 words)
+//   JMP      signed 32-bit relative offset in b|c<<16             (1 word)
+//   CJMP     a=cond, taken offset in b|c<<16, else fall through   (1 word)
+//   RET      a=result register (kNoReg for void)                  (1 word)
+//   CALL     a=dst (kNoReg for void), b=function idx, c=callsite  (1 word)
+//   CALL_EXT a=dst, b=callsite idx                                (1 word)
+//   CALL_IND a=dst, b=function-pointer register, c=callsite idx   (1 word)
+//   HALT     terminates the dispatch loop of an entry frame       (1 word)
+//   TRAP     never emitted; throws on dispatch (encoding bugs)    (1 word)
+#define TBC_CONTROL_SIMPLE_LIST(X)                                                                                     \
+	X(SELECT)                                                                                                          \
+	X(JMP)                                                                                                             \
+	X(CJMP)                                                                                                            \
+	X(RET)                                                                                                             \
+	X(CALL)                                                                                                            \
+	X(CALL_EXT)                                                                                                        \
+	X(CALL_IND)                                                                                                        \
+	X(HALT)                                                                                                            \
+	X(TRAP)
+
+// Fused compare-and-branch superinstructions (default on): a=lhs, b=rhs,
+// taken offset as signed 32-bit in word1.a|word1.b<<16, else fall through
+// (2 words). Ordered pred-major over {i32,i64} so the flattener computes
+// `CJMP_EQ_i32 + pred * 2 + isI64`.
+#define TBC_CJMP_FUSED_LIST(X)                                                                                         \
+	X(CJMP_EQ_i32, int32_t, ==)                                                                                        \
+	X(CJMP_EQ_i64, int64_t, ==)                                                                                        \
+	X(CJMP_NE_i32, int32_t, !=)                                                                                        \
+	X(CJMP_NE_i64, int64_t, !=)                                                                                        \
+	X(CJMP_LT_i32, int32_t, <)                                                                                         \
+	X(CJMP_LT_i64, int64_t, <)                                                                                         \
+	X(CJMP_LE_i32, int32_t, <=)                                                                                        \
+	X(CJMP_LE_i64, int64_t, <=)                                                                                        \
+	X(CJMP_GT_i32, int32_t, >)                                                                                         \
+	X(CJMP_GT_i64, int64_t, >)                                                                                         \
+	X(CJMP_GE_i32, int32_t, >=)                                                                                        \
+	X(CJMP_GE_i64, int64_t, >=)
+
+enum class Op : uint16_t {
+#define TBC_ENUM_V(name, fn) name,
+	TBC_VALUE_OPCODE_LIST(TBC_ENUM_V)
+#undef TBC_ENUM_V
+#define TBC_ENUM_C(name) name,
+	TBC_CONTROL_SIMPLE_LIST(TBC_ENUM_C)
+#undef TBC_ENUM_C
+#define TBC_ENUM_F(name, ctype, cmp) name,
+	    TBC_CJMP_FUSED_LIST(TBC_ENUM_F)
+#undef TBC_ENUM_F
+	        COUNT,
+};
+
+constexpr uint16_t opIndex(Op op) {
+	return static_cast<uint16_t>(op);
+}
+
+constexpr uint16_t kOpCount = opIndex(Op::COUNT);
+
+// The lowering's base + index arithmetic relies on the family layout produced
+// by the lists above; pin the corners so a reordering cannot silently corrupt
+// the opcode math.
+static_assert(opIndex(Op::ADD_f64) == opIndex(Op::ADD_i8) + 9);
+static_assert(opIndex(Op::MOD_ui64) == opIndex(Op::MOD_i8) + 7);
+static_assert(opIndex(Op::NE_i8) == opIndex(Op::EQ_i8) + 10);
+static_assert(opIndex(Op::GE_f64) == opIndex(Op::EQ_i8) + 59);
+static_assert(opIndex(Op::LOAD_b) == opIndex(Op::LOAD_i8) + 10);
+static_assert(opIndex(Op::STORE_b) == opIndex(Op::STORE_i8) + 10);
+static_assert(opIndex(Op::CAST_f64_f64) == opIndex(Op::CAST_i8_i8) + 99);
+static_assert(opIndex(Op::MOV_imm_ui64) == opIndex(Op::MOV_imm_i8) + 7);
+static_assert(opIndex(Op::CJMP_GE_i64) == opIndex(Op::CJMP_EQ_i32) + 11);
+static_assert(kOpCount < 65535);
+
+const char* opName(Op op);
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCTrampoline.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCTrampoline.cpp
@@ -1,0 +1,134 @@
+
+#include "nautilus/compiler/backends/tbc/TBCTrampoline.hpp"
+#include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
+#include "nautilus/exceptions/NotImplementedException.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
+#include <array>
+#include <atomic>
+#include <mutex>
+#include <utility>
+
+namespace nautilus::compiler::tbc {
+
+namespace {
+
+constexpr size_t kTrampolineSlots = 64;
+
+struct SlotEntry {
+	std::atomic<const TBCProgram*> program {nullptr};
+	std::atomic<uint32_t> functionIndex {0};
+};
+
+std::array<SlotEntry, kTrampolineSlots>& slotTable() {
+	static std::array<SlotEntry, kTrampolineSlots> table;
+	return table;
+}
+
+std::mutex& slotMutex() {
+	static std::mutex mutex;
+	return mutex;
+}
+
+template <size_t>
+using U64Arg = uint64_t;
+
+/// One pre-compiled trampoline per (slot, arity). The C++ compiler emits it
+/// with the native calling convention, so its address is a genuine function
+/// pointer; the slot index is baked in as a template argument, giving the
+/// body the context a C ABI cannot carry. Arguments travel as 64-bit
+/// integer-class values: narrow arguments may carry garbage in their upper
+/// bits (the caller only guarantees the declared width), which is harmless
+/// because every VM consumer reads its exact declared width.
+template <size_t Slot, class Seq>
+struct Trampoline;
+
+template <size_t Slot, size_t... I>
+struct Trampoline<Slot, std::index_sequence<I...>> {
+	static uint64_t call(U64Arg<I>... args) {
+		const auto& entry = slotTable()[Slot];
+		const TBCProgram* program = entry.program.load(std::memory_order_acquire);
+		if (program == nullptr) {
+			throw RuntimeException("tbc: call through released function trampoline");
+		}
+		[[maybe_unused]] const uint64_t values[] = {args..., 0};
+		return invoke(*program, entry.functionIndex.load(std::memory_order_relaxed), values, sizeof...(I));
+	}
+};
+
+template <size_t Slot, size_t... Arity>
+constexpr std::array<void*, sizeof...(Arity)> makeSlotRow(std::index_sequence<Arity...>) {
+	return {reinterpret_cast<void*>(&Trampoline<Slot, std::make_index_sequence<Arity>>::call)...};
+}
+
+template <size_t... Slot>
+constexpr auto makeTable(std::index_sequence<Slot...>) {
+	return std::array<std::array<void*, kTrampolineMaxArity + 1>, sizeof...(Slot)> {
+	    makeSlotRow<Slot>(std::make_index_sequence<kTrampolineMaxArity + 1>())...};
+}
+
+const auto kTrampolinePointers = makeTable(std::make_index_sequence<kTrampolineSlots>());
+
+bool isIntegerClass(Type t) {
+	switch (t) {
+	case Type::b:
+	case Type::i8:
+	case Type::i16:
+	case Type::i32:
+	case Type::i64:
+	case Type::ui8:
+	case Type::ui16:
+	case Type::ui32:
+	case Type::ui64:
+	case Type::ptr:
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace
+
+void* acquireTrampoline(const TBCProgram* program, uint32_t functionIndex) {
+	const TBCFunction& function = program->functions[functionIndex];
+	if (function.argTypes.size() > kTrampolineMaxArity) {
+		throw NotImplementedException("tbc: escaping internal function pointer with more than 8 arguments");
+	}
+	for (const auto argType : function.argTypes) {
+		if (!isIntegerClass(argType)) {
+			throw NotImplementedException(
+			    "tbc: escaping internal function pointer with float arguments is not supported");
+		}
+	}
+	if (function.returnType != Type::v && !isIntegerClass(function.returnType)) {
+		throw NotImplementedException("tbc: escaping internal function pointer with float return is not supported");
+	}
+
+	std::lock_guard<std::mutex> lock(slotMutex());
+	auto& table = slotTable();
+	// Reuse a slot this program already bound to the same function.
+	for (size_t slot = 0; slot < kTrampolineSlots; ++slot) {
+		if (table[slot].program.load(std::memory_order_relaxed) == program &&
+		    table[slot].functionIndex.load(std::memory_order_relaxed) == functionIndex) {
+			return kTrampolinePointers[slot][function.argTypes.size()];
+		}
+	}
+	for (size_t slot = 0; slot < kTrampolineSlots; ++slot) {
+		if (table[slot].program.load(std::memory_order_relaxed) == nullptr) {
+			table[slot].functionIndex.store(functionIndex, std::memory_order_relaxed);
+			table[slot].program.store(program, std::memory_order_release);
+			return kTrampolinePointers[slot][function.argTypes.size()];
+		}
+	}
+	throw RuntimeException("tbc: function trampoline pool exhausted (64 escaping internal function pointers)");
+}
+
+void releaseTrampolines(const TBCProgram* program) {
+	std::lock_guard<std::mutex> lock(slotMutex());
+	for (auto& entry : slotTable()) {
+		if (entry.program.load(std::memory_order_relaxed) == program) {
+			entry.program.store(nullptr, std::memory_order_release);
+		}
+	}
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCTrampoline.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCTrampoline.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include <cstddef>
+#include <cstdint>
+
+namespace nautilus::compiler::tbc {
+
+/// Maximum arity supported for escaping internal function pointers.
+constexpr size_t kTrampolineMaxArity = 8;
+
+/// Acquire a real, natively callable C function pointer for
+/// `program.functions[functionIndex]`.
+///
+/// Internal functions have no machine code, but their address can escape to
+/// native code (FunctionAddressOf passed through invoke()). bc solves this
+/// with dyncallback, which allocates runtime-executable memory and is
+/// therefore forbidden on iOS. Instead, tbc binds one of a fixed pool of
+/// pre-compiled template trampolines to the function: the trampoline forwards
+/// its (integer-class) arguments into the interpreter.
+///
+/// Only integer-class signatures (bool/int/pointer arguments and return, or
+/// void return) up to kTrampolineMaxArity arguments are supported — the
+/// trampolines pass everything as 64-bit integer-class values, which is
+/// ABI-compatible because every VM consumer reads its exact declared width.
+/// Float signatures throw NotImplementedException.
+///
+/// Throws RuntimeException when the pool is exhausted.
+void* acquireTrampoline(const TBCProgram* program, uint32_t functionIndex);
+
+/// Release every trampoline slot bound to `program` (called from
+/// ~TBCProgram).
+void releaseTrampolines(const TBCProgram* program);
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/test/benchmark/ExecutionBenchmark.cpp
+++ b/nautilus/test/benchmark/ExecutionBenchmark.cpp
@@ -67,6 +67,9 @@ TEST_CASE("Execution Benchmark") {
 #ifdef ENABLE_BC_BACKEND
 	backends.emplace_back("bc");
 #endif
+#ifdef ENABLE_TBC_BACKEND
+	backends.emplace_back("tbc");
+#endif
 #ifdef ENABLE_ASMJIT_BACKEND
 	backends.emplace_back("asmjit");
 #endif

--- a/nautilus/test/benchmark/TracingBenchmark.cpp
+++ b/nautilus/test/benchmark/TracingBenchmark.cpp
@@ -147,6 +147,9 @@ TEST_CASE("Backend Compilation Benchmark") {
 #ifdef ENABLE_BC_BACKEND
 	backends.emplace_back("bc");
 #endif
+#ifdef ENABLE_TBC_BACKEND
+	backends.emplace_back("tbc");
+#endif
 #ifdef ENABLE_ASMJIT_BACKEND
 	backends.emplace_back("asmjit");
 #endif

--- a/nautilus/test/common/ExecutionTest.hpp
+++ b/nautilus/test/common/ExecutionTest.hpp
@@ -21,6 +21,9 @@ inline std::vector<std::string> availableBackends(bool include_asmjit = true) {
 #ifdef ENABLE_BC_BACKEND
 	backends.emplace_back("bc");
 #endif
+#ifdef ENABLE_TBC_BACKEND
+	backends.emplace_back("tbc");
+#endif
 #ifdef ENABLE_ASMJIT_BACKEND
 	if (include_asmjit) {
 		backends.emplace_back("asmjit");

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(NAUTILUS_EXECUTION_TEST_SOURCES
         AsmJitLoweringModeTest.cpp
         BCDispatchModeTest.cpp
         BCRegisterCoalescingTest.cpp
+        TBCDispatchModeTest.cpp
         BoolExecutionTest.cpp
         CastExecutionTest.cpp
         CompilationStatisticsTest.cpp

--- a/nautilus/test/execution-tests/CompilationStatisticsTest.cpp
+++ b/nautilus/test/execution-tests/CompilationStatisticsTest.cpp
@@ -18,6 +18,8 @@ std::string getAnyBackend() {
 	return "cpp";
 #elif defined(ENABLE_TRACING) && defined(ENABLE_BC_BACKEND)
 	return "bc";
+#elif defined(ENABLE_TRACING) && defined(ENABLE_TBC_BACKEND)
+	return "tbc";
 #else
 	return "";
 #endif
@@ -157,6 +159,32 @@ TEST_CASE("CompilationStatistics: bc.registerAllocator option shrinks the regist
 	INFO("registers with allocator=" << withAlloc << " without=" << withoutAlloc);
 	REQUIRE(withAlloc <= withoutAlloc);
 	REQUIRE(withAlloc < withoutAlloc); // for this workload reuse is always possible
+}
+#endif
+
+#if defined(ENABLE_TRACING) && defined(ENABLE_TBC_BACKEND)
+TEST_CASE("CompilationStatistics: tbc backend reports code size") {
+	Options options;
+	options.setOption("engine.backend", std::string {"tbc"});
+	options.setOption("engine.compilationStrategy", std::string("legacy"));
+
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(statsAddOne);
+	REQUIRE(fn(5) == 6);
+
+	auto stats = fn.getStatistics();
+	REQUIRE(stats != nullptr);
+	REQUIRE(stats->contains("tbc.instructions"));
+	REQUIRE(stats->contains("tbc.codeSize.bytes"));
+	REQUIRE(stats->contains("tbc.registers.max"));
+	REQUIRE(stats->contains("tbc.dispatch"));
+	REQUIRE(std::get<int64_t>(*stats->find("tbc.instructions")) > 0);
+	REQUIRE(std::get<int64_t>(*stats->find("tbc.codeSize.bytes")) > 0);
+	REQUIRE(std::get<int64_t>(*stats->find("tbc.registers.max")) > 0);
+	// The recorded dispatch mode is the one actually selected after clamping
+	// to what this build supports.
+	const auto dispatch = std::get<std::string>(*stats->find("tbc.dispatch"));
+	REQUIRE((dispatch == "tailcall" || dispatch == "goto" || dispatch == "switch"));
 }
 #endif
 

--- a/nautilus/test/execution-tests/ModuleTest.cpp
+++ b/nautilus/test/execution-tests/ModuleTest.cpp
@@ -108,6 +108,8 @@ std::string getAnyBackend() {
 	return "cpp";
 #elif defined(ENABLE_TRACING) && defined(ENABLE_BC_BACKEND)
 	return "bc";
+#elif defined(ENABLE_TRACING) && defined(ENABLE_TBC_BACKEND)
+	return "tbc";
 #else
 	return "";
 #endif

--- a/nautilus/test/execution-tests/TBCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/TBCDispatchModeTest.cpp
@@ -98,9 +98,9 @@ TEST_CASE("TBC dispatch modes produce identical results") {
 	// (i + 1, b + 7, x - 100, …) and compare-fed branches, so immediate
 	// folding and compare-and-branch fusion are actually exercised.
 	const std::vector<Variant> variants = {
-	    {"switch", true, true, true},  {"goto", false, false, false},   {"goto", true, true, true},
+	    {"switch", true, true, true},   {"goto", false, false, false},     {"goto", true, true, true},
 	    {"tailcall", true, true, true}, {"tailcall", false, false, false}, {"auto", true, true, true},
-	    {"auto", true, false, true},   {"auto", false, true, false},
+	    {"auto", true, false, true},    {"auto", false, true, false},
 	};
 	for (const auto& variant : variants) {
 		DYNAMIC_SECTION(variant.name()) {

--- a/nautilus/test/execution-tests/TBCDispatchModeTest.cpp
+++ b/nautilus/test/execution-tests/TBCDispatchModeTest.cpp
@@ -1,0 +1,140 @@
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include <catch2/catch_all.hpp>
+
+// The tbc interpreter offers three dispatch skins selected via the
+// "tbc.dispatch" option: "tailcall" (musttail threading, Clang), "goto"
+// (computed goto, GCC/Clang) and "switch" (portable). "auto" — the default —
+// picks the strongest one the build supports, and unavailable requests
+// silently degrade. forEachBackend only exercises the default, so this test
+// pins that every skin and every lowering-option combination produce results
+// identical to the plain switch/no-optimization reference across a range of
+// inputs and opcode families.
+#ifdef ENABLE_TBC_BACKEND
+
+namespace nautilus::engine {
+
+namespace {
+
+val<int64_t> tbcArith(val<int64_t> a, val<int64_t> b) {
+	return (a + b) * (a - b) + (a * b) - (b + 7);
+}
+
+val<int64_t> tbcFib(val<int64_t> n) {
+	val<int64_t> a = 0;
+	val<int64_t> b = 1;
+	for (val<int64_t> i = 0; i < n; i = i + 1) {
+		val<int64_t> t = a + b;
+		a = b;
+		b = t;
+	}
+	return a;
+}
+
+val<int64_t> tbcSumSquares(val<int32_t> n) {
+	val<int64_t> sum = 0;
+	for (val<int32_t> i = 0; i < n; i++) {
+		val<int64_t> v = i;
+		sum += v * v;
+	}
+	return sum;
+}
+
+val<int64_t> tbcBranchy(val<int64_t> x) {
+	val<int64_t> r = 0;
+	if (x > 10) {
+		r = x * 2;
+	} else if (x < -5) {
+		r = x - 100;
+	} else {
+		r = x + 1;
+	}
+	return r;
+}
+
+val<int32_t> tbcCasts(val<int64_t> x) {
+	val<int32_t> a = static_cast<val<int32_t>>(x);
+	val<float> f = static_cast<val<float>>(a);
+	val<double> d = static_cast<val<double>>(f);
+	val<int64_t> back = static_cast<val<int64_t>>(d);
+	return static_cast<val<int32_t>>(back + a);
+}
+
+val<int64_t> tbcModBit(val<int64_t> a, val<int64_t> b) {
+	val<int64_t> m = a % (b + 1);
+	return m + (a & b) + (a | b) + (a ^ b);
+}
+
+engine::NautilusEngine tbcEngine(const std::string& dispatch, bool superinstructions, bool immediates,
+                                 bool coalescing) {
+	engine::Options options;
+	options.setOption("engine.backend", std::string("tbc"));
+	options.setOption("tbc.dispatch", dispatch);
+	options.setOption("tbc.superinstructions", superinstructions);
+	options.setOption("tbc.immediates", immediates);
+	options.setOption("tbc.coalescing", coalescing);
+	return engine::NautilusEngine(options);
+}
+
+struct Variant {
+	std::string dispatch;
+	bool super;
+	bool imm;
+	bool coalesce;
+	std::string name() const {
+		return dispatch + (super ? "_superinstructions" : "") + (imm ? "_immediates" : "") +
+		       (coalesce ? "_coalescing" : "");
+	}
+};
+
+} // namespace
+
+TEST_CASE("TBC dispatch modes produce identical results") {
+	// Reference: portable switch skin with every lowering optimization off.
+	auto reference = tbcEngine("switch", false, false, false);
+	// Every (dispatch, superinstructions, immediates, coalescing) combination
+	// must match the reference. The kernels contain constant right operands
+	// (i + 1, b + 7, x - 100, …) and compare-fed branches, so immediate
+	// folding and compare-and-branch fusion are actually exercised.
+	const std::vector<Variant> variants = {
+	    {"switch", true, true, true},  {"goto", false, false, false},   {"goto", true, true, true},
+	    {"tailcall", true, true, true}, {"tailcall", false, false, false}, {"auto", true, true, true},
+	    {"auto", true, false, true},   {"auto", false, true, false},
+	};
+	for (const auto& variant : variants) {
+		DYNAMIC_SECTION(variant.name()) {
+			auto alt = tbcEngine(variant.dispatch, variant.super, variant.imm, variant.coalesce);
+
+			auto cArith = reference.registerFunction(tbcArith);
+			auto aArith = alt.registerFunction(tbcArith);
+			auto cFib = reference.registerFunction(tbcFib);
+			auto aFib = alt.registerFunction(tbcFib);
+			auto cSum = reference.registerFunction(tbcSumSquares);
+			auto aSum = alt.registerFunction(tbcSumSquares);
+			auto cBranch = reference.registerFunction(tbcBranchy);
+			auto aBranch = alt.registerFunction(tbcBranchy);
+			auto cCast = reference.registerFunction(tbcCasts);
+			auto aCast = alt.registerFunction(tbcCasts);
+			auto cMod = reference.registerFunction(tbcModBit);
+			auto aMod = alt.registerFunction(tbcModBit);
+
+			for (int64_t a = -20; a <= 20; a += 3) {
+				REQUIRE(aFib(a) == cFib(a));
+				REQUIRE(aBranch(a) == cBranch(a));
+				REQUIRE(aCast(a * 1000003) == cCast(a * 1000003));
+				for (int64_t b = -20; b <= 20; b += 5) {
+					REQUIRE(aArith(a, b) == cArith(a, b));
+					REQUIRE(aMod(a, b) == cMod(a, b));
+				}
+			}
+			for (int32_t n = 0; n <= 5000; n += 777) {
+				REQUIRE(aSum(n) == cSum(n));
+			}
+		}
+	}
+}
+
+} // namespace nautilus::engine
+
+#endif // ENABLE_TBC_BACKEND

--- a/nautilus/test/execution-tests/TieredCompilationTest.cpp
+++ b/nautilus/test/execution-tests/TieredCompilationTest.cpp
@@ -28,6 +28,10 @@ std::pair<std::string, std::string> getTieredBackends() {
 	return {"bc", "mlir"};
 #elif defined(ENABLE_TRACING) && defined(ENABLE_BC_BACKEND) && defined(ENABLE_C_BACKEND)
 	return {"bc", "cpp"};
+#elif defined(ENABLE_TRACING) && defined(ENABLE_TBC_BACKEND) && defined(ENABLE_MLIR_BACKEND)
+	return {"tbc", "mlir"};
+#elif defined(ENABLE_TRACING) && defined(ENABLE_TBC_BACKEND) && defined(ENABLE_C_BACKEND)
+	return {"tbc", "cpp"};
 #else
 	return {"", ""};
 #endif
@@ -154,6 +158,12 @@ TEST_CASE("Tiered Compilation - Custom Backend Per Tier") {
 #if defined(ENABLE_BC_BACKEND) && defined(ENABLE_C_BACKEND)
 	combos.emplace_back("bc", "cpp");
 #endif
+#if defined(ENABLE_TBC_BACKEND) && defined(ENABLE_MLIR_BACKEND)
+	combos.emplace_back("tbc", "mlir");
+#endif
+#if defined(ENABLE_TBC_BACKEND) && defined(ENABLE_C_BACKEND)
+	combos.emplace_back("tbc", "cpp");
+#endif
 #endif
 
 	if (combos.empty()) {
@@ -264,6 +274,9 @@ TEST_CASE("Tiered Compilation - Standard JITCompiler Still Works") {
 #endif
 #ifdef ENABLE_BC_BACKEND
 	backends.emplace_back("bc");
+#endif
+#ifdef ENABLE_TBC_BACKEND
+	backends.emplace_back("tbc");
 #endif
 #endif
 

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -41,6 +41,9 @@ inline std::vector<std::string> configs() {
 #ifdef ENABLE_BC_BACKEND
 	result.emplace_back("bc");
 #endif
+#ifdef ENABLE_TBC_BACKEND
+	result.emplace_back("tbc");
+#endif
 #ifdef ENABLE_ASMJIT_BACKEND
 	result.emplace_back("asmjit");
 #endif


### PR DESCRIPTION
# Summary

Adds a new, from-scratch bytecode interpreter backend, registered as **`tbc`** (`engine.backend="tbc"`, `ENABLE_TBC_BACKEND`, `nautilus/src/nautilus/compiler/backends/tbc/`). The legacy `bc` backend is untouched. High performance is the main goal, plus portability to x86-64, ARM64, and platforms that forbid runtime code generation (iOS): **the backend never allocates executable memory**.

## Interpreter design

- **Dispatch**: three skins generated from one X-macro opcode list (`TBCOpcodes.hpp`), so they cannot drift:
  - *tail-call threading* via `[[clang::musttail]]` — each opcode is its own handler; `(ip, fp, ctx)` stay pinned in argument registers and every handler ends in a guaranteed tail call through the dispatch table (wasm3/upb/CPython-3.14 style). Default on Clang, works on iOS.
  - *token-threaded computed goto* — default on GCC.
  - *portable `for(;;) switch`* — fallback everywhere else.
  - Selected via `tbc.dispatch=auto|tailcall|goto|switch`; unavailable requests silently degrade to the best supported mode.
- **Code layout**: one flat, contiguous instruction stream per function; fixed 8-byte words (`uint16` opcode + 3×`uint16` operands, 32-bit relative branch offsets). No per-block vectors, no `std::variant` terminator dispatch.
- **Frames**: one contiguous per-thread VM stack. A frame holds a 3-slot header, the registers (constants arrive via a single `memcpy` of a per-function constant image), and in-frame, zeroed alloca space. Reentrancy-safe (external calls may call back into TBC code).
- **Internal calls are interpreter-native**: `CALL`/`RET` just swap the frame and instruction pointers inside the same dispatch loop. This removes bc's heaviest cost — the dyncall→dyncallback→nested-interpreter round trip for Nautilus-to-Nautilus calls.
- **External calls** (`invoke`): one `CALL_EXT` instruction with a per-call-site record; a single handler drives outgoing dyncall (no per-argument opcodes; dyncallback is not used at all).
- **Escaping internal function pointers** (`FunctionAddressOf` handed to native code): bound to a fixed pool of pre-compiled template trampolines (`TBCTrampoline.hpp`) instead of runtime-generated thunks — iOS-safe.
- **Default-on optimizations** (flags exist only for A/B): compare-and-branch fusion into 2-word superinstructions, 16-bit immediate folding (plus `MOV_imm` small-constant materialization that avoids constant slots entirely), and parallel-copy register coalescing on block-argument edges.

## Generic entry path hardening (`Executable.hpp`)

`tbc` deliberately exposes no native function pointer and is the first real user of the `GenericInvocable` path. That path gains:
- enum return support (previously `bad_any_cast` on `val<Enum>` returns),
- alias-tolerant integer unboxing (`long` vs `long long` for i64 across platforms, `char` vs `int8_t`),
- a new allocation-free `invokeRaw` fast path (raw 64-bit slots on the stack instead of `vector<std::any>`), used automatically by `Executable::Invocable` and fully backward-compatible (default falls back to the boxed route).

## Performance (Release, Clang 18, x86-64; Catch2 mean)

| benchmark | bc (default) | bc (best opt-in combo) | **tbc (default)** |
|---|---|---|---|
| fibonacci loop | 473 µs | 492 µs | **148 µs (3.2×)** |
| array-sum loop | 105.6 ms | 99.9 ms | **34.9 ms (3.0×)** |
| per-call entry (`add`) | 40.2 ns | 34.9 ns | **23.9 ns (1.7×)** |

## Testing

- `"tbc"` added to `availableBackends()` — the entire execution/val/tracing suite runs on it: **201/201 ctest suites pass** (Clang 18) and all 16,341 assertions pass with GCC 13 (exercising the computed-goto skin).
- New `TBCDispatchModeTest`: pins every dispatch skin × lowering-option combination against a de-optimized switch reference across arithmetic, loops, branches, casts, mod/bitwise kernels.
- Added to the differential fuzz harness (`Harness.hpp`) — smoke run agrees across all backends — and to both benchmark suites.
- Formatted via the CMake `format` target; remaining `format.sh` findings are pre-existing on `main` in files outside this diff.

## Notes / future work

- Escaping internal function pointers support integer-class signatures up to 8 args (pool of 64 slots); float signatures throw a clear `NotImplementedException` (no current usage).
- Possible follow-ups: `preserve_none` calling convention on the tail-call handlers, `LOAD/STORE`+offset superinstructions, zero-dependency typed thunks to replace outgoing dyncall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1ard7k4sQRd25MDeSpVAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1ard7k4sQRd25MDeSpVAX)_