### PR TITLE
[tbc] iOS support: zero-dependency typed call thunks as dyncall fallback

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,18 @@ jobs:
             cc: 'clang-21'
             cxx: 'clang++-21'
             flags: '-DENABLE_SHORT_CIRCUIT_BOOL=ON'
+          # tbc without dyncall: external calls only through the built-in
+          # typed thunks (the iOS-equivalent configuration).
+          - os: 'ubuntu-24.04'
+            cc: 'clang-21'
+            cxx: 'clang++-21'
+            flags: '-DENABLE_TBC_DYNCALL=OFF'
+          # ... and additionally without the bc backend, so dyncall is not
+          # built at all (verifies nothing else links or exports it).
+          - os: 'ubuntu-24.04'
+            cc: 'clang-21'
+            cxx: 'clang++-21'
+            flags: '-DENABLE_TBC_DYNCALL=OFF -DENABLE_BC_BACKEND=OFF'
           - os: 'ubuntu-24.04'
             cc: 'clang-21'
             cxx: 'clang++-21'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ cmake_dependent_option(ENABLE_C_BACKEND "Enable the C compiler backend" ON "ENAB
 cmake_dependent_option(ENABLE_BC_BACKEND "Enable the bytecode interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_TBC_BACKEND "Enable the threaded bytecode interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_BC_LIBFFI "Use libffi static-trampoline closures for the bytecode backend instead of dyncall callbacks (iOS-safe: no runtime-generated executable memory)" OFF "ENABLE_BC_BACKEND" OFF)
+cmake_dependent_option(ENABLE_TBC_DYNCALL "Marshal the threaded bytecode backend's outgoing external calls through dyncall (OFF: only the built-in zero-dependency typed thunks are used, dropping tbc's last third-party dependency)" ON "ENABLE_TBC_BACKEND" OFF)
 cmake_dependent_option(ENABLE_ASMJIT_BACKEND "Enable the asmjit interpreter backend" ON "ENABLE_TRACING" OFF)
 cmake_dependent_option(ENABLE_SHORT_CIRCUIT_BOOL "Trace val<bool> && / || with C++ short-circuit semantics (drops the operator overloads so the built-in operators route through val<bool>::operator bool())" OFF "ENABLE_TRACING" OFF)
 
@@ -168,7 +169,10 @@ if (ENABLE_STACKTRACE)
 endif ()
 
 
-if (ENABLE_BC_BACKEND OR ENABLE_TBC_BACKEND)
+# dyncall is needed by the bc backend (always) and by the tbc backend only
+# when its dyncall external-call marshalling is enabled; with both consumers
+# off the library must be neither built nor exported.
+if (ENABLE_BC_BACKEND OR (ENABLE_TBC_BACKEND AND ENABLE_TBC_DYNCALL))
     add_subdirectory(${THIRD_PARTY_DIR}/dyncall)
     list(APPEND EXPORT_TARGETS dyncall_s)
 

--- a/nautilus/CMakeLists.txt
+++ b/nautilus/CMakeLists.txt
@@ -9,6 +9,8 @@ endif ()
 # The libffi closure path is selected by the ENABLE_BC_LIBFFI option but exposed to
 # source as NAUTILUS_BC_LIBFFI; mirror the value so #cmakedefine emits the define.
 set(NAUTILUS_BC_LIBFFI ${ENABLE_BC_LIBFFI})
+# Same mirroring for the tbc backend's dyncall external-call marshalling.
+set(NAUTILUS_TBC_DYNCALL ${ENABLE_TBC_DYNCALL})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/nautilus/common/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/nautilus/config.hpp)
 
 add_subdirectory(src)

--- a/nautilus/include/nautilus/common/config.h.in
+++ b/nautilus/include/nautilus/common/config.h.in
@@ -5,6 +5,7 @@
 #cmakedefine ENABLE_BC_BACKEND
 #cmakedefine ENABLE_TBC_BACKEND
 #cmakedefine NAUTILUS_BC_LIBFFI
+#cmakedefine NAUTILUS_TBC_DYNCALL
 #cmakedefine ENABLE_C_BACKEND
 #cmakedefine ENABLE_MLIR_BACKEND
 #cmakedefine ENABLE_ASMJIT_BACKEND

--- a/nautilus/src/nautilus/compiler/backends/tbc/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/tbc/CMakeLists.txt
@@ -2,8 +2,12 @@
 
 if (ENABLE_TBC_BACKEND)
     # Outgoing external calls are marshaled through dyncall (no dyncallback:
-    # the tbc backend never allocates executable memory).
-    target_link_libraries(nautilus PRIVATE dyncall_s)
+    # the tbc backend never allocates executable memory) or, when dyncall is
+    # disabled or tbc.externalCall=thunks, through the built-in
+    # zero-dependency typed thunks (TBCThunkCall.cpp).
+    if (ENABLE_TBC_DYNCALL)
+        target_link_libraries(nautilus PRIVATE dyncall_s)
+    endif ()
 
     add_source_files(nautilus
             TBCBackend.cpp
@@ -11,6 +15,7 @@ if (ENABLE_TBC_BACKEND)
             TBCExecutable.cpp
             TBCInterpreter.cpp
             TBCLoweringProvider.cpp
+            TBCThunkCall.cpp
             TBCTrampoline.cpp
     )
 endif ()

--- a/nautilus/src/nautilus/compiler/backends/tbc/README.md
+++ b/nautilus/src/nautilus/compiler/backends/tbc/README.md
@@ -100,8 +100,22 @@ simply pushes further frames at `sp`.
   return to a static `HALT` instruction. No FFI, no C++ recursion.
 - **External** (`invoke`): a single `CALL_EXT` instruction referencing a
   per-call-site record `{target, argRegs, argTypes, returnType}`; one handler
-  drives the outgoing dyncall VM (arguments + call in one dispatch). Outgoing
-  dyncall builds call frames dynamically without executable memory.
+  marshals arguments + call in one dispatch, through one of two mechanisms
+  selected by `tbc.externalCall = auto | dyncall | thunks`:
+  - **dyncall** (default when built, `ENABLE_TBC_DYNCALL=ON`): drives the
+    outgoing dyncall VM, which builds call frames dynamically without
+    executable memory. Covers any signature.
+  - **typed thunks** (`TBCThunkCall.hpp`, always compiled, zero
+    dependencies): each external site is bound at backend-compile time to one
+    of ~1100 pre-compiled template callers keyed on (return kind × integer-arg
+    count × f32/f64 pattern). Integer-class arguments travel as extended
+    `uint64_t` reordered ahead of the fp arguments — ABI-sound on x86-64 SysV
+    and AArch64 (incl. Apple) because the two argument classes are
+    register-assigned independently, with caps (≤ 8 integer-class, ≤ 4
+    fp-class args) that keep every argument out of ABI-visible stack-layout
+    differences. Over-cap or off-platform sites degrade per-site to dyncall;
+    without dyncall in the build they are rejected at compile time with a
+    clear error. `auto` resolves to thunks when dyncall is not built.
 - **Indirect** (`CALL_IND`): the target register always holds a real native
   pointer (see trampolines below), so it uses the external path.
 
@@ -141,8 +155,28 @@ Optimizations are **on by default** (flags exist only for A/B benchmarking):
 - `tbc.coalescing` — block-edge parallel copies emit the minimum number of
   MOVs (one temp only for a genuine permutation cycle).
 
-Other options: `tbc.dispatch` (see above), `tbc.stackSizeKb` (default 1024),
-`tbc.registerAllocator` (default true).
+Other options: `tbc.dispatch` (see above), `tbc.externalCall` (see Calls;
+default `auto`), `tbc.stackSizeKb` (default 1024), `tbc.registerAllocator`
+(default true).
+
+## iOS support
+
+iOS forbids runtime code generation (no writable+executable pages), which
+rules out the MLIR / C++ / asmjit backends and `bc`'s dyncallback
+trampolines. `tbc` is built to run there:
+
+- **No executable memory anywhere**: bytecode is interpreted in place;
+  escaping internal function pointers come from the pre-compiled trampoline
+  pool (`TBCTrampoline.hpp`).
+- **Dispatch**: the strongest skin, tail-call threading, is Clang-based and
+  works on iOS; `tbc.dispatch = auto` selects it there.
+- **Outgoing external calls**: dyncall's forward-call VM is itself iOS-safe
+  (it builds call frames on a data stack and ships an Apple arm64 ABI
+  implementation), so a default build works. To avoid cross-compiling
+  dyncall's per-target assembly — and to drop tbc's last third-party
+  dependency altogether — configure with `-DENABLE_TBC_DYNCALL=OFF`: external
+  calls then marshal through the built-in typed thunks (see Calls), subject
+  to their signature caps.
 
 ## Testing
 
@@ -200,11 +234,17 @@ Other options: `tbc.dispatch` (see above), `tbc.stackSizeKb` (default 1024),
   fusion above reuses the same set to drop the fused-away `ADD_imm_i64`, so
   a `ptr + const` feeding a `LOAD`/`STORE` collapses from three instructions
   (`MOV_imm`, `ADD`, `LOAD`/`STORE`) to one.
-- **Zero-dependency typed call thunks**: replace outgoing dyncall with
-  template-instantiated callers selected at lowering time (signatures are
-  statically known). Requires a register-only argument cap and care with the
-  Apple arm64 stack-argument packing rules; would remove the last third-party
-  dependency.
+- ~~**Zero-dependency typed call thunks**~~ — done (`TBCThunkCall.{hpp,cpp}`):
+  outgoing external calls can marshal through pre-compiled template callers
+  bound per call site at backend-compile time (`tbc.externalCall = thunks`,
+  automatic when dyncall is not built). Caps: ≤ 8 integer-class and ≤ 4
+  fp-class arguments, x86-64 SysV / AArch64 only (the Apple arm64
+  stack-argument packing rules are sidestepped by keeping every reordered
+  argument in registers — or, for integer args 7-8 on SysV x86-64, in
+  8-byte-rounded stack slots). Over-cap sites fall back per-site to dyncall
+  when it is built. `-DENABLE_TBC_DYNCALL=OFF` drops the dyncall link
+  entirely, removing tbc's last third-party dependency; over-cap signatures
+  are then rejected at backend-compile time with a clear error.
 - **Float-signature trampolines**: extend the escaping-function-pointer pool
   beyond integer-class signatures if a use case appears.
 - **Instruction-stream prefetch hints / handler layout experiments** once

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.cpp
@@ -4,7 +4,10 @@
 #include "nautilus/compiler/backends/tbc/TBCExecutable.hpp"
 #include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
 #include "nautilus/compiler/backends/tbc/TBCLoweringProvider.hpp"
+#include "nautilus/compiler/backends/tbc/TBCThunkCall.hpp"
 #include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
+#include "nautilus/config.hpp"
+#include "nautilus/exceptions/NotImplementedException.hpp"
 #include <chrono>
 
 namespace nautilus::compiler::tbc {
@@ -36,6 +39,50 @@ const char* dispatchModeName(DispatchMode mode) {
 	}
 	return "unknown";
 }
+
+ExtCallMode parseExtCallMode(const std::string& name) {
+	if (name == "dyncall") {
+		return ExtCallMode::Dyncall;
+	}
+	if (name == "thunks") {
+		return ExtCallMode::Thunks;
+	}
+	// "auto" (and anything unknown) selects the build's default: dyncall when
+	// it is linked, the zero-dependency typed thunks otherwise.
+	return defaultExtCallMode();
+}
+
+const char* extCallModeName(ExtCallMode mode) {
+	switch (mode) {
+	case ExtCallMode::Dyncall:
+		return "dyncall";
+	case ExtCallMode::Thunks:
+		return "thunks";
+	}
+	return "unknown";
+}
+
+/// Bind every external call site (CALL_EXT and CALL_IND share the record
+/// shape; internal CALL sites never reach the external path) to a typed
+/// thunk. Sites whose signature exceeds the thunk caps degrade per-site to
+/// dyncall when it is built; without dyncall they are rejected here, at
+/// compile time, rather than at run time mid-execution.
+void resolveExtCallThunks(TBCProgram& program) {
+	for (auto& site : program.callsites) {
+		if (site.internalFnIdx != ~0u) {
+			continue;
+		}
+		resolveExtCallThunk(site);
+#ifndef NAUTILUS_TBC_DYNCALL
+		if (site.ext.fn == nullptr) {
+			throw NotImplementedException(
+			    "tbc: external call signature exceeds the typed-thunk limits (at most 8 integer-class and 4 "
+			    "float-class arguments, x86-64/AArch64 only) and dyncall is not built; rebuild with "
+			    "-DENABLE_TBC_DYNCALL=ON to marshal such calls through dyncall");
+		}
+#endif
+	}
+}
 } // namespace
 
 std::unique_ptr<Executable> TBCBackend::compile(const std::shared_ptr<ir::IRGraph>& ir, const DumpHandler& dumpHandler,
@@ -54,6 +101,8 @@ std::unique_ptr<Executable> TBCBackend::compile(const std::shared_ptr<ir::IRGrap
 	auto program = std::make_shared<TBCProgram>();
 	program->dispatch =
 	    clampDispatchMode(parseDispatchMode(options.getOptionOrDefault<std::string>("tbc.dispatch", "auto")));
+	program->extCall =
+	    clampExtCallMode(parseExtCallMode(options.getOptionOrDefault<std::string>("tbc.externalCall", "auto")));
 	const auto stackSizeKb = options.getOptionOrDefault("tbc.stackSizeKb", 1024);
 	program->minStackSlots = static_cast<uint64_t>(stackSizeKb) * 1024 / sizeof(uint64_t);
 
@@ -87,11 +136,16 @@ std::unique_ptr<Executable> TBCBackend::compile(const std::shared_ptr<ir::IRGrap
 		maxRegisters = std::max<int64_t>(maxRegisters, function.regSlots);
 	}
 
+	if (program->extCall == ExtCallMode::Thunks) {
+		resolveExtCallThunks(*program);
+	}
+
 	if (statistics != nullptr) {
 		statistics->set("tbc.instructions", totalInstructions);
 		statistics->set("tbc.codeSize.bytes", totalInstructions * static_cast<int64_t>(sizeof(Instr)));
 		statistics->set("tbc.registers.max", maxRegisters);
 		statistics->set("tbc.dispatch", std::string(dispatchModeName(program->dispatch)));
+		statistics->set("tbc.externalCall", std::string(extCallModeName(program->extCall)));
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCCode.hpp
@@ -2,9 +2,12 @@
 
 #include "nautilus/compiler/backends/tbc/TBCOpcodes.hpp"
 #include "nautilus/tracing/Types.hpp"
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace nautilus::compiler::tbc {
@@ -33,16 +36,50 @@ constexpr int32_t packedOffsetLoHi(const Instr& i) {
 	return static_cast<int32_t>(static_cast<uint32_t>(i.a) | (static_cast<uint32_t>(i.b) << 16));
 }
 
+/// Caps of the zero-dependency typed-thunk external-call path
+/// (TBCThunkCall.hpp). Chosen so that no argument the thunk reorders can land
+/// in a stack slot whose layout differs from the callee's real signature: on
+/// AArch64 (incl. Apple) 8 integer + 8 fp argument registers mean nothing
+/// spills at all; on SysV x86-64 integer args 7-8 spill into 8-byte-rounded
+/// stack slots that are layout-compatible with any integer-class parameter,
+/// and fp args never spill because the cap is below the 8 SSE registers.
+constexpr size_t kThunkMaxIntArgs = 8;
+constexpr size_t kThunkMaxFpArgs = 4;
+
+/// A pre-compiled typed caller: forwards `intArgs[0..numInt)` (extended
+/// integer-class values) and `fpArgs[0..numFp)` (raw f32/f64 slot bit
+/// patterns) to `target` with the native calling convention, and returns the
+/// result normalized into a VM slot bit pattern (0 for void).
+using ExtThunkFn = uint64_t (*)(void* target, const uint64_t* intArgs, const uint64_t* fpArgs);
+
+/// How to load one integer-class argument from its register slot. Slots store
+/// narrow integers zero-extended; the C ABIs we thunk for expect narrow
+/// *signed* arguments sign-extended by the caller (Apple arm64 mandates it,
+/// SysV callees commonly rely on it), so signed narrow types re-extend.
+enum class ArgLoad : uint8_t { Raw, SExt8, SExt16, SExt32 };
+
+/// Thunk binding resolved once at backend-compile time (TBCThunkCall.hpp).
+/// `fn == nullptr` means the site is not thunkable (signature over the caps,
+/// or unsupported target ABI) and must marshal through dyncall instead.
+struct ResolvedThunk {
+	ExtThunkFn fn = nullptr;
+	uint8_t numInt = 0;
+	uint8_t numFp = 0;
+	std::array<std::pair<uint16_t, ArgLoad>, kThunkMaxIntArgs> intLoads {};
+	std::array<uint16_t, kThunkMaxFpArgs> fpRegs {};
+};
+
 /// Per-call-site record. The instruction stream only carries the record index;
 /// argument registers, types, and the target live here. Used by CALL (internal,
-/// interpreter-native), CALL_EXT (external via dyncall), and CALL_IND (register
-/// target, internal or external).
+/// interpreter-native), CALL_EXT (external via typed thunk or dyncall), and
+/// CALL_IND (register target, internal or external).
 struct CallSite {
 	void* target = nullptr;       // external function pointer (CALL_EXT)
 	uint32_t internalFnIdx = ~0u; // callee index (CALL)
 	Type returnType = Type::v;
-	std::vector<Type> argTypes;    // callee signature, for dyncall marshaling
+	std::vector<Type> argTypes;    // callee signature, for external marshaling
 	std::vector<uint16_t> argRegs; // caller registers holding the arguments
+	ResolvedThunk ext;             // typed-thunk binding (external sites only)
 };
 
 /// One lowered function: a flat instruction stream plus its frame metadata.
@@ -69,6 +106,12 @@ struct TBCFunction {
 
 enum class DispatchMode : uint8_t { Tailcall, Goto, Switch };
 
+/// How outgoing external calls (CALL_EXT / CALL_IND) are marshaled: through
+/// the dyncall FFI (requires NAUTILUS_TBC_DYNCALL) or through the built-in
+/// zero-dependency typed thunks (per-site fallback to dyncall for signatures
+/// beyond the thunk caps).
+enum class ExtCallMode : uint8_t { Dyncall, Thunks };
+
 /// A whole compiled module: all functions plus the program-wide call-site
 /// table. Heap-allocated once and never moved afterwards: escaping internal
 /// function pointers (see TBCTrampoline.hpp) bind trampoline slots to this
@@ -84,6 +127,7 @@ struct TBCProgram {
 	std::vector<CallSite> callsites;
 	uint64_t minStackSlots = 0;
 	DispatchMode dispatch = DispatchMode::Switch;
+	ExtCallMode extCall = ExtCallMode::Dyncall;
 };
 
 } // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.cpp
@@ -1,10 +1,14 @@
 
 #include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
 #include "nautilus/compiler/backends/tbc/TBCHandlers.hpp"
+#include "nautilus/compiler/backends/tbc/TBCThunkCall.hpp"
+#include "nautilus/config.hpp"
 #include "nautilus/exceptions/RuntimeException.hpp"
 #include <algorithm>
-#include <dyncall.h>
 #include <vector>
+#ifdef NAUTILUS_TBC_DYNCALL
+#include <dyncall.h>
+#endif
 
 // Dispatch capability detection. The tail-call skin needs Clang's guaranteed
 // [[clang::musttail]]; the computed-goto skin needs the GNU labels-as-values
@@ -38,6 +42,7 @@ VMContext& tlsContext() {
 	return ctx;
 }
 
+#ifdef NAUTILUS_TBC_DYNCALL
 DCCallVM* tlsDyncallVM() {
 	struct Holder {
 		DCCallVM* vm = dcNewCallVM(4096);
@@ -48,6 +53,7 @@ DCCallVM* tlsDyncallVM() {
 	static thread_local Holder holder;
 	return holder.vm;
 }
+#endif
 
 /// The single instruction an entry frame "returns" to; its handler terminates
 /// the dispatch loop and yields the entry result slot.
@@ -75,11 +81,12 @@ uint64_t* pushFrame(VMContext* ctx, const TBCFunction& fn, uint64_t* callerFp, c
 	return fp;
 }
 
+#ifdef NAUTILUS_TBC_DYNCALL
 /// External call through dyncall: marshal the argument registers per the call
 /// site's signature, call, and write the (re-normalized) result. Outgoing
 /// dyncall builds the call frame dynamically without any runtime code
 /// generation, so this path is iOS-safe (unlike dyncallback thunks).
-void doExtCall(const CallSite& site, void* target, uint64_t* fp, uint16_t dstReg) {
+void doDyncallExtCall(const CallSite& site, void* target, uint64_t* fp, uint16_t dstReg) {
 	DCCallVM* vm = tlsDyncallVM();
 	dcReset(vm);
 	for (size_t i = 0; i < site.argRegs.size(); ++i) {
@@ -161,6 +168,25 @@ void doExtCall(const CallSite& site, void* target, uint64_t* fp, uint16_t dstReg
 		return;
 	}
 	throw RuntimeException("tbc: unsupported external call return type");
+}
+#endif // NAUTILUS_TBC_DYNCALL
+
+/// External call: sites resolved to a typed thunk (tbc.externalCall=thunks)
+/// marshal through the pre-compiled caller; everything else goes through
+/// dyncall. Neither path generates code at runtime, so both are iOS-safe.
+void doExtCall(const CallSite& site, void* target, uint64_t* fp, uint16_t dstReg) {
+	if (site.ext.fn != nullptr) {
+		doThunkExtCall(site, target, fp, dstReg);
+		return;
+	}
+#ifdef NAUTILUS_TBC_DYNCALL
+	doDyncallExtCall(site, target, fp, dstReg);
+#else
+	// Unreachable: without dyncall the backend rejects unresolvable sites at
+	// compile time (TBCBackend::compile).
+	throw RuntimeException("tbc: external call site has no thunk and dyncall is not built "
+	                       "(ENABLE_TBC_DYNCALL=OFF)");
+#endif
 }
 
 /// Control transfer produced by call/return helpers, applied by each skin.
@@ -485,6 +511,24 @@ DispatchMode clampDispatchMode(DispatchMode requested) {
 	// Modes are ordered strongest-first in the enum; a request the build
 	// cannot execute silently degrades to the best available.
 	return static_cast<uint8_t>(requested) < static_cast<uint8_t>(best) ? best : requested;
+}
+
+ExtCallMode defaultExtCallMode() {
+#ifdef NAUTILUS_TBC_DYNCALL
+	return ExtCallMode::Dyncall;
+#else
+	return ExtCallMode::Thunks;
+#endif
+}
+
+ExtCallMode clampExtCallMode([[maybe_unused]] ExtCallMode requested) {
+	// A request the build cannot execute silently degrades, mirroring
+	// clampDispatchMode: dyncall without NAUTILUS_TBC_DYNCALL becomes thunks.
+#ifndef NAUTILUS_TBC_DYNCALL
+	return ExtCallMode::Thunks;
+#else
+	return requested;
+#endif
 }
 
 uint64_t invoke(const TBCProgram& program, uint32_t functionIndex, const uint64_t* args, size_t argCount) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCInterpreter.hpp
@@ -13,6 +13,13 @@ DispatchMode bestAvailableDispatchMode();
 /// Clamp a requested mode to what the build supports.
 DispatchMode clampDispatchMode(DispatchMode requested);
 
+/// External-call marshalling this build defaults to for `tbc.externalCall =
+/// auto`: dyncall when NAUTILUS_TBC_DYNCALL is set, typed thunks otherwise.
+ExtCallMode defaultExtCallMode();
+
+/// Clamp a requested external-call mode to what the build supports.
+ExtCallMode clampExtCallMode(ExtCallMode requested);
+
 /// Execute `program.functions[functionIndex]` with the given 64-bit argument
 /// slots (already normalized per the function's argument types) and return the
 /// raw 64-bit result slot (0 for void). Runs on a thread-local contiguous VM

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCThunkCall.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCThunkCall.cpp
@@ -1,0 +1,222 @@
+
+#include "nautilus/compiler/backends/tbc/TBCThunkCall.hpp"
+#include <cstring>
+#include <type_traits>
+#include <utility>
+
+// ABI gate for the reordered typed-thunk call. The reorder trick (integer
+// args first, fp args after, each class keeping its relative order) requires
+// the two argument classes to be register-assigned independently, which holds
+// for SysV x86-64 and AAPCS64 (incl. Apple's arm64 variant) but not e.g. for
+// Windows x64, whose four argument slots are shared between classes.
+#if (defined(__x86_64__) || defined(__aarch64__)) && !defined(_WIN32)
+#define TBC_THUNKCALL_SUPPORTED 1
+#else
+#define TBC_THUNKCALL_SUPPORTED 0
+#endif
+
+namespace nautilus::compiler::tbc {
+
+namespace {
+
+// Spill-safety invariants of the reorder trick (see TBCCode.hpp): AArch64 has
+// 8 integer + 8 fp argument registers, so nothing spills at all; SysV x86-64
+// has 6 integer + 8 SSE registers, so integer args 7-8 spill into stack slots
+// that SysV rounds to 8 bytes (layout-compatible with a uint64_t parameter),
+// and fp args must never spill because a reordered fp stack arg could land in
+// a different slot than in the callee's real signature.
+static_assert(kThunkMaxIntArgs <= 8, "integer args beyond 8 would spill on AArch64 with packed layout (Apple)");
+static_assert(kThunkMaxFpArgs <= 8, "fp args must stay in registers on both supported ABIs");
+
+#if TBC_THUNKCALL_SUPPORTED
+
+template <size_t>
+using IntParam = uint64_t;
+
+template <uint32_t Bits, size_t K>
+using FpParam = std::conditional_t<((Bits >> K) & 1u) != 0, double, float>;
+
+template <class T>
+T loadFp(uint64_t slot) {
+	T value;
+	std::memcpy(&value, &slot, sizeof(T));
+	return value;
+}
+
+/// One pre-compiled caller per signature shape: `Ret` return, `sizeof...(I)`
+/// leading uint64_t (integer-class) parameters, and one f32/f64 parameter per
+/// fp position `F` (kind selected by bit `F` of `FpBits`). Calling `target`
+/// through the shape's function-pointer type is what makes the compiler emit
+/// the native argument-register moves; the cast is ABI-sound under the
+/// reorder/caps rules above (the codebase already relies on the same
+/// reasoning for the escaping-function-pointer trampolines).
+template <class Ret, uint32_t FpBits, class IntSeq, class FpSeq>
+struct Thunk;
+
+template <class Ret, uint32_t FpBits, size_t... I, size_t... F>
+struct Thunk<Ret, FpBits, std::index_sequence<I...>, std::index_sequence<F...>> {
+	static uint64_t call(void* target, [[maybe_unused]] const uint64_t* intArgs,
+	                     [[maybe_unused]] const uint64_t* fpArgs) {
+		using Fn = Ret (*)(IntParam<I>..., FpParam<FpBits, F>...);
+		const auto fn = reinterpret_cast<Fn>(target);
+		if constexpr (std::is_void_v<Ret>) {
+			fn(intArgs[I]..., loadFp<FpParam<FpBits, F>>(fpArgs[F])...);
+			return 0;
+		} else if constexpr (std::is_floating_point_v<Ret>) {
+			const Ret result = fn(intArgs[I]..., loadFp<FpParam<FpBits, F>>(fpArgs[F])...);
+			uint64_t slot = 0;
+			std::memcpy(&slot, &result, sizeof(result));
+			return slot;
+		} else {
+			// Integer-class returns travel as uint64_t; the marshaller
+			// truncates to the declared width (upper bits of a narrow return
+			// register are unspecified).
+			return static_cast<uint64_t>(fn(intArgs[I]..., loadFp<FpParam<FpBits, F>>(fpArgs[F])...));
+		}
+	}
+};
+
+/// Fp-pattern rows are flattened per fp-arg count: patterns with NF fp args
+/// occupy indices [2^NF - 1, 2^(NF+1) - 1) keyed by their f32/f64 bitmask.
+constexpr std::array<size_t, kThunkMaxFpArgs + 1> kFpPatternOffset = [] {
+	std::array<size_t, kThunkMaxFpArgs + 1> offsets {};
+	for (size_t n = 0; n <= kThunkMaxFpArgs; ++n) {
+		offsets[n] = (size_t {1} << n) - 1;
+	}
+	return offsets;
+}();
+constexpr size_t kFpPatternCount = (size_t {1} << (kThunkMaxFpArgs + 1)) - 1;
+
+using FpPatternRow = std::array<ExtThunkFn, kFpPatternCount>;
+using RetTable = std::array<FpPatternRow, kThunkMaxIntArgs + 1>;
+
+template <class Ret, size_t NumInt, size_t NumFp>
+constexpr void fillFpPatterns(FpPatternRow& row) {
+	[&]<size_t... Bits>(std::index_sequence<Bits...>) {
+		((row[kFpPatternOffset[NumFp] + Bits] =
+		      &Thunk<Ret, static_cast<uint32_t>(Bits), std::make_index_sequence<NumInt>,
+		             std::make_index_sequence<NumFp>>::call),
+		 ...);
+	}(std::make_index_sequence<(size_t {1} << NumFp)>());
+}
+
+template <class Ret, size_t NumInt>
+constexpr FpPatternRow makeFpPatternRow() {
+	FpPatternRow row {};
+	[&]<size_t... NumFp>(std::index_sequence<NumFp...>) {
+		(fillFpPatterns<Ret, NumInt, NumFp>(row), ...);
+	}(std::make_index_sequence<kThunkMaxFpArgs + 1>());
+	return row;
+}
+
+template <class Ret>
+constexpr RetTable makeRetTable() {
+	return [&]<size_t... NumInt>(std::index_sequence<NumInt...>) {
+		return RetTable {makeFpPatternRow<Ret, NumInt>()...};
+	}(std::make_index_sequence<kThunkMaxIntArgs + 1>());
+}
+
+/// Return kinds share thunks: void, all integer-class (uint64_t), f32, f64.
+enum class RetKind : uint8_t { Void = 0, Int, F32, F64 };
+
+const std::array<RetTable, 4> kThunkTable {makeRetTable<void>(), makeRetTable<uint64_t>(), makeRetTable<float>(),
+                                           makeRetTable<double>()};
+
+#endif // TBC_THUNKCALL_SUPPORTED
+
+} // namespace
+
+bool thunkCallsSupported() {
+	return TBC_THUNKCALL_SUPPORTED != 0;
+}
+
+void resolveExtCallThunk(CallSite& site) {
+	site.ext = ResolvedThunk {};
+#if TBC_THUNKCALL_SUPPORTED
+	size_t numInt = 0;
+	size_t numFp = 0;
+	uint32_t fpBits = 0;
+	for (size_t i = 0; i < site.argTypes.size(); ++i) {
+		const uint16_t reg = site.argRegs[i];
+		switch (site.argTypes[i]) {
+		case Type::b:
+		case Type::ui8:
+		case Type::ui16:
+		case Type::ui32:
+		case Type::i64:
+		case Type::ui64:
+		case Type::ptr:
+			// Slots already hold these zero-extended (or bit-exact).
+			if (numInt == kThunkMaxIntArgs) {
+				return;
+			}
+			site.ext.intLoads[numInt++] = {reg, ArgLoad::Raw};
+			break;
+		case Type::i8:
+			if (numInt == kThunkMaxIntArgs) {
+				return;
+			}
+			site.ext.intLoads[numInt++] = {reg, ArgLoad::SExt8};
+			break;
+		case Type::i16:
+			if (numInt == kThunkMaxIntArgs) {
+				return;
+			}
+			site.ext.intLoads[numInt++] = {reg, ArgLoad::SExt16};
+			break;
+		case Type::i32:
+			if (numInt == kThunkMaxIntArgs) {
+				return;
+			}
+			site.ext.intLoads[numInt++] = {reg, ArgLoad::SExt32};
+			break;
+		case Type::f32:
+			if (numFp == kThunkMaxFpArgs) {
+				return;
+			}
+			site.ext.fpRegs[numFp++] = reg;
+			break;
+		case Type::f64:
+			if (numFp == kThunkMaxFpArgs) {
+				return;
+			}
+			fpBits |= 1u << numFp;
+			site.ext.fpRegs[numFp++] = reg;
+			break;
+		default:
+			return;
+		}
+	}
+	RetKind retKind;
+	switch (site.returnType) {
+	case Type::v:
+		retKind = RetKind::Void;
+		break;
+	case Type::b:
+	case Type::i8:
+	case Type::i16:
+	case Type::i32:
+	case Type::i64:
+	case Type::ui8:
+	case Type::ui16:
+	case Type::ui32:
+	case Type::ui64:
+	case Type::ptr:
+		retKind = RetKind::Int;
+		break;
+	case Type::f32:
+		retKind = RetKind::F32;
+		break;
+	case Type::f64:
+		retKind = RetKind::F64;
+		break;
+	default:
+		return;
+	}
+	site.ext.numInt = static_cast<uint8_t>(numInt);
+	site.ext.numFp = static_cast<uint8_t>(numFp);
+	site.ext.fn = kThunkTable[static_cast<size_t>(retKind)][numInt][kFpPatternOffset[numFp] + fpBits];
+#endif
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCThunkCall.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCThunkCall.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "nautilus/compiler/backends/tbc/TBCCode.hpp"
+#include "nautilus/compiler/backends/tbc/TBCHandlers.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
+#include <cstdint>
+
+namespace nautilus::compiler::tbc {
+
+/// Zero-dependency typed call thunks for outgoing external calls.
+///
+/// dyncall's forward-call VM is iOS-safe (it builds call frames on a data
+/// stack, no executable memory), but it is the tbc backend's last third-party
+/// dependency and needs hand-written assembly per target. This path replaces
+/// it with pre-compiled C++ callers: one tiny template instantiation per
+/// signature shape (return kind x integer-arg count x fp-arg pattern), bound
+/// to each call site once at backend-compile time.
+///
+/// The thunks pass all integer-class arguments (bool/ints/pointers) as
+/// uint64_t and reorder them ahead of the fp-class arguments (f32/f64, kept
+/// in their original relative order). That is ABI-sound on SysV x86-64 and
+/// AAPCS64 (incl. Apple) because integer-class and fp-class register
+/// assignment are independent sequences, and the caps in TBCCode.hpp keep
+/// every reordered argument out of ABI-visible stack-layout differences (see
+/// the comment on kThunkMaxIntArgs). Other ABIs (e.g. Windows x64, whose four
+/// argument slots are shared between classes) are not supported: resolution
+/// leaves the site on the dyncall path there.
+
+/// True when the typed-thunk call path is ABI-sound on this target
+/// (x86-64 SysV or AArch64 AAPCS64, incl. Apple).
+bool thunkCallsSupported();
+
+/// Bind `site.ext` to a pre-compiled thunk matching the site's signature.
+/// Leaves `site.ext.fn == nullptr` when the signature exceeds the caps
+/// (more than kThunkMaxIntArgs integer-class or kThunkMaxFpArgs fp-class
+/// arguments) or the target ABI is unsupported.
+void resolveExtCallThunk(CallSite& site);
+
+/// Hot-path marshaller for a resolved site: load the argument slots per the
+/// precomputed recipes, call the thunk, and normalize the result into the
+/// destination register with the same conventions as the dyncall path.
+inline void doThunkExtCall(const CallSite& site, void* target, uint64_t* fp, uint16_t dstReg) {
+	const ResolvedThunk& thunk = site.ext;
+	uint64_t intArgs[kThunkMaxIntArgs];
+	uint64_t fpArgs[kThunkMaxFpArgs];
+	for (uint8_t i = 0; i < thunk.numInt; ++i) {
+		const auto [reg, load] = thunk.intLoads[i];
+		switch (load) {
+		case ArgLoad::Raw:
+			intArgs[i] = fp[reg];
+			break;
+		case ArgLoad::SExt8:
+			intArgs[i] = static_cast<uint64_t>(static_cast<int64_t>(readReg<int8_t>(fp, reg)));
+			break;
+		case ArgLoad::SExt16:
+			intArgs[i] = static_cast<uint64_t>(static_cast<int64_t>(readReg<int16_t>(fp, reg)));
+			break;
+		case ArgLoad::SExt32:
+			intArgs[i] = static_cast<uint64_t>(static_cast<int64_t>(readReg<int32_t>(fp, reg)));
+			break;
+		}
+	}
+	for (uint8_t i = 0; i < thunk.numFp; ++i) {
+		fpArgs[i] = fp[thunk.fpRegs[i]];
+	}
+	const uint64_t raw = thunk.fn(target, intArgs, fpArgs);
+	switch (site.returnType) {
+	case Type::v:
+		return;
+	case Type::b:
+		// Mask to the low byte: callees are only required to set the low byte
+		// of a bool return register (same rule as the dyncall path).
+		writeReg<bool>(fp, dstReg, (raw & 0xFF) != 0);
+		return;
+	case Type::i8:
+	case Type::ui8:
+		// Truncate to the declared width, then renormalize (zero-extend) into
+		// the slot: the callee only guarantees the low bits of the return
+		// register.
+		writeReg<uint8_t>(fp, dstReg, static_cast<uint8_t>(raw));
+		return;
+	case Type::i16:
+	case Type::ui16:
+		writeReg<uint16_t>(fp, dstReg, static_cast<uint16_t>(raw));
+		return;
+	case Type::i32:
+	case Type::ui32:
+		writeReg<uint32_t>(fp, dstReg, static_cast<uint32_t>(raw));
+		return;
+	case Type::i64:
+	case Type::ui64:
+	case Type::ptr:
+	case Type::f32:
+	case Type::f64:
+		// Full 64-bit slots; f32/f64 already arrive as normalized slot bit
+		// patterns from the thunk.
+		fp[dstReg] = raw;
+		return;
+	}
+	throw RuntimeException("tbc: unsupported external call return type");
+}
+
+} // namespace nautilus::compiler::tbc

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NAUTILUS_EXECUTION_TEST_SOURCES
         BCDispatchModeTest.cpp
         BCRegisterCoalescingTest.cpp
         TBCDispatchModeTest.cpp
+        TBCExternalCallModeTest.cpp
         TBCMemoryOffsetTest.cpp
         BoolExecutionTest.cpp
         CastExecutionTest.cpp

--- a/nautilus/test/execution-tests/TBCExternalCallModeTest.cpp
+++ b/nautilus/test/execution-tests/TBCExternalCallModeTest.cpp
@@ -1,0 +1,257 @@
+#include "ExecutionTest.hpp"
+#include "nautilus/Engine.hpp"
+#include "nautilus/val.hpp"
+#include <catch2/catch_all.hpp>
+#include <nautilus/config.hpp>
+
+// The tbc backend marshals outgoing external calls (CALL_EXT / CALL_IND)
+// either through dyncall or through the built-in zero-dependency typed thunks,
+// selected via the "tbc.externalCall" option ("auto" — the default — picks
+// dyncall when NAUTILUS_TBC_DYNCALL is set and thunks otherwise). forEachBackend
+// only exercises the default, so this test pins that every mode produces
+// results identical to native evaluation across the signature shapes the thunk
+// path reorders and re-extends: interleaved int/fp arguments, narrow signed
+// argument/return extension, bool/float/double returns, pointer arguments, and
+// signatures at and beyond the thunk caps (8 integer-class / 4 fp-class args).
+//
+// Kernels are local (not shared with RunctimeCallFunctions.hpp, whose helpers
+// have external linkage and live in the ExecutionTest.cpp TU).
+#ifdef ENABLE_TBC_BACKEND
+
+namespace nautilus::engine {
+
+namespace {
+
+int32_t ecAdd(int32_t x, int32_t y) {
+	return x + y;
+}
+
+bool ecIsNeg(int32_t x) {
+	return x < 0;
+}
+
+float ecMulF(float x, float y) {
+	return x * y;
+}
+
+int32_t ecPick(bool takeFirst, int32_t x, int32_t y) {
+	return takeFirst ? x : y;
+}
+
+int64_t ecDeref(int64_t* p) {
+	return *p;
+}
+
+// Interleaved integer/fp signature: the thunk reorders the three integer-class
+// arguments ahead of the double/float/double tail; every value must still
+// arrive in the right register.
+double ecMix6(int32_t a, double b, int64_t c, float d, int8_t e, double f) {
+	return static_cast<double>(a) * b + static_cast<double>(c) * static_cast<double>(d) +
+	       static_cast<double>(e) * f;
+}
+
+int16_t ecMixI16(int16_t x, int16_t y) {
+	// Same trap as RunctimeCallFunctions.hpp::mixI16: the 32-bit intermediate
+	// differs from the wrapped i16 result, so unextended upper register bits
+	// are observable.
+	return static_cast<int16_t>(x * 3 + y);
+}
+
+int16_t ecMinI16(int16_t x, int16_t y) {
+	return x < y ? x : y;
+}
+
+// Exactly at the caps: 8 integer-class args (args 7-8 spill to the stack on
+// SysV x86-64) and 4 fp args with a mixed f32/f64 pattern.
+int64_t ecSum8(int64_t a, int64_t b, int64_t c, int64_t d, int64_t e, int64_t f, int64_t g, int64_t h) {
+	return a + 2 * b + 3 * c + 4 * d + 5 * e + 6 * f + 7 * g + 8 * h;
+}
+
+double ecSumF4(float a, double b, float c, double d) {
+	return static_cast<double>(a) + 2.0 * b + 3.0 * static_cast<double>(c) + 4.0 * d;
+}
+
+// Beyond the caps: not thunkable, degrades per-site to dyncall (or is
+// rejected at compile time when dyncall is not built).
+int64_t ecSum9(int64_t a, int64_t b, int64_t c, int64_t d, int64_t e, int64_t f, int64_t g, int64_t h, int64_t i) {
+	return a + 2 * b + 3 * c + 4 * d + 5 * e + 6 * f + 7 * g + 8 * h + 9 * i;
+}
+
+double ecSumF5(double a, double b, double c, double d, double e) {
+	return a + 2 * b + 3 * c + 4 * d + 5 * e;
+}
+
+val<int32_t> kSimpleCall(val<int32_t> x, val<int32_t> y) {
+	return invoke(ecAdd, x, y);
+}
+
+val<int32_t> kLoopCall(val<int32_t> c, val<int32_t> x) {
+	val<int32_t> sum = 0;
+	for (val<int32_t> i = 0; i < c; i = i + 1) {
+		sum = invoke(ecAdd, sum, x);
+	}
+	return sum;
+}
+
+val<bool> kBoolReturn(val<int32_t> x) {
+	return invoke(ecIsNeg, x);
+}
+
+val<float> kFloatCall(val<float> x, val<float> y) {
+	return invoke(ecMulF, x, y);
+}
+
+val<int32_t> kBoolArg(val<bool> takeFirst, val<int32_t> x, val<int32_t> y) {
+	return invoke(ecPick, takeFirst, x, y);
+}
+
+val<int64_t> kPtrArg(val<int64_t*> p) {
+	return invoke(ecDeref, p);
+}
+
+val<double> kMix6(val<int32_t> a, val<double> b, val<int64_t> c, val<float> d, val<int32_t> e, val<double> f) {
+	return invoke(ecMix6, a, b, c, d, static_cast<val<int8_t>>(e), f);
+}
+
+// Regression shapes from the differential fuzzer (see
+// RunctimeCallFunctions.hpp): narrow signed return values and arguments must
+// be re-extended across the call boundary.
+val<int16_t> kNarrowReturn(val<int16_t> x, val<int16_t> y) {
+	val<int16_t> mixed = invoke(ecMixI16, x, y);
+	val<int16_t> result = 0;
+	if (mixed < val<int16_t>(int16_t(0))) {
+		result = 1;
+	}
+	return result;
+}
+
+val<int16_t> kNarrowArg(val<int64_t> x, val<int16_t> y) {
+	val<int16_t> truncated = static_cast<val<int16_t>>(x);
+	return invoke(ecMinI16, truncated, y);
+}
+
+val<int64_t> kSum8(val<int64_t> a, val<int64_t> b, val<int64_t> c, val<int64_t> d, val<int64_t> e, val<int64_t> f,
+                   val<int64_t> g, val<int64_t> h) {
+	return invoke(ecSum8, a, b, c, d, e, f, g, h);
+}
+
+val<double> kSumF4(val<float> a, val<double> b, val<float> c, val<double> d) {
+	return invoke(ecSumF4, a, b, c, d);
+}
+
+val<int64_t> kSum9(val<int64_t> a, val<int64_t> b, val<int64_t> c, val<int64_t> d, val<int64_t> e, val<int64_t> f,
+                   val<int64_t> g, val<int64_t> h, val<int64_t> i) {
+	return invoke(ecSum9, a, b, c, d, e, f, g, h, i);
+}
+
+val<double> kSumF5(val<double> a, val<double> b, val<double> c, val<double> d, val<double> e) {
+	return invoke(ecSumF5, a, b, c, d, e);
+}
+
+// CALL_IND with a native target: FunctionAddressOf of an external function
+// flows through a register and calls back out through the external path.
+val<int32_t> kFunctionPtr(val<int32_t> x) {
+	auto func = function(ecAdd);
+	x = func(x, x);
+	x = func(x, x);
+	return x;
+}
+
+engine::NautilusEngine tbcEngine(const std::string& externalCall) {
+	engine::Options options;
+	options.setOption("engine.backend", std::string("tbc"));
+	options.setOption("tbc.externalCall", externalCall);
+	return engine::NautilusEngine(options);
+}
+
+std::vector<std::string> externalCallModes() {
+	std::vector<std::string> modes = {"auto", "thunks"};
+#ifdef NAUTILUS_TBC_DYNCALL
+	modes.emplace_back("dyncall");
+#endif
+	return modes;
+}
+
+} // namespace
+
+TEST_CASE("TBC external call modes produce identical results") {
+	for (const auto& mode : externalCallModes()) {
+		DYNAMIC_SECTION(mode) {
+			auto engine = tbcEngine(mode);
+
+			auto simple = engine.registerFunction(kSimpleCall);
+			auto loop = engine.registerFunction(kLoopCall);
+			auto boolRet = engine.registerFunction(kBoolReturn);
+			auto floatCall = engine.registerFunction(kFloatCall);
+			auto boolArg = engine.registerFunction(kBoolArg);
+			auto ptrArg = engine.registerFunction(kPtrArg);
+			auto mix6 = engine.registerFunction(kMix6);
+			auto narrowReturn = engine.registerFunction(kNarrowReturn);
+			auto narrowArg = engine.registerFunction(kNarrowArg);
+			auto fnPtr = engine.registerFunction(kFunctionPtr);
+
+			for (int32_t x = -20; x <= 20; x += 7) {
+				for (int32_t y = -15; y <= 15; y += 5) {
+					REQUIRE(simple(x, y) == ecAdd(x, y));
+					REQUIRE(boolArg(x > y, x, y) == ecPick(x > y, x, y));
+				}
+				REQUIRE(boolRet(x) == ecIsNeg(x));
+				REQUIRE(fnPtr(x) == 4 * x);
+			}
+			REQUIRE(loop(10, 3) == 30);
+			REQUIRE(loop(0, 3) == 0);
+			REQUIRE(floatCall(2.5f, -4.0f) == ecMulF(2.5f, -4.0f));
+
+			int64_t cell = 0x0123456789abcdefLL;
+			REQUIRE(ptrArg(&cell) == cell);
+
+			REQUIRE(mix6(3, 2.5, -7, 1.5f, -2, 0.25) == ecMix6(3, 2.5, -7, 1.5f, int8_t(-2), 0.25));
+			REQUIRE(mix6(-1, -0.5, 1L << 40, -2.0f, 100, 8.0) == ecMix6(-1, -0.5, 1L << 40, -2.0f, int8_t(100), 8.0));
+
+			// Narrow-int extension traps (fuzzer regressions): 25158 * 3 - 24951
+			// has a positive 32-bit intermediate but a negative wrapped i16
+			// result; the truncated i64 carries live upper bits.
+			REQUIRE(narrowReturn(int16_t(25158), int16_t(-24951)) == 1);
+			REQUIRE(narrowReturn(int16_t(3), int16_t(4)) == 0);
+			REQUIRE(narrowArg(int64_t(0x7ffff0000LL + 12), int16_t(300)) ==
+			        ecMinI16(int16_t(0x7ffff0000LL + 12), int16_t(300)));
+			REQUIRE(narrowArg(int64_t(-70000), int16_t(-5)) == ecMinI16(int16_t(-70000), int16_t(-5)));
+		}
+	}
+}
+
+TEST_CASE("TBC typed thunk caps") {
+	auto engine = tbcEngine("thunks");
+
+	SECTION("signatures exactly at the caps use thunks") {
+		auto sum8 = engine.registerFunction(kSum8);
+		auto sumF4 = engine.registerFunction(kSumF4);
+		REQUIRE(sum8(1, -2, 3, -4, 5, -6, 7, -8) == ecSum8(1, -2, 3, -4, 5, -6, 7, -8));
+		REQUIRE(sumF4(1.5f, -2.25, 3.5f, 4.125) == ecSumF4(1.5f, -2.25, 3.5f, 4.125));
+	}
+
+	SECTION("signatures beyond the caps") {
+#ifdef NAUTILUS_TBC_DYNCALL
+		// Per-site degrade: over-cap sites marshal through dyncall.
+		auto sum9 = engine.registerFunction(kSum9);
+		auto sumF5 = engine.registerFunction(kSumF5);
+		REQUIRE(sum9(1, -2, 3, -4, 5, -6, 7, -8, 9) == ecSum9(1, -2, 3, -4, 5, -6, 7, -8, 9));
+		REQUIRE(sumF5(1.5, -2.25, 3.5, 4.125, -0.5) == ecSumF5(1.5, -2.25, 3.5, 4.125, -0.5));
+#else
+		// Without dyncall the backend rejects the signature when the function
+		// is compiled, not at run time mid-execution.
+		REQUIRE_THROWS([&] {
+			auto sum9 = engine.registerFunction(kSum9);
+			(void) sum9(1, -2, 3, -4, 5, -6, 7, -8, 9);
+		}());
+		REQUIRE_THROWS([&] {
+			auto sumF5 = engine.registerFunction(kSumF5);
+			(void) sumF5(1.5, -2.25, 3.5, 4.125, -0.5);
+		}());
+#endif
+	}
+}
+
+} // namespace nautilus::engine
+
+#endif // ENABLE_TBC_BACKEND

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -35,6 +35,11 @@ inline std::vector<std::string> configs() {
 #endif
 #ifdef ENABLE_TBC_BACKEND
 	result.emplace_back("tbc");
+	// Same backend with tbc.externalCall=thunks, so the zero-dependency typed
+	// thunk marshalling is continuously cross-checked against dyncall and all
+	// other backends (on ENABLE_TBC_DYNCALL=OFF builds "tbc" already resolves
+	// to thunks and this peer is redundant but harmless).
+	result.emplace_back("tbc-thunks");
 #endif
 #ifdef ENABLE_ASMJIT_BACKEND
 	result.emplace_back("asmjit");
@@ -46,6 +51,9 @@ inline engine::NautilusEngine makeEngine(const std::string& backend) {
 	engine::Options options;
 	if (backend == "interpreter") {
 		options.setOption("engine.Compilation", false);
+	} else if (backend == "tbc-thunks") {
+		options.setOption("engine.backend", std::string("tbc"));
+		options.setOption("tbc.externalCall", std::string("thunks"));
 	} else {
 		options.setOption("engine.backend", backend);
 	}


### PR DESCRIPTION
## iOS analysis

The `tbc` backend was built for platforms that forbid runtime code generation (iOS): it never allocates executable memory (pre-compiled trampoline pool instead of `bc`'s dyncallback) and its strongest dispatch skin — tail-call threading — is Clang-based and works on iOS. Its **one remaining third-party dependency was dyncall**, used in a single seam (`doExtCall`, `TBCInterpreter.cpp`) to marshal outgoing external calls (`CALL_EXT` / `CALL_IND`).

dyncall's forward-call VM is itself iOS-safe (data-stack call frames, no executable memory, ships an Apple arm64 ABI implementation), so there was no hard blocker — the fallback removes the dependency and its per-target assembly (cross-compile friction under iOS toolchains), implementing the "zero-dependency typed call thunks" item from the tbc README's future work.

## What this adds

- **`TBCThunkCall.{hpp,cpp}`**: ~1100 pre-compiled template callers keyed on (return kind × integer-arg count × f32/f64 pattern), built with the same `index_sequence` expansion as the existing trampoline pool. Each external call site is bound to its thunk **once at backend-compile time** (per-arg load recipes precompute the narrow-signed re-extension); the hot path is two tight loops + one indirect call.
- **ABI reordering**: integer-class args travel as extended `uint64_t` reordered ahead of the fp args. Sound on x86-64 SysV and AArch64 (incl. Apple) because the two argument classes are register-assigned independently. Caps (≤ 8 integer-class, ≤ 4 fp-class args) keep every argument out of ABI-visible stack-layout differences — Apple arm64's packed narrow stack-arg rule is unreachable, and SysV's integer args 7-8 spill into 8-byte-rounded slots. Other ABIs (Windows x64 shares argument slots between classes) are gated out via `thunkCallsSupported()`.
- **`tbc.externalCall = auto | dyncall | thunks`** runtime option (default `auto` = dyncall when built, thunks otherwise; silent degrade mirroring `tbc.dispatch`), reported in compilation statistics.
- **`ENABLE_TBC_DYNCALL`** CMake option (default ON). OFF drops the dyncall link/build/export for tbc — with `ENABLE_BC_BACKEND=OFF` dyncall is not configured at all, leaving tbc with zero third-party dependencies. Over-cap sites degrade per-site to dyncall when it is built; without it they are rejected at backend-compile time with an error naming the caps and the option.

## Testing

- New `TBCExternalCallModeTest` pins every mode against native evaluation across interleaved int/fp signatures, the narrow-int sign/zero-extension fuzzer-regression shapes, bool/float/double returns, pointer args, `CALL_IND` function pointers, and at/over-cap arities (including the compile-time rejection on no-dyncall builds).
- Fuzz harness gains a `tbc-thunks` differential peer so thunk marshalling is continuously cross-checked against dyncall and all other backends.
- CI matrix gains `-DENABLE_TBC_DYNCALL=OFF` (full suite over the thunk path — the iOS-equivalent configuration) and `-DENABLE_TBC_DYNCALL=OFF -DENABLE_BC_BACKEND=OFF` (verifies dyncall fully absent).
- Locally (Clang 18, Release, MLIR off): full ctest suite green on both the default build (351/351) and the `ENABLE_TBC_DYNCALL=OFF` build (351/351, where `auto` routes every external call in the whole suite through thunks); library also builds with dyncall fully removed.

## Docs

`tbc/README.md`: external-call section documents both mechanisms and the option; new **iOS support** section; the future-work bullet is marked done with the caps and fallback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtkEBsKx2dTn8NBgz1LHNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtkEBsKx2dTn8NBgz1LHNR)_