### PR TITLE
tbc: dead-MOV elimination and LOAD_off/STORE_off memory-offset superinstructions

### DIFF
--- a/nautilus/src/nautilus/compiler/DumpHandler.cpp
+++ b/nautilus/src/nautilus/compiler/DumpHandler.cpp
@@ -29,6 +29,7 @@ bool DumpHandler::shallCreateFolder() const {
 	generallyDump = generallyDump or shouldDump("after_llvm_generation");
 	generallyDump = generallyDump or shouldDump("after_cpp_generation");
 	generallyDump = generallyDump or shouldDump("after_bc_generation");
+	generallyDump = generallyDump or shouldDump("after_tbc_generation");
 	generallyDump = generallyDump or shouldDump("after_asmjit_generation");
 	generallyDump = generallyDump or shouldDump("after_asmjit_assembly");
 	return generallyDump and dumpToFile();

--- a/nautilus/src/nautilus/compiler/backends/tbc/README.md
+++ b/nautilus/src/nautilus/compiler/backends/tbc/README.md
@@ -178,13 +178,28 @@ Other options: `tbc.dispatch` (see above), `tbc.stackSizeKb` (default 1024),
   `ExecutionBenchmark.cpp` are pure arithmetic/loop kernels with no internal
   or external calls, so they can't exercise the one path that benefits —
   don't read "flat" there as the change being ineffective.
-- **Memory-offset superinstructions** (`LOAD_off` / `STORE_off`): fuse
-  `add ptr, const` feeding a single-use load/store — the dominant
-  query-compilation access pattern. Needs a small local dataflow check in the
-  flattener.
-- **Dead-MOV elimination after immediate folding**: folding leaves the
-  constant's `MOV_imm` behind when it has no other uses; a cheap liveness
-  pass over the flat stream could drop it.
+- ~~**Memory-offset superinstructions** (`LOAD_off` / `STORE_off`)~~ — done:
+  the flattener now fuses a single-use `ptr + const` immediately preceding a
+  `LOAD`/`STORE` into one instruction, once the add's own constant has been
+  immediate-folded (pointer arithmetic previously fell outside immediate
+  folding's `i32`/`i64` type check even though it emits the identical
+  `ADD_i64`; that check now also accepts `Type::ptr`). Detection matches the
+  existing compare-and-branch fusion's pattern: single-use (via the
+  lowering's existing use-count map) and adjacency in the emitted stream (so
+  nothing could have reused the base pointer's register in between) are both
+  required before fusing. Only `ptr + const` is handled, matching the exact
+  gap described above — `ptr - const` is not (would need `SUB_imm_i64`
+  matched the same way). Offsets beyond `int16_t` (`±32768`) fall back to a
+  plain `LOAD`/`STORE` fed by an unfused `ADD`, same as any other constant
+  too large to fold.
+- ~~**Dead-MOV elimination after immediate folding**~~ — done, and it now
+  generalizes to more than `MOV_imm`: the flattener tracks, per block, a set
+  of "drop this instruction" indices (originally just the trailing compare
+  in a fused branch) and any immediate-folded constant that was materialized
+  by a now-single-use `MOV_imm` adds its site to that set. Memory-offset
+  fusion above reuses the same set to drop the fused-away `ADD_imm_i64`, so
+  a `ptr + const` feeding a `LOAD`/`STORE` collapses from three instructions
+  (`MOV_imm`, `ADD`, `LOAD`/`STORE`) to one.
 - **Zero-dependency typed call thunks**: replace outgoing dyncall with
   template-instantiated callers selected at lowering time (signatures are
   statically known). Requires a register-only argument cap and care with the

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCHandlers.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCHandlers.hpp
@@ -141,6 +141,25 @@ inline void opStore(const Instr& i, uint64_t* fp) {
 	std::memcpy(reinterpret_cast<void*>(fp[i.a]), &value, sizeof(T));
 }
 
+/// Memory-offset superinstructions: fold a single-use `ptr + const` feeding a
+/// load/store into the base register plus a sign-extended 16-bit immediate,
+/// avoiding the separate ADD and its result register (LOAD_off: a=dst,
+/// b=base, c=offset; STORE_off: a=base, b=value, c=offset).
+template <class T>
+inline void opLoadOff(const Instr& i, uint64_t* fp) {
+	T value;
+	const uint64_t addr = fp[i.b] + static_cast<uint64_t>(static_cast<int64_t>(static_cast<int16_t>(i.c)));
+	std::memcpy(&value, reinterpret_cast<const void*>(addr), sizeof(T));
+	writeReg<T>(fp, i.a, value);
+}
+
+template <class T>
+inline void opStoreOff(const Instr& i, uint64_t* fp) {
+	T value = readReg<T>(fp, i.b);
+	const uint64_t addr = fp[i.a] + static_cast<uint64_t>(static_cast<int64_t>(static_cast<int16_t>(i.c)));
+	std::memcpy(reinterpret_cast<void*>(addr), &value, sizeof(T));
+}
+
 template <class T>
 inline void opBand(const Instr& i, uint64_t* fp) {
 	writeReg<T>(fp, i.a, static_cast<T>(readReg<T>(fp, i.b) & readReg<T>(fp, i.c)));

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -79,6 +79,19 @@ Op immFormOf(Op op) {
 	}
 }
 
+/// Map a LOAD/STORE opcode to its memory-offset form (LOAD_off/STORE_off),
+/// which encodes `base + imm16` instead of reading the offset from a separate
+/// register (Op::COUNT = not a LOAD/STORE opcode).
+Op memOffsetFormOf(Op op) {
+	if (opIndex(op) >= opIndex(Op::LOAD_i8) && opIndex(op) <= opIndex(Op::LOAD_b)) {
+		return static_cast<Op>(opIndex(Op::LOAD_off_i8) + (opIndex(op) - opIndex(Op::LOAD_i8)));
+	}
+	if (opIndex(op) >= opIndex(Op::STORE_i8) && opIndex(op) <= opIndex(Op::STORE_b)) {
+		return static_cast<Op>(opIndex(Op::STORE_off_i8) + (opIndex(op) - opIndex(Op::STORE_i8)));
+	}
+	return Op::COUNT;
+}
+
 /// Map an i32/i64 comparison opcode to the fused compare-and-branch form
 /// (Op::COUNT = not fusable).
 Op fusedFormOf(Op op) {
@@ -123,6 +136,17 @@ struct Terminator {
 	uint16_t retReg = kNoReg;
 };
 
+/// A foldable arithmetic op (index into `code`, immediate), plus — when the
+/// folded constant was materialized by a standalone MOV_imm with no other
+/// use — where that MOV_imm lives, so the flattener can drop it too.
+struct FoldableImmediate {
+	uint32_t codeIndex;
+	int16_t immediate;
+	bool hasDeadMovSite = false;
+	uint32_t deadMovBlock = 0;
+	uint32_t deadMovIndex = 0;
+};
+
 struct BlockCode {
 	std::vector<Instr> code;
 	Terminator term;
@@ -130,10 +154,17 @@ struct BlockCode {
 	// single-use comparison; the flattener may fuse the trailing compare into
 	// the branch (mirrors bc's fuseCompareIntoBranch).
 	bool fuseCompareIntoBranch = false;
-	// (index into `code`, immediate) pairs recorded for arithmetic ops whose
-	// right operand is a small integer constant (mirrors bc's
-	// foldableImmediates).
-	std::vector<std::pair<uint32_t, int16_t>> foldableImmediates;
+	// Arithmetic ops whose right operand is a small integer constant.
+	std::vector<FoldableImmediate> foldableImmediates;
+	// (LOAD/STORE codeIndex, ptr-add codeIndex) pairs where the add is this
+	// block's immediate predecessor instruction and computes this op's
+	// address; eligible for LOAD_off/STORE_off fusion once the add's
+	// immediate has been folded.
+	std::vector<std::pair<uint32_t, uint32_t>> fusableMemOps;
+	// Instruction indices the flattener must drop: dead MOV_imms (immediate
+	// folding absorbed their only use) and ptr-adds absorbed into a
+	// LOAD_off/STORE_off.
+	std::unordered_set<uint32_t> deadIndices;
 };
 
 using RegisterFrame = Frame<ir::OperationIdentifier, uint16_t>;
@@ -247,6 +278,14 @@ private:
 	std::unordered_map<ir::OperationIdentifier, int> usageCounts;
 	std::unordered_set<ir::OperationIdentifier> functionArgs;
 	std::vector<uint16_t> functionAllocaSlots;
+	// Where a small-constant's standalone MOV_imm landed (block, codeIndex);
+	// consulted when the constant is later folded into an immediate to see if
+	// the MOV_imm became dead.
+	std::unordered_map<ir::OperationIdentifier, std::pair<uint32_t, uint32_t>> movImmSites;
+	// Where a pointer-typed ADD's own instruction landed (block, codeIndex);
+	// consulted by a directly-following LOAD/STORE to detect a fusable
+	// `ptr + const` address computation.
+	std::unordered_map<ir::OperationIdentifier, std::pair<uint32_t, uint32_t>> ptrAddSites;
 
 	void emit(int block, Op op, uint16_t a, uint16_t b = 0, uint16_t c = 0) {
 		blocks[block].code.push_back(Instr {opIndex(op), a, b, c});
@@ -355,6 +394,8 @@ private:
 		frame.setValue(opt->getIdentifier(), target);
 		const int idx = intTypeIndex(type == Type::b ? Type::ui8 : type);
 		if (idx >= 0 && value >= -32768 && value <= 32767) {
+			movImmSites[opt->getIdentifier()] = {static_cast<uint32_t>(block),
+			                                     static_cast<uint32_t>(blocks[block].code.size())};
 			emit(block, typedOp(Op::MOV_imm_i8, idx, "const"), target, 0, static_cast<uint16_t>(value));
 			return;
 		}
@@ -393,9 +434,15 @@ private:
 
 	/// Record the arithmetic op about to be emitted as immediate-foldable when
 	/// its right operand is an i32/i64 constant fitting 16 bits (port of bc's
-	/// recordFoldableImmediate).
+	/// recordFoldableImmediate). Pointer arithmetic runs as i64 (see
+	/// arithTypeIndex) and emits the identical ADD_i64/SUB_i64 opcodes, so
+	/// `ptr + const`/`ptr - const` fold the same way — this is what lets
+	/// LOAD_off/STORE_off fusion below find an already-folded ADD_imm_i64. If
+	/// the folded constant was materialized by a standalone MOV_imm and this
+	/// is its only use, folding will leave the MOV_imm dead — record where it
+	/// is so the flattener can drop it once the fold actually happens.
 	void recordFoldableImmediate(int block, ir::Operation* rightInput, Type type) {
-		if (type != Type::i32 && type != Type::i64) {
+		if (type != Type::i32 && type != Type::i64 && type != Type::ptr) {
 			return;
 		}
 		const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(rightInput);
@@ -406,8 +453,17 @@ private:
 		if (value < -32768 || value > 32767) {
 			return;
 		}
-		blocks[block].foldableImmediates.emplace_back(static_cast<uint32_t>(blocks[block].code.size()),
-		                                              static_cast<int16_t>(value));
+		FoldableImmediate entry;
+		entry.codeIndex = static_cast<uint32_t>(blocks[block].code.size());
+		entry.immediate = static_cast<int16_t>(value);
+		const auto siteIt = movImmSites.find(constInt->getIdentifier());
+		const auto usageIt = usageCounts.find(constInt->getIdentifier());
+		if (siteIt != movImmSites.end() && usageIt != usageCounts.end() && usageIt->second == 1) {
+			entry.hasDeadMovSite = true;
+			entry.deadMovBlock = siteIt->second.first;
+			entry.deadMovIndex = siteIt->second.second;
+		}
+		blocks[block].foldableImmediates.push_back(entry);
 	}
 
 	template <class OperationType>
@@ -428,7 +484,11 @@ private:
 
 	void visitAdd(ir::AddOperation* opt, int block, RegisterFrame& frame) {
 		recordFoldableImmediate(block, opt->getRightInput(), opt->getStamp());
+		const auto codeIndex = static_cast<uint32_t>(blocks[block].code.size());
 		lowerBinary(opt, block, frame, Op::ADD_i8, arithTypeIndex(opt->getStamp()), "add");
+		if (opt->getStamp() == Type::ptr) {
+			ptrAddSites[opt->getIdentifier()] = {static_cast<uint32_t>(block), codeIndex};
+		}
 	}
 
 	void visitSub(ir::SubOperation* opt, int block, RegisterFrame& frame) {
@@ -536,8 +596,45 @@ private:
 		return idx;
 	}
 
+	/// Record the LOAD/STORE about to be emitted at `memIndex` as eligible for
+	/// memory-offset fusion when its address is a single-use `ptr + const`
+	/// that is this block's immediate predecessor instruction — adjacency
+	/// guarantees nothing could have reused the base pointer's register in
+	/// between, and the single-use check (via usageCounts, checked before
+	/// useValue() below decrements it) guarantees no other consumer still
+	/// needs the add's result register once it is fused away.
+	void recordFusableMemOp(int block, uint32_t memIndex, const ir::Operation* address) {
+		if (!options.enableSuperinstructions || !options.enableImmediates || memIndex == 0) {
+			return;
+		}
+		const auto* addOp = ir::dyn_cast<ir::AddOperation>(address);
+		if (addOp == nullptr || addOp->getStamp() != Type::ptr) {
+			return;
+		}
+		const auto* constInt = ir::dyn_cast<ir::ConstIntOperation>(addOp->getRightInput());
+		if (constInt == nullptr) {
+			return;
+		}
+		const int64_t value = constInt->getValue();
+		if (value < -32768 || value > 32767) {
+			return;
+		}
+		const auto siteIt = ptrAddSites.find(addOp->getIdentifier());
+		if (siteIt == ptrAddSites.end() || siteIt->second.first != static_cast<uint32_t>(block) ||
+		    siteIt->second.second != memIndex - 1) {
+			return;
+		}
+		const auto usageIt = usageCounts.find(addOp->getIdentifier());
+		if (usageIt == usageCounts.end() || usageIt->second != 1) {
+			return;
+		}
+		blocks[block].fusableMemOps.emplace_back(memIndex, memIndex - 1);
+	}
+
 	void visitLoad(ir::LoadOperation* opt, int block, RegisterFrame& frame) {
 		const auto address = frame.getValue(opt->getAddress()->getIdentifier());
+		const auto codeIndex = static_cast<uint32_t>(blocks[block].code.size());
+		recordFusableMemOp(block, codeIndex, opt->getAddress());
 		useValue(opt->getAddress()->getIdentifier(), frame);
 		const auto result = getResultRegister(opt, frame);
 		frame.setValue(opt->getIdentifier(), result);
@@ -547,6 +644,8 @@ private:
 	void visitStore(ir::StoreOperation* opt, int block, RegisterFrame& frame) {
 		const auto address = frame.getValue(opt->getAddress()->getIdentifier());
 		const auto value = frame.getValue(opt->getValue()->getIdentifier());
+		const auto codeIndex = static_cast<uint32_t>(blocks[block].code.size());
+		recordFusableMemOp(block, codeIndex, opt->getAddress());
 		useValue(opt->getAddress()->getIdentifier(), frame);
 		useValue(opt->getValue()->getIdentifier(), frame);
 		emit(block, typedOp(Op::STORE_i8, memTypeIndex(opt->getValue()->getStamp(), "store"), "store"), address, value);
@@ -876,16 +975,49 @@ private:
 		const uint32_t allocaSlots = out.allocaBytes > 0 ? (out.allocaBytes + 7) / 8 + 2 : 0;
 		out.frameSlots = 3 + regCount + allocaSlots;
 
-		// Fold recorded immediates into the arithmetic ops.
+		// Fold recorded immediates into the arithmetic ops. A folded constant
+		// that was materialized by its own now-unused MOV_imm drops that
+		// instruction too.
 		if (options.enableImmediates) {
 			for (auto& blk : blocks) {
-				for (const auto& [index, immediate] : blk.foldableImmediates) {
-					Instr& inst = blk.code[index];
+				for (const auto& imm : blk.foldableImmediates) {
+					Instr& inst = blk.code[imm.codeIndex];
 					const Op immOp = immFormOf(static_cast<Op>(inst.op));
 					if (immOp != Op::COUNT) {
 						inst.op = opIndex(immOp);
-						inst.c = static_cast<uint16_t>(immediate);
+						inst.c = static_cast<uint16_t>(imm.immediate);
+						if (imm.hasDeadMovSite) {
+							blocks[imm.deadMovBlock].deadIndices.insert(imm.deadMovIndex);
+						}
 					}
+				}
+			}
+		}
+
+		// Fuse a single-use `ptr + const` immediately preceding a LOAD/STORE
+		// into LOAD_off/STORE_off, once the add's own immediate has been
+		// folded above (memory-offset superinstructions).
+		if (options.enableSuperinstructions && options.enableImmediates) {
+			for (auto& blk : blocks) {
+				for (const auto& [memIndex, addIndex] : blk.fusableMemOps) {
+					const Instr& addInst = blk.code[addIndex];
+					if (static_cast<Op>(addInst.op) != Op::ADD_imm_i64) {
+						continue; // the add's constant didn't end up folded; leave both instructions intact
+					}
+					Instr& memInst = blk.code[memIndex];
+					const Op offOp = memOffsetFormOf(static_cast<Op>(memInst.op));
+					if (offOp == Op::COUNT) {
+						continue;
+					}
+					const bool isLoad = opIndex(static_cast<Op>(memInst.op)) <= opIndex(Op::LOAD_b);
+					if (isLoad) {
+						memInst.b = addInst.b;
+					} else {
+						memInst.a = addInst.b;
+					}
+					memInst.c = addInst.c;
+					memInst.op = opIndex(offOp);
+					blk.deadIndices.insert(addIndex);
 				}
 			}
 		}
@@ -910,7 +1042,12 @@ private:
 			auto& blk = blocks[b];
 			const bool fuse = shouldFuse(blk);
 			const std::size_t bodyCount = blk.code.size() - (fuse ? 1 : 0);
-			codeOut.insert(codeOut.end(), blk.code.begin(), blk.code.begin() + static_cast<long>(bodyCount));
+			for (std::size_t i = 0; i < bodyCount; ++i) {
+				if (blk.deadIndices.count(static_cast<uint32_t>(i)) > 0) {
+					continue;
+				}
+				codeOut.push_back(blk.code[i]);
+			}
 
 			const int next = static_cast<int>(b) + 1;
 			switch (blk.term.kind) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCOpcodes.hpp
@@ -121,6 +121,10 @@ namespace nautilus::compiler::tbc {
 	X(LOAD_b, (opLoad<bool>) )                                                                                         \
 	TBC_NUM10(X, STORE, opStore)                                                                                       \
 	X(STORE_b, (opStore<bool>) )                                                                                       \
+	TBC_NUM10(X, LOAD_off, opLoadOff)                                                                                  \
+	X(LOAD_off_b, (opLoadOff<bool>) )                                                                                  \
+	TBC_NUM10(X, STORE_off, opStoreOff)                                                                                \
+	X(STORE_off_b, (opStoreOff<bool>) )                                                                                \
 	TBC_INT8(X, BAND, opBand)                                                                                          \
 	TBC_INT8(X, BOR, opBor)                                                                                            \
 	TBC_INT8(X, BXOR, opBxor)                                                                                          \
@@ -201,6 +205,8 @@ static_assert(opIndex(Op::NE_i8) == opIndex(Op::EQ_i8) + 10);
 static_assert(opIndex(Op::GE_f64) == opIndex(Op::EQ_i8) + 59);
 static_assert(opIndex(Op::LOAD_b) == opIndex(Op::LOAD_i8) + 10);
 static_assert(opIndex(Op::STORE_b) == opIndex(Op::STORE_i8) + 10);
+static_assert(opIndex(Op::LOAD_off_b) == opIndex(Op::LOAD_off_i8) + 10);
+static_assert(opIndex(Op::STORE_off_b) == opIndex(Op::STORE_off_i8) + 10);
 static_assert(opIndex(Op::CAST_f64_f64) == opIndex(Op::CAST_i8_i8) + 99);
 static_assert(opIndex(Op::MOV_imm_ui64) == opIndex(Op::MOV_imm_i8) + 7);
 static_assert(opIndex(Op::CJMP_GE_i64) == opIndex(Op::CJMP_EQ_i32) + 11);

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NAUTILUS_EXECUTION_TEST_SOURCES
         BCDispatchModeTest.cpp
         BCRegisterCoalescingTest.cpp
         TBCDispatchModeTest.cpp
+        TBCMemoryOffsetTest.cpp
         BoolExecutionTest.cpp
         CastExecutionTest.cpp
         CompilationStatisticsTest.cpp

--- a/nautilus/test/execution-tests/TBCMemoryOffsetTest.cpp
+++ b/nautilus/test/execution-tests/TBCMemoryOffsetTest.cpp
@@ -1,0 +1,178 @@
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include "nautilus/val_ptr.hpp"
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+
+// Covers two tbc backend follow-ups (see
+// src/nautilus/compiler/backends/tbc/README.md, "Follow-ups"): dead-MOV
+// elimination after immediate folding, and LOAD_off/STORE_off memory-offset
+// superinstructions that fuse a single-use `ptr + const` into the
+// load/store. Both are exercised for correctness across dispatch/lowering
+// variants, and their effect on the emitted instruction stream is checked
+// directly via the after_tbc_generation dump.
+#ifdef ENABLE_TBC_BACKEND
+
+namespace nautilus::engine {
+
+namespace {
+
+struct Record {
+	int64_t a;
+	int64_t b;
+	int64_t c;
+};
+
+// Reads three fields at offsets 0, 8, 16. The address for `b` and `c` is a
+// single-use `ptr + const` immediately feeding a LOAD — fusable into
+// LOAD_off. The constant offsets are also small enough to exercise dead-MOV
+// elimination once folded into the preceding ADD.
+val<int64_t> tbcOffsetLoadSum(val<Record*> p) {
+	val<int64_t> a = p.get(&Record::a);
+	val<int64_t> b = p.get(&Record::b);
+	val<int64_t> c = p.get(&Record::c);
+	return a + b + c;
+}
+
+// Writes three fields at offsets 0, 8, 16 — exercises STORE_off.
+void tbcOffsetStoreFields(val<Record*> p, val<int64_t> a, val<int64_t> b, val<int64_t> c) {
+	p.set(&Record::a, a);
+	p.set(&Record::b, b);
+	p.set(&Record::c, c);
+}
+
+// The offset address is used by two separate loads: the add must survive as
+// a plain ADD/ADD_imm feeding both, rather than being incorrectly fused into
+// just one of them (which would leave the other reading a stale/reused
+// register once the add is dropped).
+val<int64_t> tbcOffsetAddressReused(val<int64_t*> p) {
+	auto advanced = p + 1;
+	val<int64_t> first = *advanced;
+	val<int64_t> second = *advanced;
+	return first + second * 10;
+}
+
+engine::NautilusEngine tbcEngine(const std::string& dispatch, bool superinstructions, bool immediates) {
+	engine::Options options;
+	options.setOption("engine.backend", std::string("tbc"));
+	options.setOption("tbc.dispatch", dispatch);
+	options.setOption("tbc.superinstructions", superinstructions);
+	options.setOption("tbc.immediates", immediates);
+	return engine::NautilusEngine(options);
+}
+
+std::string readFile(const std::filesystem::path& path) {
+	std::ifstream in(path);
+	std::stringstream ss;
+	ss << in.rdbuf();
+	return ss.str();
+}
+
+// DumpHandler writes under $TMPDIR/dump/<compilation-unit-id>/ with no way
+// to override the location, so snapshot the existing subdirs, run the
+// compilation, then read back the one freshly-created after_tbc_generation
+// dump (mirrors DebugInfoExecutionTest.cpp's approach for MLIR IR dumps).
+std::string dumpTbcCode(bool superinstructions, bool immediates) {
+	const auto dumpRoot = std::filesystem::temp_directory_path() / "dump";
+	std::set<std::filesystem::path> existing;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& e : std::filesystem::directory_iterator(dumpRoot)) {
+			existing.insert(e.path());
+		}
+	}
+
+	engine::Options options;
+	options.setOption("engine.backend", std::string("tbc"));
+	options.setOption("tbc.superinstructions", superinstructions);
+	options.setOption("tbc.immediates", immediates);
+	options.setOption("dump.after_tbc_generation", true);
+	NautilusEngine engine(options);
+	auto fn = engine.registerFunction(tbcOffsetLoadSum);
+	Record record {1, 2, 3};
+	REQUIRE(fn(&record) == 6);
+
+	std::string content;
+	if (std::filesystem::exists(dumpRoot)) {
+		for (const auto& dir : std::filesystem::directory_iterator(dumpRoot)) {
+			if (existing.count(dir.path()) > 0) {
+				continue;
+			}
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+				if (entry.is_regular_file() && entry.path().extension() == ".tbc") {
+					content += readFile(entry.path());
+				}
+			}
+		}
+	}
+	return content;
+}
+
+} // namespace
+
+TEST_CASE("TBC memory-offset superinstructions produce correct results") {
+	auto reference = tbcEngine("switch", false, false);
+	const std::vector<std::tuple<std::string, bool, bool>> variants = {
+	    {"switch", true, true}, {"goto", true, true}, {"goto", false, true},
+	    {"tailcall", true, true}, {"tailcall", true, false}, {"auto", true, true},
+	};
+	for (const auto& [dispatch, super, imm] : variants) {
+		DYNAMIC_SECTION(dispatch << "_super" << super << "_imm" << imm) {
+			auto alt = tbcEngine(dispatch, super, imm);
+
+			auto cLoad = reference.registerFunction(tbcOffsetLoadSum);
+			auto aLoad = alt.registerFunction(tbcOffsetLoadSum);
+			auto cStore = reference.registerFunction(tbcOffsetStoreFields);
+			auto aStore = alt.registerFunction(tbcOffsetStoreFields);
+			auto cReused = reference.registerFunction(tbcOffsetAddressReused);
+			auto aReused = alt.registerFunction(tbcOffsetAddressReused);
+
+			for (int64_t base = -5; base <= 5; ++base) {
+				Record refRecord {base, base * 2, base * 3};
+				Record altRecord {base, base * 2, base * 3};
+				REQUIRE(aLoad(&altRecord) == cLoad(&refRecord));
+
+				cStore(&refRecord, base + 10, base + 20, base + 30);
+				aStore(&altRecord, base + 10, base + 20, base + 30);
+				REQUIRE(altRecord.a == refRecord.a);
+				REQUIRE(altRecord.b == refRecord.b);
+				REQUIRE(altRecord.c == refRecord.c);
+
+				int64_t data[] = {base, base + 1, base + 2};
+				int64_t altData[] = {base, base + 1, base + 2};
+				REQUIRE(aReused(altData) == cReused(data));
+			}
+		}
+	}
+}
+
+TEST_CASE("TBC memory-offset fusion and dead-MOV elimination fire when enabled") {
+	const auto optimized = dumpTbcCode(/*superinstructions=*/true, /*immediates=*/true);
+	const auto unoptimized = dumpTbcCode(/*superinstructions=*/false, /*immediates=*/false);
+
+	REQUIRE_FALSE(optimized.empty());
+	REQUIRE_FALSE(unoptimized.empty());
+
+	// The fused address computation for the two non-zero-offset fields
+	// (b, c) must show up as LOAD_off, and must not appear at all when the
+	// optimizations are disabled.
+	CHECK(optimized.find("LOAD_off_i64") != std::string::npos);
+	CHECK(unoptimized.find("LOAD_off_i64") == std::string::npos);
+
+	// Fusing away the two pointer adds (and immediate folding + dead-MOV
+	// elimination collapsing their constant materialization) must strictly
+	// shrink the instruction count relative to the unoptimized baseline.
+	auto countLines = [](const std::string& text) {
+		return static_cast<std::size_t>(std::count(text.begin(), text.end(), '\n'));
+	};
+	CHECK(countLines(optimized) < countLines(unoptimized));
+}
+
+} // namespace nautilus::engine
+
+#endif // ENABLE_TBC_BACKEND


### PR DESCRIPTION
## Summary

Implements two follow-ups listed in the `tbc` backend's README (`nautilus/src/nautilus/compiler/backends/tbc/README.md`):

- **Dead-MOV elimination after immediate folding**: when a constant materialized by a standalone `MOV_imm` gets folded into an arithmetic op's 16-bit immediate field, that `MOV_imm` becomes dead if it had no other use. The flattener now tracks a per-block set of dead instruction indices and drops them during the final copy pass (a small generalization of the existing "drop the trailing compare when fusing a branch" mechanism).
- **Memory-offset superinstructions (`LOAD_off`/`STORE_off`)**: fuses a single-use `ptr + const` immediately preceding a `LOAD`/`STORE` into one instruction, encoding the offset directly instead of computing it via a separate `ADD` + register. Detection mirrors the existing compare-and-branch fusion: single-use (via the lowering's existing use-count map) and strict adjacency in the emitted stream (so nothing could have reused the base-pointer register in between) are both required before fusing. This builds directly on dead-MOV elimination's "drop this instruction" mechanism to remove the now-unused `ADD`.

As part of this, pointer arithmetic (`Type::ptr`) was folded into immediates too — it previously fell outside the immediate-folding type check even though it emits the identical `ADD_i64` opcode as plain `i64` arithmetic, which is what let the memory-offset fusion above actually engage.

Also fixes a small pre-existing gap found while adding a dump-based test: `DumpHandler::shallCreateFolder()` never learned about the `"after_tbc_generation"` dump name, so `dump.after_tbc_generation` silently failed to create its output directory and never wrote a file.

## Test plan

- [x] `nautilus-execution-tests` (full suite, 60 cases / 18016 assertions) — all pass
- [x] `nautilus-value-tests` and `nautilus-tracing-tests` — all pass
- [x] New `TBCMemoryOffsetTest.cpp`: correctness across dispatch/lowering-flag variants for offset loads/stores (including the must-not-fuse multi-use-address case), plus a structural check via the `after_tbc_generation` dump confirming `LOAD_off_i64` actually appears when enabled and the fused kernel emits strictly fewer instructions than the unoptimized baseline
- [x] Differential fuzz replay harness (`nautilus-fuzz-replay`, 2000 generated programs) — all backends + interpreter agree
- [x] `cmake --build . --target format` / `./format.sh` — no violations in changed files

Built and tested locally with `clang++-18` (Clang 21 was unavailable in this environment); MLIR backend disabled for build speed, `bc`/`cpp`/`asmjit`/`tbc` all enabled for the fuzz cross-check.

https://claude.ai/code/session_016JycotS2yrdMt8onTk8Cp6


---
_Generated by [Claude Code](https://claude.ai/code/session_016JycotS2yrdMt8onTk8Cp6)_