### PR TITLE
Extend NautilusFunction tests to cover all val&lt;T&gt; data types

### DIFF
--- a/nautilus/test/common/NautilusFunction.hpp
+++ b/nautilus/test/common/NautilusFunction.hpp
@@ -205,4 +205,162 @@ val<int32_t> nautilusFunctionGetFuncPtr(val<int32_t> a, val<int32_t> b) {
 	return invoke(applyFnPtr, fnPtr, a, b);
 }
 
+// ---------------------------------------------------------------------------
+// Data-type coverage: one NautilusFunction call per val<T> specialization
+// (signed/unsigned integers of every width, floating point, bool, pointer,
+// and enum), so the NautilusFunction call path is exercised for all types.
+// ---------------------------------------------------------------------------
+
+// Test: NautilusFunction over val<int8_t>
+val<int8_t> addInt8Helper(val<int8_t> a, val<int8_t> b) {
+	return a + b;
+}
+
+static auto nautilusAddInt8 = NautilusFunction {"addInt8", addInt8Helper};
+
+val<int8_t> nautilusFunctionInt8(val<int8_t> a, val<int8_t> b) {
+	return nautilusAddInt8(a, b);
+}
+
+// Test: NautilusFunction over val<uint8_t>
+val<uint8_t> mulUInt8Helper(val<uint8_t> a, val<uint8_t> b) {
+	return a * b;
+}
+
+static auto nautilusMulUInt8 = NautilusFunction {"mulUInt8", mulUInt8Helper};
+
+val<uint8_t> nautilusFunctionUInt8(val<uint8_t> a, val<uint8_t> b) {
+	return nautilusMulUInt8(a, b);
+}
+
+// Test: NautilusFunction over val<int16_t>
+val<int16_t> subInt16Helper(val<int16_t> a, val<int16_t> b) {
+	return a - b;
+}
+
+static auto nautilusSubInt16 = NautilusFunction {"subInt16", subInt16Helper};
+
+val<int16_t> nautilusFunctionInt16(val<int16_t> a, val<int16_t> b) {
+	return nautilusSubInt16(a, b);
+}
+
+// Test: NautilusFunction over val<uint16_t>
+val<uint16_t> addUInt16Helper(val<uint16_t> a, val<uint16_t> b) {
+	return a + b;
+}
+
+static auto nautilusAddUInt16 = NautilusFunction {"addUInt16", addUInt16Helper};
+
+val<uint16_t> nautilusFunctionUInt16(val<uint16_t> a, val<uint16_t> b) {
+	return nautilusAddUInt16(a, b);
+}
+
+// Test: NautilusFunction over val<uint32_t>
+val<uint32_t> mulUInt32Helper(val<uint32_t> a, val<uint32_t> b) {
+	return a * b;
+}
+
+static auto nautilusMulUInt32 = NautilusFunction {"mulUInt32", mulUInt32Helper};
+
+val<uint32_t> nautilusFunctionUInt32(val<uint32_t> a, val<uint32_t> b) {
+	return nautilusMulUInt32(a, b);
+}
+
+// Test: NautilusFunction over val<int64_t>
+val<int64_t> addInt64Helper(val<int64_t> a, val<int64_t> b) {
+	return a + b;
+}
+
+static auto nautilusAddInt64 = NautilusFunction {"addInt64", addInt64Helper};
+
+val<int64_t> nautilusFunctionInt64(val<int64_t> a, val<int64_t> b) {
+	return nautilusAddInt64(a, b);
+}
+
+// Test: NautilusFunction over val<uint64_t>
+val<uint64_t> mulUInt64Helper(val<uint64_t> a, val<uint64_t> b) {
+	return a * b;
+}
+
+static auto nautilusMulUInt64 = NautilusFunction {"mulUInt64", mulUInt64Helper};
+
+val<uint64_t> nautilusFunctionUInt64(val<uint64_t> a, val<uint64_t> b) {
+	return nautilusMulUInt64(a, b);
+}
+
+// Test: NautilusFunction over val<float>
+val<float> addFloatHelper(val<float> a, val<float> b) {
+	return a + b;
+}
+
+static auto nautilusAddFloat = NautilusFunction {"addFloat", addFloatHelper};
+
+val<float> nautilusFunctionFloat(val<float> a, val<float> b) {
+	return nautilusAddFloat(a, b);
+}
+
+// Test: NautilusFunction over val<double>
+val<double> mulDoubleHelper(val<double> a, val<double> b) {
+	return a * b;
+}
+
+static auto nautilusMulDouble = NautilusFunction {"mulDouble", mulDoubleHelper};
+
+val<double> nautilusFunctionDouble(val<double> a, val<double> b) {
+	return nautilusMulDouble(a, b);
+}
+
+// Test: NautilusFunction over val<bool>
+val<bool> andBoolHelper(val<bool> a, val<bool> b) {
+	return a && b;
+}
+
+static auto nautilusAndBool = NautilusFunction {"andBool", andBoolHelper};
+
+val<bool> nautilusFunctionBool(val<bool> a, val<bool> b) {
+	return nautilusAndBool(a, b);
+}
+
+// Test: NautilusFunction reading through a val<int32_t*> pointer argument
+val<int32_t> derefAddHelper(val<int32_t*> ptr, val<int32_t> addend) {
+	return *ptr + addend;
+}
+
+static auto nautilusDerefAdd = NautilusFunction {"derefAdd", derefAddHelper};
+
+val<int32_t> nautilusFunctionPtr(val<int32_t*> ptr, val<int32_t> addend) {
+	return nautilusDerefAdd(ptr, addend);
+}
+
+// Test: NautilusFunction writing through a val<double*> pointer argument
+void writeDoubleHelper(val<double*> ptr, val<double> value) {
+	*ptr = value;
+}
+
+static auto nautilusWriteDouble = NautilusFunction {"writeDouble", writeDoubleHelper};
+
+val<double> nautilusFunctionPtrWrite(val<double*> ptr, val<double> value) {
+	nautilusWriteDouble(ptr, value);
+	return *ptr;
+}
+
+// Test: NautilusFunction over an enum-typed val<T> argument
+enum class NautilusFunctionColor : int32_t { RED, GREEN, BLUE };
+
+val<int32_t> colorToCodeHelper(val<NautilusFunctionColor> color) {
+	if (color == NautilusFunctionColor::RED) {
+		return val<int32_t>(1);
+	} else if (color == NautilusFunctionColor::GREEN) {
+		return val<int32_t>(2);
+	} else {
+		return val<int32_t>(3);
+	}
+}
+
+static auto nautilusColorToCode = NautilusFunction {"colorToCode", colorToCodeHelper};
+
+val<int32_t> nautilusFunctionEnum(val<NautilusFunctionColor> color) {
+	return nautilusColorToCode(color);
+}
+
 } // namespace nautilus::engine

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionBool.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionBool.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+andBool($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = $1 and $2 :bool
+	return ($3) :bool
+}
+execute($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = func_*($1,$2) :bool
+	return ($3) :bool
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionBool.shortcircuit.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionBool.shortcircuit.nautilus
@@ -1,0 +1,29 @@
+nautilus {
+andBool($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	if $1 ? Block_1($2) : Block_2() :void
+
+Block_1($2:bool):
+	if $2 ? Block_3() : Block_4() :void
+
+Block_3():
+	$5 = true :bool
+	br Block_5($5) :void
+
+Block_5($5:bool):
+	return ($5) :bool
+
+Block_4():
+	$11 = false :bool
+	br Block_5($11) :void
+
+Block_2():
+	$8 = false :bool
+	br Block_5($8) :void
+}
+execute($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = func_*($1,$2) :bool
+	return ($3) :bool
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionDouble.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionDouble.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:f64, $2:f64) :f64 {
+Block_0($1:f64, $2:f64):
+	$3 = func_*($1,$2) :f64
+	return ($3) :f64
+}
+mulDouble($1:f64, $2:f64) :f64 {
+Block_0($1:f64, $2:f64):
+	$3 = $1 * $2 :f64
+	return ($3) :f64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionEnum.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionEnum.nautilus
@@ -1,0 +1,33 @@
+nautilus {
+colorToCode($1:i32) :i32 {
+Block_0($1:i32):
+	$2 = 0 :i32
+	$3 = $1 == $2 :bool
+	if $3 ? Block_1() : Block_2($1) :void
+
+Block_1():
+	$5 = 1 :i32
+	br Block_5($5) :void
+
+Block_5($5:i32):
+	return ($5) :i32
+
+Block_2($1:i32):
+	$7 = 1 :i32
+	$8 = $1 == $7 :bool
+	if $8 ? Block_3() : Block_4() :void
+
+Block_3():
+	$10 = 2 :i32
+	br Block_5($10) :void
+
+Block_4():
+	$12 = 3 :i32
+	br Block_5($12) :void
+}
+execute($1:i32) :i32 {
+Block_0($1:i32):
+	$2 = func_*($1) :i32
+	return ($2) :i32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionFloat.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionFloat.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+addFloat($1:f32, $2:f32) :f32 {
+Block_0($1:f32, $2:f32):
+	$3 = $1 + $2 :f32
+	return ($3) :f32
+}
+execute($1:f32, $2:f32) :f32 {
+Block_0($1:f32, $2:f32):
+	$3 = func_*($1,$2) :f32
+	return ($3) :f32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInt16.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInt16.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+execute($1:i16, $2:i16) :i16 {
+Block_0($1:i16, $2:i16):
+	$3 = func_*($1,$2) :i16
+	return ($3) :i16
+}
+subInt16($1:i16, $2:i16) :i16 {
+Block_0($1:i16, $2:i16):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 - $4 :i32
+	$6 = $5 cast_to i16 :i16
+	return ($6) :i16
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInt64.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInt64.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+addInt64($1:i64, $2:i64) :i64 {
+Block_0($1:i64, $2:i64):
+	$3 = $1 + $2 :i64
+	return ($3) :i64
+}
+execute($1:i64, $2:i64) :i64 {
+Block_0($1:i64, $2:i64):
+	$3 = func_*($1,$2) :i64
+	return ($3) :i64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInt8.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionInt8.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+addInt8($1:i8, $2:i8) :i8 {
+Block_0($1:i8, $2:i8):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 + $4 :i32
+	$6 = $5 cast_to i8 :i8
+	return ($6) :i8
+}
+execute($1:i8, $2:i8) :i8 {
+Block_0($1:i8, $2:i8):
+	$3 = func_*($1,$2) :i8
+	return ($3) :i8
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionPtr.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionPtr.nautilus
@@ -1,0 +1,13 @@
+nautilus {
+derefAdd($1:ptr, $2:i32) :i32 {
+Block_0($1:ptr, $2:i32):
+	$6 = load($1) :i32
+	$7 = $6 + $2 :i32
+	return ($7) :i32
+}
+execute($1:ptr, $2:i32) :i32 {
+Block_0($1:ptr, $2:i32):
+	$3 = func_*($1,$2) :i32
+	return ($3) :i32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionPtrWrite.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionPtrWrite.nautilus
@@ -1,0 +1,13 @@
+nautilus {
+execute($1:ptr, $2:f64) :f64 {
+Block_0($1:ptr, $2:f64):
+	func_*($1,$2) :void
+	$6 = load($1) :f64
+	return ($6) :f64
+}
+writeDouble($1:ptr, $2:f64) :void {
+Block_0($1:ptr, $2:f64):
+	store($2, $1) :void
+	return :void
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt16.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt16.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+addUInt16($1:ui16, $2:ui16) :ui16 {
+Block_0($1:ui16, $2:ui16):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 + $4 :i32
+	$6 = $5 cast_to ui16 :ui16
+	return ($6) :ui16
+}
+execute($1:ui16, $2:ui16) :ui16 {
+Block_0($1:ui16, $2:ui16):
+	$3 = func_*($1,$2) :ui16
+	return ($3) :ui16
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt32.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt32.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:ui32, $2:ui32) :ui32 {
+Block_0($1:ui32, $2:ui32):
+	$3 = func_*($1,$2) :ui32
+	return ($3) :ui32
+}
+mulUInt32($1:ui32, $2:ui32) :ui32 {
+Block_0($1:ui32, $2:ui32):
+	$3 = $1 * $2 :ui32
+	return ($3) :ui32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt64.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt64.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:ui64, $2:ui64) :ui64 {
+Block_0($1:ui64, $2:ui64):
+	$3 = func_*($1,$2) :ui64
+	return ($3) :ui64
+}
+mulUInt64($1:ui64, $2:ui64) :ui64 {
+Block_0($1:ui64, $2:ui64):
+	$3 = $1 * $2 :ui64
+	return ($3) :ui64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt8.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_constant_folding/nautilusFunctionUInt8.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+execute($1:ui8, $2:ui8) :ui8 {
+Block_0($1:ui8, $2:ui8):
+	$3 = func_*($1,$2) :ui8
+	return ($3) :ui8
+}
+mulUInt8($1:ui8, $2:ui8) :ui8 {
+Block_0($1:ui8, $2:ui8):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 * $4 :i32
+	$6 = $5 cast_to ui8 :ui8
+	return ($6) :ui8
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionBool.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionBool.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+andBool($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = $1 and $2 :bool
+	return ($3) :bool
+}
+execute($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = func_*($1,$2) :bool
+	return ($3) :bool
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionBool.shortcircuit.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionBool.shortcircuit.nautilus
@@ -1,0 +1,29 @@
+nautilus {
+andBool($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	if $1 ? Block_1($2) : Block_2() :void
+
+Block_1($2:bool):
+	if $2 ? Block_3() : Block_4() :void
+
+Block_3():
+	$5 = true :bool
+	br Block_5($5) :void
+
+Block_5($5:bool):
+	return ($5) :bool
+
+Block_4():
+	$11 = false :bool
+	br Block_5($11) :void
+
+Block_2():
+	$8 = false :bool
+	br Block_5($8) :void
+}
+execute($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = func_*($1,$2) :bool
+	return ($3) :bool
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionDouble.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionDouble.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:f64, $2:f64) :f64 {
+Block_0($1:f64, $2:f64):
+	$3 = func_*($1,$2) :f64
+	return ($3) :f64
+}
+mulDouble($1:f64, $2:f64) :f64 {
+Block_0($1:f64, $2:f64):
+	$3 = $1 * $2 :f64
+	return ($3) :f64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionEnum.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionEnum.nautilus
@@ -1,0 +1,33 @@
+nautilus {
+colorToCode($1:i32) :i32 {
+Block_0($1:i32):
+	$2 = 0 :i32
+	$3 = $1 == $2 :bool
+	if $3 ? Block_1() : Block_2($1) :void
+
+Block_1():
+	$5 = 1 :i32
+	br Block_5($5) :void
+
+Block_5($5:i32):
+	return ($5) :i32
+
+Block_2($1:i32):
+	$7 = 1 :i32
+	$8 = $1 == $7 :bool
+	if $8 ? Block_3() : Block_4() :void
+
+Block_3():
+	$10 = 2 :i32
+	br Block_5($10) :void
+
+Block_4():
+	$12 = 3 :i32
+	br Block_5($12) :void
+}
+execute($1:i32) :i32 {
+Block_0($1:i32):
+	$2 = func_*($1) :i32
+	return ($2) :i32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionFloat.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionFloat.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+addFloat($1:f32, $2:f32) :f32 {
+Block_0($1:f32, $2:f32):
+	$3 = $1 + $2 :f32
+	return ($3) :f32
+}
+execute($1:f32, $2:f32) :f32 {
+Block_0($1:f32, $2:f32):
+	$3 = func_*($1,$2) :f32
+	return ($3) :f32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInt16.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInt16.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+execute($1:i16, $2:i16) :i16 {
+Block_0($1:i16, $2:i16):
+	$3 = func_*($1,$2) :i16
+	return ($3) :i16
+}
+subInt16($1:i16, $2:i16) :i16 {
+Block_0($1:i16, $2:i16):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 - $4 :i32
+	$6 = $5 cast_to i16 :i16
+	return ($6) :i16
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInt64.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInt64.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+addInt64($1:i64, $2:i64) :i64 {
+Block_0($1:i64, $2:i64):
+	$3 = $1 + $2 :i64
+	return ($3) :i64
+}
+execute($1:i64, $2:i64) :i64 {
+Block_0($1:i64, $2:i64):
+	$3 = func_*($1,$2) :i64
+	return ($3) :i64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInt8.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionInt8.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+addInt8($1:i8, $2:i8) :i8 {
+Block_0($1:i8, $2:i8):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 + $4 :i32
+	$6 = $5 cast_to i8 :i8
+	return ($6) :i8
+}
+execute($1:i8, $2:i8) :i8 {
+Block_0($1:i8, $2:i8):
+	$3 = func_*($1,$2) :i8
+	return ($3) :i8
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionPtr.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionPtr.nautilus
@@ -1,0 +1,13 @@
+nautilus {
+derefAdd($1:ptr, $2:i32) :i32 {
+Block_0($1:ptr, $2:i32):
+	$6 = load($1) :i32
+	$7 = $6 + $2 :i32
+	return ($7) :i32
+}
+execute($1:ptr, $2:i32) :i32 {
+Block_0($1:ptr, $2:i32):
+	$3 = func_*($1,$2) :i32
+	return ($3) :i32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionPtrWrite.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionPtrWrite.nautilus
@@ -1,0 +1,13 @@
+nautilus {
+execute($1:ptr, $2:f64) :f64 {
+Block_0($1:ptr, $2:f64):
+	func_*($1,$2) :void
+	$6 = load($1) :f64
+	return ($6) :f64
+}
+writeDouble($1:ptr, $2:f64) :void {
+Block_0($1:ptr, $2:f64):
+	store($2, $1) :void
+	return :void
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt16.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt16.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+addUInt16($1:ui16, $2:ui16) :ui16 {
+Block_0($1:ui16, $2:ui16):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 + $4 :i32
+	$6 = $5 cast_to ui16 :ui16
+	return ($6) :ui16
+}
+execute($1:ui16, $2:ui16) :ui16 {
+Block_0($1:ui16, $2:ui16):
+	$3 = func_*($1,$2) :ui16
+	return ($3) :ui16
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt32.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt32.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:ui32, $2:ui32) :ui32 {
+Block_0($1:ui32, $2:ui32):
+	$3 = func_*($1,$2) :ui32
+	return ($3) :ui32
+}
+mulUInt32($1:ui32, $2:ui32) :ui32 {
+Block_0($1:ui32, $2:ui32):
+	$3 = $1 * $2 :ui32
+	return ($3) :ui32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt64.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt64.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:ui64, $2:ui64) :ui64 {
+Block_0($1:ui64, $2:ui64):
+	$3 = func_*($1,$2) :ui64
+	return ($3) :ui64
+}
+mulUInt64($1:ui64, $2:ui64) :ui64 {
+Block_0($1:ui64, $2:ui64):
+	$3 = $1 * $2 :ui64
+	return ($3) :ui64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt8.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/after_empty_block_elim/nautilusFunctionUInt8.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+execute($1:ui8, $2:ui8) :ui8 {
+Block_0($1:ui8, $2:ui8):
+	$3 = func_*($1,$2) :ui8
+	return ($3) :ui8
+}
+mulUInt8($1:ui8, $2:ui8) :ui8 {
+Block_0($1:ui8, $2:ui8):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 * $4 :i32
+	$6 = $5 cast_to ui8 :ui8
+	return ($6) :ui8
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionBool.shortcircuit.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionBool.shortcircuit.trace
@@ -1,0 +1,22 @@
+ANDBOOL:
+B0($1:bool,$2:bool)
+	CMP	$3	$1	B1($2)	B2()	:void
+B1($2:bool)
+	CMP	$4	$2	B3()	B4()	:void
+B2()
+	CONST	$8	false	:bool
+	JMP	$0	B5($8)	:void
+B3()
+	CONST	$5	true	:bool
+	JMP	$0	B5($5)	:void
+B4()
+	CONST	$11	false	:bool
+	JMP	$0	B5($11)	:void
+B5($5:bool)
+	RETURN	$0	$5	:bool
+
+EXECUTE:
+B0($1:bool,$2:bool)
+	CALL	$3	func_*($1,$2)	:bool
+	RETURN	$0	$3	:bool
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionBool.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionBool.trace
@@ -1,0 +1,10 @@
+ANDBOOL:
+B0($1:bool,$2:bool)
+	AND	$3	$1	$2	:bool
+	RETURN	$0	$3	:bool
+
+EXECUTE:
+B0($1:bool,$2:bool)
+	CALL	$3	func_*($1,$2)	:bool
+	RETURN	$0	$3	:bool
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionDouble.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionDouble.trace
@@ -1,0 +1,10 @@
+EXECUTE:
+B0($1:f64,$2:f64)
+	CALL	$3	func_*($1,$2)	:f64
+	RETURN	$0	$3	:f64
+
+MULDOUBLE:
+B0($1:f64,$2:f64)
+	MUL	$3	$1	$2	:f64
+	RETURN	$0	$3	:f64
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionEnum.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionEnum.trace
@@ -1,0 +1,26 @@
+COLORTOCODE:
+B0($1:i32)
+	CONST	$2	0	:i32
+	EQ	$3	$1	$2	:bool
+	CMP	$4	$3	B1()	B2($1)	:void
+B1()
+	CONST	$5	1	:i32
+	JMP	$0	B5($5)	:void
+B2($1:i32)
+	CONST	$7	1	:i32
+	EQ	$8	$1	$7	:bool
+	CMP	$9	$8	B3()	B4()	:void
+B3()
+	CONST	$10	2	:i32
+	JMP	$0	B5($10)	:void
+B4()
+	CONST	$12	3	:i32
+	JMP	$0	B5($12)	:void
+B5($5:i32)
+	RETURN	$0	$5	:i32
+
+EXECUTE:
+B0($1:i32)
+	CALL	$2	func_*($1)	:i32
+	RETURN	$0	$2	:i32
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionFloat.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionFloat.trace
@@ -1,0 +1,10 @@
+ADDFLOAT:
+B0($1:f32,$2:f32)
+	ADD	$3	$1	$2	:f32
+	RETURN	$0	$3	:f32
+
+EXECUTE:
+B0($1:f32,$2:f32)
+	CALL	$3	func_*($1,$2)	:f32
+	RETURN	$0	$3	:f32
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionInt16.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionInt16.trace
@@ -1,0 +1,13 @@
+EXECUTE:
+B0($1:i16,$2:i16)
+	CALL	$3	func_*($1,$2)	:i16
+	RETURN	$0	$3	:i16
+
+SUBINT16:
+B0($1:i16,$2:i16)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	SUB	$5	$3	$4	:i32
+	CAST	$6	$5	:i16
+	RETURN	$0	$6	:i16
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionInt64.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionInt64.trace
@@ -1,0 +1,10 @@
+ADDINT64:
+B0($1:i64,$2:i64)
+	ADD	$3	$1	$2	:i64
+	RETURN	$0	$3	:i64
+
+EXECUTE:
+B0($1:i64,$2:i64)
+	CALL	$3	func_*($1,$2)	:i64
+	RETURN	$0	$3	:i64
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionInt8.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionInt8.trace
@@ -1,0 +1,13 @@
+ADDINT8:
+B0($1:i8,$2:i8)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	ADD	$5	$3	$4	:i32
+	CAST	$6	$5	:i8
+	RETURN	$0	$6	:i8
+
+EXECUTE:
+B0($1:i8,$2:i8)
+	CALL	$3	func_*($1,$2)	:i8
+	RETURN	$0	$3	:i8
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionPtr.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionPtr.trace
@@ -1,0 +1,11 @@
+DEREFADD:
+B0($1:ptr,$2:i32)
+	LOAD	$6	$1	:i32
+	ADD	$7	$6	$2	:i32
+	RETURN	$0	$7	:i32
+
+EXECUTE:
+B0($1:ptr,$2:i32)
+	CALL	$3	func_*($1,$2)	:i32
+	RETURN	$0	$3	:i32
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionPtrWrite.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionPtrWrite.trace
@@ -1,0 +1,11 @@
+EXECUTE:
+B0($1:ptr,$2:f64)
+	CALL	$3	func_*($1,$2)	:void
+	LOAD	$6	$1	:f64
+	RETURN	$0	$6	:f64
+
+WRITEDOUBLE:
+B0($1:ptr,$2:f64)
+	STORE	$7	$1	$2	:void
+	RETURN	$0	:void
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt16.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt16.trace
@@ -1,0 +1,13 @@
+ADDUINT16:
+B0($1:ui16,$2:ui16)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	ADD	$5	$3	$4	:i32
+	CAST	$6	$5	:ui16
+	RETURN	$0	$6	:ui16
+
+EXECUTE:
+B0($1:ui16,$2:ui16)
+	CALL	$3	func_*($1,$2)	:ui16
+	RETURN	$0	$3	:ui16
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt32.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt32.trace
@@ -1,0 +1,10 @@
+EXECUTE:
+B0($1:ui32,$2:ui32)
+	CALL	$3	func_*($1,$2)	:ui32
+	RETURN	$0	$3	:ui32
+
+MULUINT32:
+B0($1:ui32,$2:ui32)
+	MUL	$3	$1	$2	:ui32
+	RETURN	$0	$3	:ui32
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt64.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt64.trace
@@ -1,0 +1,10 @@
+EXECUTE:
+B0($1:ui64,$2:ui64)
+	CALL	$3	func_*($1,$2)	:ui64
+	RETURN	$0	$3	:ui64
+
+MULUINT64:
+B0($1:ui64,$2:ui64)
+	MUL	$3	$1	$2	:ui64
+	RETURN	$0	$3	:ui64
+

--- a/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt8.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/after_ssa/nautilusFunctionUInt8.trace
@@ -1,0 +1,13 @@
+EXECUTE:
+B0($1:ui8,$2:ui8)
+	CALL	$3	func_*($1,$2)	:ui8
+	RETURN	$0	$3	:ui8
+
+MULUINT8:
+B0($1:ui8,$2:ui8)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	MUL	$5	$3	$4	:i32
+	CAST	$6	$5	:ui8
+	RETURN	$0	$6	:ui8
+

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionBool.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionBool.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+andBool($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = $1 and $2 :bool
+	return ($3) :bool
+}
+execute($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = func_*($1,$2) :bool
+	return ($3) :bool
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionBool.shortcircuit.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionBool.shortcircuit.nautilus
@@ -1,0 +1,29 @@
+nautilus {
+andBool($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	if $1 ? Block_1($2) : Block_2() :void
+
+Block_1($2:bool):
+	if $2 ? Block_3() : Block_4() :void
+
+Block_3():
+	$5 = true :bool
+	br Block_5($5) :void
+
+Block_5($5:bool):
+	return ($5) :bool
+
+Block_4():
+	$11 = false :bool
+	br Block_5($11) :void
+
+Block_2():
+	$8 = false :bool
+	br Block_5($8) :void
+}
+execute($1:bool, $2:bool) :bool {
+Block_0($1:bool, $2:bool):
+	$3 = func_*($1,$2) :bool
+	return ($3) :bool
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionDouble.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionDouble.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:f64, $2:f64) :f64 {
+Block_0($1:f64, $2:f64):
+	$3 = func_*($1,$2) :f64
+	return ($3) :f64
+}
+mulDouble($1:f64, $2:f64) :f64 {
+Block_0($1:f64, $2:f64):
+	$3 = $1 * $2 :f64
+	return ($3) :f64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionEnum.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionEnum.nautilus
@@ -1,0 +1,33 @@
+nautilus {
+colorToCode($1:i32) :i32 {
+Block_0($1:i32):
+	$2 = 0 :i32
+	$3 = $1 == $2 :bool
+	if $3 ? Block_1() : Block_2($1) :void
+
+Block_1():
+	$5 = 1 :i32
+	br Block_5($5) :void
+
+Block_5($5:i32):
+	return ($5) :i32
+
+Block_2($1:i32):
+	$7 = 1 :i32
+	$8 = $1 == $7 :bool
+	if $8 ? Block_3() : Block_4() :void
+
+Block_3():
+	$10 = 2 :i32
+	br Block_5($10) :void
+
+Block_4():
+	$12 = 3 :i32
+	br Block_5($12) :void
+}
+execute($1:i32) :i32 {
+Block_0($1:i32):
+	$2 = func_*($1) :i32
+	return ($2) :i32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionFloat.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionFloat.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+addFloat($1:f32, $2:f32) :f32 {
+Block_0($1:f32, $2:f32):
+	$3 = $1 + $2 :f32
+	return ($3) :f32
+}
+execute($1:f32, $2:f32) :f32 {
+Block_0($1:f32, $2:f32):
+	$3 = func_*($1,$2) :f32
+	return ($3) :f32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInt16.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInt16.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+execute($1:i16, $2:i16) :i16 {
+Block_0($1:i16, $2:i16):
+	$3 = func_*($1,$2) :i16
+	return ($3) :i16
+}
+subInt16($1:i16, $2:i16) :i16 {
+Block_0($1:i16, $2:i16):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 - $4 :i32
+	$6 = $5 cast_to i16 :i16
+	return ($6) :i16
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInt64.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInt64.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+addInt64($1:i64, $2:i64) :i64 {
+Block_0($1:i64, $2:i64):
+	$3 = $1 + $2 :i64
+	return ($3) :i64
+}
+execute($1:i64, $2:i64) :i64 {
+Block_0($1:i64, $2:i64):
+	$3 = func_*($1,$2) :i64
+	return ($3) :i64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInt8.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionInt8.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+addInt8($1:i8, $2:i8) :i8 {
+Block_0($1:i8, $2:i8):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 + $4 :i32
+	$6 = $5 cast_to i8 :i8
+	return ($6) :i8
+}
+execute($1:i8, $2:i8) :i8 {
+Block_0($1:i8, $2:i8):
+	$3 = func_*($1,$2) :i8
+	return ($3) :i8
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionPtr.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionPtr.nautilus
@@ -1,0 +1,13 @@
+nautilus {
+derefAdd($1:ptr, $2:i32) :i32 {
+Block_0($1:ptr, $2:i32):
+	$6 = load($1) :i32
+	$7 = $6 + $2 :i32
+	return ($7) :i32
+}
+execute($1:ptr, $2:i32) :i32 {
+Block_0($1:ptr, $2:i32):
+	$3 = func_*($1,$2) :i32
+	return ($3) :i32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionPtrWrite.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionPtrWrite.nautilus
@@ -1,0 +1,13 @@
+nautilus {
+execute($1:ptr, $2:f64) :f64 {
+Block_0($1:ptr, $2:f64):
+	func_*($1,$2) :void
+	$6 = load($1) :f64
+	return ($6) :f64
+}
+writeDouble($1:ptr, $2:f64) :void {
+Block_0($1:ptr, $2:f64):
+	store($2, $1) :void
+	return :void
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt16.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt16.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+addUInt16($1:ui16, $2:ui16) :ui16 {
+Block_0($1:ui16, $2:ui16):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 + $4 :i32
+	$6 = $5 cast_to ui16 :ui16
+	return ($6) :ui16
+}
+execute($1:ui16, $2:ui16) :ui16 {
+Block_0($1:ui16, $2:ui16):
+	$3 = func_*($1,$2) :ui16
+	return ($3) :ui16
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt32.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt32.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:ui32, $2:ui32) :ui32 {
+Block_0($1:ui32, $2:ui32):
+	$3 = func_*($1,$2) :ui32
+	return ($3) :ui32
+}
+mulUInt32($1:ui32, $2:ui32) :ui32 {
+Block_0($1:ui32, $2:ui32):
+	$3 = $1 * $2 :ui32
+	return ($3) :ui32
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt64.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt64.nautilus
@@ -1,0 +1,12 @@
+nautilus {
+execute($1:ui64, $2:ui64) :ui64 {
+Block_0($1:ui64, $2:ui64):
+	$3 = func_*($1,$2) :ui64
+	return ($3) :ui64
+}
+mulUInt64($1:ui64, $2:ui64) :ui64 {
+Block_0($1:ui64, $2:ui64):
+	$3 = $1 * $2 :ui64
+	return ($3) :ui64
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt8.nautilus
+++ b/nautilus/test/data/nautilus-function-call-tests/ir/nautilusFunctionUInt8.nautilus
@@ -1,0 +1,15 @@
+nautilus {
+execute($1:ui8, $2:ui8) :ui8 {
+Block_0($1:ui8, $2:ui8):
+	$3 = func_*($1,$2) :ui8
+	return ($3) :ui8
+}
+mulUInt8($1:ui8, $2:ui8) :ui8 {
+Block_0($1:ui8, $2:ui8):
+	$3 = $1 cast_to i32 :i32
+	$4 = $2 cast_to i32 :i32
+	$5 = $3 * $4 :i32
+	$6 = $5 cast_to ui8 :ui8
+	return ($6) :ui8
+}
+} //nautilus

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionBool.shortcircuit.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionBool.shortcircuit.trace
@@ -1,0 +1,22 @@
+ANDBOOL:
+B0($1:bool,$2:bool)
+	CMP	$3	$1	B1()	B2()	:void
+B1()
+	CMP	$4	$2	B3()	B4()	:void
+B2()
+	CONST	$8	false	:bool
+	ASSIGN	$5	$8	:bool
+	RETURN	$0	$5	:bool
+B3()
+	CONST	$5	true	:bool
+	RETURN	$0	$5	:bool
+B4()
+	CONST	$11	false	:bool
+	ASSIGN	$5	$11	:bool
+	RETURN	$0	$5	:bool
+
+EXECUTE:
+B0($1:bool,$2:bool)
+	CALL	$3	func_*($1,$2)	:bool
+	RETURN	$0	$3	:bool
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionBool.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionBool.trace
@@ -1,0 +1,10 @@
+ANDBOOL:
+B0($1:bool,$2:bool)
+	AND	$3	$1	$2	:bool
+	RETURN	$0	$3	:bool
+
+EXECUTE:
+B0($1:bool,$2:bool)
+	CALL	$3	func_*($1,$2)	:bool
+	RETURN	$0	$3	:bool
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionDouble.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionDouble.trace
@@ -1,0 +1,10 @@
+EXECUTE:
+B0($1:f64,$2:f64)
+	CALL	$3	func_*($1,$2)	:f64
+	RETURN	$0	$3	:f64
+
+MULDOUBLE:
+B0($1:f64,$2:f64)
+	MUL	$3	$1	$2	:f64
+	RETURN	$0	$3	:f64
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionEnum.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionEnum.trace
@@ -1,0 +1,24 @@
+COLORTOCODE:
+B0($1:i32)
+	CONST	$2	0	:i32
+	EQ	$3	$1	$2	:bool
+	CMP	$4	$3	B1()	B2()	:void
+B1()
+	CONST	$5	1	:i32
+	RETURN	$0	$5	:i32
+B2()
+	CONST	$7	1	:i32
+	EQ	$8	$1	$7	:bool
+	CMP	$9	$8	B3()	B4()	:void
+B3()
+	CONST	$10	2	:i32
+	RETURN	$0	$10	:i32
+B4()
+	CONST	$12	3	:i32
+	RETURN	$0	$12	:i32
+
+EXECUTE:
+B0($1:i32)
+	CALL	$2	func_*($1)	:i32
+	RETURN	$0	$2	:i32
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionFloat.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionFloat.trace
@@ -1,0 +1,10 @@
+ADDFLOAT:
+B0($1:f32,$2:f32)
+	ADD	$3	$1	$2	:f32
+	RETURN	$0	$3	:f32
+
+EXECUTE:
+B0($1:f32,$2:f32)
+	CALL	$3	func_*($1,$2)	:f32
+	RETURN	$0	$3	:f32
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionInt16.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionInt16.trace
@@ -1,0 +1,13 @@
+EXECUTE:
+B0($1:i16,$2:i16)
+	CALL	$3	func_*($1,$2)	:i16
+	RETURN	$0	$3	:i16
+
+SUBINT16:
+B0($1:i16,$2:i16)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	SUB	$5	$3	$4	:i32
+	CAST	$6	$5	:i16
+	RETURN	$0	$6	:i16
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionInt64.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionInt64.trace
@@ -1,0 +1,10 @@
+ADDINT64:
+B0($1:i64,$2:i64)
+	ADD	$3	$1	$2	:i64
+	RETURN	$0	$3	:i64
+
+EXECUTE:
+B0($1:i64,$2:i64)
+	CALL	$3	func_*($1,$2)	:i64
+	RETURN	$0	$3	:i64
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionInt8.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionInt8.trace
@@ -1,0 +1,13 @@
+ADDINT8:
+B0($1:i8,$2:i8)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	ADD	$5	$3	$4	:i32
+	CAST	$6	$5	:i8
+	RETURN	$0	$6	:i8
+
+EXECUTE:
+B0($1:i8,$2:i8)
+	CALL	$3	func_*($1,$2)	:i8
+	RETURN	$0	$3	:i8
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionPtr.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionPtr.trace
@@ -1,0 +1,14 @@
+DEREFADD:
+B0($1:ptr,$2:i32)
+	ASSIGN	$3	$1	:ptr
+	ASSIGN	$4	$3	:ptr
+	ASSIGN	$5	$2	:i32
+	LOAD	$6	$4	:i32
+	ADD	$7	$6	$5	:i32
+	RETURN	$0	$7	:i32
+
+EXECUTE:
+B0($1:ptr,$2:i32)
+	CALL	$3	func_*($1,$2)	:i32
+	RETURN	$0	$3	:i32
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionPtrWrite.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionPtrWrite.trace
@@ -1,0 +1,17 @@
+EXECUTE:
+B0($1:ptr,$2:f64)
+	CALL	$3	func_*($1,$2)	:void
+	ASSIGN	$4	$1	:ptr
+	ASSIGN	$5	$4	:ptr
+	LOAD	$6	$5	:f64
+	RETURN	$0	$6	:f64
+
+WRITEDOUBLE:
+B0($1:ptr,$2:f64)
+	ASSIGN	$3	$2	:f64
+	ASSIGN	$4	$1	:ptr
+	ASSIGN	$5	$4	:ptr
+	ASSIGN	$6	$3	:f64
+	STORE	$7	$5	$6	:void
+	RETURN	$0	:void
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt16.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt16.trace
@@ -1,0 +1,13 @@
+ADDUINT16:
+B0($1:ui16,$2:ui16)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	ADD	$5	$3	$4	:i32
+	CAST	$6	$5	:ui16
+	RETURN	$0	$6	:ui16
+
+EXECUTE:
+B0($1:ui16,$2:ui16)
+	CALL	$3	func_*($1,$2)	:ui16
+	RETURN	$0	$3	:ui16
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt32.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt32.trace
@@ -1,0 +1,10 @@
+EXECUTE:
+B0($1:ui32,$2:ui32)
+	CALL	$3	func_*($1,$2)	:ui32
+	RETURN	$0	$3	:ui32
+
+MULUINT32:
+B0($1:ui32,$2:ui32)
+	MUL	$3	$1	$2	:ui32
+	RETURN	$0	$3	:ui32
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt64.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt64.trace
@@ -1,0 +1,10 @@
+EXECUTE:
+B0($1:ui64,$2:ui64)
+	CALL	$3	func_*($1,$2)	:ui64
+	RETURN	$0	$3	:ui64
+
+MULUINT64:
+B0($1:ui64,$2:ui64)
+	MUL	$3	$1	$2	:ui64
+	RETURN	$0	$3	:ui64
+

--- a/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt8.trace
+++ b/nautilus/test/data/nautilus-function-call-tests/tracing/nautilusFunctionUInt8.trace
@@ -1,0 +1,13 @@
+EXECUTE:
+B0($1:ui8,$2:ui8)
+	CALL	$3	func_*($1,$2)	:ui8
+	RETURN	$0	$3	:ui8
+
+MULUINT8:
+B0($1:ui8,$2:ui8)
+	CAST	$3	$1	:i32
+	CAST	$4	$2	:i32
+	MUL	$5	$3	$4	:i32
+	CAST	$6	$5	:ui8
+	RETURN	$0	$6	:ui8
+

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -1015,6 +1015,77 @@ void nautilusFunctionExecutionTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(0, 0) == 0);
 		REQUIRE(f(-5, 5) == 0);
 	}
+
+	SECTION("nautilusFunctionInt8") {
+		auto f = engine.registerFunction(nautilusFunctionInt8);
+		REQUIRE(f(int8_t(3), int8_t(4)) == int8_t(7));
+		REQUIRE(f(int8_t(-100), int8_t(-27)) == int8_t(-127));
+	}
+	SECTION("nautilusFunctionUInt8") {
+		auto f = engine.registerFunction(nautilusFunctionUInt8);
+		REQUIRE(f(uint8_t(3), uint8_t(4)) == uint8_t(12));
+		REQUIRE(f(uint8_t(0), uint8_t(200)) == uint8_t(0));
+	}
+	SECTION("nautilusFunctionInt16") {
+		auto f = engine.registerFunction(nautilusFunctionInt16);
+		REQUIRE(f(int16_t(10), int16_t(4)) == int16_t(6));
+		REQUIRE(f(int16_t(-1000), int16_t(500)) == int16_t(-1500));
+	}
+	SECTION("nautilusFunctionUInt16") {
+		auto f = engine.registerFunction(nautilusFunctionUInt16);
+		REQUIRE(f(uint16_t(3), uint16_t(4)) == uint16_t(7));
+		REQUIRE(f(uint16_t(60000), uint16_t(5000)) == uint16_t(65000));
+	}
+	SECTION("nautilusFunctionUInt32") {
+		auto f = engine.registerFunction(nautilusFunctionUInt32);
+		REQUIRE(f(uint32_t(6), uint32_t(7)) == uint32_t(42));
+		REQUIRE(f(uint32_t(0), uint32_t(123456)) == uint32_t(0));
+	}
+	SECTION("nautilusFunctionInt64") {
+		auto f = engine.registerFunction(nautilusFunctionInt64);
+		REQUIRE(f(int64_t(3), int64_t(4)) == int64_t(7));
+		REQUIRE(f(int64_t(-9000000000LL), int64_t(1000000000LL)) == int64_t(-8000000000LL));
+	}
+	SECTION("nautilusFunctionUInt64") {
+		auto f = engine.registerFunction(nautilusFunctionUInt64);
+		REQUIRE(f(uint64_t(6), uint64_t(7)) == uint64_t(42));
+		REQUIRE(f(uint64_t(0), uint64_t(123456789ULL)) == uint64_t(0));
+	}
+	SECTION("nautilusFunctionFloat") {
+		auto f = engine.registerFunction(nautilusFunctionFloat);
+		REQUIRE(f(3.5f, 4.25f) == 7.75f);
+		REQUIRE(f(0.0f, 0.0f) == 0.0f);
+	}
+	SECTION("nautilusFunctionDouble") {
+		auto f = engine.registerFunction(nautilusFunctionDouble);
+		REQUIRE(f(3.5, 2.0) == 7.0);
+		REQUIRE(f(0.0, 123.456) == 0.0);
+	}
+	SECTION("nautilusFunctionBool") {
+		auto f = engine.registerFunction(nautilusFunctionBool);
+		REQUIRE(f(true, true) == true);
+		REQUIRE(f(true, false) == false);
+		REQUIRE(f(false, false) == false);
+	}
+	SECTION("nautilusFunctionPtr") {
+		auto f = engine.registerFunction(nautilusFunctionPtr);
+		int32_t value = 10;
+		REQUIRE(f(&value, 5) == 15);
+		value = -3;
+		REQUIRE(f(&value, 3) == 0);
+	}
+	SECTION("nautilusFunctionPtrWrite") {
+		auto f = engine.registerFunction(nautilusFunctionPtrWrite);
+		double value = 0.0;
+		REQUIRE(f(&value, 42.5) == 42.5);
+		REQUIRE(value == 42.5);
+	}
+	SECTION("nautilusFunctionEnum") {
+		auto f = engine.registerFunction(nautilusFunctionEnum);
+		REQUIRE(f(NautilusFunctionColor::RED) == 1);
+		REQUIRE(f(NautilusFunctionColor::GREEN) == 2);
+		REQUIRE(f(NautilusFunctionColor::BLUE) == 3);
+	}
 }
 
 void valueExecutionTest(engine::NautilusEngine& engine) {

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -13,6 +13,8 @@
 #include "nautilus/Engine.hpp"
 #include "nautilus/val_concepts.hpp"
 #include <catch2/catch_all.hpp>
+#include <cmath>
+#include <limits>
 namespace nautilus::engine {
 
 val<bool> makeConstantOfTracingValue(val<int> ref) {
@@ -1020,51 +1022,90 @@ void nautilusFunctionExecutionTest(engine::NautilusEngine& engine) {
 		auto f = engine.registerFunction(nautilusFunctionInt8);
 		REQUIRE(f(int8_t(3), int8_t(4)) == int8_t(7));
 		REQUIRE(f(int8_t(-100), int8_t(-27)) == int8_t(-127));
+		REQUIRE(f(int8_t(0), int8_t(0)) == int8_t(0));
+		// Two's-complement wraparound at the int8_t boundaries.
+		REQUIRE(f(std::numeric_limits<int8_t>::max(), int8_t(1)) == std::numeric_limits<int8_t>::min());
+		REQUIRE(f(std::numeric_limits<int8_t>::min(), int8_t(-1)) == std::numeric_limits<int8_t>::max());
+		REQUIRE(f(std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::min()) == int8_t(0));
 	}
 	SECTION("nautilusFunctionUInt8") {
 		auto f = engine.registerFunction(nautilusFunctionUInt8);
 		REQUIRE(f(uint8_t(3), uint8_t(4)) == uint8_t(12));
 		REQUIRE(f(uint8_t(0), uint8_t(200)) == uint8_t(0));
+		// Unsigned wraparound (mod 256) at and beyond the uint8_t max.
+		REQUIRE(f(std::numeric_limits<uint8_t>::max(), uint8_t(1)) == std::numeric_limits<uint8_t>::max());
+		REQUIRE(f(std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()) == uint8_t(1));
+		REQUIRE(f(uint8_t(128), uint8_t(2)) == uint8_t(0));
 	}
 	SECTION("nautilusFunctionInt16") {
 		auto f = engine.registerFunction(nautilusFunctionInt16);
 		REQUIRE(f(int16_t(10), int16_t(4)) == int16_t(6));
 		REQUIRE(f(int16_t(-1000), int16_t(500)) == int16_t(-1500));
+		REQUIRE(f(int16_t(0), int16_t(0)) == int16_t(0));
+		// Two's-complement wraparound at the int16_t boundaries.
+		REQUIRE(f(std::numeric_limits<int16_t>::min(), int16_t(1)) == std::numeric_limits<int16_t>::max());
+		REQUIRE(f(std::numeric_limits<int16_t>::max(), int16_t(-1)) == std::numeric_limits<int16_t>::min());
 	}
 	SECTION("nautilusFunctionUInt16") {
 		auto f = engine.registerFunction(nautilusFunctionUInt16);
 		REQUIRE(f(uint16_t(3), uint16_t(4)) == uint16_t(7));
 		REQUIRE(f(uint16_t(60000), uint16_t(5000)) == uint16_t(65000));
+		// Unsigned wraparound (mod 65536) at and beyond the uint16_t max.
+		REQUIRE(f(std::numeric_limits<uint16_t>::max(), uint16_t(1)) == uint16_t(0));
+		REQUIRE(f(std::numeric_limits<uint16_t>::max(), std::numeric_limits<uint16_t>::max()) == uint16_t(65534));
 	}
 	SECTION("nautilusFunctionUInt32") {
 		auto f = engine.registerFunction(nautilusFunctionUInt32);
 		REQUIRE(f(uint32_t(6), uint32_t(7)) == uint32_t(42));
 		REQUIRE(f(uint32_t(0), uint32_t(123456)) == uint32_t(0));
+		// Unsigned wraparound (mod 2^32) at and beyond the uint32_t max.
+		REQUIRE(f(std::numeric_limits<uint32_t>::max(), uint32_t(1)) == std::numeric_limits<uint32_t>::max());
+		REQUIRE(f(uint32_t(1) << 16, uint32_t(1) << 16) == uint32_t(0));
 	}
 	SECTION("nautilusFunctionInt64") {
 		auto f = engine.registerFunction(nautilusFunctionInt64);
 		REQUIRE(f(int64_t(3), int64_t(4)) == int64_t(7));
 		REQUIRE(f(int64_t(-9000000000LL), int64_t(1000000000LL)) == int64_t(-8000000000LL));
+		REQUIRE(f(int64_t(0), int64_t(0)) == int64_t(0));
+		// Two's-complement wraparound at the int64_t boundaries.
+		REQUIRE(f(std::numeric_limits<int64_t>::max(), int64_t(1)) == std::numeric_limits<int64_t>::min());
+		REQUIRE(f(std::numeric_limits<int64_t>::min(), int64_t(-1)) == std::numeric_limits<int64_t>::max());
 	}
 	SECTION("nautilusFunctionUInt64") {
 		auto f = engine.registerFunction(nautilusFunctionUInt64);
 		REQUIRE(f(uint64_t(6), uint64_t(7)) == uint64_t(42));
 		REQUIRE(f(uint64_t(0), uint64_t(123456789ULL)) == uint64_t(0));
+		// Unsigned wraparound (mod 2^64) at and beyond the uint64_t max.
+		REQUIRE(f(std::numeric_limits<uint64_t>::max(), uint64_t(1)) == std::numeric_limits<uint64_t>::max());
+		REQUIRE(f(uint64_t(1) << 32, uint64_t(1) << 32) == uint64_t(0));
 	}
 	SECTION("nautilusFunctionFloat") {
 		auto f = engine.registerFunction(nautilusFunctionFloat);
 		REQUIRE(f(3.5f, 4.25f) == 7.75f);
 		REQUIRE(f(0.0f, 0.0f) == 0.0f);
+		REQUIRE(f(-3.5f, -4.25f) == -7.75f);
+		REQUIRE(f(1.0f, std::numeric_limits<float>::epsilon()) == 1.0f + std::numeric_limits<float>::epsilon());
+		// Overflow to +/-infinity beyond the finite float range.
+		REQUIRE(std::isinf(f(std::numeric_limits<float>::max(), std::numeric_limits<float>::max())));
+		REQUIRE(std::isinf(f(-std::numeric_limits<float>::max(), -std::numeric_limits<float>::max())));
 	}
 	SECTION("nautilusFunctionDouble") {
 		auto f = engine.registerFunction(nautilusFunctionDouble);
 		REQUIRE(f(3.5, 2.0) == 7.0);
 		REQUIRE(f(0.0, 123.456) == 0.0);
+		REQUIRE(f(-3.5, 2.0) == -7.0);
+		// Underflow to zero for a product below the smallest representable magnitude.
+		REQUIRE(f(std::numeric_limits<double>::min(), std::numeric_limits<double>::min()) == 0.0);
+		// Overflow to +infinity beyond the finite double range.
+		REQUIRE(std::isinf(f(std::numeric_limits<double>::max(), 2.0)));
+		// Sign of a negative-zero product is preserved.
+		REQUIRE(std::signbit(f(-0.0, 5.0)));
 	}
 	SECTION("nautilusFunctionBool") {
 		auto f = engine.registerFunction(nautilusFunctionBool);
 		REQUIRE(f(true, true) == true);
 		REQUIRE(f(true, false) == false);
+		REQUIRE(f(false, true) == false);
 		REQUIRE(f(false, false) == false);
 	}
 	SECTION("nautilusFunctionPtr") {
@@ -1073,15 +1114,30 @@ void nautilusFunctionExecutionTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(&value, 5) == 15);
 		value = -3;
 		REQUIRE(f(&value, 3) == 0);
+		value = 0;
+		REQUIRE(f(&value, 0) == 0);
+		// Two's-complement wraparound of the addition through the pointer load.
+		value = std::numeric_limits<int32_t>::max();
+		REQUIRE(f(&value, 1) == std::numeric_limits<int32_t>::min());
+		value = std::numeric_limits<int32_t>::min();
+		REQUIRE(f(&value, -1) == std::numeric_limits<int32_t>::max());
 	}
 	SECTION("nautilusFunctionPtrWrite") {
 		auto f = engine.registerFunction(nautilusFunctionPtrWrite);
 		double value = 0.0;
 		REQUIRE(f(&value, 42.5) == 42.5);
 		REQUIRE(value == 42.5);
+		REQUIRE(f(&value, -123.456) == -123.456);
+		REQUIRE(value == -123.456);
+		REQUIRE(f(&value, std::numeric_limits<double>::max()) == std::numeric_limits<double>::max());
+		REQUIRE(value == std::numeric_limits<double>::max());
+		// Overwriting a non-zero value with zero exercises the store path, not just its initial value.
+		REQUIRE(f(&value, 0.0) == 0.0);
+		REQUIRE(value == 0.0);
 	}
 	SECTION("nautilusFunctionEnum") {
 		auto f = engine.registerFunction(nautilusFunctionEnum);
+		// Exhaustive over the whole enum domain.
 		REQUIRE(f(NautilusFunctionColor::RED) == 1);
 		REQUIRE(f(NautilusFunctionColor::GREEN) == 2);
 		REQUIRE(f(NautilusFunctionColor::BLUE) == 3);

--- a/nautilus/test/execution-tests/TracingTest.cpp
+++ b/nautilus/test/execution-tests/TracingTest.cpp
@@ -731,6 +731,19 @@ TEST_CASE("Nautilus Function Call Trace Test") {
 	    {"nautilusFunctionInlineMember", details::createFunctionWrapper(nautilusFunctionInlineMember)},
 	    {"nautilusFunctionMultipleInline", details::createFunctionWrapper(nautilusFunctionMultipleInline)},
 	    {"nautilusFunctionGetFuncPtr", details::createFunctionWrapper(nautilusFunctionGetFuncPtr)},
+	    {"nautilusFunctionInt8", details::createFunctionWrapper(nautilusFunctionInt8)},
+	    {"nautilusFunctionUInt8", details::createFunctionWrapper(nautilusFunctionUInt8)},
+	    {"nautilusFunctionInt16", details::createFunctionWrapper(nautilusFunctionInt16)},
+	    {"nautilusFunctionUInt16", details::createFunctionWrapper(nautilusFunctionUInt16)},
+	    {"nautilusFunctionUInt32", details::createFunctionWrapper(nautilusFunctionUInt32)},
+	    {"nautilusFunctionInt64", details::createFunctionWrapper(nautilusFunctionInt64)},
+	    {"nautilusFunctionUInt64", details::createFunctionWrapper(nautilusFunctionUInt64)},
+	    {"nautilusFunctionFloat", details::createFunctionWrapper(nautilusFunctionFloat)},
+	    {"nautilusFunctionDouble", details::createFunctionWrapper(nautilusFunctionDouble)},
+	    {"nautilusFunctionBool", details::createFunctionWrapper(nautilusFunctionBool)},
+	    {"nautilusFunctionPtr", details::createFunctionWrapper(nautilusFunctionPtr)},
+	    {"nautilusFunctionPtrWrite", details::createFunctionWrapper(nautilusFunctionPtrWrite)},
+	    {"nautilusFunctionEnum", details::createFunctionWrapper(nautilusFunctionEnum)},
 	};
 	runTraceTests("nautilus-function-call-tests", tests);
 }


### PR DESCRIPTION
## Summary
- Add a `NautilusFunction` helper/wrapper pair in `nautilus/test/common/NautilusFunction.hpp` for every `val<T>` specialization that wasn't already exercised through the `NautilusFunction` call path: signed/unsigned integers of all widths (`int8_t`/`uint8_t`/`int16_t`/`uint16_t`/`uint32_t`/`int64_t`/`uint64_t` — `int32_t` was already covered), `float`, `double`, `bool`, pointer arguments read and written through `val<T*>`, and an enum-typed argument.
- Wire the new functions into `nautilusFunctionExecutionTest()` in `ExecutionTest.cpp`, which runs under both the interpreter and every compiled backend (`bc`, `cpp` in this build), and into the `"Nautilus Function Call Trace Test"` list in `TracingTest.cpp`, which runs under both trace contexts (`ExceptionBasedTraceContext`, `LazyTraceContext`).
- Check in the generated `tracing` / `after_ssa` / `ir` / `after_constant_folding` / `after_empty_block_elim` reference dumps for the new trace-test cases under `nautilus/test/data/nautilus-function-call-tests/`.

## Test plan
- [x] `nautilus-execution-tests "NautilusFunction*"` — 230 assertions in 2 test cases (interpreter + compiled backends), all passing.
- [x] `nautilus-tracing-tests "Nautilus Function Call Trace Test"` — 280 assertions, all passing (both trace contexts, first run auto-generated the new reference dumps, verified stable on rerun).
- [x] Full `nautilus-execution-tests` suite — 9598 assertions passing.
- [x] Full `nautilus-tracing-tests` suite — 4670 assertions passing.
- Built locally with `clang++-18` (MLIR/AsmJit backends disabled to keep the build light — clang++-21 / MLIR weren't available in this environment); the added code has no dependency on either backend so this doesn't affect coverage of the change itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_019hfcE3XX4XEoMwZXUE7hDz)_