### PR TITLE
[fuzzer] Sweep compiler-option / IR-pass permutations in the differential check

### DIFF
--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -19,30 +19,102 @@
 
 namespace nautilus::fuzz {
 
-/// Backends compiled into this build, mirroring testing::availableBackends().
-/// The interpreter is always present and acts as an extra differential peer.
-inline std::vector<std::string> configs() {
-	std::vector<std::string> result;
-	result.emplace_back("interpreter");
+/// Layers extra options on top of a config's backend defaults (empty == plain
+/// defaults). Mirrors testing::OptionsTweak in test/common/ExecutionTest.hpp.
+using OptionsTweak = std::function<void(engine::Options&)>;
+
+/// One (backend, option-permutation) differential peer. Every generated
+/// program is compiled once per Config; because the differential oracle is
+/// optimization-level-independent (the *result* must never depend on which
+/// passes ran or how a value was lowered), any two Configs -- and the native
+/// oracle -- must agree. `label` names the permutation so a finding records
+/// *which* configuration disagreed, not just the backend; `tweak` layers the
+/// permutation's options over the backend defaults.
+struct Config {
+	std::string backend;
+	std::string label;
+	OptionsTweak tweak;
+};
+
+/// The differential config matrix: for every backend compiled into this build
+/// (mirroring testing::availableBackends()), a curated menu of option
+/// permutations. The interpreter is always present as an extra peer.
+///
+/// The differential oracle is optimization-level-independent, so each
+/// permutation is a free extra peer: the same program under two option sets
+/// must agree, and both must match the native oracle -- a disagreement is a
+/// miscompile a single default build would never surface. This is a
+/// deliberately BOUNDED, curated menu of high-value toggles -- NOT a cartesian
+/// product (see fuzz/README.md "Config sweep"). Each compiling backend runs its
+/// plain defaults plus a small set of IR-pass permutations that each exercise a
+/// distinct lowering/optimization path; a pass author soaking a not-yet-default
+/// pass adds one entry here (see the README).
+inline std::vector<Config> configs() {
+	std::vector<Config> result;
+
+	// The interpreter runs uncompiled (engine.Compilation=false), so the IR
+	// optimization pipeline never runs for it -- IR-pass tweaks would be exact
+	// no-op rebuilds. It contributes a single differential peer.
+	result.push_back({"interpreter", "default", {}});
+
+	// Appends one compiling backend's permutation menu: plain defaults plus the
+	// shared IR-pass sweep, plus any backend-specific `extra` permutations.
+	auto addCompiling = [&result](const std::string& backend, std::vector<Config> extra = {}) {
+		result.push_back({backend, "default", {}});
+		// Individual default-ON optimization passes flipped OFF, each isolating a
+		// distinct lowering path. NOTE: we deliberately do NOT expose a blanket
+		// `ir.runPasses=false` -- that also disables constant folding, and the
+		// resulting unoptimized IR of a large generated program overruns the BC
+		// backend's 16-bit (`short`) register file (see README.md "Known
+		// findings"); these per-pass toggles keep constant folding on, so the IR
+		// stays bounded while still exercising the un-optimized path.
+		result.push_back({backend, "no-dead-code-elim", [](engine::Options& o) {
+			                  o.setOption("ir.disableDeadCodeElimination", true);
+		                  }});
+		result.push_back({backend, "no-const-branch-fold", [](engine::Options& o) {
+			                  o.setOption("ir.disableConstantBranchFolding", true);
+		                  }});
+		// A currently default-OFF pass flipped ON. This is exactly the
+		// "extended differential-fuzzer soak before the default flips" gate the
+		// IR-pass milestone (#343 and siblings) requires: point the fuzzer here
+		// to soak a not-yet-default pass against the oracle. StrengthReduction
+		// is the one opt-in pass wired today (see CompilationPipeline.cpp); add
+		// a sibling entry for the next pass you promote.
+		result.push_back({backend, "strength-reduction", [](engine::Options& o) {
+			                  o.setOption("ir.enableStrengthReduction", true);
+		                  }});
+		// A default-ON P0 pass flipped OFF: differentially tests the
+		// un-simplified lowering path against the simplified default.
+		result.push_back({backend, "no-algebraic-simpl", [](engine::Options& o) {
+			                  o.setOption("ir.disableAlgebraicSimplification", true);
+		                  }});
+		for (auto& c : extra) {
+			result.push_back(std::move(c));
+		}
+	};
+
 #ifdef ENABLE_MLIR_BACKEND
-	result.emplace_back("mlir");
+	// MLIR-specific: intrinsic lowering off exercises the non-intrinsic path.
+	addCompiling("mlir", {{"mlir", "no-intrinsics", [](engine::Options& o) {
+		                       o.setOption("mlir.enableIntrinsics", false);
+	                       }}});
 #endif
 #ifdef ENABLE_C_BACKEND
-	result.emplace_back("cpp");
+	addCompiling("cpp");
 #endif
 #ifdef ENABLE_BC_BACKEND
-	result.emplace_back("bc");
+	addCompiling("bc");
 #endif
 #ifdef ENABLE_TBC_BACKEND
-	result.emplace_back("tbc");
+	addCompiling("tbc");
 #endif
 #ifdef ENABLE_ASMJIT_BACKEND
-	result.emplace_back("asmjit");
+	addCompiling("asmjit");
 #endif
 	return result;
 }
 
-inline engine::NautilusEngine makeEngine(const std::string& backend) {
+inline engine::NautilusEngine makeEngine(const std::string& backend, const OptionsTweak& tweak = {}) {
 	engine::Options options;
 	if (backend == "interpreter") {
 		options.setOption("engine.Compilation", false);
@@ -64,6 +136,11 @@ inline engine::NautilusEngine makeEngine(const std::string& backend) {
 		options.setOption("ir.verifyAfterEachPass", true);
 		options.setOption("ir.failOnVerifyError", true);
 	}
+	// The config's option permutation wins over the backend defaults and env
+	// hooks above (matches testing::makeEngine's tweak-last ordering).
+	if (tweak) {
+		tweak(options);
+	}
 	return engine::NautilusEngine(options);
 }
 
@@ -74,6 +151,7 @@ inline engine::NautilusEngine makeEngine(const std::string& backend) {
 /// signature shape.
 struct Finding {
 	std::string backend;
+	std::string config; // option-permutation label that disagreed (see configs()), e.g. "no-ir-passes"
 	std::string typeName;
 	std::string shape; // which signature shape generated this kernel, see below
 	std::string program;
@@ -106,6 +184,7 @@ inline void printFinding(const Finding& f) {
 	if (f.exception) {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: EXCEPTION ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
+		std::fprintf(stderr, "config   : %s\n", f.config.c_str());
 		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
 		std::fprintf(stderr, "shape    : %s\n", f.shape.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
@@ -115,6 +194,7 @@ inline void printFinding(const Finding& f) {
 	} else {
 		std::fprintf(stderr, "\n==== Nautilus differential fuzzer: MISMATCH ====\n");
 		std::fprintf(stderr, "backend  : %s\n", f.backend.c_str());
+		std::fprintf(stderr, "config   : %s\n", f.config.c_str());
 		std::fprintf(stderr, "type     : %s\n", f.typeName.c_str());
 		std::fprintf(stderr, "shape    : %s\n", f.shape.c_str());
 		std::fprintf(stderr, "program  : %s\n", f.program.c_str());
@@ -264,9 +344,9 @@ std::vector<Finding> checkOneArity(ByteReader& reader) {
 	const std::string shapeName = "arity" + std::to_string(N);
 
 	std::vector<Finding> findings;
-	for (const auto& backend : configs()) {
+	for (const auto& cfg : configs()) {
 		try {
-			auto engine = makeEngine(backend);
+			auto engine = makeEngine(cfg.backend, cfg.tweak);
 			std::function<ArityKernelSignature<T, N>> kernel = [&ast](val<T*> mem, auto... a) {
 				TracedArgs<T, static_cast<std::size_t>(N)> traced {a...};
 				return evalNautilus<T>(ast, mem, traced);
@@ -277,12 +357,12 @@ std::vector<Finding> checkOneArity(ByteReader& reader) {
 				return compiled(memory.data(), args[Is]...);
 			}(std::make_index_sequence<static_cast<std::size_t>(N)> {});
 			if (!valuesEqual<T>(got, expected)) {
-				findings.push_back({backend, typeSuffix<T>(), shapeName, program, argStrs, memoryStrs,
+				findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), shapeName, program, argStrs, memoryStrs,
 				                    formatValue<T>(expected), formatValue<T>(got), false, "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back(
-			    {backend, typeSuffix<T>(), shapeName, program, argStrs, memoryStrs, "", "", true, e.what(), hasParam});
+			findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), shapeName, program, argStrs, memoryStrs, "",
+			                    "", true, e.what(), hasParam});
 		}
 	}
 	return findings;
@@ -320,9 +400,9 @@ std::vector<Finding> checkOneMixed(ByteReader& reader) {
 	}
 
 	std::vector<Finding> findings;
-	for (const auto& backend : configs()) {
+	for (const auto& cfg : configs()) {
 		try {
-			auto engine = makeEngine(backend);
+			auto engine = makeEngine(cfg.backend, cfg.tweak);
 			std::function<MixedKernelSignature<T>> kernel = [&ast](val<T*> mem, val<S> p0, val<T> p1, val<T> p2) {
 				TracedArgs<T, N> traced {convertClampedTraced<S, T>(p0), p1, p2};
 				return evalNautilus<T>(ast, mem, traced);
@@ -331,12 +411,12 @@ std::vector<Finding> checkOneMixed(ByteReader& reader) {
 			memory = initialMemory;
 			const T got = compiled(memory.data(), secondaryRaw, arg1, arg2);
 			if (!valuesEqual<T>(got, expected)) {
-				findings.push_back({backend, typeSuffix<T>(), "mixed", program, argStrs, memoryStrs,
+				findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), "mixed", program, argStrs, memoryStrs,
 				                    formatValue<T>(expected), formatValue<T>(got), false, "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back(
-			    {backend, typeSuffix<T>(), "mixed", program, argStrs, memoryStrs, "", "", true, e.what(), hasParam});
+			findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), "mixed", program, argStrs, memoryStrs, "", "",
+			                    true, e.what(), hasParam});
 		}
 	}
 	return findings;
@@ -377,9 +457,9 @@ std::vector<Finding> checkOneNarrowReturn(ByteReader& reader) {
 	}
 
 	std::vector<Finding> findings;
-	for (const auto& backend : configs()) {
+	for (const auto& cfg : configs()) {
 		try {
-			auto engine = makeEngine(backend);
+			auto engine = makeEngine(cfg.backend, cfg.tweak);
 			std::function<NarrowReturnKernelSignature<T>> kernel = [&ast](val<T*> mem, val<T> a, val<T> b, val<T> c) {
 				TracedArgs<T, N> traced {a, b, c};
 				TracedValue<T> result = evalNautilus<T>(ast, mem, traced);
@@ -389,13 +469,13 @@ std::vector<Finding> checkOneNarrowReturn(ByteReader& reader) {
 			memory = initialMemory;
 			const NarrowReturnType got = compiled(memory.data(), args[0], args[1], args[2]);
 			if (!valuesEqual<NarrowReturnType>(got, expected)) {
-				findings.push_back({backend, typeSuffix<T>(), "narrowReturn", program, argStrs, memoryStrs,
-				                    formatValue<NarrowReturnType>(expected), formatValue<NarrowReturnType>(got), false,
-				                    "", hasParam});
+				findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), "narrowReturn", program, argStrs,
+				                    memoryStrs, formatValue<NarrowReturnType>(expected),
+				                    formatValue<NarrowReturnType>(got), false, "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back({backend, typeSuffix<T>(), "narrowReturn", program, argStrs, memoryStrs, "", "", true,
-			                    e.what(), hasParam});
+			findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), "narrowReturn", program, argStrs, memoryStrs,
+			                    "", "", true, e.what(), hasParam});
 		}
 	}
 	return findings;
@@ -441,9 +521,9 @@ std::vector<Finding> checkOneVoidReturn(ByteReader& reader) {
 	}
 
 	std::vector<Finding> findings;
-	for (const auto& backend : configs()) {
+	for (const auto& cfg : configs()) {
 		try {
-			auto engine = makeEngine(backend);
+			auto engine = makeEngine(cfg.backend, cfg.tweak);
 			std::function<VoidReturnKernelSignature<T>> kernel = [&ast](val<T*> mem, val<T> a, val<T> b, val<T> c) {
 				TracedArgs<T, N> traced {a, b, c};
 				TracedValue<T> result = evalNautilus<T>(ast, mem, traced);
@@ -453,13 +533,13 @@ std::vector<Finding> checkOneVoidReturn(ByteReader& reader) {
 			memory = initialMemory;
 			compiled(memory.data(), args[0], args[1], args[2]);
 			if (!arraysEqual<T, BUFFER_ELEMS>(memory, expectedMemory)) {
-				findings.push_back({backend, typeSuffix<T>(), "voidReturn", program, argStrs, memoryStrs,
+				findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), "voidReturn", program, argStrs, memoryStrs,
 				                    formatArray<T, BUFFER_ELEMS>(expectedMemory), formatArray<T, BUFFER_ELEMS>(memory),
 				                    false, "", hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back({backend, typeSuffix<T>(), "voidReturn", program, argStrs, memoryStrs, "", "", true,
-			                    e.what(), hasParam});
+			findings.push_back({cfg.backend, cfg.label, typeSuffix<T>(), "voidReturn", program, argStrs, memoryStrs, "",
+			                    "", true, e.what(), hasParam});
 		}
 	}
 	return findings;
@@ -555,9 +635,9 @@ inline std::vector<Finding> checkOneEnum(ByteReader& reader) {
 	}
 
 	std::vector<Finding> findings;
-	for (const auto& backend : configs()) {
+	for (const auto& cfg : configs()) {
 		try {
-			auto engine = makeEngine(backend);
+			auto engine = makeEngine(cfg.backend, cfg.tweak);
 			// The kernel returns val<Underlying>, not val<FuzzEnum>: unlike
 			// every other domain here, val<FuzzEnum>::raw_type (Underlying) is
 			// NOT val<FuzzEnum> itself (val_enum.hpp), so registerFunction's
@@ -576,12 +656,13 @@ inline std::vector<Finding> checkOneEnum(ByteReader& reader) {
 			memory = initialMemory;
 			const FuzzEnum got = static_cast<FuzzEnum>(compiled(memory.data(), args[0], args[1], args[2]));
 			if (!valuesEqual<FuzzEnum>(got, expected)) {
-				findings.push_back({backend, typeSuffix<FuzzEnum>(), "arity3", program, argStrs, memoryStrs,
-				                    formatValue<FuzzEnum>(expected), formatValue<FuzzEnum>(got), false, "", hasParam});
+				findings.push_back({cfg.backend, cfg.label, typeSuffix<FuzzEnum>(), "arity3", program, argStrs,
+				                    memoryStrs, formatValue<FuzzEnum>(expected), formatValue<FuzzEnum>(got), false, "",
+				                    hasParam});
 			}
 		} catch (const std::exception& e) {
-			findings.push_back({backend, typeSuffix<FuzzEnum>(), "arity3", program, argStrs, memoryStrs, "", "", true,
-			                    e.what(), hasParam});
+			findings.push_back({cfg.backend, cfg.label, typeSuffix<FuzzEnum>(), "arity3", program, argStrs, memoryStrs,
+			                    "", "", true, e.what(), hasParam});
 		}
 	}
 	return findings;

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -33,9 +33,10 @@ bug because every generated program is fully defined by construction.
     first finding, like libFuzzer).
   * `nautilus-fuzz-replay <file> ...` — replay specific saved inputs.
   * `nautilus-fuzz-replay --survey [N]` — run N inputs **without** aborting and
-    print findings bucketed by `(backend, type, kind)`, to triage how many
-    distinct bug classes exist (e.g. an `i8`-only bug breaks out from an
-    `f64`-only one instead of merging into one bucket).
+    print findings bucketed by `(backend, config, type, shape, kind)`, to triage
+    how many distinct bug classes exist (e.g. an `i8`-only bug breaks out from an
+    `f64`-only one instead of merging into one bucket; an option-gated miscompile
+    breaks out from a plain backend bug — see [Config sweep](#config-sweep)).
 
 ## Scope: twelve value domains
 
@@ -402,6 +403,66 @@ mismatch.
 This is what makes the native oracle (`EvalNative.hpp`) a valid reference for
 every one of the ten domains.
 
+## Config sweep
+
+The differential oracle is **optimization-level-independent**: the *result* of
+a well-defined program must never depend on which IR passes ran or how a value
+was lowered. So beyond running each program on every backend and every
+[signature shape](#kernel-signature-space), the harness runs it under several
+**compiler-option permutations per backend** — each one a free extra
+differential peer. The same program under two option sets must produce the same
+answer, and both must match the native oracle; a disagreement is a miscompile
+that a single default build would never surface.
+
+`configs()` in `Harness.hpp` returns a list of `(backend, label, OptionsTweak)`
+`Config`s. The menu is deliberately **curated and bounded** — a small set of
+high-value toggles, not a cartesian product (this is a slow, soundness-oriented
+fuzzer). Each compiling backend runs:
+
+| Config label | Tweak | Why |
+|--------------|-------|-----|
+| `default`              | *(none)* | the backend's shipping defaults — the baseline peer |
+| `no-dead-code-elim`    | `ir.disableDeadCodeElimination=true` | a default-**on** P0 pass flipped **off** |
+| `no-const-branch-fold` | `ir.disableConstantBranchFolding=true` | a default-**on** P0 pass flipped **off** |
+| `strength-reduction`   | `ir.enableStrengthReduction=true` | a currently default-**off** pass flipped **on** |
+| `no-algebraic-simpl`   | `ir.disableAlgebraicSimplification=true` | a default-**on** P0 pass flipped **off** |
+
+MLIR additionally runs `no-intrinsics` (`mlir.enableIntrinsics=false`). The
+interpreter runs uncompiled (`engine.Compilation=false`), so the IR pipeline
+never runs for it and it contributes a single `default` peer.
+
+These are per-pass toggles that keep constant folding **on**, so the IR stays
+bounded. There is deliberately **no** blanket `ir.runPasses=false` peer:
+disabling the whole pipeline also disables constant folding, and the resulting
+unoptimized IR of a large generated program overruns the BC backend's 16-bit
+register file (see [Known findings](#known-findings)) — a pre-existing
+scalability crash unrelated to the miscompiles this fuzzer hunts.
+
+A finding records **which** permutation disagreed (the `config` field on
+`Finding`, printed by the harness and part of the `--survey` bucket key), so an
+option-gated bug is distinguished from a plain backend bug.
+
+### Targeting a not-yet-default pass for a soak
+
+The IR-pass milestone (`docs/design/ir-pass-improvements.md`, #343 and siblings)
+gates flipping a pass default-on on "an extended differential-fuzzer soak before
+the default flips … any finding → fix or revert the rule". This sweep is that
+gate. To soak a pass that is still default-off, add one line to the
+`addCompiling` menu in `configs()` (`Harness.hpp`) flipping its toggle on — the
+`strength-reduction` entry is the worked example (`ir.enableStrengthReduction`).
+Then run a long soak:
+
+```bash
+./nautilus/test/fuzz/nautilus-fuzz -max_total_time=3600     # coverage-guided
+./nautilus/test/fuzz/nautilus-fuzz-replay --survey 20000    # or a triage survey
+```
+
+Any finding under that config's label is an option-gated miscompile: fix the
+pass (or revert the default-flip), then **pin** the minimized reproducer as a
+fixed `forEachBackend` regression test with the option tweak applied
+(`makeEngine(backend, tweak)` — see `test/common/ExecutionTest.hpp`), and note
+it under [Known findings](#known-findings).
+
 ## Build & run
 
 Requires Clang (libFuzzer). Opt-in via `-DENABLE_FUZZING=ON`; the target is kept
@@ -460,12 +521,35 @@ A crash input is a self-contained reproducer:
 ./nautilus/test/fuzz/nautilus-fuzz -minimize_crash=1 -runs=10000 crash-<hash>
 ```
 
-On a mismatch the harness prints the offending **backend**, the pretty-printed
+On a mismatch the harness prints the offending **backend**, the **config**
+(option permutation, see [Config sweep](#config-sweep)), the pretty-printed
 **program**, the **args**, and the expected/actual values. Drop the printed
 program + args into a fixed `forEachBackend` case under
-`test/execution-tests/` so the bug stays covered after it is fixed.
+`test/execution-tests/` so the bug stays covered after it is fixed. When the
+`config` is anything other than `default`, the bug is **option-gated**: pass the
+same tweak to `makeEngine(backend, tweak)` (e.g.
+`[](engine::Options& o) { o.setOption("ir.enableStrengthReduction", true); }`)
+in the regression test, or it will not reproduce.
 
 ## Known findings
+
+The [config sweep](#config-sweep) itself surfaced a pre-existing BC-backend
+scalability crash while it was being built. An early version of the sweep
+included a blanket `ir.runPasses=false` peer; on a large generated `f64`
+arity-4 program (deeply nested `Cast`/`If`/`Loop`), turning the *whole* IR
+pipeline off — constant folding included — leaves an unoptimized IR with tens
+of thousands of live SSA values. The BC backend indexes its register file with
+16-bit `short`s (`OpCode`/`Code::arguments` in
+`compiler/backends/bc/ByteCode.hpp`), so the register index overflows past
+32767 and `BCLoweringProvider::lower` writes out of bounds, corrupting a
+`bc::Code` vector's control block — the process dies in `Code::~Code()` freeing
+a garbage pointer (a SIGSEGV/`free(0x1)`, no differential report). This is a
+BC register-space limit, not a miscompile, and the optimization passes normally
+keep the IR well under it; it is orthogonal to what this fuzzer hunts. The
+sweep therefore does **not** expose `ir.runPasses=false` — it uses per-pass
+toggles that keep constant folding on (see [Config sweep](#config-sweep)) — and
+the BC 16-bit-register limit is left to be fixed (graceful error, or a wider
+index) as a separate change.
 
 On its first run this fuzzer reproduces a real bug: the IR constant-folding pass
 folds unsigned integer comparison/division/modulo/right-shift with **signed**

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -177,10 +177,13 @@ int builtinCorpus() {
 }
 
 // Survey mode: run many inputs WITHOUT aborting, bucketing findings by
-// (backend, type, has-runtime-parameter) and keeping one example per bucket.
-// Used to see whether distinct bug classes exist (e.g. a mismatch involving a
-// runtime parameter would point to a codegen bug rather than constant
-// folding; the type breaks out e.g. an i8-only bug from an f64-only one).
+// (backend, config, type, shape, has-runtime-parameter) and keeping one example
+// per bucket. Used to see whether distinct bug classes exist (e.g. a mismatch
+// involving a runtime parameter would point to a codegen bug rather than
+// constant folding; the type breaks out e.g. an i8-only bug from an f64-only
+// one; the config permutation breaks out an option-gated miscompile -- one that
+// only appears under a non-default IR-pass toggle -- from a plain backend bug
+// that reproduces under every config).
 // Each bucket's first input is also saved to fuzz-finding-<n>.bin in the
 // working directory so it can be replayed (`nautilus-fuzz-replay <file>`)
 // and minimized -- essential when a finding depends on the runtime buffer
@@ -196,7 +199,7 @@ int survey(int iterations) {
 		const std::vector<uint8_t> buf = randomBuffer();
 		for (const auto& f : nautilus::fuzz::checkOne(buf.data(), buf.size())) {
 			++totalFindings;
-			const std::string key = f.backend + "|" + f.typeName + "|" + f.shape +
+			const std::string key = f.backend + "|" + f.config + "|" + f.typeName + "|" + f.shape +
 			                        (f.exception ? "|exception|" + f.what : (f.hasParam ? "|has-param" : "|all-const"));
 			counts[key]++;
 			if (!buckets.count(key)) {


### PR DESCRIPTION
Closes #360. (Rebased onto `main` after #376 wired the fuzzer into CI; re-applied on top of the new signature-shape / bool+enum harness.)

## Problem

The differential fuzzer compiled every generated program exactly one way per backend (`makeEngine` set only `engine.backend`). Miscompiles that only appear under a **non-default** compiler configuration were therefore invisible, and — as #360 notes — a not-yet-default IR pass could never be soaked against the oracle, which the IR-pass milestone (#343 and siblings) explicitly requires ("extended differential-fuzzer soak before the default flips") before flipping a pass default-on.

## Approach

The differential oracle is **optimization-level-independent**: a well-defined program's *result* must never depend on which IR passes ran or how a value was lowered. So each option permutation is a free extra differential peer — the same program under two option sets must agree, and both must match the native oracle.

- `configs()` (`Harness.hpp`) now returns a list of `(backend, label, OptionsTweak)` `Config`s instead of a flat backend list. `makeEngine(backend, tweak)` applies the tweak last. All 5 signature-shape/domain check loops iterate it.
- Each **compiling** backend runs a **curated, bounded** menu (not a cartesian product):
  - `default` — shipping defaults (baseline peer)
  - `no-dead-code-elim` — `ir.disableDeadCodeElimination=true` (default-on P0 pass off)
  - `no-const-branch-fold` — `ir.disableConstantBranchFolding=true` (default-on P0 pass off)
  - `strength-reduction` — `ir.enableStrengthReduction=true` (**a currently default-off pass flipped on** — the worked "soak a not-yet-default pass" example)
  - `no-algebraic-simpl` — `ir.disableAlgebraicSimplification=true` (default-on P0 pass off)
  - MLIR additionally: `no-intrinsics` (`mlir.enableIntrinsics=false`)
  - All are **per-pass** toggles that keep constant folding on, so the IR stays bounded (see the finding below).
- The interpreter runs uncompiled (`engine.Compilation=false`), so it stays a single `default` peer.
- `Finding` gains a `config` field recording **which** permutation disagreed; the harness prints it, and `--survey` (`ReplayMain.cpp`) buckets on `(backend, config, type, shape, kind)` so an option-gated bug is distinguished from a plain backend bug.
- `fuzz/README.md` documents the config sweep and gives a step-by-step for pointing the fuzzer at a not-yet-default pass for a soak.

## Finding surfaced while building the sweep

An early version included a blanket `ir.runPasses=false` peer. On a large generated `f64` arity-4 program, turning the *whole* pipeline off (constant folding included) leaves an unoptimized IR with tens of thousands of live SSA values, which **overruns the BC backend's 16-bit (`short`) register file** — `BCLoweringProvider::lower` writes out of bounds and the process dies in `bc::Code::~Code()` freeing a garbage pointer (SIGSEGV/`free(0x1)`, no differential report). This is a BC register-space **scalability limit, not a miscompile**; the optimization passes normally keep the IR well under it. The sweep therefore uses per-pass toggles that keep the IR bounded, and the BC limit is documented under README "Known findings" to be fixed (graceful error / wider index) as a separate change.

## Acceptance criteria

- [x] Differential check runs each program under multiple option permutations per backend, including a currently-non-default IR-pass toggle (`ir.enableStrengthReduction`) flipped on.
- [x] `Finding` / survey buckets identify the option permutation, not just the backend.
- [x] Replay smoke corpus stays green under the expanded config matrix (verified below). The one crash the sweep surfaced is a pre-existing BC scalability limit, excluded + documented, not a miscompile that needs a `forEachBackend` pin.
- [x] `README.md` documents the config sweep and how to target a specific pass for a soak.

## Verification

Built `nautilus-fuzz-replay` (`-DENABLE_FUZZER_REPLAY=ON`, clang-18). Full built-in smoke corpus (2000 programs) under the expanded matrix on `bc`/`tbc`/interpreter:

```
OK: 2000 generated programs agreed across all backends + interpreter (540 known pre-existing tracer/IR exceptions tolerated)
```

Also confirmed green with `cpp` + `asmjit` backends additionally enabled (shorter run — cpp compiles are slow). Changed files are clang-format-18 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YGzFV9np9PWhkqowN7WF2