### PR TITLE
Extend NegateOp to lower float unary minus to a real sign-flip (#319)

### DIFF
--- a/nautilus/include/nautilus/val_arith.hpp
+++ b/nautilus/include/nautilus/val_arith.hpp
@@ -51,6 +51,14 @@ namespace nautilus {
 /// @see val_bool.hpp for the bool specialization
 /// @see val_details.hpp for implementation utilities
 
+namespace details {
+/// Forward declaration: negation (bitwise NOT for integral types, IEEE-754
+/// sign-flip for floating-point types). Defined below; declared here so
+/// `operator-()`'s inline float branch can call it by qualified name.
+template <is_arithmetic LHS>
+val<LHS> neg(const val<LHS>& value);
+} // namespace details
+
 // Partial specialization for arithmetic types only
 template <typename ValueType>
     requires is_arithmetic<ValueType>
@@ -179,11 +187,10 @@ public:
 			// `0 - x` is not IEEE-754 negation: subtraction of two exactly
 			// equal-magnitude operands rounds to +0.0 in the default
 			// round-to-nearest mode, so `0.0 - 0.0` is `+0.0`, not the `-0.0`
-			// that negating `+0.0` must produce. Multiplication's sign is
-			// always the XOR of its operands' signs, so `-1 * x` flips the
-			// sign bit correctly for zero (and every other value) instead of
-			// going through cancellation.
-			return (ValueType) -1 * *this;
+			// that negating `+0.0` must produce. Route through NEGATE instead,
+			// a real sign-bit flip that is correct for zero (and every other
+			// value) instead of going through cancellation.
+			return details::neg(*this);
 		} else {
 			return (ValueType) 0 - *this;
 		}
@@ -234,8 +241,9 @@ private:
 
 namespace details {
 
-/// Bitwise negation (NOT) operation for integral types
-template <is_integral LHS>
+/// Negation operation: bitwise NOT (~x) for integral types, IEEE-754
+/// sign-flip (-x) for floating-point types.
+template <is_arithmetic LHS>
 val<LHS> neg(const val<LHS>& val) {
 #ifdef ENABLE_TRACING
 	if (tracing::inTracer()) {
@@ -243,7 +251,11 @@ val<LHS> neg(const val<LHS>& val) {
 		return tc;
 	}
 #endif
-	return ~RawValueResolver<LHS>::getRawValue(val);
+	if constexpr (std::floating_point<LHS>) {
+		return -RawValueResolver<LHS>::getRawValue(val);
+	} else {
+		return ~RawValueResolver<LHS>::getRawValue(val);
+	}
 }
 
 // Type helper for integer promotion rules

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -602,6 +602,13 @@ void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, Reg
 void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
 	auto src = frame.getValue(op->getInput()->getIdentifier());
 	auto result = allocReg(op->getStamp());
+	if (isFloatType(op->getStamp())) {
+		// ARM64 has a native FNEG vector instruction: a real IEEE-754
+		// sign-flip, correct for every input including zero.
+		cc.fneg(toVec(result), toVec(src));
+		bindResult(op->getIdentifier(), result, frame);
+		return;
+	}
 	cc.mvn(toGp(result), toGp(src));
 	// mvn flips the full 64-bit register, including the extension padding.
 	// That happens to stay correct for signed stamps (flipping a sign bit

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -960,8 +960,40 @@ void AsmJitLoweringProvider::LoweringContext::visitNot(ir::NotOperation* op, Reg
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* op, RegisterFrame& frame) {
+	auto stamp = op->getStamp();
+	if (isFloatType(stamp)) {
+		// IEEE-754 sign-flip: XOR the sign bit against a mask constant. This is
+		// correct for every input including zero, unlike bitwise NOT (undefined
+		// on floats) or `0 - x` (mis-signs zero).
+		auto input = frame.getValue(op->getInput()->getIdentifier());
+		auto result = allocReg(stamp);
+		auto xDst = toXmm(result);
+		cc.movaps(xDst, toXmm(input));
+		// Load the mask into a register first (matching visitConstFloat's
+		// established pattern) rather than using it as a direct memory operand
+		// to the XOR itself.
+		auto maskReg = allocReg(stamp);
+		auto xMask = toXmm(maskReg);
+		if (stamp == Type::f32) {
+			uint32_t bits = 0x80000000u;
+			float mask;
+			memcpy(&mask, &bits, sizeof(mask));
+			auto mem = cc.newFloatConst(ConstPoolScope::kLocal, mask);
+			cc.movss(xMask, mem);
+			cc.xorps(xDst, xMask);
+		} else {
+			uint64_t bits = 0x8000000000000000ULL;
+			double mask;
+			memcpy(&mask, &bits, sizeof(mask));
+			auto mem = cc.newDoubleConst(ConstPoolScope::kLocal, mask);
+			cc.movsd(xMask, mem);
+			cc.xorpd(xDst, xMask);
+		}
+		bindResult(op->getIdentifier(), result, frame);
+		return;
+	}
 	// NegateOperation is bitwise NOT (~x): result = input XOR all-ones.
-	auto result = allocReg(op->getStamp());
+	auto result = allocReg(stamp);
 	auto gDst = toGp(result);
 	cc.mov(gDst, gpOperand(op->getInput(), frame));
 	cc.not_(gDst);
@@ -969,7 +1001,7 @@ void AsmJitLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* o
 	// That happens to stay correct for signed stamps (flipping a sign bit
 	// flips its replicated extension consistently) but is wrong for unsigned
 	// stamps, whose invariant is a zero-extended (not flipped) upper half.
-	narrowToStamp(gDst, op->getStamp());
+	narrowToStamp(gDst, stamp);
 	bindResult(op->getIdentifier(), result, frame);
 }
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -430,6 +430,9 @@ void dyncallCalld(const OpCode& op, RegisterFile& regs) {
 	X(BRSH_ui64, bitwiseRSH<uint64_t>)                                                                                 \
 	/* bitwise: bnot */                                                                                                \
 	X(BNEGATE_I64, bitwiseNot<int64_t>)                                                                                \
+	/* negate: float sign-flip */                                                                                      \
+	X(NEG_f, neg<float>)                                                                                               \
+	X(NEG_d, neg<double>)                                                                                              \
 	/* select */                                                                                                       \
 	X(SELECT_i8, selectOp<int8_t>)                                                                                     \
 	X(SELECT_i16, selectOp<int16_t>)                                                                                   \

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -1709,7 +1709,18 @@ void BCLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* negat
 	useValue(negateOperation->getInput()->getIdentifier(), frame);
 	auto resultReg = getResultRegister(negateOperation, frame);
 	frame.setValue(negateOperation->getIdentifier(), resultReg);
-	ByteCode bc = ByteCode::BNEGATE_I64;
+	ByteCode bc;
+	switch (negateOperation->getStamp()) {
+	case Type::f32:
+		bc = ByteCode::NEG_f;
+		break;
+	case Type::f64:
+		bc = ByteCode::NEG_d;
+		break;
+	default:
+		bc = ByteCode::BNEGATE_I64;
+		break;
+	}
 	OpCode oc = {bc, input, -1, resultReg};
 	program.blocks[block].code.emplace_back(oc);
 }

--- a/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
@@ -371,6 +371,8 @@ enum class ByteCode : short {
 	BRSH_ui64,
 	// negate
 	BNEGATE_I64,
+	NEG_f,
+	NEG_d,
 	// select
 	SELECT_i8,
 	SELECT_i16,
@@ -746,6 +748,18 @@ template <class RegisterType>
 void bitwiseNot(const OpCode& c, RegisterFile& regs) {
 	auto l = readReg<RegisterType>(regs, c.reg1);
 	writeReg(regs, c.output, ~l);
+}
+
+/**
+ * @brief Defines an IEEE-754 sign-flip negate in the bytecode interpreter
+ * @tparam RegisterType
+ * @param c
+ * @param regs
+ */
+template <class RegisterType>
+void neg(const OpCode& c, RegisterFile& regs) {
+	auto l = readReg<RegisterType>(regs, c.reg1);
+	writeReg(regs, c.output, -l);
 }
 
 /**

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -455,7 +455,14 @@ void CPPLoweringProvider::LoweringContext::visitNegate(ir::NegateOperation* nega
 		blockArguments << getType(negateOperation->getStamp()) << " " << resultVar << ";\n";
 		frame.setValue(negateOperation->getIdentifier(), resultVar);
 	}
-	blocks[blockIndex] << resultVar << " = ~" << input << ";\n";
+	auto stamp = negateOperation->getStamp();
+	if (stamp == Type::f32 || stamp == Type::f64) {
+		// Bitwise NOT (~) is not valid on float/double in C++; unary minus is
+		// the real IEEE-754 sign-flip and is correct for every input including zero.
+		blocks[blockIndex] << resultVar << " = -" << input << ";\n";
+	} else {
+		blocks[blockIndex] << resultVar << " = ~" << input << ";\n";
+	}
 }
 
 void CPPLoweringProvider::LoweringContext::visitNot(ir::NotOperation* notOperation, short blockIndex,

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -554,10 +554,16 @@ void MLIRLoweringProvider::generateMLIR(const ir::BasicBlock* basicBlock, ValueF
 
 void MLIRLoweringProvider::visitNegate(ir::NegateOperation* negateOperation, ValueFrame& frame) {
 	auto input = frame.getValue(negateOperation->getInput()->getIdentifier());
-	auto constInt = builder->create<mlir::arith::ConstantOp>(getNameLoc("location"), input.getType(),
-	                                                         builder->getIntegerAttr(input.getType(), ~0));
-	auto negate = builder->create<mlir::arith::XOrIOp>(getNameLoc("comparison"), input, constInt);
-	frame.setValue(negateOperation->getIdentifier(), negate);
+	if (isFloat(negateOperation->getStamp())) {
+		auto negate = builder->create<mlir::LLVM::FNegOp>(getNameLoc("binOpResult"), input.getType(), input,
+		                                                  mlir::LLVM::FastmathFlags::none);
+		frame.setValue(negateOperation->getIdentifier(), negate);
+	} else {
+		auto constInt = builder->create<mlir::arith::ConstantOp>(getNameLoc("location"), input.getType(),
+		                                                         builder->getIntegerAttr(input.getType(), ~0));
+		auto negate = builder->create<mlir::arith::XOrIOp>(getNameLoc("comparison"), input, constInt);
+		frame.setValue(negateOperation->getIdentifier(), negate);
+	}
 }
 
 void MLIRLoweringProvider::visitNot(ir::NotOperation* notOperation, ValueFrame& frame) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCHandlers.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCHandlers.hpp
@@ -170,6 +170,11 @@ inline void opBnot(const Instr& i, uint64_t* fp) {
 	writeReg<int64_t>(fp, i.a, ~readReg<int64_t>(fp, i.b));
 }
 
+template <class T>
+inline void opNeg(const Instr& i, uint64_t* fp) {
+	writeReg<T>(fp, i.a, -readReg<T>(fp, i.b));
+}
+
 template <class S, class D>
 inline void opCast(const Instr& i, uint64_t* fp) {
 	writeReg<D>(fp, i.a, static_cast<D>(readReg<S>(fp, i.b)));

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -512,9 +512,15 @@ private:
 		useValue(opt->getInput()->getIdentifier(), frame);
 		const auto result = getResultRegister(opt, frame);
 		frame.setValue(opt->getIdentifier(), result);
-		// Bitwise negation runs on the full 64-bit slot (bc parity: consumers
-		// always read their exact width, so high garbage is unobservable).
-		emit(block, Op::BNOT_i64, result, input);
+		if (opt->getStamp() == Type::f32) {
+			emit(block, Op::NEG_f32, result, input);
+		} else if (opt->getStamp() == Type::f64) {
+			emit(block, Op::NEG_f64, result, input);
+		} else {
+			// Bitwise negation runs on the full 64-bit slot (bc parity: consumers
+			// always read their exact width, so high garbage is unobservable).
+			emit(block, Op::BNOT_i64, result, input);
+		}
 	}
 
 	// ── Memory ───────────────────────────────────────────────────────────────

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
@@ -127,6 +127,9 @@ namespace nautilus::compiler::tbc {
 	TBC_INT8(X, SHL, opShl)                                                                                            \
 	TBC_INT8(X, SHR, opShr)                                                                                            \
 	X(BNOT_i64, (opBnot))                                                                                              \
+	/* negate: float sign-flip */                                                                                      \
+	X(NEG_f32, (opNeg<float>) )                                                                                        \
+	X(NEG_f64, (opNeg<double>) )                                                                                       \
 	TBC_CAST_GRID(X)                                                                                                   \
 	TBC_IMM_ARITH_LIST(X)
 

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -157,8 +157,8 @@ struct formatter<nautilus::compiler::ir::Operation> : formatter<std::string_view
 
 template <>
 struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::OperationIdentifier& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::OperationIdentifier& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", op.getId());
 		return out;
@@ -176,8 +176,8 @@ struct formatter<nautilus::compiler::ir::BlockIdentifier> : formatter<std::strin
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlockInvocation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "Block_{}(", op.getBlock()->getIdentifier());
 		const auto args = op.getArguments();
@@ -204,8 +204,8 @@ struct formatter<nautilus::compiler::ir::IfOperation> : formatter<std::string_vi
 
 template <>
 struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 
 		if (op.getStamp() != nautilus::Type::v) {
@@ -319,7 +319,9 @@ auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::c
 	}
 	case OpType::NegateOp: {
 		const auto* negateOp = nautilus::compiler::ir::cast<NegateOperation>(&op);
-		fmt::format_to(out, "{} = ~{}", op.getIdentifier(), negateOp->getInput()->getIdentifier());
+		const char* symbol =
+		    (negateOp->getStamp() == nautilus::Type::f32 || negateOp->getStamp() == nautilus::Type::f64) ? "-" : "~";
+		fmt::format_to(out, "{} = {}{}", op.getIdentifier(), symbol, negateOp->getInput()->getIdentifier());
 		break;
 	}
 	case OpType::AllocaOp: {
@@ -356,8 +358,8 @@ auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::c
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlock& block, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlock& block,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "\nBlock_{}(", block.getIdentifier());
 		const auto& args = block.getArguments();
@@ -378,8 +380,8 @@ struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_vie
 
 template <>
 struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::FunctionOperation& func, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::FunctionOperation& func,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}(", func.getName());
 		// The trace-to-IR conversion leaves `inputArgs`/`inputArgNames` empty;

--- a/nautilus/test/common/ExpressionFunctions.hpp
+++ b/nautilus/test/common/ExpressionFunctions.hpp
@@ -183,7 +183,11 @@ val<T> shiftRight(val<T> x, val<T> y) {
 
 template <typename T>
 val<T> negate(val<T> x) {
-	return ~x;
+	if constexpr (std::is_floating_point_v<T>) {
+		return -x;
+	} else {
+		return ~x;
+	}
 }
 
 template <typename T>
@@ -212,9 +216,7 @@ val<int32_t> constructComplexReturnObject(val<int32_t> a, val<int32_t> b) {
 
 val<int32_t> constructComplexReturnObject2(val<int32_t> a, val<int32_t> b) {
 	val<int32_t> t = 0;
-	{
-		t = constructComplexReturnObject(a, b);
-	}
+	{ t = constructComplexReturnObject(a, b); }
 	return t + 42;
 }
 

--- a/nautilus/test/data/expression-tests/after_constant_folding/negate_f32.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/negate_f32.nautilus
@@ -1,0 +1,7 @@
+nautilus {
+execute($1:f32) :f32 {
+Block_0($1:f32):
+	$2 = -$1 :f32
+	return ($2) :f32
+}
+} //nautilus

--- a/nautilus/test/data/expression-tests/after_constant_folding/negate_f64.nautilus
+++ b/nautilus/test/data/expression-tests/after_constant_folding/negate_f64.nautilus
@@ -1,0 +1,7 @@
+nautilus {
+execute($1:f64) :f64 {
+Block_0($1:f64):
+	$2 = -$1 :f64
+	return ($2) :f64
+}
+} //nautilus

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/negate_f32.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/negate_f32.nautilus
@@ -1,0 +1,7 @@
+nautilus {
+execute($1:f32) :f32 {
+Block_0($1:f32):
+	$2 = -$1 :f32
+	return ($2) :f32
+}
+} //nautilus

--- a/nautilus/test/data/expression-tests/after_empty_block_elim/negate_f64.nautilus
+++ b/nautilus/test/data/expression-tests/after_empty_block_elim/negate_f64.nautilus
@@ -1,0 +1,7 @@
+nautilus {
+execute($1:f64) :f64 {
+Block_0($1:f64):
+	$2 = -$1 :f64
+	return ($2) :f64
+}
+} //nautilus

--- a/nautilus/test/data/expression-tests/after_ssa/negate_f32.trace
+++ b/nautilus/test/data/expression-tests/after_ssa/negate_f32.trace
@@ -1,0 +1,5 @@
+EXECUTE:
+B0($1:f32)
+	NEGATE	$2	$1	:f32
+	RETURN	$0	$2	:f32
+

--- a/nautilus/test/data/expression-tests/after_ssa/negate_f64.trace
+++ b/nautilus/test/data/expression-tests/after_ssa/negate_f64.trace
@@ -1,0 +1,5 @@
+EXECUTE:
+B0($1:f64)
+	NEGATE	$2	$1	:f64
+	RETURN	$0	$2	:f64
+

--- a/nautilus/test/data/expression-tests/ir/negate_f32.nautilus
+++ b/nautilus/test/data/expression-tests/ir/negate_f32.nautilus
@@ -1,0 +1,7 @@
+nautilus {
+execute($1:f32) :f32 {
+Block_0($1:f32):
+	$2 = -$1 :f32
+	return ($2) :f32
+}
+} //nautilus

--- a/nautilus/test/data/expression-tests/ir/negate_f64.nautilus
+++ b/nautilus/test/data/expression-tests/ir/negate_f64.nautilus
@@ -1,0 +1,7 @@
+nautilus {
+execute($1:f64) :f64 {
+Block_0($1:f64):
+	$2 = -$1 :f64
+	return ($2) :f64
+}
+} //nautilus

--- a/nautilus/test/data/expression-tests/tracing/negate_f32.trace
+++ b/nautilus/test/data/expression-tests/tracing/negate_f32.trace
@@ -1,0 +1,5 @@
+EXECUTE:
+B0($1:f32)
+	NEGATE	$2	$1	:f32
+	RETURN	$0	$2	:f32
+

--- a/nautilus/test/data/expression-tests/tracing/negate_f64.trace
+++ b/nautilus/test/data/expression-tests/tracing/negate_f64.trace
@@ -1,0 +1,5 @@
+EXECUTE:
+B0($1:f64)
+	NEGATE	$2	$1	:f64
+	RETURN	$0	$2	:f64
+

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -46,6 +46,24 @@ void expressionTests(engine::NautilusEngine& engine) {
 		REQUIRE(f(INT_MIN) == INT_MAX);
 	}
 
+	SECTION("floatUnaryMinus") {
+		auto f = engine.registerFunction(negate<float>);
+		REQUIRE(f(42.5f) == -42.5f);
+		REQUIRE(f(-42.5f) == 42.5f);
+		// IEEE-754 sign-flip must be exact for zero, not just numerically equal
+		// (0.0f == -0.0f, so the value alone can't distinguish them).
+		REQUIRE(std::signbit(f(0.0f)));
+		REQUIRE_FALSE(std::signbit(f(-0.0f)));
+	}
+
+	SECTION("doubleUnaryMinus") {
+		auto f = engine.registerFunction(negate<double>);
+		REQUIRE(f(42.5) == -42.5);
+		REQUIRE(f(-42.5) == 42.5);
+		REQUIRE(std::signbit(f(0.0)));
+		REQUIRE_FALSE(std::signbit(f(-0.0)));
+	}
+
 	SECTION("uintBitwiseNegate") {
 		auto f = engine.registerFunction(negate<uint32_t>);
 		REQUIRE(f((uint32_t) 0) == UINT_MAX);

--- a/nautilus/test/execution-tests/TracingTest.cpp
+++ b/nautilus/test/execution-tests/TracingTest.cpp
@@ -179,6 +179,8 @@ TEST_CASE("Expression Trace Test") {
 	    {"shiftRight_i64", details::createFunctionWrapper(shiftRight<int64_t>)},
 	    {"shiftRight_ui64", details::createFunctionWrapper(shiftRight<uint64_t>)},
 	    {"negate_i8", details::createFunctionWrapper(negate<int8_t>)},
+	    {"negate_f32", details::createFunctionWrapper(negate<float>)},
+	    {"negate_f64", details::createFunctionWrapper(negate<double>)},
 	    {"logicalNot_bool", details::createFunctionWrapper(logicalNot<bool>)},
 	    {"mulInt64AndNotDefinedI64", details::createFunctionWrapper(mulInt64AndNotDefinedI64)},
 	    {"subInt8AndInt8", details::createFunctionWrapper(subInt8AndInt8)},


### PR DESCRIPTION
## Summary

Closes #319 with the approach the issue's author asked about instead of the one it proposed: rather than adding a brand-new `FNegOp` IR opcode, this extends the existing `NegateOp` to dispatch on its already-present `Type` stamp, exactly the way `AddOp`/`SubOp`/`MulOp` already support both int and float behind one opcode name.

`NegateOperation` was never int-specific by construction — it already stores `input->getStamp()` like every other arithmetic IR op. It just happened to be used exclusively for integer bitwise-complement (`~x`), while float unary minus bypassed it entirely and traced a `MulOp` (`-1 * x`) instead, per #318's IEEE-754 zero-sign fix. Every backend already implements an `isFloat`/`isFloatType` dispatch branch for `AddOp`/`SubOp`/`MulOp`; `NegateOp` was the only shared-opcode visitor that ignored the stamp.

## Changes

- **`val_arith.hpp`**: float `operator-()` now routes through `details::neg` (tracing `NEGATE`) instead of `(ValueType)-1 * *this`. `details::neg` widened from `is_integral` to `is_arithmetic`, with an `if constexpr` branch for real unary-minus on floats vs bitwise-NOT on integers.
- **mlir**: `visitNegate` now branches on `isFloat(stamp)`, lowering to `LLVM::FNegOp` for floats (mirrors the existing `FMulOp`/`FAddOp` pattern) instead of always emitting the integer XOR-with-all-ones path.
- **cpp**: emits real unary `-` for float stamps instead of `~` (which doesn't compile on `float`/`double`).
- **bc / tbc**: add dedicated float negate opcodes (`NEG_f`/`NEG_d` and `NEG_f32`/`NEG_f64` respectively) with interpreter handlers doing a plain unary `-`, leaving the existing integer bitwise-NOT opcode untouched.
- **asmjit x64**: float branch loads a sign-bit mask constant into an XMM register and XORs it in (`xorps`/`xorpd`) instead of a real multiply.
- **asmjit a64**: float branch uses the native `fneg` vector instruction.
- **IRGraph pretty-printer**: prints `-` instead of `~` for float `NegateOp` so IR dumps read correctly (cosmetic, but touches the exact code path this PR changes).

Int-stamp behavior is unchanged in every backend — only a new float branch was added alongside the existing path.

## Test plan

- [x] Added `negate_f32`/`negate_f64` trace/IR golden fixtures (`test/data/expression-tests/`), alongside the existing `negate_i8`.
- [x] Added `floatUnaryMinus`/`doubleUnaryMinus` end-to-end execution tests (`ExecutionTest.cpp`), including explicit `-0.0`/`0.0` sign-bit checks via `std::signbit`, exercised across all backends via the existing `forEachBackendWithTraceMode` harness.
- [x] Full local build (Clang 18, MLIR backend disabled — see note below) and `ctest --test-dir nautilus`: 210/210 passing.
- [ ] MLIR backend (`LLVM::FNegOp`) could not be exercised locally — the sandboxed session's network egress policy blocks the MLIR binary release download. The call mirrors the already-working `FMulOp`/`FAddOp` calls in the same file; CI's MLIR-enabled build matrix should validate it. Flagging for reviewer attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016iuwWngsZgM9KfmYFsw1oT)_