### PR TITLE
Merge duplicated Int/Float evaluators in the differential fuzzer

### DIFF
--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -181,23 +181,7 @@ struct EvalContext {
 };
 
 template <typename T>
-T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx);
-template <typename T>
-T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx);
-
-/// Dispatches to whichever of evalNativeInt/evalNativeFloat matches T's
-/// domain. Used by the memory-domain helpers below (evalNativePtr, and the
-/// Load/Store cases inside evalNativeInt/evalNativeFloat) since they are
-/// shared between both domains and need to evaluate value-domain
-/// subexpressions (offsets, stored values) generated in that same domain.
-template <typename T>
-T evalNativeValue(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
-	if constexpr (std::is_floating_point_v<T>) {
-		return evalNativeFloat<T>(ast, idx, args, ctx);
-	} else {
-		return evalNativeInt<T>(ast, idx, args, ctx);
-	}
-}
+T evalNativeGeneric(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx);
 
 /// Evaluate a pointer-domain node (Kind::PtrBase/PtrAdd/PtrSub, see Ast.hpp)
 /// to a buffer index. Always in [0, BUFFER_ELEMS) by construction --
@@ -208,17 +192,49 @@ int evalNativePtr(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::PtrAdd:
-		return clampBufferIndex<T>(evalNativeValue<T>(ast, n.kid[0], args, ctx));
+		return clampBufferIndex<T>(evalNativeGeneric<T>(ast, n.kid[0], args, ctx));
 	case Kind::PtrSub:
-		return (BUFFER_ELEMS - 1) - clampBufferIndex<T>(evalNativeValue<T>(ast, n.kid[0], args, ctx));
+		return (BUFFER_ELEMS - 1) - clampBufferIndex<T>(evalNativeGeneric<T>(ast, n.kid[0], args, ctx));
 	case Kind::PtrBase:
 	default:
 		return 0;
 	}
 }
 
+/// Shared body of the six Ptr* comparison kinds: both native evaluators
+/// (formerly evalNativeInt/evalNativeFloat, now a single evalNativeGeneric)
+/// reduced their pointer-domain kids to plain buffer indices and compared
+/// those, so the comparison itself never depended on T -- pulled out once
+/// here instead of appearing twice.
+inline bool comparePtrIndices(Kind kind, int a, int b) {
+	switch (kind) {
+	case Kind::PtrEq:
+		return a == b;
+	case Kind::PtrNe:
+		return a != b;
+	case Kind::PtrLt:
+		return a < b;
+	case Kind::PtrLe:
+		return a <= b;
+	case Kind::PtrGt:
+		return a > b;
+	default: // Kind::PtrGe
+		return a >= b;
+	}
+}
+
+/// Single evaluator for both the integer and float domains. The two used to
+/// be separate functions (evalNativeInt/evalNativeFloat) that duplicated
+/// every control-flow, memory, call and comparison case verbatim -- the
+/// exact kind of duplication that let the Select short-circuit bug (see
+/// README.md) need fixing in two places instead of one. The domain still
+/// matters for a handful of operations (float has no bitwise/modulo ops;
+/// signed integer arithmetic needs the wraparound helpers; float division
+/// needs no non-zero-divisor guard), so those cases branch internally via
+/// `if constexpr` -- the same pattern already used by safeDivisor/castThrough
+/// above -- rather than being split back into two functions.
 template <typename T>
-T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
+T evalNativeGeneric(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
@@ -238,60 +254,68 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 		// side effect while the traced kernel still performs it, breaking
 		// oracle/traced parity for any program that stores inside a Select
 		// branch.
-		const T c = evalNativeInt<T>(ast, n.kid[0], args, ctx);
-		const T t = evalNativeInt<T>(ast, n.kid[1], args, ctx);
-		const T f = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+		const T c = evalNativeGeneric<T>(ast, n.kid[0], args, ctx);
+		const T t = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
+		const T f = evalNativeGeneric<T>(ast, n.kid[2], args, ctx);
 		return c != T(0) ? t : f;
 	}
 	case Kind::If: {
-		const T c = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		const T c = evalNativeGeneric<T>(ast, n.kid[0], args, ctx);
 		// Mirror the traced kernel: the else-branch is evaluated unconditionally,
 		// the then-branch only when the condition holds.
-		const T e = evalNativeInt<T>(ast, n.kid[2], args, ctx);
-		return c != T(0) ? evalNativeInt<T>(ast, n.kid[1], args, ctx) : e;
+		const T e = evalNativeGeneric<T>(ast, n.kid[2], args, ctx);
+		return c != T(0) ? evalNativeGeneric<T>(ast, n.kid[1], args, ctx) : e;
 	}
 	case Kind::Loop: {
-		const T rawCount = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		const T rawCount = evalNativeGeneric<T>(ast, n.kid[0], args, ctx);
 		const int trips = clampTripCount<T>(rawCount);
-		T acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+		T acc = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
 		for (int i = 0; i < trips; ++i) {
 			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
-			acc = evalNativeInt<T>(ast, n.kid[2], args, ctx);
+			acc = evalNativeGeneric<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;
 	}
 	case Kind::StaticLoop: {
 		const int trips = static_cast<int>(n.imm);
-		T acc = evalNativeInt<T>(ast, n.kid[0], args, ctx);
+		T acc = evalNativeGeneric<T>(ast, n.kid[0], args, ctx);
 		for (int i = 0; i < trips; ++i) {
 			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
-			acc = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+			acc = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;
 	}
 	case Kind::Neg: {
-		const T v = evalNativeInt<T>(ast, n.kid[0], args, ctx);
-		if constexpr (std::is_signed_v<T>) {
+		const T v = evalNativeGeneric<T>(ast, n.kid[0], args, ctx);
+		if constexpr (std::is_floating_point_v<T>) {
+			return static_cast<T>(-v);
+		} else if constexpr (std::is_signed_v<T>) {
 			return wrappingNeg<T>(v);
 		} else {
 			return static_cast<T>(-v);
 		}
 	}
 	case Kind::Not:
-		return static_cast<T>(~evalNativeInt<T>(ast, n.kid[0], args, ctx));
+		// Integer domain only (FLOAT_KINDS never generates Not); guarded so the
+		// bitwise-complement expression doesn't need to compile for float T.
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(~evalNativeGeneric<T>(ast, n.kid[0], args, ctx));
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::LNot:
-		return evalNativeInt<T>(ast, n.kid[0], args, ctx) == T(0) ? T(1) : T(0);
+		return evalNativeGeneric<T>(ast, n.kid[0], args, ctx) == T(0) ? T(1) : T(0);
 	case Kind::Cast:
-		return castThrough<T>(evalNativeInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
+		return castThrough<T>(evalNativeGeneric<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	case Kind::Load: {
 		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
 		return (*ctx.memory)[static_cast<size_t>(i)];
 	}
 	case Kind::Store: {
 		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
-		const T v = evalNativeValue<T>(ast, n.kid[1], args, ctx);
+		const T v = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
 		(*ctx.memory)[static_cast<size_t>(i)] = v;
 		return v;
 	}
@@ -307,207 +331,81 @@ T evalNativeInt(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, 
 	case Kind::PtrGe: {
 		const int a = evalNativePtr<T>(ast, n.kid[0], args, ctx);
 		const int b = evalNativePtr<T>(ast, n.kid[1], args, ctx);
-		bool r = false;
-		switch (n.kind) {
-		case Kind::PtrEq:
-			r = (a == b);
-			break;
-		case Kind::PtrNe:
-			r = (a != b);
-			break;
-		case Kind::PtrLt:
-			r = (a < b);
-			break;
-		case Kind::PtrLe:
-			r = (a <= b);
-			break;
-		case Kind::PtrGt:
-			r = (a > b);
-			break;
-		default:
-			r = (a >= b);
-			break;
-		}
-		return r ? T(1) : T(0);
+		return comparePtrIndices(n.kind, a, b) ? T(1) : T(0);
 	}
 	default:
 		break;
 	}
 
-	const T l = evalNativeInt<T>(ast, n.kid[0], args, ctx);
-	const T r = evalNativeInt<T>(ast, n.kid[1], args, ctx);
+	const T l = evalNativeGeneric<T>(ast, n.kid[0], args, ctx);
+	const T r = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
 	switch (n.kind) {
 	case Kind::Add:
-		if constexpr (std::is_signed_v<T>) {
+		if constexpr (std::is_floating_point_v<T>) {
+			return static_cast<T>(l + r);
+		} else if constexpr (std::is_signed_v<T>) {
 			return wrappingAdd<T>(l, r);
 		} else {
 			return static_cast<T>(l + r);
 		}
 	case Kind::Sub:
-		if constexpr (std::is_signed_v<T>) {
+		if constexpr (std::is_floating_point_v<T>) {
+			return static_cast<T>(l - r);
+		} else if constexpr (std::is_signed_v<T>) {
 			return wrappingSub<T>(l, r);
 		} else {
 			return static_cast<T>(l - r);
 		}
 	case Kind::Mul:
-		if constexpr (std::is_signed_v<T>) {
+		if constexpr (std::is_floating_point_v<T>) {
+			return static_cast<T>(l * r);
+		} else if constexpr (std::is_signed_v<T>) {
 			return wrappingMul<T>(l, r);
 		} else {
 			return static_cast<T>(l * r);
 		}
 	case Kind::Div:
-		return static_cast<T>(l / safeDivisor<T>(r));
+		if constexpr (std::is_floating_point_v<T>) {
+			return static_cast<T>(l / r); // well-defined IEEE 754: produces +-inf / NaN for r == 0
+		} else {
+			return static_cast<T>(l / safeDivisor<T>(r));
+		}
 	case Kind::Mod:
-		return static_cast<T>(l % safeDivisor<T>(r));
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(l % safeDivisor<T>(r));
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::And:
-		return static_cast<T>(l & r);
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(l & r);
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Or:
-		return static_cast<T>(l | r);
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(l | r);
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Xor:
-		return static_cast<T>(l ^ r);
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(l ^ r);
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Shl:
-		return static_cast<T>(l << (r & T(sizeof(T) * 8 - 1)));
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(l << (r & T(sizeof(T) * 8 - 1)));
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Shr:
-		return static_cast<T>(l >> (r & T(sizeof(T) * 8 - 1)));
-	// LAnd/LOr sit in this binary tail so l and r are both already evaluated
-	// unconditionally -- deliberate, see the Kind::LAnd comment in Ast.hpp.
-	case Kind::LAnd:
-		return (l != T(0)) && (r != T(0)) ? T(1) : T(0);
-	case Kind::LOr:
-		return (l != T(0)) || (r != T(0)) ? T(1) : T(0);
-	case Kind::Call:
-		// Direct call of the same instantiation the traced kernel invoke()s.
-		return n.imm % NUM_CALLEES == 0 ? calleeMix<T>(l, r) : calleeMin<T>(l, r);
-	case Kind::Eq:
-		return l == r ? T(1) : T(0);
-	case Kind::Ne:
-		return l != r ? T(1) : T(0);
-	case Kind::Lt:
-		return l < r ? T(1) : T(0);
-	case Kind::Le:
-		return l <= r ? T(1) : T(0);
-	case Kind::Gt:
-		return l > r ? T(1) : T(0);
-	case Kind::Ge:
-		return l >= r ? T(1) : T(0);
-	default:
-		return T(0); // unreachable
-	}
-}
-
-template <typename T>
-T evalNativeFloat(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
-	const Node& n = ast.nodes[idx];
-	switch (n.kind) {
-	case Kind::Const:
-		return unpackImm<T>(n.imm);
-	case Kind::Param:
-		return args[n.imm % NUM_PARAMS];
-	case Kind::LoopIndex:
-		return ctx.loopStack.back().index;
-	case Kind::LoopAcc:
-		return ctx.loopStack.back().acc;
-	case Kind::Select: {
-		// See the identical comment in evalNativeInt's Select case: both
-		// branches must be evaluated unconditionally to match the traced
-		// kernel's data-mux `select`, now that Store can live inside them.
-		const T c = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
-		const T t = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
-		const T f = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
-		return c != T(0) ? t : f;
-	}
-	case Kind::If: {
-		const T c = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
-		const T e = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
-		return c != T(0) ? evalNativeFloat<T>(ast, n.kid[1], args, ctx) : e;
-	}
-	case Kind::Loop: {
-		const T rawCount = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
-		const int trips = clampTripCount<T>(rawCount);
-		T acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
-		for (int i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
-			acc = evalNativeFloat<T>(ast, n.kid[2], args, ctx);
-			ctx.loopStack.pop_back();
+		if constexpr (!std::is_floating_point_v<T>) {
+			return static_cast<T>(l >> (r & T(sizeof(T) * 8 - 1)));
+		} else {
+			__builtin_unreachable();
 		}
-		return acc;
-	}
-	case Kind::StaticLoop: {
-		const int trips = static_cast<int>(n.imm);
-		T acc = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
-		for (int i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(LoopFrame<T> {static_cast<T>(i), acc});
-			acc = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
-			ctx.loopStack.pop_back();
-		}
-		return acc;
-	}
-	case Kind::Neg:
-		return static_cast<T>(-evalNativeFloat<T>(ast, n.kid[0], args, ctx));
-	case Kind::LNot:
-		return evalNativeFloat<T>(ast, n.kid[0], args, ctx) == T(0) ? T(1) : T(0);
-	case Kind::Cast:
-		return castThrough<T>(evalNativeFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
-	case Kind::Load: {
-		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
-		return (*ctx.memory)[static_cast<size_t>(i)];
-	}
-	case Kind::Store: {
-		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
-		const T v = evalNativeValue<T>(ast, n.kid[1], args, ctx);
-		(*ctx.memory)[static_cast<size_t>(i)] = v;
-		return v;
-	}
-	case Kind::PtrToInt: {
-		const int i = evalNativePtr<T>(ast, n.kid[0], args, ctx);
-		return static_cast<T>(reinterpret_cast<uintptr_t>(&(*ctx.memory)[static_cast<size_t>(i)]));
-	}
-	case Kind::PtrEq:
-	case Kind::PtrNe:
-	case Kind::PtrLt:
-	case Kind::PtrLe:
-	case Kind::PtrGt:
-	case Kind::PtrGe: {
-		const int a = evalNativePtr<T>(ast, n.kid[0], args, ctx);
-		const int b = evalNativePtr<T>(ast, n.kid[1], args, ctx);
-		bool r = false;
-		switch (n.kind) {
-		case Kind::PtrEq:
-			r = (a == b);
-			break;
-		case Kind::PtrNe:
-			r = (a != b);
-			break;
-		case Kind::PtrLt:
-			r = (a < b);
-			break;
-		case Kind::PtrLe:
-			r = (a <= b);
-			break;
-		case Kind::PtrGt:
-			r = (a > b);
-			break;
-		default:
-			r = (a >= b);
-			break;
-		}
-		return r ? T(1) : T(0);
-	}
-	default:
-		break;
-	}
-
-	const T l = evalNativeFloat<T>(ast, n.kid[0], args, ctx);
-	const T r = evalNativeFloat<T>(ast, n.kid[1], args, ctx);
-	switch (n.kind) {
-	case Kind::Add:
-		return static_cast<T>(l + r);
-	case Kind::Sub:
-		return static_cast<T>(l - r);
-	case Kind::Mul:
-		return static_cast<T>(l * r);
-	case Kind::Div:
-		return static_cast<T>(l / r); // well-defined IEEE 754: produces +-inf / NaN for r == 0
 	// LAnd/LOr sit in this binary tail so l and r are both already evaluated
 	// unconditionally -- deliberate, see the Kind::LAnd comment in Ast.hpp.
 	case Kind::LAnd:
@@ -540,11 +438,7 @@ template <typename T>
 T evalNative(const Ast& ast, const std::array<T, NUM_PARAMS>& args, std::array<T, BUFFER_ELEMS>& memory) {
 	detail::EvalContext<T> ctx;
 	ctx.memory = &memory;
-	if constexpr (std::is_floating_point_v<T>) {
-		return detail::evalNativeFloat<T>(ast, ast.root, args, ctx);
-	} else {
-		return detail::evalNativeInt<T>(ast, ast.root, args, ctx);
-	}
+	return detail::evalNativeGeneric<T>(ast, ast.root, args, ctx);
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -149,22 +149,7 @@ struct TracedEvalContext {
 };
 
 template <typename T>
-TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx);
-template <typename T>
-TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx);
-
-/// Dispatches to whichever of evalNautilusInt/evalNautilusFloat matches T's
-/// domain -- the traced mirror of EvalNative.hpp's evalNativeValue, needed
-/// for the same reason (evalNautilusPtr and the Load/Store cases below are
-/// shared between both domains).
-template <typename T>
-TracedValue<T> evalNautilusValue(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
-	if constexpr (std::is_floating_point_v<T>) {
-		return evalNautilusFloat<T>(ast, idx, args, ctx);
-	} else {
-		return evalNautilusInt<T>(ast, idx, args, ctx);
-	}
-}
+TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx);
 
 /// Traced mirror of EvalNative.hpp's evalNativePtr: evaluates a
 /// pointer-domain node to a real val<T*>, using the exact same
@@ -174,11 +159,11 @@ val<T*> evalNautilusPtr(const Ast& ast, int idx, const TracedArgs<T>& args, Trac
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::PtrAdd: {
-		val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusValue<T>(ast, n.kid[0], args, ctx));
+		val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusGeneric<T>(ast, n.kid[0], args, ctx));
 		return ctx.basePtr + off;
 	}
 	case Kind::PtrSub: {
-		val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusValue<T>(ast, n.kid[0], args, ctx));
+		val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusGeneric<T>(ast, n.kid[0], args, ctx));
 		return ctx.lastPtr - off;
 	}
 	case Kind::PtrBase:
@@ -187,8 +172,37 @@ val<T*> evalNautilusPtr(const Ast& ast, int idx, const TracedArgs<T>& args, Trac
 	}
 }
 
+/// Traced mirror of EvalNative.hpp's comparePtrIndices: the shared body of
+/// the six Ptr* comparison kinds, producing a real val<bool> from the two
+/// val<T*> operator overloads under test.
 template <typename T>
-TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
+val<bool> comparePtrTraced(Kind kind, val<T*> a, val<T*> b) {
+	switch (kind) {
+	case Kind::PtrEq:
+		return a == b;
+	case Kind::PtrNe:
+		return a != b;
+	case Kind::PtrLt:
+		return a < b;
+	case Kind::PtrLe:
+		return a <= b;
+	case Kind::PtrGt:
+		return a > b;
+	default: // Kind::PtrGe
+		return a >= b;
+	}
+}
+
+/// Single traced evaluator for both the integer and float domains -- the
+/// traced mirror of EvalNative.hpp's evalNativeGeneric, merged from the
+/// former evalNautilusInt/evalNautilusFloat pair for the same reason (see
+/// evalNativeGeneric's comment): every control-flow, memory, call and
+/// comparison case was duplicated verbatim between the two. Only a handful
+/// of operations are genuinely domain-specific (float has no bitwise/modulo
+/// ops; float division needs no non-zero-divisor guard), gated via
+/// `if constexpr`.
+template <typename T>
+TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
@@ -200,28 +214,28 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 	case Kind::LoopAcc:
 		return ctx.loopStack.back().acc;
 	case Kind::Select: {
-		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
-		TracedValue<T> t = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
-		TracedValue<T> f = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+		TracedValue<T> c = evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> t = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> f = evalNautilusGeneric<T>(ast, n.kid[2], args, ctx);
 		return select(c != TracedValue<T>(T(0)), t, f);
 	}
 	case Kind::If: {
-		TracedValue<T> c = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> c = evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
 		// Else-branch first (unconditional), then conditionally overwrite with
 		// the then-branch inside a real traced branch -> produces a phi/merge.
-		TracedValue<T> result = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+		TracedValue<T> result = evalNautilusGeneric<T>(ast, n.kid[2], args, ctx);
 		if (c != TracedValue<T>(T(0))) {
-			result = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+			result = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
 		}
 		return result;
 	}
 	case Kind::Loop: {
-		TracedValue<T> rawCount = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> rawCount = evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
 		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
-		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> acc = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
 		for (val<int32_t> i = 0; i < trips; i = i + 1) {
 			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
-			acc = evalNautilusInt<T>(ast, n.kid[2], args, ctx);
+			acc = evalNautilusGeneric<T>(ast, n.kid[2], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;
@@ -232,24 +246,30 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 		// constant (the static_val makes every iteration's snapshot hash
 		// unique -- the same pattern as test/common/StaticLoopFunctions.hpp).
 		const int64_t trips = static_cast<int64_t>(n.imm);
-		TracedValue<T> acc = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		TracedValue<T> acc = evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
 		for (static_val<int64_t> i = 0; i < trips; ++i) {
 			ctx.loopStack.push_back(TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc});
-			acc = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+			acc = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
 			ctx.loopStack.pop_back();
 		}
 		return acc;
 	}
 	case Kind::Neg:
-		return -evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		return -evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
 	case Kind::Not:
-		return ~evalNautilusInt<T>(ast, n.kid[0], args, ctx);
+		// Integer domain only (FLOAT_KINDS never generates Not); guarded so
+		// operator~ doesn't need to exist for val<float>/val<double>.
+		if constexpr (!std::is_floating_point_v<T>) {
+			return ~evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::LNot: {
-		val<bool> b = evalNautilusInt<T>(ast, n.kid[0], args, ctx) != TracedValue<T>(T(0));
+		val<bool> b = evalNautilusGeneric<T>(ast, n.kid[0], args, ctx) != TracedValue<T>(T(0));
 		return select(!b, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	}
 	case Kind::Cast:
-		return castThroughTraced<T>(evalNautilusInt<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
+		return castThroughTraced<T>(evalNautilusGeneric<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 	case Kind::Load: {
 		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
 		TracedValue<T> v = *p;
@@ -257,7 +277,7 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 	}
 	case Kind::Store: {
 		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
-		TracedValue<T> v = evalNautilusValue<T>(ast, n.kid[1], args, ctx);
+		TracedValue<T> v = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
 		*p = v;
 		return v;
 	}
@@ -271,35 +291,15 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 	case Kind::PtrGe: {
 		val<T*> a = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
 		val<T*> b = evalNautilusPtr<T>(ast, n.kid[1], args, ctx);
-		val<bool> cmp(false);
-		switch (n.kind) {
-		case Kind::PtrEq:
-			cmp = (a == b);
-			break;
-		case Kind::PtrNe:
-			cmp = (a != b);
-			break;
-		case Kind::PtrLt:
-			cmp = (a < b);
-			break;
-		case Kind::PtrLe:
-			cmp = (a <= b);
-			break;
-		case Kind::PtrGt:
-			cmp = (a > b);
-			break;
-		default:
-			cmp = (a >= b);
-			break;
-		}
+		val<bool> cmp = comparePtrTraced<T>(n.kind, a, b);
 		return select(cmp, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	}
 	default:
 		break;
 	}
 
-	TracedValue<T> l = evalNautilusInt<T>(ast, n.kid[0], args, ctx);
-	TracedValue<T> r = evalNautilusInt<T>(ast, n.kid[1], args, ctx);
+	TracedValue<T> l = evalNautilusGeneric<T>(ast, n.kid[0], args, ctx);
+	TracedValue<T> r = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
 	switch (n.kind) {
 	case Kind::Add:
 		return l + r;
@@ -308,19 +308,47 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 	case Kind::Mul:
 		return l * r;
 	case Kind::Div:
-		return l / safeDivisorTraced<T>(r);
+		if constexpr (std::is_floating_point_v<T>) {
+			return l / r; // well-defined IEEE 754: produces +-inf / NaN for r == 0
+		} else {
+			return l / safeDivisorTraced<T>(r);
+		}
 	case Kind::Mod:
-		return l % safeDivisorTraced<T>(r);
+		if constexpr (!std::is_floating_point_v<T>) {
+			return l % safeDivisorTraced<T>(r);
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::And:
-		return l & r;
+		if constexpr (!std::is_floating_point_v<T>) {
+			return l & r;
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Or:
-		return l | r;
+		if constexpr (!std::is_floating_point_v<T>) {
+			return l | r;
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Xor:
-		return l ^ r;
+		if constexpr (!std::is_floating_point_v<T>) {
+			return l ^ r;
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Shl:
-		return l << (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
+		if constexpr (!std::is_floating_point_v<T>) {
+			return l << (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::Shr:
-		return l >> (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
+		if constexpr (!std::is_floating_point_v<T>) {
+			return l >> (r & TracedValue<T>(T(sizeof(T) * 8 - 1)));
+		} else {
+			__builtin_unreachable();
+		}
 	case Kind::LAnd: {
 		// Real val<bool> conjunction under test. l and r are both already
 		// evaluated (side-effect parity with the native oracle regardless of
@@ -355,152 +383,6 @@ TracedValue<T> evalNautilusInt(const Ast& ast, int idx, const TracedArgs<T>& arg
 	}
 }
 
-template <typename T>
-TracedValue<T> evalNautilusFloat(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
-	const Node& n = ast.nodes[idx];
-	switch (n.kind) {
-	case Kind::Const:
-		return TracedValue<T>(unpackImm<T>(n.imm));
-	case Kind::Param:
-		return args[n.imm % NUM_PARAMS];
-	case Kind::LoopIndex:
-		return ctx.loopStack.back().index;
-	case Kind::LoopAcc:
-		return ctx.loopStack.back().acc;
-	case Kind::Select: {
-		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
-		TracedValue<T> t = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
-		TracedValue<T> f = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
-		return select(c != TracedValue<T>(T(0)), t, f);
-	}
-	case Kind::If: {
-		TracedValue<T> c = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
-		TracedValue<T> result = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
-		if (c != TracedValue<T>(T(0))) {
-			result = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
-		}
-		return result;
-	}
-	case Kind::Loop: {
-		TracedValue<T> rawCount = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
-		val<int32_t> trips = clampTripCountTraced<T>(rawCount);
-		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
-		for (val<int32_t> i = 0; i < trips; i = i + 1) {
-			ctx.loopStack.push_back(TracedLoopFrame<T> {static_cast<TracedValue<T>>(i), acc});
-			acc = evalNautilusFloat<T>(ast, n.kid[2], args, ctx);
-			ctx.loopStack.pop_back();
-		}
-		return acc;
-	}
-	case Kind::StaticLoop: {
-		// See the Kind::StaticLoop comment in evalNautilusInt.
-		const int64_t trips = static_cast<int64_t>(n.imm);
-		TracedValue<T> acc = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
-		for (static_val<int64_t> i = 0; i < trips; ++i) {
-			ctx.loopStack.push_back(TracedLoopFrame<T> {TracedValue<T>(static_cast<T>(static_cast<int64_t>(i))), acc});
-			acc = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
-			ctx.loopStack.pop_back();
-		}
-		return acc;
-	}
-	case Kind::Neg:
-		return -evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
-	case Kind::LNot: {
-		val<bool> b = evalNautilusFloat<T>(ast, n.kid[0], args, ctx) != TracedValue<T>(T(0));
-		return select(!b, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	}
-	case Kind::Cast:
-		return castThroughTraced<T>(evalNautilusFloat<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
-	case Kind::Load: {
-		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
-		TracedValue<T> v = *p;
-		return v;
-	}
-	case Kind::Store: {
-		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
-		TracedValue<T> v = evalNautilusValue<T>(ast, n.kid[1], args, ctx);
-		*p = v;
-		return v;
-	}
-	case Kind::PtrToInt:
-		return static_cast<TracedValue<T>>(evalNautilusPtr<T>(ast, n.kid[0], args, ctx));
-	case Kind::PtrEq:
-	case Kind::PtrNe:
-	case Kind::PtrLt:
-	case Kind::PtrLe:
-	case Kind::PtrGt:
-	case Kind::PtrGe: {
-		val<T*> a = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
-		val<T*> b = evalNautilusPtr<T>(ast, n.kid[1], args, ctx);
-		val<bool> cmp(false);
-		switch (n.kind) {
-		case Kind::PtrEq:
-			cmp = (a == b);
-			break;
-		case Kind::PtrNe:
-			cmp = (a != b);
-			break;
-		case Kind::PtrLt:
-			cmp = (a < b);
-			break;
-		case Kind::PtrLe:
-			cmp = (a <= b);
-			break;
-		case Kind::PtrGt:
-			cmp = (a > b);
-			break;
-		default:
-			cmp = (a >= b);
-			break;
-		}
-		return select(cmp, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	}
-	default:
-		break;
-	}
-
-	TracedValue<T> l = evalNautilusFloat<T>(ast, n.kid[0], args, ctx);
-	TracedValue<T> r = evalNautilusFloat<T>(ast, n.kid[1], args, ctx);
-	switch (n.kind) {
-	case Kind::Add:
-		return l + r;
-	case Kind::Sub:
-		return l - r;
-	case Kind::Mul:
-		return l * r;
-	case Kind::Div:
-		return l / r; // well-defined IEEE 754: produces +-inf / NaN for r == 0
-	case Kind::LAnd: {
-		// See the Kind::LAnd comment in evalNautilusInt.
-		val<bool> lb = l != TracedValue<T>(T(0));
-		val<bool> rb = r != TracedValue<T>(T(0));
-		return select(lb && rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	}
-	case Kind::LOr: {
-		val<bool> lb = l != TracedValue<T>(T(0));
-		val<bool> rb = r != TracedValue<T>(T(0));
-		return select(lb || rb, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	}
-	case Kind::Call:
-		// See the Kind::Call comment in evalNautilusInt.
-		return n.imm % NUM_CALLEES == 0 ? invoke(&calleeMix<T>, l, r) : invoke(&calleeMin<T>, l, r);
-	case Kind::Eq:
-		return select(l == r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	case Kind::Ne:
-		return select(l != r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	case Kind::Lt:
-		return select(l < r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	case Kind::Le:
-		return select(l <= r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	case Kind::Gt:
-		return select(l > r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	case Kind::Ge:
-		return select(l >= r, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
-	default:
-		return TracedValue<T>(T(0)); // unreachable
-	}
-}
-
 } // namespace detail
 
 template <typename T>
@@ -508,11 +390,7 @@ TracedValue<T> evalNautilus(const Ast& ast, val<T*> basePtr, const TracedArgs<T>
 	detail::TracedEvalContext<T> ctx;
 	ctx.basePtr = basePtr;
 	ctx.lastPtr = basePtr + static_cast<int32_t>(BUFFER_ELEMS - 1);
-	if constexpr (std::is_floating_point_v<T>) {
-		return detail::evalNautilusFloat<T>(ast, ast.root, args, ctx);
-	} else {
-		return detail::evalNautilusInt<T>(ast, ast.root, args, ctx);
-	}
+	return detail::evalNautilusGeneric<T>(ast, ast.root, args, ctx);
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/Types.hpp
+++ b/nautilus/test/fuzz/Types.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace nautilus::fuzz {
 
@@ -121,31 +122,15 @@ auto dispatchFloatType(TypeId target, Fn&& fn) {
 
 /// Top-level dispatch across all ten types, used once per fuzzer input to
 /// pick which monomorphic instantiation of the generator/evaluator to run.
+/// Delegates to dispatchIntType/dispatchFloatType rather than re-enumerating
+/// all ten types itself, so the type -> concrete-type mapping lives in
+/// exactly one place per domain.
 template <typename Fn>
 auto dispatchAnyType(TypeId target, Fn&& fn) {
-	switch (target) {
-	case TypeId::I8:
-		return fn.template operator()<int8_t>();
-	case TypeId::I16:
-		return fn.template operator()<int16_t>();
-	case TypeId::I32:
-		return fn.template operator()<int32_t>();
-	case TypeId::I64:
-		return fn.template operator()<int64_t>();
-	case TypeId::U8:
-		return fn.template operator()<uint8_t>();
-	case TypeId::U16:
-		return fn.template operator()<uint16_t>();
-	case TypeId::U32:
-		return fn.template operator()<uint32_t>();
-	case TypeId::U64:
-		return fn.template operator()<uint64_t>();
-	case TypeId::F32:
-		return fn.template operator()<float>();
-	case TypeId::F64:
-		return fn.template operator()<double>();
+	if (isFloatType(target)) {
+		return dispatchFloatType(target, std::forward<Fn>(fn));
 	}
-	__builtin_unreachable();
+	return dispatchIntType(target, std::forward<Fn>(fn));
 }
 
 /// Compile-time type -> short suffix, the mirror of typeName(TypeId) for use


### PR DESCRIPTION
## Summary

Investigated the differential AST fuzzer under `nautilus/test/fuzz/` and found its two most important files each split into a nearly-identical Int/Float pair (`evalNativeInt`/`evalNativeFloat` in `EvalNative.hpp`, `evalNautilusInt`/`evalNautilusFloat` in `EvalNautilus.hpp`). ~90% of each pair — every control-flow, memory, call and comparison case — was duplicated verbatim. This is exactly the hazard the fuzzer's own README documents: a prior Select short-circuit fix (see "Known findings") had to be applied in both copies by hand.

- Merge each Int/Float pair into a single `evalNativeGeneric`/`evalNautilusGeneric`, using `if constexpr` to gate the handful of genuinely domain-specific operations (bitwise/modulo ops, signed-arithmetic wraparound, float division needing no non-zero-divisor guard) — the same pattern already used by `safeDivisor`/`castThrough` in these files.
- Extract the pointer-comparison switch (previously duplicated 4x across the two Int/Float pairs) into one small helper per file (`comparePtrIndices`, `comparePtrTraced`).
- Simplify `Types.hpp`'s `dispatchAnyType` to delegate to `dispatchIntType`/`dispatchFloatType` instead of re-enumerating all ten types a third time.

Net: `EvalNative.hpp` 550→444 lines, `EvalNautilus.hpp` 518→396 lines, with no change in behavior or test coverage — same AST generation, same node kinds, same backends exercised.

## Test plan

- [x] Configured a lean build (`-DENABLE_MLIR_BACKEND=OFF -DENABLE_ASMJIT_BACKEND=OFF -DENABLE_FUZZER_REPLAY=ON`, cpp/bc/tbc backends + interpreter) and confirmed it builds clean under the project's strict warning set (`-Wall -Wextra -Werror=return-type`, etc.)
- [x] Ran the built-in 2000-program smoke corpus (`nautilus-fuzz-replay`) before and after the refactor — both pass, all backends agree with the native oracle
- [x] Ran a larger `--survey` pass across tens of thousands of generated programs to further stress the merged evaluators for any behavioral drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSoV3sGE7oYonXLpViKoiq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSoV3sGE7oYonXLpViKoiq)_