### PR TITLE
Give an actionable error when MLIR binary download fails

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -63,7 +63,16 @@ function(download_file url filename)
         endif ()
     endwhile ()
     if (CURRENT_ITERATION EQUAL MAX_RETRIES)
-        message(FATAL_ERROR "Aborting: retry attempts exceeded while failing to download ${url}")
+        message(FATAL_ERROR
+                "Aborting: retry attempts exceeded while failing to download ${url}\n"
+                "Last error: ${ERROR_MESSAGE}\n"
+                "This download failure is most commonly caused by the build machine not "
+                "being able to reach GitHub release assets (e.g. a restrictive proxy/firewall, "
+                "or a sandboxed environment whose network access is scoped to this repository "
+                "only and excludes other repositories such as nebulastream/mlir-binaries, which "
+                "hosts the pre-built MLIR binaries). Verify network/proxy access to ${url}, or "
+                "avoid the download entirely by pointing the build at a local LLVM/MLIR "
+                "installation via -DUSE_EXTERNAL_MLIR=ON.")
     endif ()
 endfunction(download_file)
 


### PR DESCRIPTION
## Summary

Investigated why the pre-built MLIR dependency import (`cmake/ImportMLIR.cmake` → `download_file()` in `cmake/macros.cmake`) can fail to import.

**Findings:**
- The MLIR pre-built binaries are hosted as GitHub release assets in a separate repository, `nebulastream/mlir-binaries`.
- Real CI (`.github/workflows/pr.yml`) currently builds successfully against the pinned `MLIR_VERSION` (21.1.2), confirming the version pin and download mechanism itself are correct — there is no bug in the pinned version or the release asset naming.
- The failure mode reproduced here comes from a build environment whose network/proxy access is restricted to a single repository and excludes `nebulastream/mlir-binaries`, causing the release-asset download to be rejected. `download_file()` previously surfaced this only as an opaque `"HTTP response code said error"` with no indication of the cause or how to work around it.

**Fix:**
- `download_file()`'s final failure message now explains that this class of failure is typically caused by restricted network/proxy access to the separate `mlir-binaries` repo, and points at `-DUSE_EXTERNAL_MLIR=ON` as the documented escape hatch for building against a locally installed LLVM/MLIR instead of downloading the pre-built binaries.

## Test plan

- [x] Verified locally that a forced download failure now prints the new, actionable `FATAL_ERROR` message (previously just `"Aborting: retry attempts exceeded while failing to download <url>"`).
- [x] No functional/behavioral change to the success path — verified `download_file()` still passes through unmodified on a successful download (retry loop and status handling unchanged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PqUZcaYXrPkaUoGjF7N634)_