### PR TITLE
[fuzz] Fuzz the kernel signature space: param count, mixed types, narrow/void returns

### DIFF
--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -10,13 +10,10 @@
 
 namespace nautilus::fuzz {
 
-/// Number of parameters every generated kernel takes.
-inline constexpr uint32_t NUM_PARAMS = 3;
-
 enum class Kind : uint8_t {
 	// Leaves
 	Const, // imm holds the literal value, packed via packImm<T>
-	Param, // imm holds the parameter index in [0, NUM_PARAMS)
+	Param, // imm holds the parameter index in [0, numParams)
 	// Binary arithmetic / bitwise (integer domain only, except Add/Sub/Mul/Div which also apply to floats)
 	Add,
 	Sub,
@@ -244,7 +241,8 @@ inline bool isPtrCompare(Kind k) {
 }
 
 template <typename T>
-int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth);
+int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth,
+                 uint32_t numParams);
 
 /// Build a bounded pointer-domain expression: either the raw base pointer, or
 /// a single-hop offset from it (`Kind::PtrAdd`/`Kind::PtrSub`) computed from a
@@ -253,11 +251,12 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 /// so every pointer this can produce is directly `base + clampBufferIndex(x)`
 /// or `end - clampBufferIndex(x)` -- always an in-bounds index into the
 /// shared buffer, with no need to reason about compounding offsets across
-/// hops. `depth`/`budget`/`loopDepth`/`breakDepth` are threaded through
-/// exactly like generateNode's, so the shared node budget still bounds total
-/// tree size.
+/// hops. `depth`/`budget`/`loopDepth`/`breakDepth`/`numParams` are threaded
+/// through exactly like generateNode's, so the shared node budget still
+/// bounds total tree size.
 template <typename T>
-int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth) {
+int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth,
+                    uint32_t numParams) {
 	const uint8_t sel = reader.byte();
 	const bool leaf = depth <= 0 || budget <= 1 || reader.exhausted() || (sel & 0x1) == 0;
 
@@ -271,7 +270,7 @@ int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int lo
 
 	node.kind = (sel & 0x2) ? Kind::PtrAdd : Kind::PtrSub;
 	--budget;
-	node.kid[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
+	node.kid[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
 	const int idx = static_cast<int>(ast.nodes.size());
 	ast.nodes.push_back(node);
 	return idx;
@@ -285,9 +284,13 @@ int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int lo
 /// no real per-iteration branch to hook a data-dependent early exit/skip
 /// into -- unrolling always runs every iteration regardless of runtime data.
 /// Both are passed by value: they naturally "pop" back down via the call
-/// stack on return, no explicit restore needed.
+/// stack on return, no explicit restore needed. `numParams` is the number of
+/// value-domain kernel parameters Kind::Param may reference (the AST's
+/// logical arity, independent of the concrete kernel signature the harness
+/// eventually compiles it into).
 template <typename T>
-int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth) {
+int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth,
+                 uint32_t numParams) {
 	const uint8_t sel = reader.byte();
 	bool leaf = depth <= 0 || budget <= 1 || reader.exhausted();
 	if (!leaf) {
@@ -302,7 +305,7 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 			node.kind = (sel & 0x1) ? Kind::LoopAcc : Kind::LoopIndex;
 		} else if (sel & 0x4) {
 			node.kind = Kind::Param;
-			node.imm = reader.byte() % NUM_PARAMS;
+			node.imm = reader.byte() % numParams;
 		} else {
 			node.kind = Kind::Const;
 			node.imm = packImm<T>(reader.consume<T>());
@@ -343,16 +346,16 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 		// count (kid[0]) and init (kid[1]) live in the *outer* scope -- they
 		// must not see this loop's own LoopIndex/LoopAcc. Only the body
 		// (kid[2]) is generated one loop (and one break scope) deeper.
-		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
-		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
-		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth + 1);
+		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth + 1, numParams);
 	} else if (node.kind == Kind::While) {
 		// init (kid[0]) lives in the *outer* scope. cond (kid[1]) and body
 		// (kid[2]) both see this loop's LoopIndex/LoopAcc and are legal
 		// LoopBreak/LoopContinue sites.
-		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
-		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth + 1);
-		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth + 1);
+		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth + 1, numParams);
+		kids[2] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth + 1, numParams);
 	} else if (node.kind == Kind::StaticLoop) {
 		// Trip count is a generation-time constant (imm), not an expression:
 		// a trace-time loop cannot depend on runtime data by definition. The
@@ -360,19 +363,19 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 		// break scope deeper (LoopBreak/LoopContinue stay illegal -- see
 		// generateNode's breakDepth comment).
 		node.imm = reader.byte() % (LOOP_MAX_TRIPS + 1);
-		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
-		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth);
+		kids[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth + 1, breakDepth, numParams);
 	} else if (node.kind == Kind::Load || node.kind == Kind::PtrToInt) {
-		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
+		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
 	} else if (node.kind == Kind::Store) {
-		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
-		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
+		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+		kids[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
 	} else if (isPtrCompare(node.kind)) {
-		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
-		kids[1] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
+		kids[0] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+		kids[1] = generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
 	} else {
 		for (int i = 0; i < childCount; ++i) {
-			kids[i] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth);
+			kids[i] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
 		}
 	}
 	node.kid[0] = kids[0];
@@ -386,13 +389,16 @@ int generateNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopD
 } // namespace detail
 
 /// Build a random, always-valid AST of type T from the reader. Never returns
-/// an empty tree: an empty buffer yields a single Const(0) leaf.
+/// an empty tree: an empty buffer yields a single Const(0) leaf. `numParams`
+/// bounds which parameter indices Kind::Param leaves may reference (must be
+/// >= 1); it is independent of the concrete kernel signature the harness
+/// eventually compiles the AST into.
 template <typename T>
-Ast generate(ByteReader& reader) {
+Ast generate(ByteReader& reader, uint32_t numParams) {
 	Ast ast;
 	ast.nodes.reserve(MAX_NODES + 1);
 	int budget = MAX_NODES;
-	ast.root = detail::generateNode<T>(ast, reader, MAX_DEPTH, budget, /*loopDepth=*/0, /*breakDepth=*/0);
+	ast.root = detail::generateNode<T>(ast, reader, MAX_DEPTH, budget, /*loopDepth=*/0, /*breakDepth=*/0, numParams);
 	return ast;
 }
 

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <span>
 #include <type_traits>
 #include <vector>
 
@@ -80,22 +81,13 @@ T safeDivisor(T r) {
 }
 
 /// The only UB-prone leg of any cast crossing the int/float domain: clamp a
-/// float into To's representable range before truncating, using the
-/// power-of-two boundary helpers from Types.hpp (shared verbatim with
-/// EvalNautilus.hpp so the boundary math can't drift between the two).
-/// NaN maps to 0; out-of-range maps to To's min/max.
+/// float into To's representable range before truncating. Thin wrapper
+/// around Types.hpp's convertClamped (shared with EvalNautilus.hpp and the
+/// harness's kernel-boundary conversions so the boundary math can't drift
+/// between them). NaN maps to 0; out-of-range maps to To's min/max.
 template <typename From, typename To>
 To clampFloatToInt(From v) {
-	if (std::isnan(v)) {
-		return To(0);
-	}
-	if (v < loLimitInclusive<From, To>()) {
-		return std::numeric_limits<To>::min();
-	}
-	if (v >= hiLimitExclusive<From, To>()) {
-		return std::numeric_limits<To>::max();
-	}
-	return static_cast<To>(v);
+	return convertClamped<From, To>(v);
 }
 
 /// Unified "cast through" dispatch: (From)(To)v for any target TypeId,
@@ -194,14 +186,14 @@ struct EvalContext {
 };
 
 template <typename T>
-T evalNativeGeneric(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx);
+T evalNativeGeneric(const Ast& ast, int idx, std::span<const T> args, EvalContext<T>& ctx);
 
 /// Evaluate a pointer-domain node (Kind::PtrBase/PtrAdd/PtrSub, see Ast.hpp)
 /// to a buffer index. Always in [0, BUFFER_ELEMS) by construction --
 /// generatePtrNode never nests, so there is no "current pointer" state to
 /// track, just a single offset off of index 0 or BUFFER_ELEMS - 1.
 template <typename T>
-int evalNativePtr(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
+int evalNativePtr(const Ast& ast, int idx, std::span<const T> args, EvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::PtrAdd:
@@ -247,13 +239,13 @@ inline bool comparePtrIndices(Kind kind, int a, int b) {
 /// `if constexpr` -- the same pattern already used by safeDivisor/castThrough
 /// above -- rather than being split back into two functions.
 template <typename T>
-T evalNativeGeneric(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& args, EvalContext<T>& ctx) {
+T evalNativeGeneric(const Ast& ast, int idx, std::span<const T> args, EvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
 		return unpackImm<T>(n.imm);
 	case Kind::Param:
-		return args[n.imm % NUM_PARAMS];
+		return args[n.imm % args.size()];
 	case Kind::LoopIndex:
 		return ctx.loopStack.back().index;
 	case Kind::LoopAcc:
@@ -514,7 +506,7 @@ T evalNativeGeneric(const Ast& ast, int idx, const std::array<T, NUM_PARAMS>& ar
 } // namespace detail
 
 template <typename T>
-T evalNative(const Ast& ast, const std::array<T, NUM_PARAMS>& args, std::array<T, BUFFER_ELEMS>& memory) {
+T evalNative(const Ast& ast, std::span<const T> args, std::array<T, BUFFER_ELEMS>& memory) {
 	detail::EvalContext<T> ctx;
 	ctx.memory = &memory;
 	return detail::evalNativeGeneric<T>(ast, ast.root, args, ctx);

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -10,6 +10,7 @@
 #include <nautilus/static.hpp>
 #include <nautilus/val.hpp>
 #include <nautilus/val_ptr.hpp>
+#include <span>
 #include <type_traits>
 #include <vector>
 
@@ -18,8 +19,13 @@ namespace nautilus::fuzz {
 template <typename T>
 using TracedValue = val<T>;
 
-template <typename T>
-using TracedArgs = std::array<TracedValue<T>, NUM_PARAMS>;
+/// A kernel's logical value-domain arguments (the AST's Kind::Param domain),
+/// sized to whatever arity the current signature shape uses -- independent of
+/// the concrete kernel signature the harness compiles the AST into (which may
+/// carry extra/differently-typed parameters converted into this domain at
+/// the boundary, see convertClampedTraced below).
+template <typename T, std::size_t N>
+using TracedArgs = std::array<TracedValue<T>, N>;
 
 /**
  * @brief Realize an AST as traced Nautilus operations.
@@ -162,13 +168,14 @@ struct TracedEvalContext {
 };
 
 template <typename T>
-TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx);
+TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, std::span<const TracedValue<T>> args,
+                                   TracedEvalContext<T>& ctx);
 
 /// Traced mirror of EvalNative.hpp's evalNativePtr: evaluates a
 /// pointer-domain node to a real val<T*>, using the exact same
 /// operator+/operator- val<T*> arithmetic under test.
 template <typename T>
-val<T*> evalNautilusPtr(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
+val<T*> evalNautilusPtr(const Ast& ast, int idx, std::span<const TracedValue<T>> args, TracedEvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::PtrAdd: {
@@ -215,13 +222,14 @@ val<bool> comparePtrTraced(Kind kind, val<T*> a, val<T*> b) {
 /// ops; float division needs no non-zero-divisor guard), gated via
 /// `if constexpr`.
 template <typename T>
-TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, const TracedArgs<T>& args, TracedEvalContext<T>& ctx) {
+TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, std::span<const TracedValue<T>> args,
+                                   TracedEvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::Const:
 		return TracedValue<T>(unpackImm<T>(n.imm));
 	case Kind::Param:
-		return args[n.imm % NUM_PARAMS];
+		return args[n.imm % args.size()];
 	case Kind::LoopIndex:
 		return ctx.loopStack.back().index;
 	case Kind::LoopAcc:
@@ -465,11 +473,28 @@ TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, const TracedArgs<T>&
 } // namespace detail
 
 template <typename T>
-TracedValue<T> evalNautilus(const Ast& ast, val<T*> basePtr, const TracedArgs<T>& args) {
+TracedValue<T> evalNautilus(const Ast& ast, val<T*> basePtr, std::span<const TracedValue<T>> args) {
 	detail::TracedEvalContext<T> ctx;
 	ctx.basePtr = basePtr;
 	ctx.lastPtr = basePtr + static_cast<int32_t>(BUFFER_ELEMS - 1);
 	return detail::evalNautilusGeneric<T>(ast, ast.root, args, ctx);
+}
+
+/// Traced counterpart of Types.hpp's convertClamped: converts a val<From>
+/// kernel-boundary value (an extra "mixed" parameter, or the final result on
+/// its way to a narrow/differently-typed return) into a val<To>, well-defined
+/// for every input. Reuses detail::clampFloatToIntTraced for the one
+/// UB-prone leg (float->int) exactly like castThroughTraced does for a
+/// same-domain round-trip Cast; every other direction is a plain
+/// static_cast, mirroring Types.hpp::convertClamped so the native oracle and
+/// the traced kernel agree on every boundary conversion by construction.
+template <typename From, typename To>
+TracedValue<To> convertClampedTraced(TracedValue<From> v) {
+	if constexpr (std::is_floating_point_v<From> && !std::is_floating_point_v<To>) {
+		return detail::clampFloatToIntTraced<From, To>(v);
+	} else {
+		return static_cast<TracedValue<To>>(v);
+	}
 }
 
 } // namespace nautilus::fuzz

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -13,19 +13,11 @@
 #include <functional>
 #include <nautilus/Engine.hpp>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace nautilus::fuzz {
-
-static_assert(NUM_PARAMS == 3, "The harness wires exactly three same-typed parameters.");
-
-// registerFunction expects the traced (val<>) return type in the signature; the
-// resulting CompiledFunction is then callable with -- and returns -- raw scalars.
-// The leading val<T*> is the shared BUFFER_ELEMS-element buffer every
-// generated program's pointer-domain nodes (Kind::PtrBase et al., see
-// Ast.hpp) index into.
-template <typename T>
-using KernelSignature = val<T>(val<T*>, val<T>, val<T>, val<T>);
 
 /// Backends compiled into this build, mirroring testing::availableBackends().
 /// The interpreter is always present and acts as an extra differential peer.
@@ -77,11 +69,13 @@ inline engine::NautilusEngine makeEngine(const std::string& backend) {
 
 /// A single backend disagreeing with the native oracle (or throwing). All
 /// value fields are pre-formatted strings (built where the concrete type T
-/// is still known, inside checkOneTyped<T>) so this struct itself stays
-/// type-agnostic across all ten generated domains.
+/// is still known, inside the checkOne* functions below) so this struct
+/// itself stays type-agnostic across all ten generated domains and every
+/// signature shape.
 struct Finding {
 	std::string backend;
 	std::string typeName;
+	std::string shape; // which signature shape generated this kernel, see below
 	std::string program;
 	std::vector<std::string> args;
 	std::vector<std::string> memory; // shared buffer's initial contents (see Kind::PtrBase, Ast.hpp)
@@ -100,11 +94,20 @@ inline void printMemory(const std::vector<std::string>& memory) {
 	std::fprintf(stderr, "]\n");
 }
 
+inline void printArgs(const std::vector<std::string>& args) {
+	std::fprintf(stderr, "args     : ");
+	for (size_t i = 0; i < args.size(); ++i) {
+		std::fprintf(stderr, "%sp%zu=%s", i == 0 ? "" : " ", i, args[i].c_str());
+	}
+	std::fprintf(stderr, "\n");
+}
+
 inline void printFinding(const Finding& f) {
 	if (f.exception) {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: EXCEPTION ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
 		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
+		std::fprintf(stderr, "shape    : %s\n", f.shape.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
 		printMemory(f.memory);
 		std::fprintf(stderr, "what()   : %s\n", f.what.c_str());
@@ -113,8 +116,9 @@ inline void printFinding(const Finding& f) {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: MISMATCH ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
 		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
+		std::fprintf(stderr, "shape    : %s\n", f.shape.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
-		std::fprintf(stderr, "args     : p0=%s p1=%s p2=%s\n", f.args[0].c_str(), f.args[1].c_str(), f.args[2].c_str());
+		printArgs(f.args);
 		printMemory(f.memory);
 		std::fprintf(stderr, "expected : %s (native oracle)\n", f.expected.c_str());
 		std::fprintf(stderr, "got      : %s\n", f.got.c_str());
@@ -132,29 +136,113 @@ inline bool astHasParam(const Ast& ast) {
 	return false;
 }
 
-/// Core differential check for one input at a fixed concrete type T: build a
-/// program + args, evaluate it natively, compile/run on every backend +
-/// interpreter, and collect every backend that disagrees or throws. Does not
-/// abort -- callers decide. `reader` continues from wherever the caller (the
-/// type-dispatching checkOne) left off, so the whole pipeline -- type
-/// selection, AST generation, arg generation -- is one linear, deterministic
-/// pass over a single buffer.
+/**
+ * @brief The kernel-boundary signature space (issue #355).
+ *
+ * Every generated program's *internal* AST evaluation is always monomorphic
+ * in one type T (unchanged from before -- see Ast.hpp/EvalNative.hpp/
+ * EvalNautilus.hpp). What varies here is the shape of the `registerFunction`
+ * signature the AST is compiled into: how many T-valued parameters
+ * Kind::Param may reference (the AST's logical arity, `generate`'s
+ * `numParams`), whether the kernel's *declared* parameter list matches that
+ * arity 1:1 in type, and what the kernel returns.
+ *
+ * `registerFunction` needs a compile-time-known std::function, so rather
+ * than synthesizing arbitrary signatures at runtime this enumerates a small,
+ * bounded menu of concrete shapes and dispatches to them -- one instantiation
+ * per (shape, T) pair:
+ *
+ *   - arity{1,2,3,4}: N T-typed parameters, T-typed return (N in the menu
+ *     below). arity3 is the harness's original fixed shape.
+ *   - mixed: 3 T-typed logical parameters, but the kernel's first *declared*
+ *     parameter is a secondary type S cross-domain from T (int when T is
+ *     float, double when T is int -- see MixedSecondaryType), converted to T
+ *     immediately at the boundary before joining the AST's T-only argument
+ *     domain. Exercises the register-class interleaving between float and
+ *     integer parameters at the kernel entry, never reached when every
+ *     parameter is uniformly T.
+ *   - narrowReturn: 3 T-typed parameters, but the kernel returns a fixed
+ *     narrow integer type (int8_t) instead of T -- the AST still evaluates
+ *     in T, with the result cast down at the return boundary. Exercises the
+ *     narrow-integer-return extension/truncation ABI.
+ *   - voidReturn: 3 T-typed parameters, `void` return. The AST's result has
+ *     no return-value ABI to compare, so it (and, on the traced side,
+ *     whatever Store side effects the AST itself performed) is instead
+ *     diffed via the shared buffer's final contents: the computed root value
+ *     is explicitly written to the buffer's first slot on both the native
+ *     and traced side before the buffer is compared elementwise.
+ *
+ * All conversions across a type boundary (mixed's incoming parameter,
+ * narrowReturn's outgoing return) go through Types.hpp's convertClamped /
+ * EvalNautilus.hpp's convertClampedTraced -- the same NaN/out-of-range-safe
+ * recipe already used for Kind::Cast, applied once more at the ABI boundary
+ * instead of inside the AST -- so every boundary conversion stays
+ * well-defined for all input bytes and native/traced parity is guaranteed by
+ * construction, not by convention.
+ */
+inline constexpr uint32_t NUM_SIGNATURE_SHAPES = 7;
+
+template <typename T, int N>
+struct ArityTraits;
+
 template <typename T>
-std::vector<Finding> checkOneTyped(ByteReader& reader) {
-	const Ast ast = generate<T>(reader);
+struct ArityTraits<T, 1> {
+	using Signature = val<T>(val<T*>, val<T>);
+};
+template <typename T>
+struct ArityTraits<T, 2> {
+	using Signature = val<T>(val<T*>, val<T>, val<T>);
+};
+template <typename T>
+struct ArityTraits<T, 3> {
+	using Signature = val<T>(val<T*>, val<T>, val<T>, val<T>);
+};
+template <typename T>
+struct ArityTraits<T, 4> {
+	using Signature = val<T>(val<T*>, val<T>, val<T>, val<T>, val<T>);
+};
+
+template <typename T, int N>
+using ArityKernelSignature = typename ArityTraits<T, N>::Signature;
+
+/// Cross-domain secondary type for the "mixed" shape: a float T pairs with a
+/// 32-bit int, an integer T pairs with a double -- always the *other*
+/// register class from T, so the mixed parameter genuinely exercises
+/// int/float interleaving at the kernel boundary rather than just a
+/// different width within the same class.
+template <typename T>
+using MixedSecondaryType = std::conditional_t<std::is_floating_point_v<T>, int32_t, double>;
+
+template <typename T>
+using MixedKernelSignature = val<T>(val<T*>, val<MixedSecondaryType<T>>, val<T>, val<T>);
+
+/// Fixed narrow return type for the narrowReturn shape (see the module
+/// comment above); deliberately independent of T; used in the same historical
+/// direction (narrow int return) that already produced ProxyCall/IndirectCall
+/// ABI bugs for `Call` (see README.md "Known findings").
+using NarrowReturnType = int8_t;
+
+template <typename T>
+using NarrowReturnKernelSignature = val<NarrowReturnType>(val<T*>, val<T>, val<T>, val<T>);
+
+template <typename T>
+using VoidReturnKernelSignature = void(val<T*>, val<T>, val<T>, val<T>);
+
+/// arity{1,2,3,4}: N T-typed parameters, T-typed return -- the generalization
+/// of the harness's original fixed 3-parameter shape to a small bounded menu
+/// of arities (param-count coverage: 1, 2, 3, and >=4 register/stack-passed
+/// arguments).
+template <typename T, int N>
+std::vector<Finding> checkOneArity(ByteReader& reader) {
+	static_assert(N >= 1 && N <= 4, "arity shape menu only covers N in [1, 4]");
+	const Ast ast = generate<T>(reader, static_cast<uint32_t>(N));
 	const bool hasParam = astHasParam(ast);
 
-	std::array<T, NUM_PARAMS> args {};
-	for (uint32_t i = 0; i < NUM_PARAMS; ++i) {
+	std::array<T, N> args {};
+	for (int i = 0; i < N; ++i) {
 		args[i] = reader.consume<T>();
 	}
 
-	// Initial contents of the shared buffer every pointer-domain node indexes
-	// into (see Kind::PtrBase, Ast.hpp). `memory` is declared once and reused
-	// -- reset to `initialMemory` before every run below -- rather than
-	// freshly constructed per run, so its address stays identical across the
-	// native oracle and every backend; that's what makes Kind::PtrToInt's
-	// pointer->integer cast comparable at all (it embeds a real address).
 	std::array<T, BUFFER_ELEMS> initialMemory {};
 	for (int i = 0; i < BUFFER_ELEMS; ++i) {
 		initialMemory[i] = reader.consume<T>();
@@ -164,7 +252,121 @@ std::vector<Finding> checkOneTyped(ByteReader& reader) {
 	const T expected = evalNative<T>(ast, args, memory);
 	const std::string program = toString<T>(ast);
 	std::vector<std::string> argStrs;
-	argStrs.reserve(NUM_PARAMS);
+	argStrs.reserve(N);
+	for (T a : args) {
+		argStrs.push_back(formatValue<T>(a));
+	}
+	std::vector<std::string> memoryStrs;
+	memoryStrs.reserve(BUFFER_ELEMS);
+	for (T v : initialMemory) {
+		memoryStrs.push_back(formatValue<T>(v));
+	}
+	const std::string shapeName = "arity" + std::to_string(N);
+
+	std::vector<Finding> findings;
+	for (const auto& backend : configs()) {
+		try {
+			auto engine = makeEngine(backend);
+			std::function<ArityKernelSignature<T, N>> kernel = [&ast](val<T*> mem, auto... a) {
+				TracedArgs<T, static_cast<std::size_t>(N)> traced {a...};
+				return evalNautilus<T>(ast, mem, traced);
+			};
+			auto compiled = engine.registerFunction(kernel);
+			memory = initialMemory;
+			const T got = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+				return compiled(memory.data(), args[Is]...);
+			}(std::make_index_sequence<static_cast<std::size_t>(N)> {});
+			if (!valuesEqual<T>(got, expected)) {
+				findings.push_back({backend, typeSuffix<T>(), shapeName, program, argStrs, memoryStrs,
+				                    formatValue<T>(expected), formatValue<T>(got), false, "", hasParam});
+			}
+		} catch (const std::exception& e) {
+			findings.push_back(
+			    {backend, typeSuffix<T>(), shapeName, program, argStrs, memoryStrs, "", "", true, e.what(), hasParam});
+		}
+	}
+	return findings;
+}
+
+/// mixed: 3 logical T parameters, but the kernel's first declared parameter
+/// is MixedSecondaryType<T> and gets converted to T immediately at the
+/// boundary (both natively and traced) before joining the AST's T-only
+/// argument domain -- see the module comment above.
+template <typename T>
+std::vector<Finding> checkOneMixed(ByteReader& reader) {
+	using S = MixedSecondaryType<T>;
+	constexpr int N = 3;
+	const Ast ast = generate<T>(reader, N);
+	const bool hasParam = astHasParam(ast);
+
+	const S secondaryRaw = reader.consume<S>();
+	const T arg1 = reader.consume<T>();
+	const T arg2 = reader.consume<T>();
+	std::array<T, N> args {convertClamped<S, T>(secondaryRaw), arg1, arg2};
+
+	std::array<T, BUFFER_ELEMS> initialMemory {};
+	for (int i = 0; i < BUFFER_ELEMS; ++i) {
+		initialMemory[i] = reader.consume<T>();
+	}
+	std::array<T, BUFFER_ELEMS> memory = initialMemory;
+
+	const T expected = evalNative<T>(ast, args, memory);
+	const std::string program = toString<T>(ast);
+	const std::vector<std::string> argStrs {formatValue<S>(secondaryRaw), formatValue<T>(arg1), formatValue<T>(arg2)};
+	std::vector<std::string> memoryStrs;
+	memoryStrs.reserve(BUFFER_ELEMS);
+	for (T v : initialMemory) {
+		memoryStrs.push_back(formatValue<T>(v));
+	}
+
+	std::vector<Finding> findings;
+	for (const auto& backend : configs()) {
+		try {
+			auto engine = makeEngine(backend);
+			std::function<MixedKernelSignature<T>> kernel = [&ast](val<T*> mem, val<S> p0, val<T> p1, val<T> p2) {
+				TracedArgs<T, N> traced {convertClampedTraced<S, T>(p0), p1, p2};
+				return evalNautilus<T>(ast, mem, traced);
+			};
+			auto compiled = engine.registerFunction(kernel);
+			memory = initialMemory;
+			const T got = compiled(memory.data(), secondaryRaw, arg1, arg2);
+			if (!valuesEqual<T>(got, expected)) {
+				findings.push_back({backend, typeSuffix<T>(), "mixed", program, argStrs, memoryStrs,
+				                    formatValue<T>(expected), formatValue<T>(got), false, "", hasParam});
+			}
+		} catch (const std::exception& e) {
+			findings.push_back(
+			    {backend, typeSuffix<T>(), "mixed", program, argStrs, memoryStrs, "", "", true, e.what(), hasParam});
+		}
+	}
+	return findings;
+}
+
+/// narrowReturn: 3 T-typed parameters; the kernel returns NarrowReturnType
+/// instead of T. The AST still evaluates in T -- only the final result is
+/// cast down at the return boundary, on both the native and traced side.
+template <typename T>
+std::vector<Finding> checkOneNarrowReturn(ByteReader& reader) {
+	constexpr int N = 3;
+	const Ast ast = generate<T>(reader, N);
+	const bool hasParam = astHasParam(ast);
+
+	std::array<T, N> args {};
+	for (int i = 0; i < N; ++i) {
+		args[i] = reader.consume<T>();
+	}
+
+	std::array<T, BUFFER_ELEMS> initialMemory {};
+	for (int i = 0; i < BUFFER_ELEMS; ++i) {
+		initialMemory[i] = reader.consume<T>();
+	}
+	std::array<T, BUFFER_ELEMS> memory = initialMemory;
+
+	const T rawExpected = evalNative<T>(ast, args, memory);
+	const NarrowReturnType expected = convertClamped<T, NarrowReturnType>(rawExpected);
+	const std::string program = toString<T>(ast);
+	std::vector<std::string> argStrs;
+	argStrs.reserve(N);
 	for (T a : args) {
 		argStrs.push_back(formatValue<T>(a));
 	}
@@ -178,32 +380,125 @@ std::vector<Finding> checkOneTyped(ByteReader& reader) {
 	for (const auto& backend : configs()) {
 		try {
 			auto engine = makeEngine(backend);
-			std::function<KernelSignature<T>> kernel = [&ast](val<T*> mem, val<T> a, val<T> b, val<T> c) {
-				const TracedArgs<T> traced {a, b, c};
-				return evalNautilus<T>(ast, mem, traced);
+			std::function<NarrowReturnKernelSignature<T>> kernel = [&ast](val<T*> mem, val<T> a, val<T> b, val<T> c) {
+				TracedArgs<T, N> traced {a, b, c};
+				TracedValue<T> result = evalNautilus<T>(ast, mem, traced);
+				return convertClampedTraced<T, NarrowReturnType>(result);
 			};
 			auto compiled = engine.registerFunction(kernel);
 			memory = initialMemory;
-			const T got = compiled(memory.data(), args[0], args[1], args[2]);
-			if (!valuesEqual<T>(got, expected)) {
-				findings.push_back({backend, typeSuffix<T>(), program, argStrs, memoryStrs, formatValue<T>(expected),
-				                    formatValue<T>(got), false, "", hasParam});
+			const NarrowReturnType got = compiled(memory.data(), args[0], args[1], args[2]);
+			if (!valuesEqual<NarrowReturnType>(got, expected)) {
+				findings.push_back({backend, typeSuffix<T>(), "narrowReturn", program, argStrs, memoryStrs,
+				                    formatValue<NarrowReturnType>(expected), formatValue<NarrowReturnType>(got), false,
+				                    "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back(
-			    {backend, typeSuffix<T>(), program, argStrs, memoryStrs, "", "", true, e.what(), hasParam});
+			findings.push_back({backend, typeSuffix<T>(), "narrowReturn", program, argStrs, memoryStrs, "", "", true,
+			                    e.what(), hasParam});
 		}
 	}
 	return findings;
 }
 
-/// Pick one of the ten generated types from the first byte of the buffer,
-/// then dispatch into the matching checkOneTyped<T> instantiation, passing
-/// the same reader along so determinism/replay is preserved end to end.
+/// voidReturn: 3 T-typed parameters, `void` return -- a Store-only kernel.
+/// The AST's computed root value has no return-value ABI to exercise, so it
+/// is explicitly written to the buffer's first slot on both the native and
+/// traced side (in addition to whatever Store side effects the AST itself
+/// performs), and the whole buffer is diffed elementwise instead of a scalar
+/// return.
+template <typename T>
+std::vector<Finding> checkOneVoidReturn(ByteReader& reader) {
+	constexpr int N = 3;
+	const Ast ast = generate<T>(reader, N);
+	const bool hasParam = astHasParam(ast);
+
+	std::array<T, N> args {};
+	for (int i = 0; i < N; ++i) {
+		args[i] = reader.consume<T>();
+	}
+
+	std::array<T, BUFFER_ELEMS> initialMemory {};
+	for (int i = 0; i < BUFFER_ELEMS; ++i) {
+		initialMemory[i] = reader.consume<T>();
+	}
+	std::array<T, BUFFER_ELEMS> memory = initialMemory;
+
+	const T rootValue = evalNative<T>(ast, args, memory);
+	memory[0] = rootValue;
+	const std::array<T, BUFFER_ELEMS> expectedMemory = memory;
+
+	const std::string program = toString<T>(ast);
+	std::vector<std::string> argStrs;
+	argStrs.reserve(N);
+	for (T a : args) {
+		argStrs.push_back(formatValue<T>(a));
+	}
+	std::vector<std::string> memoryStrs;
+	memoryStrs.reserve(BUFFER_ELEMS);
+	for (T v : initialMemory) {
+		memoryStrs.push_back(formatValue<T>(v));
+	}
+
+	std::vector<Finding> findings;
+	for (const auto& backend : configs()) {
+		try {
+			auto engine = makeEngine(backend);
+			std::function<VoidReturnKernelSignature<T>> kernel = [&ast](val<T*> mem, val<T> a, val<T> b, val<T> c) {
+				TracedArgs<T, N> traced {a, b, c};
+				TracedValue<T> result = evalNautilus<T>(ast, mem, traced);
+				*mem = result;
+			};
+			auto compiled = engine.registerFunction(kernel);
+			memory = initialMemory;
+			compiled(memory.data(), args[0], args[1], args[2]);
+			if (!arraysEqual<T, BUFFER_ELEMS>(memory, expectedMemory)) {
+				findings.push_back({backend, typeSuffix<T>(), "voidReturn", program, argStrs, memoryStrs,
+				                    formatArray<T, BUFFER_ELEMS>(expectedMemory), formatArray<T, BUFFER_ELEMS>(memory),
+				                    false, "", hasParam});
+			}
+		} catch (const std::exception& e) {
+			findings.push_back({backend, typeSuffix<T>(), "voidReturn", program, argStrs, memoryStrs, "", "", true,
+			                    e.what(), hasParam});
+		}
+	}
+	return findings;
+}
+
+/// Dispatch a single input, at a fixed concrete type T, to the signature
+/// shape selected by `shape % NUM_SIGNATURE_SHAPES`. `reader` continues from
+/// wherever the caller (checkOne) left off, so the whole pipeline -- type
+/// selection, shape selection, AST generation, arg generation -- is one
+/// linear, deterministic pass over a single buffer.
+template <typename T>
+std::vector<Finding> checkOneTyped(ByteReader& reader, uint32_t shape) {
+	switch (shape % NUM_SIGNATURE_SHAPES) {
+	case 0:
+		return checkOneArity<T, 1>(reader);
+	case 1:
+		return checkOneArity<T, 2>(reader);
+	case 2:
+		return checkOneArity<T, 3>(reader);
+	case 3:
+		return checkOneArity<T, 4>(reader);
+	case 4:
+		return checkOneMixed<T>(reader);
+	case 5:
+		return checkOneNarrowReturn<T>(reader);
+	default:
+		return checkOneVoidReturn<T>(reader);
+	}
+}
+
+/// Pick one of the ten generated types and one of the signature shapes from
+/// the first two bytes of the buffer, then dispatch into the matching
+/// checkOneTyped<T> instantiation, passing the same reader along so
+/// determinism/replay is preserved end to end.
 inline std::vector<Finding> checkOne(const uint8_t* data, size_t size) {
 	ByteReader reader(data, size);
 	const TypeId ty = ALL_TYPES[reader.byte() % (sizeof(ALL_TYPES) / sizeof(ALL_TYPES[0]))];
-	return dispatchAnyType(ty, [&]<typename T>() { return checkOneTyped<T>(reader); });
+	const uint32_t shape = reader.byte();
+	return dispatchAnyType(ty, [&]<typename T>() { return checkOneTyped<T>(reader, shape); });
 }
 
 /// libFuzzer behavior: abort (so the input is captured as a reproducer) on the

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -19,7 +19,7 @@ bug because every generated program is fully defined by construction.
 | `Ast.hpp`          | Tagged AST, depth/node-budgeted generator (templated on the value type), and a pretty printer. |
 | `EvalNative.hpp`   | Independent C++ ground-truth interpreter (the oracle), templated on the value type. |
 | `EvalNautilus.hpp` | Walks the same AST emitting `val<T>` ops for tracing/compilation. |
-| `Harness.hpp`      | Shared differential check (`checkOne`/`runOne`) used by both drivers; dispatches each input to the right `T`. |
+| `Harness.hpp`      | Shared differential check (`checkOne`/`runOne`) used by both drivers; dispatches each input to the right `T` and kernel signature shape (see "Kernel signature space"). |
 | `FuzzMain.cpp`     | `LLVMFuzzerTestOneInput`: coverage-guided libFuzzer entry point. |
 | `ReplayMain.cpp`   | Plain-`main` driver: replay saved inputs, smoke corpus, or `--survey`. |
 
@@ -43,7 +43,10 @@ Each generated program is monomorphic in one of ten types, picked from the
 first byte of the fuzzer input: `int8_t/16/32/64_t`, `uint8/16/32/64_t`,
 `float`, `double` (`TypeId` in `Types.hpp`). The rest of the input (AST shape,
 constants, parameters) is generated and evaluated entirely in that one type,
-mirroring how the original `uint64_t`-only fuzzer worked.
+mirroring how the original `uint64_t`-only fuzzer worked. The second byte of
+the input separately picks the kernel *signature* shape the AST is compiled
+into -- see "Kernel signature space" below -- independent of this type
+selection.
 
 * **Integer domain** (8 widths/signs): arithmetic (`+ - * / %`), bitwise
   (`& | ^ << >> ~`), unary negate, comparisons, logical ops, `Select`/`If`,
@@ -184,6 +187,57 @@ principle as everything else here.
   kernel exactly; `If` needed no change since its native/traced forms
   already evaluate the else-branch unconditionally and the then-branch only
   when taken (see the `Kind::If` comment in `EvalNative.hpp`).
+
+## Kernel signature space
+
+Every generated program's internal AST evaluation is monomorphic in one type
+`T`, as above -- what additionally varies, per input, is the shape of the
+`registerFunction` signature the AST is compiled into. The original harness
+wired every kernel to exactly three `T`-typed parameters and a `T`-typed
+return; `Harness.hpp` now draws a second byte from the input (right after the
+type-select byte) and reduces it modulo `NUM_SIGNATURE_SHAPES` to pick one of
+a small, bounded menu of concrete shapes, each a distinct `registerFunction`
+instantiation:
+
+* **`arity{1,2,3,4}`**: `N` `T`-typed parameters, `T`-typed return, for `N` in
+  `{1, 2, 3, 4}` -- `arity3` is the original fixed shape. Covers parameter-count
+  variation: empty/near-empty prologues, argument-register exhaustion, and
+  (on `arity4`) stack-passed arguments, exercising `registerFunction`'s
+  prologue/epilogue and argument marshalling independent of the AST itself.
+* **`mixed`**: 3 logical `T` parameters, but the kernel's first *declared*
+  parameter is a secondary type cross-domain from `T` (a 32-bit int when `T`
+  is a float type, a `double` when `T` is an integer type -- see
+  `MixedSecondaryType` in `Harness.hpp`), converted to `T` immediately at the
+  boundary (both natively and traced) before joining the AST's `T`-only
+  argument domain. Exercises the register-class interleaving between integer
+  and floating-point kernel parameters (SysV/AAPCS64 classification), never
+  reached when every declared parameter is uniformly `T`.
+* **`narrowReturn`**: 3 `T`-typed parameters, but the kernel returns a fixed
+  narrow integer type (`int8_t`) instead of `T`. The AST still evaluates in
+  `T`; only the final result is cast down at the return boundary, on both the
+  native and traced side. Exercises the same narrow-integer-return
+  extension/truncation direction that previously produced real
+  `ProxyCall`/`IndirectCall` ABI bugs for `Call` (see "Known findings"), this
+  time at the kernel's own return rather than an internal helper call.
+* **`voidReturn`**: 3 `T`-typed parameters, `void` return -- a Store-only
+  kernel. A `void`-returning kernel has no return-value ABI to compare, so
+  the AST's computed root value is instead explicitly written to the shared
+  buffer's first slot on both the native and traced side (in addition to
+  whatever `Store` side effects the AST itself performs), and the whole
+  buffer is diffed elementwise afterward instead of a scalar return.
+
+All conversions across a type boundary (`mixed`'s incoming parameter,
+`narrowReturn`'s outgoing return) go through the same NaN/out-of-range-safe
+recipe already used for `Kind::Cast` (`Types.hpp::convertClamped` /
+`EvalNautilus.hpp::convertClampedTraced`), applied once more at the ABI
+boundary instead of inside the AST, so every boundary conversion stays
+well-defined for all input bytes and native/traced parity is guaranteed by
+construction.
+
+This is the kernel-boundary twin of the `invoke()`-callee coverage fuzzed by
+`Kind::Call` (`Callees.hpp`): both marshal arguments/returns, but through
+different code paths (`registerFunction` entry vs. `ProxyCall`), so both are
+worth fuzzing independently.
 
 ## Soundness model
 

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -39,14 +39,17 @@ std::vector<uint8_t> readFile(const char* path) {
 
 std::vector<uint8_t> randomBuffer() {
 	// 256, not the original 96/128/160: on top of the type-select byte, the
-	// Cast target-type byte, and Loop/LoopIndex/LoopAcc kind-selection, the
-	// memory domain (Load/Store/PtrToInt/Ptr-comparisons, each drawing a
+	// signature-shape-select byte (Harness.hpp's NUM_SIGNATURE_SHAPES menu --
+	// param count, mixed-type params, narrow/void returns), the Cast
+	// target-type byte, and Loop/LoopIndex/LoopAcc kind-selection, the memory
+	// domain (Load/Store/PtrToInt/Ptr-comparisons, each drawing a
 	// pointer-domain subexpression) now consumes its own kind-selection
 	// bytes, and after AST generation every input additionally pays for
 	// BUFFER_ELEMS*sizeof(T) bytes of initial buffer contents (up to 8*8=64
-	// bytes for i64/f64) on top of the three existing NUM_PARAMS args. A
-	// larger buffer keeps tree richness -- and the odds of generating a
-	// nontrivial Load/Store/pointer comparison -- comparable to before.
+	// bytes for i64/f64) on top of the shape's own arg count (1-3 T-typed
+	// args, depending on shape). A larger buffer keeps tree richness -- and
+	// the odds of generating a nontrivial Load/Store/pointer comparison --
+	// comparable to before.
 	const size_t len = nextRand() % 256;
 	std::vector<uint8_t> buf(len);
 	for (size_t i = 0; i < len; ++i) {
@@ -88,7 +91,7 @@ int survey(int iterations) {
 		const std::vector<uint8_t> buf = randomBuffer();
 		for (const auto& f : nautilus::fuzz::checkOne(buf.data(), buf.size())) {
 			++totalFindings;
-			const std::string key = f.backend + "|" + f.typeName +
+			const std::string key = f.backend + "|" + f.typeName + "|" + f.shape +
 			                        (f.exception ? "|exception" : (f.hasParam ? "|has-param" : "|all-const"));
 			counts[key]++;
 			if (!buckets.count(key)) {
@@ -110,9 +113,11 @@ int survey(int iterations) {
 	for (const auto& [key, example] : buckets) {
 		std::printf("\n[%s]  x%d\n  example: %s\n", key.c_str(), counts[key], example.program.c_str());
 		if (!example.exception) {
-			std::printf("  args p0=%s p1=%s p2=%s  expected=%s got=%s\n", example.args[0].c_str(),
-			            example.args[1].c_str(), example.args[2].c_str(), example.expected.c_str(),
-			            example.got.c_str());
+			std::printf("  args ");
+			for (size_t i = 0; i < example.args.size(); ++i) {
+				std::printf("%sp%zu=%s", i == 0 ? "" : " ", i, example.args[i].c_str());
+			}
+			std::printf("  expected=%s got=%s\n", example.expected.c_str(), example.got.c_str());
 		} else {
 			std::printf("  exception: %s\n", example.what.c_str());
 		}

--- a/nautilus/test/fuzz/Types.hpp
+++ b/nautilus/test/fuzz/Types.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -196,6 +197,19 @@ bool valuesEqual(T a, T b) {
 	}
 }
 
+/// Elementwise valuesEqual over a whole buffer -- used to diff a void-return
+/// (Store-only) kernel's final buffer contents against the native oracle's,
+/// since std::array::operator== would report two agreeing NaNs as a mismatch.
+template <typename T, size_t M>
+bool arraysEqual(const std::array<T, M>& a, const std::array<T, M>& b) {
+	for (size_t i = 0; i < M; ++i) {
+		if (!valuesEqual<T>(a[i], b[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
 /// Smallest `From` value that is already out of range for `To` (i.e. the
 /// first representative for which a float->int cast is UB). Deliberately
 /// compared against a power-of-two boundary rather than
@@ -224,6 +238,48 @@ constexpr From loLimitInclusive() {
 	} else {
 		return From(0);
 	}
+}
+
+/// Convert a native `From` value to `To`, well-defined for every input.
+/// Every direction except float->int is a plain (always-safe) static_cast;
+/// float->int is the only UB-prone leg, so it alone is range-clamped via the
+/// hiLimitExclusive/loLimitInclusive boundary above (NaN -> 0, out-of-range
+/// -> To's min/max) -- the exact same recipe EvalNative.hpp's
+/// castThrough/clampFloatToInt use for a same-domain round-trip Cast, reused
+/// here for a one-way conversion at a kernel signature boundary (parameter
+/// marshalling from a "mixed" secondary type, or a narrow/void return).
+template <typename From, typename To>
+To convertClamped(From v) {
+	if constexpr (std::is_floating_point_v<From> && !std::is_floating_point_v<To>) {
+		if (std::isnan(v)) {
+			return To(0);
+		}
+		if (v < loLimitInclusive<From, To>()) {
+			return std::numeric_limits<To>::min();
+		}
+		if (v >= hiLimitExclusive<From, To>()) {
+			return std::numeric_limits<To>::max();
+		}
+		return static_cast<To>(v);
+	} else {
+		return static_cast<To>(v);
+	}
+}
+
+/// Diagnostic-only formatting of a fixed-size array (the shared pointer
+/// buffer) for failure reports -- shared by the scalar-return and
+/// void/buffer-diffing signature shapes alike.
+template <typename T, size_t M>
+std::string formatArray(const std::array<T, M>& arr) {
+	std::string out = "[";
+	for (size_t i = 0; i < M; ++i) {
+		if (i != 0) {
+			out += ", ";
+		}
+		out += formatValue<T>(arr[i]);
+	}
+	out += "]";
+	return out;
 }
 
 } // namespace nautilus::fuzz


### PR DESCRIPTION
Closes #355.

## Summary

The differential AST fuzzer (`nautilus/test/fuzz/`) previously wired every generated kernel to a fixed `registerFunction` signature: exactly three same-typed `val<T>` parameters and a `val<T>` return. That left the `registerFunction` ABI boundary itself (prologue/epilogue, argument marshalling, return convention) mostly unfuzzed, even though the rest of the kernel body was fuzzed heavily.

`Harness.hpp` now draws a second byte per input (right after the existing type-select byte) and reduces it modulo a bounded menu of 7 concrete signature shapes, one `registerFunction` instantiation per `(shape, T)` pair:

- **`arity{1,2,3,4}`** — `N` `T`-typed parameters, `T`-typed return, for `N` in `{1, 2, 3, 4}` (`arity3` is the original fixed shape). Covers parameter-count variation: near-empty prologues, argument-register exhaustion, and stack-passed arguments on `arity4`.
- **`mixed`** — 3 logical `T` parameters, but the kernel's first *declared* parameter is a secondary type cross-domain from `T` (a 32-bit int when `T` is a float type, a `double` when `T` is an integer type), converted to `T` immediately at the boundary before joining the AST's `T`-only argument domain. Exercises the register-class interleaving between integer and floating-point kernel parameters (SysV/AAPCS64 classification).
- **`narrowReturn`** — 3 `T`-typed parameters, but the kernel returns a fixed narrow integer type (`int8_t`) instead of `T`. The AST still evaluates in `T`; only the final result is cast down at the return boundary. Exercises the same narrow-integer-return extension/truncation direction that previously produced real `ProxyCall`/`IndirectCall` ABI bugs for `Call` (see README "Known findings"), this time at the kernel's own return.
- **`voidReturn`** — 3 `T`-typed parameters, `void` return: a Store-only kernel. The computed root value is explicitly written to the shared buffer's first slot on both the native oracle and the traced kernel, and the whole buffer is diffed elementwise instead of a scalar return.

All conversions across a type boundary (`mixed`'s incoming parameter, `narrowReturn`'s outgoing return) go through the same NaN/out-of-range-safe recipe already used for `Kind::Cast` (new `Types.hpp::convertClamped` / `EvalNautilus.hpp::convertClampedTraced`), so every boundary conversion stays well-defined for all input bytes and native/traced parity is guaranteed by construction.

## Changes

- `Ast.hpp` / `EvalNative.hpp` / `EvalNautilus.hpp`: the AST's logical parameter count (`NUM_PARAMS`) is no longer a fixed global — `generate`/`evalNative`/`evalNautilus` take the arity as a runtime value/`std::span` instead of a hardcoded 3-element array, so the same generator/evaluator code works for any of the menu's arities.
- `Types.hpp`: adds `convertClamped<From, To>` (native) and `arraysEqual`/`formatArray` (buffer diffing/formatting for `voidReturn`).
- `EvalNautilus.hpp`: adds `convertClampedTraced<From, To>`, the traced counterpart.
- `Harness.hpp`: the bulk of the change — defines the bounded signature-shape menu and one `checkOne*` function per shape family (`checkOneArity<T, N>`, `checkOneMixed<T>`, `checkOneNarrowReturn<T>`, `checkOneVoidReturn<T>`), dispatched from `checkOneTyped`/`checkOne`. `Finding` gained a `shape` field; `printFinding`/survey-mode printing generalized to loop over however many args a shape actually has (previously hardcoded 3).
- `ReplayMain.cpp`: survey bucket keys now include `shape`; the args-printing loop no longer assumes exactly 3 positional args (would have been UB for the new `arity1`/`arity2` shapes).
- `README.md`: new "Kernel signature space" section documenting the shape menu.

## Test plan

- [x] Local build (Clang, interpreter + C + BC + AsmJit backends) via `cmake -DENABLE_FUZZER_REPLAY=ON ...`.
- [x] `./nautilus-fuzz-replay` (2000-iteration deterministic smoke corpus): `OK: 2000 generated programs agreed across all backends + interpreter`.
- [x] `./nautilus-fuzz-replay --survey 800`: `0 total findings` across all 7 signature shapes × 10 types × 4 backends.
- [x] Standalone shape-distribution check confirms all 7 shapes are drawn roughly uniformly from random input.
- [x] `clang-format-18 --dry-run --Werror` clean on all touched files.
- [ ] MLIR backend not exercised in this environment (not built here); left to CI, which builds it by default for `nautilus-fuzz`/`nautilus-fuzz-replay`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeFZ7NzRxqbpEnpjCgq2r6)_