### PR TITLE
Design doc: IR optimization passes for the direct-lowering backends (asmjit, bc, tbc)

### DIFF
--- a/docs/design/ir-abstraction-milestone.md
+++ b/docs/design/ir-abstraction-milestone.md
@@ -310,7 +310,7 @@ rewiring again.
 
 ## 5. Sequencing within the milestone
 
-Three PRs, each independently green:
+Three PRs, each independently green (tracking issues: #338, #339, #340):
 
 1. **IR-0a — Analysis & verification:** `Dominators` (D1–D3), fixtures
    (§3.4 + self-tests), verifier checks V1–V6 with tests, V6 calibration,

--- a/docs/design/ir-abstraction-milestone.md
+++ b/docs/design/ir-abstraction-milestone.md
@@ -310,7 +310,7 @@ rewiring again.
 
 ## 5. Sequencing within the milestone
 
-Three PRs, each independently green (tracking issues: #338, #339, #340):
+Three PRs, each independently green (tracking issue: #338):
 
 1. **IR-0a — Analysis & verification:** `Dominators` (D1–D3), fixtures
    (§3.4 + self-tests), verifier checks V1–V6 with tests, V6 calibration,

--- a/docs/design/ir-abstraction-milestone.md
+++ b/docs/design/ir-abstraction-milestone.md
@@ -1,0 +1,339 @@
+# Milestone IR-0: Hardening the Nautilus IR Abstraction
+
+**Status:** Proposed
+**Parent design:** [ir-pass-improvements.md](ir-pass-improvements.md) — this
+milestone replaces and expands that document's "Phase 0 infrastructure"
+(§4.2) with concrete, testable requirements. The pass catalog (DCE,
+simplification, branch folding, …) builds strictly on top of what is
+specified here.
+**Implementation guide:** [agent playbook](ir-pass-improvements-agent-playbook.md), milestone M0.
+
+---
+
+## 1. Why an abstraction milestone first
+
+Every planned pass performs the same five mutations: *replace uses*, *erase*,
+*create/insert*, *change block-argument arity*, *rewire CFG edges*. Today each
+of these is either missing, unsafe, or reinvented per pass. The evidence is
+in the tree:
+
+1. **Def→use direction does not exist.** `Operation::getInputs()` gives
+   use→def edges only; `Usages::countUsages` gives counts, not users. So
+   `ConstantFoldingAndCopyPropagationPass` rewires consumers by rescanning
+   the whole function per fold round — a fixed-point loop that is
+   O(ops × folds). Every new pass would inherit that shape.
+2. **Invocation operands are invisible to generic traversal.**
+   `BasicBlockInvocation` stores its arguments in the base
+   `Operation::inputs` span (good), but the invocation itself is *embedded in
+   the terminator* — it is not in `BasicBlock::getOperations()`. Any code
+   that walks "all ops in all blocks" silently misses every block-edge
+   operand unless it also calls `getSuccessorInvocations()`. Issue **#327**
+   (stale consumer pointers after constant folding) was exactly this trap,
+   and `countUsages`, the verifier, and the folding pass each carry their own
+   special case for it today.
+3. **There is no fresh-identifier authority.**
+   `StrengthReductionPass.cpp` hand-rolls `computeNextId(ir)` (a max-scan)
+   and threads a `uint32_t& nextId` through its helpers. Issue **#321**
+   (asmjit merged-value corruption) was an identifier collision. Nothing
+   prevents the next pass from re-creating it.
+4. **Block-argument arity is a two-sided invariant with no owner.**
+   `BasicBlock::addArgument` documents: *"callers are responsible for the
+   invocation side"*. There is no `removeArgument` on either side at all —
+   the planned `BlockArgumentPruningPass` has no primitive to build on.
+5. **Erase has no safety rail.** `BasicBlock::removeOperation` detaches an
+   op regardless of remaining uses; a #327-style dangling pointer is one
+   forgotten rewire away, discovered only if a test happens to run the
+   verifier.
+6. **The verifier cannot see the bugs the new passes will write.** It checks
+   structure (terminators, ownership, stale pointers, pred *membership*) but
+   not: identifier uniqueness (would have caught #321 statically),
+   invocation/block-arg arity, SSA dominance of operands, stamp agreement on
+   block edges, or predecessor *multiplicity* (a block targeted by both arms
+   of one `if` must list that predecessor twice).
+
+This milestone fixes the write path (a `FunctionRewriter` mutation facade)
+and the read-back path (verifier completeness) before any new pass lands, so
+that pass authors — human or agent — get invariants by construction and
+violations at the point of the bug, not three passes later in a backend
+miscompile.
+
+## 2. Scope
+
+**In scope**
+
+- `Dominators` analysis helper (needed by both the verifier and later passes).
+- `FunctionRewriter`: a per-function mutation session that owns use tracking,
+  identifier minting, safe erase, insertion, atomic block-argument mutation,
+  and CFG rewiring.
+- Verifier completion: six new invariant checks with precise error messages.
+- Shared test fixtures (`IRGraphFixtures` extensions) for all future pass
+  tests.
+- Retrofit of the three existing passes onto the new primitives as the
+  proof-of-fit gate (behavior-preserving).
+
+**Out of scope**
+
+- Any change to `Operation`'s 32-byte layout (no intrusive use-lists — use
+  tracking is an external side table owned by the rewriter session).
+- Any new pass, any pipeline/default change (that is PR-1+ of the parent
+  design).
+- `IRPassManager` fixed-point groups and the `apply()`→`bool` change (they
+  remain in the parent design's rollout as the step after this milestone;
+  they depend on nothing here and nothing here depends on them).
+
+## 3. Design
+
+### 3.1 `Dominators` (`ir/passes/Dominators.{hpp,cpp}`)
+
+Iterative dominator computation (Cooper–Harvey–Kennedy) over reverse
+post-order from the entry block. Requires valid predecessor lists
+(`IRPassManager` already calls `rebuildPredecessorLists`; standalone users
+call it themselves).
+
+```cpp
+class Dominators {
+public:
+	explicit Dominators(const FunctionOperation& fn); // preds must be valid
+	/// True iff a dominates b. a dominates itself.
+	[[nodiscard]] bool dominates(const BasicBlock* a, const BasicBlock* b) const;
+	/// True iff block is reachable from the entry block.
+	[[nodiscard]] bool isReachable(const BasicBlock* block) const;
+	/// Blocks in reverse post-order (reachable blocks only).
+	[[nodiscard]] const std::vector<const BasicBlock*>& reversePostOrder() const;
+};
+```
+
+Semantics for unreachable blocks (they exist transiently, e.g. after branch
+folding and before the unreachable sweep): `isReachable` is false,
+`dominates(x, unreachable)` is false for all `x`, and unreachable blocks are
+absent from RPO. Consumers must not ask for dominance *of* an unreachable
+block's contents; the verifier (V3) restricts its dominance checking to
+reachable blocks accordingly.
+
+### 3.2 `FunctionRewriter` (`ir/passes/FunctionRewriter.{hpp,cpp}`)
+
+A mutation session over one function. Construction is O(function); every
+primitive is O(affected entities) — **no primitive may rescan the function**.
+This is what turns the folding pass's O(ops × folds) loop into O(ops + edges).
+
+```cpp
+class FunctionRewriter {
+public:
+	FunctionRewriter(FunctionOperation& fn, common::Arena& arena);
+
+	// ── Use queries (uniform over operand edges AND invocation arguments) ──
+	struct Use { Operation* user; uint32_t operandIndex; };   // user may be a BasicBlockInvocation
+	[[nodiscard]] std::span<const Use> usesOf(const Operation* op) const;
+	[[nodiscard]] size_t useCount(const Operation* op) const;
+	[[nodiscard]] bool hasUses(const Operation* op) const;
+	[[nodiscard]] BasicBlock* definingBlock(const Operation* op) const; // block args included
+
+	// ── Value rewiring ──
+	/// Rewires every use of from (operand slots and invocation arguments)
+	/// to to. O(uses(from)).
+	void replaceAllUses(Operation* from, Operation* to);
+
+	// ── Identifiers ──
+	/// Strictly greater than every identifier in the function at session
+	/// start and every identifier previously minted by this session.
+	[[nodiscard]] OperationIdentifier freshId();
+
+	// ── Creation & insertion ──
+	/// Arena-allocates T (injecting the arena per the uniform ctor
+	/// convention), registers its operand uses, and inserts it.
+	template <typename T, typename... Args>
+	T* createBeforeTerminator(BasicBlock* block, Args&&... args);
+	template <typename T, typename... Args>
+	T* createBefore(Operation* anchor, Args&&... args);
+
+	// ── Erasure ──
+	/// Precondition: useCount(op) == 0 and op is not a terminator.
+	/// Detaches op from its block and unregisters its operand uses.
+	/// Throws RuntimeException on a live op (testable safety rail).
+	void erase(Operation* op);
+	/// erase(op) if op is pure and use-free, then cascade into operands
+	/// that became use-free and pure. Returns number of ops erased.
+	size_t eraseIfDead(Operation* op);
+
+	// ── Block arguments (both sides of the arity invariant, atomically) ──
+	/// Precondition: the argument has no uses. Removes argument slot i of
+	/// block AND the i-th argument of every invocation targeting block
+	/// (including multiple invocations from one predecessor).
+	void removeBlockArgument(BasicBlock* block, size_t index);
+	/// Appends an argument of the given stamp; valueForEdge is called once
+	/// per invocation targeting block to supply that edge's value.
+	BasicBlockArgument* addBlockArgument(BasicBlock* block, Type stamp,
+	                                     const std::function<Operation*(BasicBlockInvocation&)>& valueForEdge);
+
+	// ── CFG ──
+	/// Retargets an invocation; predecessor lists stay consistent
+	/// (delegates to BasicBlockInvocation::setBlock).
+	void setInvocationTarget(BasicBlockInvocation& inv, BasicBlock* newTarget);
+	/// Replaces the terminator; predecessor lists of old and new
+	/// successors stay consistent; use table updated for both terminators'
+	/// operands and invocation arguments.
+	void replaceTerminator(BasicBlock* block, Operation* newTerminator);
+	/// Precondition: block has no predecessors and is not the entry block.
+	/// Detaches the block (FunctionOperation::detachBasicBlock) and
+	/// unregisters all uses originating in it. Throws otherwise.
+	void eraseBlock(BasicBlock* block);
+};
+```
+
+Design decisions, with rationale:
+
+- **External use table, not intrusive use-lists.** `Operation` is a packed
+  32-byte arena object with a `static_assert` on its size; growing it for a
+  users pointer taxes every compile to benefit only the pass pipeline. The
+  side table (`unordered_map<const Operation*, small vector<Use>>`) is built
+  once per session in O(n) and maintained incrementally. Because invocation
+  arguments already live in `Operation::inputs`, a `Use` whose `user` is the
+  invocation is representable and rewireable via the same
+  `Operation::setInput` path — **the invocation special case exists in
+  exactly one place** (the table builder), instead of in every pass.
+- **Session discipline.** While a rewriter is live, all mutation of that
+  function goes through it; bypassing it (raw `removeOperation`,
+  `setInput`, …) leaves the table stale. This is a documented contract, the
+  same one `getPredecessors()` already has. Enforcement is the verifier run
+  after every pass in tests, plus debug-build assertions inside the rewriter
+  where cheap (e.g. `erase` re-checking membership).
+- **Throwing preconditions, not UB.** `erase`, `removeBlockArgument`,
+  `eraseBlock` throw `RuntimeException` on contract violation. Throwing is
+  chosen over `assert` because it is testable with Catch2
+  (`REQUIRE_THROWS_AS`) and active in Release test runs.
+- **`eraseIfDead` lives here, not in the DCE pass.** The cascade ("erasing a
+  consumer may free its producers") is the reusable core; the future
+  `DeadCodeEliminationPass` becomes a ~20-line driver that seeds the cascade
+  from all ops. Simplification/CSE/branch-folding get correct cleanup for
+  free by calling `eraseIfDead` on whatever they orphan.
+- **`freshId()` subsumes `computeNextId`.** The max-scan moves into the
+  session constructor; `StrengthReductionPass`'s local copy is deleted in the
+  retrofit step. Uniqueness is then verifier-enforced (V2), closing the #321
+  class at both ends.
+
+### 3.3 Verifier completion (`ir/passes/IRVerifier.cpp`)
+
+Six new checks, added to the existing ones. All run unconditionally in
+`verify()` (the verifier is already opt-in per run via
+`ir.verifyBeforePipeline` / `ir.verifyAfterEachPass`); all must stay
+O(function) or O(function × dom-depth). Every error message must name the
+function, block, and offending operation identifier(s), and state expected
+vs. actual — the existing message style.
+
+| ID | Invariant |
+|----|-----------|
+| **V1** | Every `BasicBlockInvocation`'s argument count equals its target block's argument count. |
+| **V2** | Operation identifiers (block ops **and** block arguments) are unique within a function. |
+| **V3** | SSA dominance: for every operand edge in a *reachable* block, the definition dominates the use. Same block: definition at a lower operation index (block arguments precede all operations; a terminator's invocation arguments are uses at the terminator's position). Cross-block: `Dominators::dominates(defBlock, useBlock)`, with block arguments defined at their block's head. Unreachable blocks keep only the existing structural checks. |
+| **V4** | Predecessor lists match incoming edges as a **multiset**: for each block, the number of times block `p` appears in `getPredecessors()` equals the number of invocations in `p`'s terminator targeting it. Replaces the current one-directional membership check. |
+| **V5** | The entry block has no predecessors, and its argument count and stamps match `FunctionOperation::getInputArgs()`. |
+| **V6** | Stamp agreement on block edges: each invocation argument's stamp equals the corresponding block argument's stamp. *Calibration step:* before enabling, run the full test corpus with V6 counted-but-not-failing; if legitimate mismatches exist in today's IR (e.g. deliberate ptr/int punning from tracing), narrow V6 to the mismatch classes that are genuinely illegal and document the exemptions in the check itself.* |
+
+### 3.4 Shared fixtures (`test/ir-pass-tests/IRGraphFixtures.hpp`)
+
+New builders, used by this milestone's tests and by every subsequent pass
+test:
+
+- `makeDiamondGraph()` — entry → if → (then, else) → merge(arg) → ret; the
+  merge block takes one argument fed differently by each arm.
+- `makeSharedTargetIfGraph()` — an `if` whose **both** invocations target the
+  same block (the duplicate-predecessor case).
+- `makeNaturalLoopGraph()` — preheader → header(args: iv, acc) ⇄ latch, header
+  → exit; loop-carried and loop-invariant arguments.
+- `makeDeadChainGraph()` — a pure chain (const → cast → add) with zero uses
+  next to a live result, plus a use-free `StoreOperation` (must never count
+  as dead).
+- Each builder returns a verifier-clean graph (asserted in a fixture
+  self-test), so pass tests start from a known-good baseline.
+
+## 4. Requirements and acceptance tests
+
+Conventions for every test in this milestone: construct via
+`IRGraphFixtures`, run mutations, then `REQUIRE(IRVerifier::verify(*ir).ok())`
+(with the V1–V6 checks active) unless the test *is* a verifier-negative test.
+Test files: `DominatorsTest.cpp`, `FunctionRewriterTest.cpp`, extended
+`IRVerifierTest.cpp`, `IRGraphFixturesTest.cpp` (self-checks).
+
+### D — Dominators
+
+| Req | Requirement | Acceptance tests |
+|-----|-------------|------------------|
+| D1 | Correct dominance on the standard shapes | Diamond: entry dominates all; neither arm dominates merge; merge does not dominate arms. Loop: preheader dominates header/latch/exit; header dominates latch; latch does not dominate exit. Chain: transitive. Self: `dominates(b,b)` true. |
+| D2 | Unreachable handling per §3.1 | Graph with a detached cycle: `isReachable` false for its blocks, absent from RPO, `dominates(entry, unreachableBlock)` false; construction does not throw. |
+| D3 | Determinism | RPO identical across two constructions of the same graph. |
+
+### M — FunctionRewriter mutation primitives
+
+| Req | Requirement | Acceptance tests |
+|-----|-------------|------------------|
+| M1 | **Uniform use model.** `usesOf/useCount/hasUses` count operand edges and invocation-argument edges identically; `definingBlock` covers ops and block arguments. | Value used once by an `AddOperation` and once as an invocation argument → `useCount == 2` and `usesOf` names both users (one of them a `BasicBlockInvocation`). Unused const → `hasUses` false. Block argument's defining block reported correctly. |
+| M2 | **`replaceAllUses` is complete and incremental.** After the call, `useCount(from) == 0`, `to` gained exactly the moved uses, and *no other* counts changed. Must cover invocation arguments (the #327 shape). | (a) Diamond fixture: replace the value one arm passes to the merge block; the invocation now passes the replacement; `erase(from)` succeeds; verifier green (stale-pointer + V3 would catch omissions). (b) Value with mixed uses (op operand + invocation arg + return value) — all three rewired. (c) Counts on an unrelated op unchanged. |
+| M3 | **Safe erase.** `erase` on a live op throws `RuntimeException` and mutates nothing; successful `erase` detaches and decrements its operands' counts. | `REQUIRE_THROWS_AS` on a used op, then verify the graph is byte-identical (`toString()` unchanged). Erase a use-free op: gone from `getOperations()`, operand counts decremented, verifier green. Erasing a terminator throws. |
+| M4 | **`eraseIfDead` cascade with purity boundary.** Erases the maximal dead pure chain; never erases non-pure ops (`isPureOp` is the single oracle); returns the count. | Dead-chain fixture: `eraseIfDead(add)` returns 3 (add, cast, const), live sibling untouched. Use-free `StoreOperation`: returns 0, store remains. Chain feeding both a dead and a live consumer: shared producer survives. Second call returns 0 (idempotence). |
+| M5 | **Fresh-identifier authority.** `freshId()` values are strictly greater than all pre-existing ids and never repeat within a session, including after erases. | Mint two ids on a fixture: both unique vs. every existing op/arg id (checked by V2 after creating ops with them) and unequal. Erase an op, mint again: still no reuse. |
+| M6 | **Creation & insertion.** `createBefore*` inserts at the documented position, registers the new op's operand uses, and assigns a fresh id automatically. | `createBeforeTerminator<AddOperation>` lands at index `size-2`; its operands' use counts incremented; V2/V3 green. `createBefore(anchor)` lands immediately before anchor. |
+| M7 | **Atomic block-argument removal.** `removeBlockArgument` updates the block and *every* invocation targeting it in one call; throws (mutating nothing) if the argument has uses. | Diamond fixture: remove the merge block's unused second argument (add one in the fixture) → both arm invocations shrink; V1 green. **Shared-target-if fixture: both invocations of the single predecessor shrink.** Natural-loop fixture: removing a header argument updates preheader and latch edges. Live argument → throws, graph unchanged. |
+| M8 | **Atomic block-argument addition.** `addBlockArgument` appends the argument and exactly one value per incoming invocation (callback per edge); fresh id; stamp as given. | Loop fixture: add a pointer argument with distinct preheader/latch values (the strength-reduction shape) → V1/V2/V3/V6 green; callback invoked exactly twice. Shared-target-if: callback invoked once per *invocation* (twice), not per predecessor block. |
+| M9 | **CFG primitives preserve the predecessor multiset.** `setInvocationTarget`, `replaceTerminator`, `eraseBlock` leave `getPredecessors()` exactly matching edges (V4-checkable at any point). `eraseBlock` throws on the entry block or on a block with predecessors. | Retarget one arm of a diamond to a new block → old target loses one pred entry (still keeping others), new target gains one; V4 green. Replace an `IfOperation` with a `BranchOperation` to one of its targets → the other target's pred entry removed. Detached-cycle fixture: `eraseBlock` succeeds on pred-free block, throws on entry and on a block with preds. |
+| M10 | **No full-function rescans after construction.** Contract: every primitive is O(affected uses/args/edges). | Code-review contract (documented per method in the header) + a large-graph smoke test: a generated straight-line function with 5,000 ops; perform 1,000 `replaceAllUses` + `eraseIfDead` operations; test asserts completion and verifier-green only (no timing assertions — wall-clock flake is worse than no check; the complexity gate is review). |
+
+### V — Verifier completion
+
+Each check needs at least one *catches-the-violation* test (build the broken
+graph with raw IR APIs, bypassing the rewriter) and one *accepts-legal-IR*
+test (the fixtures). Error-message tests assert the message names the
+offending identifiers.
+
+| Req | Requirement | Negative test (must flag) | Positive test (must stay silent) |
+|-----|-------------|---------------------------|----------------------------------|
+| V1 | Invocation arity == target arity | Invocation with one argument too few (built via `clearArguments` + partial re-add) | All fixtures |
+| V2 | Unique op/arg identifiers per function | Two ops sharing an id (the #321 shape); duplicated between an op and a block argument | All fixtures; ids minted via `freshId` |
+| V3 | Def dominates use (reachable blocks) | (a) use before def in the same block; (b) merge block using a value defined in only one diamond arm; (c) value defined in a loop body used in the preheader | Diamond + loop fixtures (incl. loop-carried args — the legal cyclic case); detached-cycle graph is not dominance-checked |
+| V4 | Predecessor multiset == incoming edges | Shared-target-if graph with the duplicate pred entry manually removed once; a stale extra pred entry | Shared-target-if fixture (predecessor listed exactly twice) |
+| V5 | Entry: no preds; args match signature | Branch retargeted to the entry block; entry arg count != `getInputArgs().size()`; stamp mismatch in slot 0 | All fixtures |
+| V6 | Edge stamp agreement (post-calibration; see §3.3) | Invocation passing an `i64` into a `ptr` block argument | All fixtures; whatever exemptions calibration documented |
+| V7 | **Corpus gate:** the whole execution-test suite runs verifier-clean. Add an env-var hook (e.g. `NAUTILUS_IR_VERIFY=1`) that makes the shared test engine options enable `ir.verifyAfterEachPass` + `ir.failOnVerifyError` (wire it where `test/common/ExecutionTest.hpp` builds engine options). | — | One full `ctest` run and one fuzz-replay smoke run with the hook enabled must be green before the milestone merges; the hook stays for future CI use. |
+
+### F — Retrofit (proof-of-fit gate)
+
+| Req | Requirement | Acceptance |
+|-----|-------------|------------|
+| F1 | `ConstantFoldingAndCopyPropagationPass` reimplemented on `FunctionRewriter` (`replaceAllUses`, `eraseIfDead`, worklist instead of whole-function rescan per round). | All existing `ConstantFoldingAndCopyPropagationTest` cases pass unchanged; `test/data/**` dumps unchanged (full suite green); folding leaves no dead feeding constants behind on a new chained-fold unit test (`(5+3)*2`: the `5`, `3`, and `8` constants are gone, only `16` remains). |
+| F2 | `EmptyBlockEliminationPass` uses rewriter CFG/argument primitives instead of hand-rolled rewiring. | Existing `EmptyBlockEliminationTest` cases pass unchanged; full suite green. |
+| F3 | `StrengthReductionPass` uses `freshId()`/creation primitives; local `computeNextId` and `nextId` threading deleted. | Existing behavior preserved (its tests + `ir.enableStrengthReduction` execution runs); no remaining `computeNextId` in the tree. |
+| F4 | Whole-milestone regression gate. | Full `ctest` suite, fuzz-replay smoke corpus, and the V7 verifier-enabled run all green; `./format.sh` clean. |
+
+If a retrofit reveals the rewriter API cannot express something a pass needs,
+**change the rewriter in this milestone** (and its tests) rather than letting
+the pass bypass it — the entire point is that PR-1+ never touches raw
+rewiring again.
+
+## 5. Sequencing within the milestone
+
+Three PRs, each independently green:
+
+1. **IR-0a — Analysis & verification:** `Dominators` (D1–D3), fixtures
+   (§3.4 + self-tests), verifier checks V1–V6 with tests, V6 calibration,
+   V7 env hook. No mutation-API changes; existing passes must already
+   satisfy V1–V6 (if one does not, fixing that latent bug is in-scope for
+   IR-0a and gets its own regression test).
+2. **IR-0b — FunctionRewriter:** the class + M1–M10 tests. No pass changes.
+3. **IR-0c — Retrofit:** F1–F4.
+
+Order rationale: the verifier lands first so the rewriter is developed
+against a net that already catches arity/dominance/id bugs; the retrofit
+lands last as the proof that the abstraction fits real passes.
+
+## 6. Definition of done (milestone)
+
+1. All D/M/V/F requirement tests exist and pass; every mutation test runs the
+   full verifier at the end.
+2. `ctest --test-dir nautilus` green; fuzz-replay smoke green; V7 run green.
+3. No pass or utility outside `FunctionRewriter` mints `OperationIdentifier`s
+   or hand-rolls consumer rewiring (grep gate: `computeNextId` gone;
+   `replaceArgument`/raw `setInput` uses outside the rewriter and the
+   IR-construction phases are reviewed and justified).
+4. Header docs on `FunctionRewriter`, `Dominators`, and each new verifier
+   check follow the house documentation style (scope, guards, complexity).
+5. `cmake --build build --target format` applied; zero new warnings.
+6. Parent design doc's §4.2 stays accurate (it references this file).

--- a/docs/design/ir-pass-improvements-agent-playbook.md
+++ b/docs/design/ir-pass-improvements-agent-playbook.md
@@ -17,10 +17,10 @@ approved in-branch.
   rewiring, and fixed-point loops.
 - **Never hand-roll purity or rewiring.** Side-effect queries go through
   `OperationProperties.hpp` (`isPureOp`, `mayReadMemory`, `mayWriteMemory`).
-  Use-rewiring goes through `RewriteUtil::replaceAllUses` (created in M0).
-  CFG edits go through `BasicBlock::replaceSuccessor`,
-  `replaceTerminatorOperation`, `BasicBlockInvocation::setBlock`, and the
-  predecessor helpers — never mutate `predecessors` semantics by hand.
+  From M0 onward, all mutation inside passes goes through `FunctionRewriter`
+  (use rewiring, erase, creation, block arguments, CFG edits, fresh
+  identifiers) — see [ir-abstraction-milestone.md](ir-abstraction-milestone.md).
+  Never mutate `predecessors` semantics or invocation argument lists by hand.
 - **Style**: tabs, 120 cols, `CamelCase` classes, `lower_case` locals,
   member `trailing_underscore_` only where the file you're editing already
   does so — match the surrounding file. Doxygen-style class comment on every
@@ -71,12 +71,37 @@ opts.setOption("ir.failOnVerifyError", true);
 
 ## 2. Milestones
 
-### M0 — Infrastructure (PR-0)
+### M0 — IR abstraction milestone (PR-0a, PR-0b, PR-0c)
 
-Files: `ir/passes/IRPass.hpp`, `IRPassManager.{hpp,cpp}`, new
-`RewriteUtil.{hpp,cpp}`, new `Dominators.{hpp,cpp}`, `IRVerifier.cpp`,
-`ir/passes/CMakeLists.txt`, plus the three existing passes and
-`LegacyCompiler.cpp`.
+This milestone is fully specified — requirement by requirement, test by
+test — in [ir-abstraction-milestone.md](ir-abstraction-milestone.md). That
+document is the contract; implement against its requirement IDs and check
+each one off in the PR description. Summary of the three PRs:
+
+- **M0.1 / PR-0a — Analysis & verification.** `Dominators` (requirements
+  D1–D3), the shared `IRGraphFixtures` builders (§3.4 there, with
+  self-tests), and verifier checks V1–V6 with their negative/positive test
+  pairs, plus the V7 corpus hook (`NAUTILUS_IR_VERIFY=1` wired into the
+  shared test engine options). Run the V6 calibration step before enabling
+  it as an error. If an existing pass violates a new check, fixing that
+  latent bug is in scope and gets a regression test.
+- **M0.2 / PR-0b — `FunctionRewriter`.** The mutation facade per §3.2 of the
+  milestone doc, satisfying requirements M1–M10 with
+  `FunctionRewriterTest.cpp`. No pass changes in this PR.
+- **M0.3 / PR-0c — Retrofit.** Requirements F1–F4: port
+  `ConstantFoldingAndCopyPropagation` and `EmptyBlockElimination` onto the
+  rewriter, replace `StrengthReduction`'s hand-rolled `computeNextId`/
+  `nextId` threading with `freshId()`. Strictly behavior-preserving: all
+  existing tests and `test/data/**` dumps unchanged, full suite + fuzz
+  smoke + V7 run green.
+
+If the rewriter API cannot express something a retrofit needs, extend the
+rewriter (and its tests) in M0.3 — do not let a pass bypass it.
+
+### M0.4 — Pass-manager mechanics (PR-0d)
+
+Files: `ir/passes/IRPass.hpp`, `IRPassManager.{hpp,cpp}`, the three existing
+passes, `LegacyCompiler.cpp`.
 
 1. Change `IRPass::apply` to return `bool` (true iff the graph changed).
    Update the three existing passes — each already tracks a `changed` flag
@@ -90,24 +115,10 @@ Files: `ir/passes/IRPass.hpp`, `IRPassManager.{hpp,cpp}`, new
    constructing the group. Record `irPasses.pipelineIterations` in
    statistics. Per-pass timing/delta statistics must aggregate across
    iterations (sum the ms, sum the deltas).
-3. Extract `replaceAllUses(FunctionOperation&, Operation* from, Operation* to)`
-   into `RewriteUtil` from the copy-propagation logic in
-   `ConstantFoldingAndCopyPropagationPass.cpp`; make that pass call it. It
-   must cover: every operation's `getInputs()` span (rewire via `setInput`)
-   and every terminator's `BasicBlockInvocation` arguments, in every block of
-   the function.
-4. Add `Dominators` (iterative Cooper–Harvey–Kennedy over RPO from the entry
-   block). API: constructed from a `FunctionOperation&` (after predecessor
-   lists are valid), `bool dominates(const BasicBlock*, const BasicBlock*)`.
-5. Verifier: add the invocation-arity check — for every terminator
-   invocation, `invocation.getArguments().size() == target->getArguments().size()`
-   (use the real accessor names from `BasicBlockInvocation.hpp`).
-6. Tests: `IRPassManagerTest.cpp` gains fixed-point-group cases (group
+3. Tests: `IRPassManagerTest.cpp` gains fixed-point-group cases (group
    converges; maxIterations bound respected; no-change passes skipped in
-   dumps). `IRVerifierTest.cpp` gains arity-violation cases (construct a
-   deliberately broken graph). Add `DominatorsTest.cpp` (diamond, loop,
-   chain).
-7. **Behavioral gate**: with the pipeline in `LegacyCompiler.cpp` expressed
+   dumps).
+4. **Behavioral gate**: with the pipeline in `LegacyCompiler.cpp` expressed
    as a maxIterations=1 group of the existing passes, all test-data dumps and
    the whole suite must be unchanged. Run the full suite + fuzz smoke.
 
@@ -116,10 +127,12 @@ Files: `ir/passes/IRPass.hpp`, `IRPassManager.{hpp,cpp}`, new
 Files: new `ir/passes/DeadCodeEliminationPass.{hpp,cpp}`, `LegacyCompiler.cpp`,
 new `test/ir-pass-tests/DeadCodeEliminationTest.cpp`, `docs/options.md`.
 
-1. Implement per design §4.3-A. Reuse `Usages::countUsages` for the initial
-   counts; maintain counts incrementally while erasing (`removeOperation`),
-   loop to fixed point within the function. Only ops with
-   `isPureOp(op->getOperationType())`, not terminators, not block arguments.
+1. Implement per design §4.3-A as a thin driver over
+   `FunctionRewriter::eraseIfDead` (the cascade, purity oracle, and use
+   tracking already live there — see milestone requirement M4): open a
+   rewriter session per function, seed `eraseIfDead` from every operation,
+   done. Only pure non-terminator ops are ever erased; block arguments are
+   untouched (Pass E owns arity).
 2. Register default-on behind `ir.disableDeadCodeElimination`, positioned per
    design §4.4 (for now: after EmptyBlockElimination inside the group).
 3. Tests: dead const chain removed; dead cast removed; op used only by a

--- a/docs/design/ir-pass-improvements-agent-playbook.md
+++ b/docs/design/ir-pass-improvements-agent-playbook.md
@@ -1,0 +1,247 @@
+# Agent Playbook: Implementing the IR Pass Improvements
+
+Instructions for an implementation agent (Sonnet-class) executing the design
+in [ir-pass-improvements.md](ir-pass-improvements.md). Read that document
+first; this one tells you *how to work*, in what order, and how to verify each
+step. Do not start a milestone before its predecessor is merged or explicitly
+approved in-branch.
+
+## 0. Ground rules
+
+- **One milestone per branch/PR.** Keep diffs reviewable. Branch names:
+  `claude/ir-pass-<milestone>-<session-id>`.
+- **Read before writing.** Before touching a file, read it fully. Before
+  writing a pass, read all three existing passes
+  (`ConstantFoldingAndCopyPropagationPass.cpp`, `EmptyBlockEliminationPass.cpp`,
+  `StrengthReductionPass.cpp`) — they encode the house style for traversal,
+  rewiring, and fixed-point loops.
+- **Never hand-roll purity or rewiring.** Side-effect queries go through
+  `OperationProperties.hpp` (`isPureOp`, `mayReadMemory`, `mayWriteMemory`).
+  Use-rewiring goes through `RewriteUtil::replaceAllUses` (created in M0).
+  CFG edits go through `BasicBlock::replaceSuccessor`,
+  `replaceTerminatorOperation`, `BasicBlockInvocation::setBlock`, and the
+  predecessor helpers — never mutate `predecessors` semantics by hand.
+- **Style**: tabs, 120 cols, `CamelCase` classes, `lower_case` locals,
+  member `trailing_underscore_` only where the file you're editing already
+  does so — match the surrounding file. Doxygen-style class comment on every
+  pass header describing exact scope and guards (copy the tone of
+  `EmptyBlockEliminationPass.hpp`).
+- **Format before every commit**: `cmake --build build --target format`,
+  then confirm `./format.sh` is clean.
+- **Compiler**: Clang 21 (`-DCMAKE_CXX_COMPILER=clang++-21`).
+- If reality contradicts the design doc (an API is missing, an invariant
+  doesn't hold), stop and report the discrepancy in the PR/summary instead of
+  improvising a workaround.
+
+## 1. Build & test commands (use these exactly)
+
+```bash
+# One-time configure
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-21 \
+      -DENABLE_TESTS=ON -DENABLE_FUZZER_REPLAY=ON ..
+
+# Build + full test suite
+cmake --build . -j && ctest --test-dir nautilus --output-on-failure
+
+# Just the IR pass tests (fast inner loop — run the Catch2 binary directly;
+# ctest registers individual TEST_CASE names, not the suite name)
+./nautilus/test/ir-pass-tests/nautilus-ir-pass-tests
+
+# Differential fuzzer smoke corpus (must be clean before every push)
+./nautilus/test/fuzz/nautilus-fuzz-replay
+
+# Benchmarks (separate Release build; needed for measurement milestones)
+cmake -B build-rel -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++-21 \
+      -DENABLE_BENCHMARKS=ON .
+cmake --build build-rel -j --target ExecutionBenchmark
+```
+
+(If a target/test name differs, discover the real one via
+`ctest --test-dir nautilus -N` and the `CMakeLists.txt` of the directory —
+do not guess.)
+
+Every new pass test must set, on the `engine::Options` given to
+`IRPassManager`:
+
+```cpp
+opts.setOption("ir.verifyAfterEachPass", true);
+opts.setOption("ir.failOnVerifyError", true);
+```
+
+## 2. Milestones
+
+### M0 — Infrastructure (PR-0)
+
+Files: `ir/passes/IRPass.hpp`, `IRPassManager.{hpp,cpp}`, new
+`RewriteUtil.{hpp,cpp}`, new `Dominators.{hpp,cpp}`, `IRVerifier.cpp`,
+`ir/passes/CMakeLists.txt`, plus the three existing passes and
+`LegacyCompiler.cpp`.
+
+1. Change `IRPass::apply` to return `bool` (true iff the graph changed).
+   Update the three existing passes — each already tracks a `changed` flag
+   internally; surface it. Update `IRPassManager::run` to skip the
+   `dumpAfterEachPass` dump when a pass reports no change (keep verification
+   behavior as-is).
+2. Add fixed-point groups to `IRPassManager`. Simplest workable API:
+   `void addFixedPointGroup(std::vector<std::unique_ptr<IRPass>> passes, size_t maxIterations)`
+   where a plain `addPass` is a group of one with one iteration. Read
+   `ir.maxPipelineIterations` (default 4) in `LegacyCompiler.cpp` when
+   constructing the group. Record `irPasses.pipelineIterations` in
+   statistics. Per-pass timing/delta statistics must aggregate across
+   iterations (sum the ms, sum the deltas).
+3. Extract `replaceAllUses(FunctionOperation&, Operation* from, Operation* to)`
+   into `RewriteUtil` from the copy-propagation logic in
+   `ConstantFoldingAndCopyPropagationPass.cpp`; make that pass call it. It
+   must cover: every operation's `getInputs()` span (rewire via `setInput`)
+   and every terminator's `BasicBlockInvocation` arguments, in every block of
+   the function.
+4. Add `Dominators` (iterative Cooper–Harvey–Kennedy over RPO from the entry
+   block). API: constructed from a `FunctionOperation&` (after predecessor
+   lists are valid), `bool dominates(const BasicBlock*, const BasicBlock*)`.
+5. Verifier: add the invocation-arity check — for every terminator
+   invocation, `invocation.getArguments().size() == target->getArguments().size()`
+   (use the real accessor names from `BasicBlockInvocation.hpp`).
+6. Tests: `IRPassManagerTest.cpp` gains fixed-point-group cases (group
+   converges; maxIterations bound respected; no-change passes skipped in
+   dumps). `IRVerifierTest.cpp` gains arity-violation cases (construct a
+   deliberately broken graph). Add `DominatorsTest.cpp` (diamond, loop,
+   chain).
+7. **Behavioral gate**: with the pipeline in `LegacyCompiler.cpp` expressed
+   as a maxIterations=1 group of the existing passes, all test-data dumps and
+   the whole suite must be unchanged. Run the full suite + fuzz smoke.
+
+### M1 — DeadCodeEliminationPass (PR-1)
+
+Files: new `ir/passes/DeadCodeEliminationPass.{hpp,cpp}`, `LegacyCompiler.cpp`,
+new `test/ir-pass-tests/DeadCodeEliminationTest.cpp`, `docs/options.md`.
+
+1. Implement per design §4.3-A. Reuse `Usages::countUsages` for the initial
+   counts; maintain counts incrementally while erasing (`removeOperation`),
+   loop to fixed point within the function. Only ops with
+   `isPureOp(op->getOperationType())`, not terminators, not block arguments.
+2. Register default-on behind `ir.disableDeadCodeElimination`, positioned per
+   design §4.4 (for now: after EmptyBlockElimination inside the group).
+3. Tests: dead const chain removed; dead cast removed; op used only by a
+   dead op removed (transitivity); store/call/load NOT removed even when
+   unused; op used only as invocation argument NOT removed; idempotence.
+4. Full suite + fuzz smoke. Capture `ir.operations` before/after on two
+   test-data categories (`engine.logStatistics` or the dump files) and put
+   the numbers in the PR description.
+
+### M2 — AlgebraicSimplificationPass (PR-2)
+
+Files: new pass + test, `LegacyCompiler.cpp`, `docs/options.md`.
+
+1. Implement the rule set of design §4.3-B **exactly** — the float and
+   signedness carve-outs are the specification, not suggestions. Structure:
+   one `simplify<OpKind>` helper per op family returning
+   `Operation*` replacement or `nullptr`; the driver walks each block,
+   applies, uses `replaceAllUses`, and lets the op die (DCE cleans up —
+   do not duplicate removal logic).
+2. Canonicalization (const-to-right) must use a strict test
+   (`left is const && right is not const`) so repeated application is a
+   no-op — this is what makes the fixed-point group terminate.
+3. Tests: every rule, positive and negative (at minimum: float `x*0` NOT
+   folded, float `x+0` NOT folded, `x-x` float NOT folded, signed vs unsigned
+   shift behavior preserved, cast-of-cast only in the lossless cases,
+   comparator swap correctness for `<`/`<=` when canonicalizing).
+   Idempotence test.
+4. Full suite + fuzz smoke, plus a longer replay/survey run
+   (`nautilus-fuzz-replay --survey 200000` if available) because this pass
+   has the widest semantic surface. Any finding: fix or revert the rule —
+   never ship a rule with a known finding.
+
+### M3 — ConstantBranchFoldingPass (PR-3)
+
+Per design §4.3-C. New pass + tests; runs inside the group after
+simplification. Key test cases: if(true)/if(false) fold with argument lists
+preserved; both-arms-same-target-same-args fold; unreachable diamond arm
+removed; unreachable *loop* (cycle not reachable from entry) removed; entry
+block never removed; predecessor lists correct afterwards (verifier enforces).
+After this lands, check the interaction test: constant compare → (existing
+folding) → constant bool → (this pass) → straight line, in one pipeline run.
+
+### M4 — BlockMergingPass (PR-4)
+
+Per design §4.3-D. Merge only when: terminator is unconditional branch,
+target has exactly one predecessor, target ≠ source, target is not the entry
+block. Rewrite target's block-argument uses to the invocation's actual
+arguments via `replaceAllUses` **before** splicing. Tests: chain of
+single-pred blocks collapses to one; block with two preds NOT merged;
+self-loop NOT merged; loop latch→header NOT merged (header has 2 preds);
+argument values correctly substituted (build a graph where the argument is
+used by an op and by a nested invocation).
+
+### M5 — BlockArgumentPruningPass (PR-5)
+
+Per design §4.3-E. This is the invariant-heaviest pass:
+
+- Remove an argument slot and every corresponding invocation argument in the
+  same mutation step; run the verifier in every test (arity check from M0
+  will catch drift).
+- Same-value pass-through: ignore self-referential edges (latch passing the
+  header's own argument back) when checking all-preds-agree; require the
+  agreed value's defining block to dominate the target (`Dominators`).
+- Entry block: never touched.
+- Tests: unused arg pruned everywhere; loop-invariant carried arg replaced by
+  preheader value (the marquee case — assert the loop body now reads the
+  outer value directly); arg used only by dead code (order with DCE: run
+  group, expect both gone); args where preds disagree NOT pruned; dominance
+  failure NOT pruned.
+
+### M6 — StrengthReduction default flip (PR-6, measurement-only)
+
+1. Release build, run `ExecutionBenchmark` on `tbc`, `bc`, `asmjit` with
+   `ir.enableStrengthReduction` off vs on (now that A+B clean its residue).
+   ≥ 5 runs, report medians.
+2. If no interpreter kernel regresses > 2%: flip the default (design §4.3),
+   update `StrengthReductionPass.hpp`'s comment and `docs/options.md`, keep a
+   disable option. If it still regresses: do NOT flip; update the header
+   comment with the fresh numbers and close the milestone with the report.
+
+### M7 — LocalCSEPass (PR-7) and M8 — LICM (PR-8)
+
+Per design §4.3-F/G. LICM ships opt-in (`ir.enableLICM`); extract the
+natural-loop matcher from `StrengthReductionPass.cpp` into a shared helper
+(`passes/LoopInfo.{hpp,cpp}`) as part of M8 and make StrengthReduction use it
+(behavior-preserving refactor, verified by its existing tests). LICM tests
+must include: div/mod NOT hoisted (non-const divisor), load NOT hoisted,
+chain-hoisting (op depending on hoisted op hoists too), nested-loop-shaped
+graph (only the matched natural loop is transformed).
+
+## 3. Definition of done — every milestone
+
+1. `cmake --build build -j` clean, zero warnings introduced.
+2. `ctest --test-dir nautilus --output-on-failure` fully green.
+3. `./nautilus/test/fuzz/nautilus-fuzz-replay` (smoke corpus) clean.
+4. New pass: unit tests exist, include an idempotence case and at least three
+   negative cases; test options enable verify-after-each-pass + fail-on-error.
+5. `cmake --build build --target format` run; `./format.sh` clean.
+6. `docs/options.md` updated for any new option.
+7. PR description: what/why (link the design doc section), test evidence,
+   and for measurement-relevant milestones the benchmark/op-count numbers.
+8. Commit messages: imperative mood, one logical change per commit.
+
+## 4. Known traps (learned from this codebase's history)
+
+- **#327**: replacing an op without rewiring *invocation arguments* leaves
+  stale pointers that the verifier now catches — but only if your test turns
+  the verifier on. Always route through `replaceAllUses`.
+- **#321**: block-argument identifier collisions corrupted asmjit merged
+  values. When you create or substitute block arguments, never reuse
+  identifiers; when pruning, don't renumber survivors.
+- `Operation` has a **non-virtual destructor** and lives in an arena: never
+  `delete` an operation, never keep an op alive outside its arena's lifetime,
+  and "removing" means detaching from the block's vector only.
+- `BasicBlock::getPredecessors()` is a maintained cache, valid only if every
+  CFG edit went through the wiring helpers. If you bypass them, the verifier's
+  pred/succ symmetry check will fail far from your bug.
+- A block may list the same predecessor **twice** (both arms of an `if`
+  targeting one block). `removePredecessor` removes one occurrence — call it
+  once per edge, not once per block.
+- The interpreters' cost model is dispatch-bound: a transformation that adds
+  ops to remove "work" (the StrengthReduction lesson) can be a net loss.
+  When in doubt, measure on `tbc` before assuming.
+- `mlir` and `cpp` run the same pipeline: your pass must be
+  semantics-preserving universally, not just "good enough for interpreters".

--- a/docs/design/ir-pass-improvements.md
+++ b/docs/design/ir-pass-improvements.md
@@ -470,24 +470,27 @@ Layered, matching what the repo already has:
 Land in small PRs, in dependency order; every PR leaves `main` green with
 defaults unchanged until the measurement gate passes:
 
+Tracking issues group the PRs into four milestones: #338 (IR-0 +
+pass-manager infrastructure), #342 (P0), #345 (P1), #347 (P2).
+
 1. **PR-0a/0b/0c** Milestone IR-0 (see
    [ir-abstraction-milestone.md](ir-abstraction-milestone.md)):
-   `Dominators` + verifier completion (V1–V7, #338), `FunctionRewriter`
-   mutation facade (#339), retrofit of the three existing passes onto it
-   (#340). Behavior-preserving throughout.
-2. **PR-0d** Pass-manager mechanics: `apply()`→`bool`, fixed-point groups
-   (#341). No behavior change (group of existing passes with maxIter 1
-   reproduces today's pipeline bit-for-bit).
+   `Dominators` + verifier completion (V1–V7), `FunctionRewriter` mutation
+   facade, retrofit of the three existing passes onto it. Behavior-
+   preserving throughout. (#338)
+2. **PR-0d** Pass-manager mechanics: `apply()`→`bool`, fixed-point groups.
+   No behavior change (group of existing passes with maxIter 1 reproduces
+   today's pipeline bit-for-bit). (#338)
 3. **PR-1** DCE (A) — default on immediately (risk is minimal, effect is
-   large and strictly shrinking) (#342).
-4. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak (#343).
-5. **PR-3** ConstantBranchFolding + unreachable removal (C) (#344).
-6. **PR-4** BlockMerging (D) (#345).
-7. **PR-5** BlockArgumentPruning (E) (#346).
-8. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op)
-   (#347).
-9. **PR-7** LocalCSE (F) (#348).
-10. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak (#349).
+   large and strictly shrinking). (#342)
+4. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak. (#342)
+5. **PR-3** ConstantBranchFolding + unreachable removal (C). (#342)
+6. **PR-4** BlockMerging (D). (#345)
+7. **PR-5** BlockArgumentPruning (E). (#345)
+8. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op).
+   (#347)
+9. **PR-7** LocalCSE (F). (#347)
+10. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak. (#347)
 
 Each pass PR: pass + unit tests + options.md entry + benchmark numbers in the
 description. The companion playbook encodes this as agent milestones.

--- a/docs/design/ir-pass-improvements.md
+++ b/docs/design/ir-pass-improvements.md
@@ -153,6 +153,16 @@ Infrastructure that already exists and that new passes must build on:
 
 ### 4.2 Infrastructure changes (Phase 0)
 
+> **Expanded into its own milestone.** Items (c)–(e) below, plus safe
+> mutation primitives the pass catalog assumes (use tracking, safe erase,
+> fresh-identifier minting, atomic block-argument mutation, CFG rewiring)
+> and a fuller set of verifier invariants, are specified with concrete
+> requirements and acceptance tests in
+> [ir-abstraction-milestone.md](ir-abstraction-milestone.md) (Milestone
+> IR-0). That milestone lands **first**; items (a)–(b) below follow it as a
+> separate small PR. Where this section and the milestone doc overlap, the
+> milestone doc is authoritative.
+
 **(a) `IRPass::apply` returns `bool` (changed).**
 All three existing passes already track an internal `changed` flag for their
 fixed-point loops; surface it. The manager uses it to skip per-pass dumps and
@@ -168,11 +178,12 @@ unreachable blocks; block merging exposes dead args; DCE exposes empty
 blocks). Statistics keep per-pass attribution; add a
 `irPasses.pipelineIterations` counter.
 
-**(c) Shared rewrite utility** — `passes/RewriteUtil.{hpp,cpp}`:
-`replaceAllUses(FunctionOperation& fn, Operation* from, Operation* to)`
-walking every block's operations' input spans **and** every terminator's
-`BasicBlockInvocation` arguments. Extracted from
-`ConstantFoldingAndCopyPropagationPass` (which then calls it).
+**(c) Shared mutation facade** — `passes/FunctionRewriter.{hpp,cpp}`: a
+per-function mutation session owning use tracking, `replaceAllUses`
+(covering operand spans **and** `BasicBlockInvocation` arguments), safe
+erase with a dead-chain cascade, fresh-identifier minting, atomic
+block-argument mutation, and CFG rewiring. Fully specified in the milestone
+doc (§3.2 there); the pass catalog below refers to its primitives by name.
 
 **(d) Dominance helper** — `passes/Dominators.{hpp,cpp}`: iterative
 dominator-tree computation (Cooper–Harvey–Kennedy over reverse post order).
@@ -198,11 +209,11 @@ Remove operations that are pure (`isPureOp`, includes `Constant` ops) and have
 zero uses. Iterate to a fixed point within the pass (removing a consumer can
 kill its producers).
 
-Algorithm (per function): compute use counts (reuse `Usages::countUsages`,
-counting operation inputs + invocation arguments); walk blocks in reverse,
-erase zero-use pure non-terminator ops via `BasicBlock::removeOperation`,
-decrement the counts of their inputs, repeat until no change. Block arguments
-are **not** removed here (Pass E owns the arity invariant).
+Algorithm (per function): a thin driver over
+`FunctionRewriter::eraseIfDead` (milestone requirement M4 — the cascade,
+purity oracle, and incremental use tracking live in the rewriter): open a
+session, seed the cascade from every operation. Block arguments are **not**
+removed here (Pass E owns the arity invariant).
 
 Benefits: sweeps constant-folding residue (dead feeding constants → smaller
 `tbc` constant image → faster every call), strength-reduction residue (the
@@ -459,19 +470,23 @@ Layered, matching what the repo already has:
 Land in small PRs, in dependency order; every PR leaves `main` green with
 defaults unchanged until the measurement gate passes:
 
-1. **PR-0** Infrastructure: `apply()`→`bool`, fixed-point groups,
-   `RewriteUtil`, verifier arity check, `Dominators`. Pure refactor +
-   additive; no behavior change (group of existing passes with maxIter 1
-   reproduces today's pipeline bit-for-bit).
-2. **PR-1** DCE (A) — default on immediately (risk is minimal, effect is
+1. **PR-0a/0b/0c** Milestone IR-0 (see
+   [ir-abstraction-milestone.md](ir-abstraction-milestone.md)):
+   `Dominators` + verifier completion (V1–V7), `FunctionRewriter` mutation
+   facade, retrofit of the three existing passes onto it. Behavior-
+   preserving throughout.
+2. **PR-0d** Pass-manager mechanics: `apply()`→`bool`, fixed-point groups.
+   No behavior change (group of existing passes with maxIter 1 reproduces
+   today's pipeline bit-for-bit).
+3. **PR-1** DCE (A) — default on immediately (risk is minimal, effect is
    large and strictly shrinking).
-3. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak.
-4. **PR-3** ConstantBranchFolding + unreachable removal (C).
-5. **PR-4** BlockMerging (D).
-6. **PR-5** BlockArgumentPruning (E).
-7. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op).
-8. **PR-7** LocalCSE (F).
-9. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak.
+4. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak.
+5. **PR-3** ConstantBranchFolding + unreachable removal (C).
+6. **PR-4** BlockMerging (D).
+7. **PR-5** BlockArgumentPruning (E).
+8. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op).
+9. **PR-7** LocalCSE (F).
+10. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak.
 
 Each pass PR: pass + unit tests + options.md entry + benchmark numbers in the
 description. The companion playbook encodes this as agent milestones.

--- a/docs/design/ir-pass-improvements.md
+++ b/docs/design/ir-pass-improvements.md
@@ -472,21 +472,22 @@ defaults unchanged until the measurement gate passes:
 
 1. **PR-0a/0b/0c** Milestone IR-0 (see
    [ir-abstraction-milestone.md](ir-abstraction-milestone.md)):
-   `Dominators` + verifier completion (V1–V7), `FunctionRewriter` mutation
-   facade, retrofit of the three existing passes onto it. Behavior-
-   preserving throughout.
-2. **PR-0d** Pass-manager mechanics: `apply()`→`bool`, fixed-point groups.
-   No behavior change (group of existing passes with maxIter 1 reproduces
-   today's pipeline bit-for-bit).
+   `Dominators` + verifier completion (V1–V7, #338), `FunctionRewriter`
+   mutation facade (#339), retrofit of the three existing passes onto it
+   (#340). Behavior-preserving throughout.
+2. **PR-0d** Pass-manager mechanics: `apply()`→`bool`, fixed-point groups
+   (#341). No behavior change (group of existing passes with maxIter 1
+   reproduces today's pipeline bit-for-bit).
 3. **PR-1** DCE (A) — default on immediately (risk is minimal, effect is
-   large and strictly shrinking).
-4. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak.
-5. **PR-3** ConstantBranchFolding + unreachable removal (C).
-6. **PR-4** BlockMerging (D).
-7. **PR-5** BlockArgumentPruning (E).
-8. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op).
-9. **PR-7** LocalCSE (F).
-10. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak.
+   large and strictly shrinking) (#342).
+4. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak (#343).
+5. **PR-3** ConstantBranchFolding + unreachable removal (C) (#344).
+6. **PR-4** BlockMerging (D) (#345).
+7. **PR-5** BlockArgumentPruning (E) (#346).
+8. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op)
+   (#347).
+9. **PR-7** LocalCSE (F) (#348).
+10. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak (#349).
 
 Each pass PR: pass + unit tests + options.md entry + benchmark numbers in the
 description. The companion playbook encodes this as agent milestones.

--- a/docs/design/ir-pass-improvements.md
+++ b/docs/design/ir-pass-improvements.md
@@ -1,0 +1,500 @@
+# Design: IR Optimization Passes for Direct-Lowering Backends
+
+**Status:** Proposed
+**Audience:** Nautilus contributors; implementation agents (see the companion
+[agent playbook](ir-pass-improvements-agent-playbook.md))
+**Scope:** `nautilus/src/nautilus/compiler/ir/passes/` and the pass pipeline in
+`LegacyCompiler::compileToIR`
+
+---
+
+## 1. Motivation
+
+Nautilus has five backends with two fundamentally different relationships to
+the Nautilus IR:
+
+| Backend | Downstream optimizer | Consequence of a redundant IR op |
+|---|---|---|
+| `mlir` | Full MLIR + LLVM pass pipeline | Usually optimized away for free |
+| `cpp` | Host C++ compiler (`-O2`) | Usually optimized away for free |
+| `asmjit` (x64/a64) | Only a small post-RA peephole | One or more machine instructions + a vreg, forever |
+| `bc` | None | One interpreter dispatch **per execution** |
+| `tbc` | None | One interpreter dispatch **per execution** |
+
+For `asmjit`, `bc`, and `tbc`, the IR pass pipeline **is the entire
+optimizer**. Every operation that survives `compileToIR` is lowered 1:1:
+
+- `bc`/`tbc` lowering walks `block->getOperations()` and emits an instruction
+  per op (`TBCLoweringProvider::processBlock`, `BCLoweringProvider`
+  equivalents). A dead pure op is not just wasted code size — it is a wasted
+  dispatch on every call and every loop iteration.
+- In `tbc`, every `Const*Operation` occupies a slot in the function's
+  *constant image*, which is `memcpy`'d into the frame **on every call**
+  (`TBCCode.hpp`). Dead constants make every invocation slower.
+- Block-argument edges lower to parallel-copy `MOV`s at every block
+  transition (`bc`/`tbc` coalescing minimizes but cannot eliminate them;
+  asmjit materializes merged values similarly). A redundant block argument is
+  a redundant `MOV` per loop iteration.
+- `asmjit` has no mid-end: IR op count maps directly to instruction count and
+  register pressure; its free-list allocator spills when pressure grows.
+
+The cost model for the interpreters is **dispatch-bound**: dynamic executed-op
+count dominates wall clock (see `backends/tbc/README.md`). The cost model for
+`asmjit` is conventional (instructions + register pressure). Both are served
+by the same lever: **fewer, more canonical IR operations reaching the
+backend.**
+
+### Evidence this is the current bottleneck
+
+- `StrengthReductionPass` is *correct* but ships **default-off** because it
+  leaves behind an unfolded `ptr + 0` and a dead cast, which regress the
+  dispatch-bound interpreters (`StrengthReductionPass.hpp`,
+  `LegacyCompiler.cpp:171-177`). The pass is blocked on cleanup passes that
+  don't exist yet.
+- `ConstantFoldingAndCopyPropagationPass` replaces the folded op in place, but
+  the *feeding* constants frequently become dead and are still lowered (and,
+  in `tbc`, still copied per call).
+- The `tbc` README's follow-up list ("dead-MOV elimination after immediate
+  folding") is a backend-local symptom of a missing IR-level DCE.
+- Tracing produces structurally noisy IR by construction: one block per
+  control-flow merge, pass-through block arguments for every live value, and
+  repeated subexpressions the trace could not deduplicate across blocks.
+
+## 2. Current state (inventory)
+
+Infrastructure that already exists and that new passes must build on:
+
+- **Pass framework** — `IRPass` (`apply(IRGraph&)`, `getName()`),
+  `IRPassManager` (registration order, option-driven verification/dumping,
+  per-pass timing + block/op deltas via `CompilationStatistics`), predecessor
+  lists rebuilt before each run (`rebuildPredecessorLists`).
+- **Passes** — `ConstantFoldingAndCopyPropagationPass` (default on),
+  `EmptyBlockEliminationPass` (default on), `StrengthReductionPass`
+  (opt-in via `ir.enableStrengthReduction`).
+- **Analysis** — `IRVerifier` (structural invariants incl. stale-pointer
+  detection, #327), `IRStatistics` (block/op counts), `Usages::countUsages`
+  (per-function static use counts; already consumed by the asmjit branch
+  fusion).
+- **Op metadata** — `OperationProperties.hpp`: constant-time per-optype flags
+  `Constant / Terminator / MayReadMem / MayWriteMem / Pure`. This is the
+  purity oracle for DCE/CSE/LICM.
+- **Generic rewiring** — `Operation::getInputs()` + `Operation::setInput()`
+  span-based operand access across all op kinds; `BasicBlock::replaceSuccessor`
+  and invocation helpers keep the predecessor invariant.
+- **Test surface** — `test/ir-pass-tests/` (Catch2 unit tests over
+  programmatically built graphs via `IRGraphFixtures.hpp`), the whole
+  execution/val suite parameterized over all backends
+  (`test/common/ExecutionTest.hpp::availableBackends()`), the differential
+  AST fuzzer (`test/fuzz/`, behavioral cross-backend equivalence), and
+  `test/benchmark/ExecutionBenchmark.cpp`.
+
+### Gaps
+
+1. No **dead code elimination** — the single biggest omission; everything
+   else produces garbage that currently cannot be swept.
+2. No **algebraic simplification / canonicalization** (`x+0`, `x*1`, `x*0`,
+   same-type casts, `not(not x)`, constant-to-the-right canonicalization…).
+3. No **constant branch folding** (`if(constBool)` survives as a conditional
+   branch even after folding proves the condition) and no **unreachable block
+   elimination**.
+4. No **block merging** — `EmptyBlockElimination` only removes *fully empty*
+   blocks; a single-predecessor block reached by an unconditional branch still
+   costs a `JMP` dispatch + edge copies per execution.
+5. No **block-argument pruning** — unused and pass-through-invariant
+   arguments survive as per-iteration `MOV`s.
+6. No **CSE**, no **LICM**.
+7. `IRPass::apply` returns `void`, so the manager cannot iterate pass groups
+   to a fixed point or skip work when nothing changed.
+8. `IRVerifier` does not check invocation-argument arity against target-block
+   argument arity — an invariant the new block-arg passes will stress.
+
+## 3. Goals / non-goals
+
+**Goals**
+
+- Reduce the *dynamic* op count reaching `bc`/`tbc` and the static op count /
+  register pressure reaching `asmjit`, measurably, on the existing benchmark
+  kernels and on trace-shaped IR generally.
+- Unblock `StrengthReductionPass` becoming default-on.
+- Keep every pass idempotent, composable, verifier-clean, and option-gated,
+  matching the existing framework contract (`IRPass.hpp`).
+- Keep `mlir`/`cpp` correctness unaffected (they run the same pipeline; the
+  passes must be semantics-preserving everywhere).
+
+**Non-goals**
+
+- No new IR operation kinds (e.g. a GEP/load-with-offset op). Backend-local
+  superinstruction fusion (tbc `LOAD_off`/`STORE_off`) stays in the backends.
+- No changes to backend register allocators or dispatch machinery.
+- No inlining (ProxyCall inlining is a separate, larger design).
+- No full sparse-conditional constant propagation; the folding pass stays
+  syntactic.
+
+## 4. Design
+
+### 4.1 Guiding principles
+
+1. **Purity comes from one place**: `OperationProperties.hpp`
+   (`isPureOp` / `mayReadMemory` / `mayWriteMemory`). No pass hand-rolls an
+   op-type switch to decide side effects.
+2. **Rewiring comes from one place**: a new shared utility (§4.2) built on
+   `Operation::setInput` + terminator invocation arguments, extracted from the
+   logic that already exists inside the constant-folding pass. Bug #327
+   (stale consumer pointers) must be impossible to reintroduce per-pass.
+3. **CFG invariants are maintained, not rebuilt**: passes use
+   `replaceSuccessor` / `BasicBlockInvocation::setBlock` /
+   `add|removePredecessor` so `getPredecessors()` stays truthful mid-pipeline.
+   The verifier (run with `ir.verifyAfterEachPass` + `ir.failOnVerifyError`
+   in all pass tests) is the enforcement mechanism.
+4. **Every transformation is measured before it defaults on**, on all three
+   target backends — the StrengthReduction lesson: a locally "obvious" win can
+   regress a dispatch-bound cost model. Benchmarks gate defaults; options gate
+   rollback.
+
+### 4.2 Infrastructure changes (Phase 0)
+
+**(a) `IRPass::apply` returns `bool` (changed).**
+All three existing passes already track an internal `changed` flag for their
+fixed-point loops; surface it. The manager uses it to skip per-pass dumps and
+verification when nothing changed, and to drive (b).
+
+**(b) Fixed-point pass groups in `IRPassManager`.**
+Add `beginFixedPointGroup(maxIterations = 4)` / `endFixedPointGroup()` (or an
+`addFixedPointGroup(std::vector<std::unique_ptr<IRPass>>, size_t)` — pick the
+simpler to implement). A group re-runs while any member reports a change,
+bounded by `maxIterations` (option `ir.maxPipelineIterations`, default 4).
+Rationale: the cleanup passes enable each other (branch folding exposes
+unreachable blocks; block merging exposes dead args; DCE exposes empty
+blocks). Statistics keep per-pass attribution; add a
+`irPasses.pipelineIterations` counter.
+
+**(c) Shared rewrite utility** — `passes/RewriteUtil.{hpp,cpp}`:
+`replaceAllUses(FunctionOperation& fn, Operation* from, Operation* to)`
+walking every block's operations' input spans **and** every terminator's
+`BasicBlockInvocation` arguments. Extracted from
+`ConstantFoldingAndCopyPropagationPass` (which then calls it).
+
+**(d) Dominance helper** — `passes/Dominators.{hpp,cpp}`: iterative
+dominator-tree computation (Cooper–Harvey–Kennedy over reverse post order).
+Functions here are small (tens of blocks); simplicity beats asymptotics.
+Needed by block-argument pruning and LICM. Exposes
+`bool dominates(const BasicBlock* a, const BasicBlock* b)` plus RPO order.
+
+**(e) Verifier extension**: every `BasicBlockInvocation`'s argument count must
+equal its target block's argument count. Cheap, and it turns the classic
+block-arg-pruning bug into an immediate, pinpointed failure instead of a
+backend miscompile.
+
+### 4.3 Pass catalog
+
+Priority key: **P0** = highest leverage / lowest risk, do first.
+Each pass: default state, algorithm sketch, who benefits, risks.
+
+---
+
+#### Pass A (P0): `DeadCodeEliminationPass` — default **on** (`ir.disableDeadCodeElimination`)
+
+Remove operations that are pure (`isPureOp`, includes `Constant` ops) and have
+zero uses. Iterate to a fixed point within the pass (removing a consumer can
+kill its producers).
+
+Algorithm (per function): compute use counts (reuse `Usages::countUsages`,
+counting operation inputs + invocation arguments); walk blocks in reverse,
+erase zero-use pure non-terminator ops via `BasicBlock::removeOperation`,
+decrement the counts of their inputs, repeat until no change. Block arguments
+are **not** removed here (Pass E owns the arity invariant).
+
+Benefits: sweeps constant-folding residue (dead feeding constants → smaller
+`tbc` constant image → faster every call), strength-reduction residue (the
+dead cast), and trace noise. Reduces `asmjit` vreg pressure. This is the
+enabling pass for everything else.
+
+Risks: none structural — removal of a zero-use pure op cannot invalidate any
+consumer by definition; the #327-style hazard (dangling pointers) is exactly
+what the verifier's stale-pointer check catches.
+
+---
+
+#### Pass B (P0): `AlgebraicSimplificationPass` — default **on** (`ir.disableAlgebraicSimplification`)
+
+Local, pattern-per-op rewrites; each either replaces the op's uses with an
+existing operand (then the op dies in DCE) or folds it to a constant:
+
+- Additive/multiplicative identities: `x+0`, `0+x`, `x-0`, `x*1`, `1*x`,
+  `x/1` → `x`; `x*0`, `0*x` → `0` (integers only; float `0*x` is **not**
+  folded — NaN/−0.0); `x-x` → `0` (integers only).
+- Bitwise: `x&x`, `x|x` → `x`; `x^x` → `0`; `x&0` → `0`; `x|0`, `x^0`,
+  `x<<0`, `x>>0` → `x`.
+- Boolean: `and(x,true)` → `x`, `and(x,false)` → `false`, `or` duals,
+  `not(not(x))` → `x`, `not(compare)` → inverted comparator.
+- Casts: cast to the identical stamp → operand; cast-of-cast collapse only
+  when provably lossless (widening chain of same signedness, or inner width ≥
+  outer width for truncations); anything else left alone.
+- `select(constBool, a, b)` → `a`/`b`; `select(c, x, x)` → `x`.
+- **Canonicalization: constant operand to the right** for commutative ops
+  (`add`, `mul`, `and`, `or`, `xor`, `eq`, `ne` — with comparator swap for
+  ordered compares). This directly widens the reach of the existing backend
+  immediate-folding optimizations, which only inspect the **right** operand
+  (`tbc.immediates`; asmjit x64 immediate folding).
+
+`ptr + 0` (any pointer-typed add with integer constant 0) → base pointer —
+this specifically removes the strength-reduction residue.
+
+Benefits: all three backends, 1 dispatch/instruction per hit per execution;
+canonicalization multiplies the value of existing backend optimizations.
+
+Risks: float semantics (be strictly conservative: only identity folds that
+are IEEE-exact — `x+0.0` is *not* safe for −0.0, so skip float additive
+identities entirely in v1); signedness of shifts and compares. Every rule
+gets a differential-fuzzer soak (§5).
+
+---
+
+#### Pass C (P0): `ConstantBranchFoldingPass` + unreachable-block removal — default **on** (`ir.disableConstantBranchFolding`)
+
+Two coupled steps, one pass:
+
+1. Every `IfOperation` whose condition is a `ConstBooleanOperation` is
+   replaced (via `replaceTerminatorOperation`) with a `BranchOperation` that
+   adopts the taken side's `BasicBlockInvocation` (target + arguments). The
+   not-taken edge's predecessor entry is removed. Also: `IfOperation` whose
+   true and false invocations target the same block **with identical argument
+   lists** → `BranchOperation`.
+2. Unreachable-block sweep: DFS from the entry block; any unreached block is
+   detached from `FunctionOperation`'s block list (arena reclaims memory at
+   compile end; predecessor lists of reachable blocks are already correct
+   because step 1 removed the edges).
+
+Closes the loop that constant folding opens: today `compare(c1,c2)` folds to
+a constant that still drives a *conditional* branch at runtime. After this
+pass the branch is unconditional, the dead arm disappears, and
+`EmptyBlockElimination`/block merging collapse the rest.
+
+Benefits: interpreters lose a conditional-dispatch per execution and whole
+dead regions; asmjit loses dead code and the branch. Especially valuable for
+traced code with configuration-like constants.
+
+Risks: predecessor-list bookkeeping (mitigated by 4.1(3) + verifier); entry
+block must never be removed.
+
+---
+
+#### Pass D (P1): `BlockMergingPass` — default **on** (`ir.disableBlockMerging`)
+
+If block `p` ends in an unconditional `BranchOperation` targeting `s`, and `s`
+has exactly one predecessor (`p`) and `s != p`: rewrite every use of each of
+`s`'s block arguments to the corresponding invocation argument (via
+`replaceAllUses`), splice `s`'s non-terminator operations onto the end of `p`
+(replacing `p`'s branch), adopt `s`'s terminator, fix successor predecessor
+lists, delete `s`. Iterate to fixed point (chains collapse).
+
+This is the generalization of `EmptyBlockEliminationPass` for the
+single-predecessor case; the empty-block pass remains for the
+multi-predecessor case it uniquely handles. Long term the two could unify;
+not required now.
+
+Benefits: one `JMP` dispatch + one full set of edge-copy `MOV`s per execution
+per merged block — trace-generated IR is full of these seams. asmjit: shorter
+code, fewer merged-value shuffles (#321 territory).
+
+Risks: use-rewriting must cover invocation arguments (use `replaceAllUses`,
+nothing hand-rolled); ordering with Pass C (run after, so unreachable blocks
+don't get merged pointlessly).
+
+---
+
+#### Pass E (P1): `BlockArgumentPruningPass` — default **on** (`ir.disableBlockArgumentPruning`)
+
+Two prunes per block (skip the entry block — its arguments are the function
+ABI):
+
+1. **Unused argument**: a block argument with zero uses in its block
+   (including transitively via invocation args — use counts again). Remove
+   the argument *and* the corresponding argument slot from **every**
+   predecessor invocation targeting the block.
+2. **Same-value pass-through**: every predecessor passes the *identical*
+   `Operation*` `v` for the slot, and `v`'s defining block dominates the
+   target block (Dominators helper; block arguments count as defined in their
+   block). Replace all uses of the argument with `v`, then remove the slot as
+   in (1). This is the SSA-phi-elimination analog and it is what deletes
+   loop-invariant loop-carried arguments (preheader and latch both pass `v`).
+
+Benefits: each pruned slot is a per-edge-execution `MOV` in `bc`/`tbc` (per
+**iteration** for loop headers) and a register freed in all three backends.
+Also shrinks `tbc` frame size.
+
+Risks: the arity invariant — argument list and every predecessor invocation
+must change atomically; guarded by the new verifier arity check (4.2(e)).
+Dominance check must be correct for the self-referential case (a loop header
+argument passed back to itself through the latch counts as "same value `v`"
+only if the *other* predecessors agree on `v`; the standard rule: ignore
+self-references when checking agreement).
+
+---
+
+#### Pass F (P2): `LocalCSEPass` — default **on** after measurement (`ir.disableLocalCSE`)
+
+Per-block value numbering over pure ops: key =
+`(opType, stamp, canonicalized operand identities, op-specific payload —
+comparator, cast target, shift kind…)`. On a hit, `replaceAllUses(dup, first)`
+and let DCE remove it. Commutative ops normalize operand order (Pass B's
+canonicalization already helps). Memory ops excluded in v1 (no alias
+analysis); do **not** CSE loads.
+
+Scope note: block-local only. A dominator-scoped CSE is a straightforward
+extension using 4.2(d) but v1 stays local — trace IR has long straight-line
+blocks after Pass D, which is where the duplicates live.
+
+---
+
+#### Pass G (P2): `LoopInvariantCodeMotionPass` — default **off** initially (`ir.enableLICM`)
+
+Reuse and extract the natural-loop recognizer from `StrengthReductionPass`
+(single preheader + single latch) into a shared helper. Hoist a pure op into
+the preheader when all its operands are defined outside the loop (or already
+hoisted). **Never** hoist `DivOp`/`ModOp` (they trap on zero — speculation
+across the loop-taken check is unsound when the loop body would not have
+executed) unless the divisor is a non-zero constant. Loads are not hoisted in
+v1 (no alias analysis).
+
+Benefits: interpreters save `(hoisted ops) × (iterations − 1)` dispatches —
+the highest per-hit payoff of any pass here; asmjit saves re-computation.
+
+Risks: highest of the set — correctness depends on the loop matcher and the
+speculation policy; hence opt-in first, promote to default after a fuzz soak
+and benchmark sweep.
+
+---
+
+#### Enablement: `StrengthReductionPass` default **on**
+
+After A + B land (they remove exactly the residue documented in
+`StrengthReductionPass.hpp`), re-benchmark on `bc`, `tbc`, and `asmjit`. If
+the regression is gone, flip the default (`ir.enableStrengthReduction` →
+`ir.disableStrengthReduction`, keeping the old option recognized or migrating
+it — grep consumers). If it still regresses the interpreters, keep it opt-in
+and record the numbers in the pass header.
+
+---
+
+#### Explicitly deferred (documented, not designed here)
+
+- **If-to-Select** for tiny diamonds (backends have `SelectOperation`
+  support; `tbc` has a fused `SELECT`): promising but needs a cost heuristic;
+  revisit after P0–P2 numbers exist.
+- Dominator-scoped CSE, load CSE / redundant-load elimination (needs an
+  aliasing story), ProxyCall inlining, sparse conditional constant
+  propagation.
+
+### 4.4 Pipeline
+
+```
+compileToIR:
+  … existing tracing / SSA / IR generation …
+  if ir.runPasses (default true):
+    FixedPointGroup (maxIterations = ir.maxPipelineIterations, default 4):
+      1. ConstantFoldingAndCopyPropagation   (existing)
+      2. AlgebraicSimplification             (B)
+      3. ConstantBranchFolding + unreachable (C)
+      4. EmptyBlockElimination               (existing)
+      5. BlockMerging                        (D)
+      6. LocalCSE                            (F, once defaulted)
+      7. DeadCodeElimination                 (A)
+      8. BlockArgumentPruning                (E)
+    Then (outside the group, single-shot):
+      9. LICM                                (G, opt-in)
+     10. StrengthReduction (+ one more Simplify/DCE round if it changed)
+```
+
+Ordering rationale: folding creates constants → simplification canonicalizes
+and exposes constant conditions → branch folding kills edges → CFG cleanup
+merges what remains → CSE dedupes the longer straight-line blocks → DCE
+sweeps everything the previous passes orphaned → arg pruning last because
+every CFG change can strand arguments. The group loops because each pass
+feeds the ones "above" it on the next iteration; 4 iterations is empirically
+generous for trace-shaped IR (validate via the new
+`irPasses.pipelineIterations` statistic; the group is convergent because every
+pass strictly shrinks blocks/ops/args or is a no-op — canonicalization must
+use a strict order test so it cannot ping-pong).
+
+All new default-on passes follow the existing option convention
+(`ir.disableX`), opt-in passes use `ir.enableX` (see
+`LegacyCompiler.cpp:163-180`). Document all new options in `docs/options.md`.
+
+## 5. Testing & validation strategy
+
+Layered, matching what the repo already has:
+
+1. **Unit tests** — one `test/ir-pass-tests/<Pass>Test.cpp` per pass, built on
+   `IRGraphFixtures.hpp` (extend fixtures as needed: loop graph, diamond
+   graph, dead-op graph). Every test runs the manager with
+   `ir.verifyAfterEachPass = true` and `ir.failOnVerifyError = true`.
+   Idempotence test per pass: run twice, assert the second run reports
+   no change. Negative tests matter as much as positive ones (float `0*x`
+   NOT folded; div NOT hoisted; entry block args NOT pruned; self-loop
+   handling).
+2. **Verifier tests** — the new arity check gets its own
+   `IRVerifierTest.cpp` cases.
+3. **Whole-suite execution** — the full execution/val/tracing suites already
+   run across every backend (`availableBackends()`); they must pass with the
+   new defaults on. This is the primary miscompile net for `mlir`/`cpp` too.
+4. **Differential fuzzer** — `nautilus-fuzz-replay` smoke corpus in CI-like
+   runs during development; a longer `nautilus-fuzz` soak (≥ an hour) before
+   flipping any pass default. The fuzzer generates loops, casts, selects and
+   all ten numeric domains — precisely the risk surface of passes B/E/G. Add
+   a fuzz configuration that runs with each new pass individually disabled to
+   bisect any finding quickly.
+5. **Benchmarks** — `test/benchmark/ExecutionBenchmark.cpp` on `tbc`, `bc`,
+   `asmjit` (Release, Clang 21), before/after per pass and for the final
+   pipeline. Record numbers in the PR description. Acceptance gate for
+   default-on: no kernel regresses > 2% on any of the three backends, and the
+   targeted kernels improve.
+6. **Statistics as regression tripwire** — `ir.operations` /
+   per-pass deltas via `engine.logStatistics` provide static-count evidence
+   (e.g. "DCE removes N ops on the fibonacci kernel") that is stable across
+   machines, unlike wall clock.
+
+## 6. Rollout plan
+
+Land in small PRs, in dependency order; every PR leaves `main` green with
+defaults unchanged until the measurement gate passes:
+
+1. **PR-0** Infrastructure: `apply()`→`bool`, fixed-point groups,
+   `RewriteUtil`, verifier arity check, `Dominators`. Pure refactor +
+   additive; no behavior change (group of existing passes with maxIter 1
+   reproduces today's pipeline bit-for-bit).
+2. **PR-1** DCE (A) — default on immediately (risk is minimal, effect is
+   large and strictly shrinking).
+3. **PR-2** AlgebraicSimplification (B) — default on after fuzz soak.
+4. **PR-3** ConstantBranchFolding + unreachable removal (C).
+5. **PR-4** BlockMerging (D).
+6. **PR-5** BlockArgumentPruning (E).
+7. **PR-6** StrengthReduction default flip (measurement PR; may be a no-op).
+8. **PR-7** LocalCSE (F).
+9. **PR-8** LICM (G) — opt-in; separate default-flip PR after soak.
+
+Each pass PR: pass + unit tests + options.md entry + benchmark numbers in the
+description. The companion playbook encodes this as agent milestones.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stale consumer pointers after replacement (repeat of #327) | Single `replaceAllUses` utility; verifier stale-pointer check runs after every pass in all tests |
+| Block-arg / invocation arity drift | New verifier arity check (4.2(e)); pruning is the only pass allowed to change arity |
+| Float semantics broken by simplification | Conservative rule set (no float additive identities, no float `x*0`); fuzzer float domains |
+| Dispatch-bound cost-model regressions (StrengthReduction lesson) | Per-backend benchmark gate before any default flips; every pass individually disableable |
+| Pass-group non-termination / ping-ponging | Strict-decrease or strict-canonical-order rules per rewrite; hard `maxIterations` bound; iteration-count statistic |
+| Predecessor-list cache drift mid-pipeline | Passes must use the wiring helpers; verifier checks pred/succ symmetry |
+| Compile-time growth (Nautilus compiles per query) | Per-pass `ms` statistics already recorded; budget: full pipeline ≤ 15% of `frontend.totalMs` on the benchmark suite |
+
+## 8. Success metrics
+
+- `exec_tbc_*` / `exec_bc_*` / asmjit benchmark kernels: measurable wall-clock
+  improvement on loop kernels (target: ≥ 10% on at least the pointer/loop
+  kernels once D+E+G land; A–C alone may be small on the existing kernels —
+  their payoff is on trace-noise-heavy real workloads, tracked via op-count
+  deltas).
+- `ir.operations` after passes reduced vs. baseline on the test-data corpus.
+- `StrengthReductionPass` default-on with no interpreter regression.
+- Zero new fuzzer findings attributable to the passes after soak.


### PR DESCRIPTION
## What

Adds three documents under `docs/design/`:

- **`ir-pass-improvements.md`** — a design for extending the IR pass pipeline, targeted at the backends that lower Nautilus IR literally and therefore have no downstream optimizer: `asmjit` (post-RA peephole only), `bc`, and `tbc` (one interpreter dispatch per surviving IR op, per execution).
- **`ir-abstraction-milestone.md`** — the initial milestone (IR-0): hardening the IR abstraction itself before any new pass lands. Specifies a `Dominators` helper, a `FunctionRewriter` mutation facade (uniform use tracking across operand and invocation-argument edges, safe erase with dead-chain cascade, fresh-identifier minting, atomic block-argument mutation, CFG rewiring), and six new verifier invariants — each as a numbered requirement with named acceptance tests, plus a behavior-preserving retrofit of the three existing passes as the proof-of-fit gate.
- **`ir-pass-improvements-agent-playbook.md`** — milestone-by-milestone implementation instructions for a follow-up implementation agent (build/test commands, per-pass definition of done, invariant traps learned from #321/#327).

## Why

For `bc`/`tbc` the cost model is dispatch-bound: every dead or redundant IR op is a wasted dispatch on every call and loop iteration, dead constants inflate the per-call constant-image `memcpy` in `tbc`, and redundant block arguments are per-iteration parallel-copy MOVs. For `asmjit`, IR op count maps 1:1 to instructions and register pressure. The current pipeline (constant folding, empty-block elimination, opt-in strength reduction) has no DCE, simplification, branch folding, block merging, or block-arg pruning — `StrengthReductionPass` is default-off today precisely because nothing cleans up its `ptr+0`/dead-cast residue.

The abstraction milestone exists because every planned pass performs the same five mutations (replace uses, erase, create/insert, change block-arg arity, rewire edges), and today each is missing, unsafe, or reinvented per pass: def→use edges don't exist (folding rescans the function per fixed-point round), invocation operands are invisible to generic traversal (the root of #327), identifier minting is hand-rolled per pass (the root of #321), block-argument arity is a two-sided invariant with no owner, and the verifier cannot see any of these bug classes.

## Tracking issues

Four milestone issues (each covers several small PRs):

| Milestone | Issue |
|---|---|
| IR-0 — IR abstraction hardening + pass-manager infrastructure | #338 |
| P0 — DCE, algebraic simplification, constant branch folding | #342 |
| P1 — block merging, block-argument pruning | #345 |
| P2 — StrengthReduction default flip, LocalCSE, LICM | #347 |

## Proposal summary

Phased, each pass option-gated and benchmark-gated before defaulting on:

1. **Milestone IR-0** (#338): verifier completion (arity, id uniqueness, SSA dominance, predecessor multiset, entry ABI, edge stamps) → `FunctionRewriter` → retrofit of existing passes → pass-manager mechanics (changed-flags, fixed-point groups).
2. **P0 passes** (#342): dead code elimination, algebraic simplification (incl. const-to-right canonicalization that widens the existing `tbc.immediates`/asmjit immediate folding), constant branch folding + unreachable-block removal.
3. **P1 passes** (#345): single-predecessor block merging, block-argument pruning (unused + same-value pass-through, which deletes loop-invariant carried args).
4. **P2** (#347): StrengthReduction default-flip measurement, local CSE, LICM (opt-in first).

Validation strategy leans on the existing layers: `test/ir-pass-tests` unit tests with verify-after-each-pass, the cross-backend execution suite, the differential AST fuzzer, and `ExecutionBenchmark` gates on all three target backends.

## Notes

- Docs only — no code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6cwMeCYXgN7pWhQNQ6zb