### PR TITLE
[fuzzer] Allow compounding pointer arithmetic in the memory/pointer domain

### DIFF
--- a/nautilus/test/fuzz/Ast.hpp
+++ b/nautilus/test/fuzz/Ast.hpp
@@ -153,17 +153,31 @@ enum class Kind : uint8_t {
 	// Never chosen directly by generateNode/INT_KINDS/FLOAT_KINDS, and never
 	// the AST root -- only reachable as a kid of one of the memory-domain
 	// nodes above, built by generatePtrNode. Always resolve to an in-bounds
-	// index of the shared buffer (no nesting -- see generatePtrNode), so every
-	// Load/Store/comparison is guaranteed well-defined by construction.
+	// index of the shared buffer -- provably so even when PtrAdd/PtrSub nest
+	// (see generatePtrNode) -- so every Load/Store/comparison is guaranteed
+	// well-defined by construction.
 	//
-	// PtrBase: the raw pointer parameter, i.e. `&memory[0]`.
+	// PtrBase: the raw pointer parameter, i.e. `&memory[0]`. The only true
+	// leaf of the pointer domain; every PtrAdd/PtrSub chain bottoms out here.
 	PtrBase,
-	// PtrAdd: kid[0] = value-domain offset expression (type T). Result =
-	// `base + clampBufferIndex<T>(offset)`, exercising val<T*>::operator+.
+	// PtrAdd: kid[0] = a nested pointer-domain node (either a Kind::PtrBase
+	// leaf, or -- up to PTR_MAX_HOPS deep, see generatePtrNode -- another
+	// PtrAdd/PtrSub), kid[1] = value-domain offset expression (type T).
+	// Result = `kid[0] + clampIndexMod<T>(offset, capacity)`, where the offset is
+	// reduced modulo however much room is left between kid[0]'s (always
+	// in-bounds, by induction) index and the end of the buffer, so the
+	// result is provably in [0, BUFFER_ELEMS) for *any* value kid[0]
+	// resolves to at runtime -- see evalNativePtr/evalNautilusPtr. When
+	// kid[0] is the base leaf this reduces to the original single-hop
+	// `base + clampBufferIndex<T>(offset)`. Exercises val<T*>::operator+,
+	// chained hop-over-hop when nested.
 	PtrAdd,
-	// PtrSub: kid[0] = value-domain offset expression (type T). Result =
-	// `(base + (BUFFER_ELEMS - 1)) - clampBufferIndex<T>(offset)`, exercising
-	// val<T*>::operator-.
+	// PtrSub: same kid layout as PtrAdd. Result = `kid[0] -
+	// clampIndexMod<T>(offset, capacity)`, the offset reduced modulo however much
+	// room is left between index 0 and kid[0]'s index -- the mirror-image
+	// bound of PtrAdd's. When kid[0] is the base leaf this reduces to the
+	// original `(base + (BUFFER_ELEMS - 1)) - clampBufferIndex<T>(offset)`.
+	// Exercises val<T*>::operator-, chained hop-over-hop when nested.
 	PtrSub
 };
 
@@ -199,6 +213,17 @@ inline constexpr int LOOP_MAX_TRIPS = 8;
 /// small enough to keep the oracle/traced buffers cheap, large enough to make
 /// pointer differences/comparisons non-trivial.
 inline constexpr int BUFFER_ELEMS = 8;
+
+/// Maximum number of chained `PtrAdd`/`PtrSub` hops `generatePtrNode` may
+/// nest on top of the `PtrBase` leaf (a bare `PtrBase` is zero hops; the
+/// original single-hop `base + clampBufferIndex(x)`/`end - clampBufferIndex(x)`
+/// is one hop). Bounded purely to keep pointer-domain subtrees small and AST
+/// generation deterministic/terminating -- staying in bounds does not depend
+/// on this constant: `evalNativePtr`/`evalNautilusPtr` derive each hop's
+/// clamp modulus from however much room is actually left between the
+/// previous hop's (already-proven in-bounds) index and the buffer edge, so
+/// the in-bounds invariant holds inductively for a chain of any length.
+inline constexpr int PTR_MAX_HOPS = 2;
 
 namespace detail {
 
@@ -249,8 +274,6 @@ inline int arity(Kind k) {
 	case Kind::Cast:
 	case Kind::Load:
 	case Kind::PtrToInt:
-	case Kind::PtrAdd:
-	case Kind::PtrSub:
 		return 1;
 	case Kind::Select:
 	case Kind::If:
@@ -258,7 +281,9 @@ inline int arity(Kind k) {
 	case Kind::While:
 		return 3;
 	default:
-		// Includes LoopBreak/LoopContinue (kid[0] = cond, kid[1] = value).
+		// Includes LoopBreak/LoopContinue (kid[0] = cond, kid[1] = value) and
+		// PtrAdd/PtrSub (kid[0] = nested pointer-domain node, kid[1] =
+		// value-domain offset expression -- see generatePtrNode).
 		return 2;
 	}
 }
@@ -289,20 +314,26 @@ inline int pushPtrBase(Ast& ast) {
 }
 
 /// Build a bounded pointer-domain expression: either the raw base pointer, or
-/// a single-hop offset from it (`Kind::PtrAdd`/`Kind::PtrSub`) computed from a
-/// value-domain offset expression. Deliberately never nests (a PtrAdd's own
-/// child is always a value-domain node, never another pointer-domain node),
-/// so every pointer this can produce is directly `base + clampBufferIndex(x)`
-/// or `end - clampBufferIndex(x)` -- always an in-bounds index into the
-/// shared buffer, with no need to reason about compounding offsets across
-/// hops. `depth`/`budget`/`loopDepth`/`breakDepth`/`numParams` are threaded
-/// through exactly like generateNode's, so the shared node budget still
-/// bounds total tree size.
+/// an offset from a nested pointer-domain expression (`Kind::PtrAdd`/
+/// `Kind::PtrSub`) computed from a value-domain offset expression. May nest
+/// up to `PTR_MAX_HOPS` hops deep (`hopsRemaining` counts hops still
+/// available, decremented on each recursive call for kid[0], the nested
+/// pointer -- kid[1], the offset expression, is always value-domain, never
+/// pointer-domain, so nesting only ever grows along kid[0]). Every pointer
+/// this can produce is still provably in [0, BUFFER_ELEMS) by construction:
+/// `evalNativePtr`/`evalNautilusPtr` never apply a fixed modulus to a hop's
+/// offset, they derive it from however much room is actually left between
+/// the *previous* hop's (already-proven in-bounds) index and the relevant
+/// buffer edge, so nesting to any depth preserves the invariant inductively
+/// -- `PTR_MAX_HOPS` only bounds tree size/generation cost, not soundness.
+/// `depth`/`budget`/`loopDepth`/`breakDepth`/`numParams` are threaded through
+/// exactly like generateNode's, so the shared node budget still bounds total
+/// tree size.
 template <typename T>
 int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int loopDepth, int breakDepth,
-                    uint32_t numParams) {
+                    uint32_t numParams, int hopsRemaining = PTR_MAX_HOPS) {
 	const uint8_t sel = reader.byte();
-	bool leaf = depth <= 0 || budget <= 1 || reader.exhausted() || (sel & 0x1) == 0;
+	bool leaf = depth <= 0 || budget <= 1 || reader.exhausted() || hopsRemaining <= 0 || (sel & 0x1) == 0;
 	if constexpr (std::is_same_v<T, bool>) {
 		// val<bool> has no arithmetic to build a PtrAdd/PtrSub offset from (see
 		// BOOL_KINDS); every bool-domain pointer node stays at the buffer's
@@ -320,7 +351,9 @@ int generatePtrNode(Ast& ast, ByteReader& reader, int depth, int& budget, int lo
 
 	node.kind = (sel & 0x2) ? Kind::PtrAdd : Kind::PtrSub;
 	--budget;
-	node.kid[0] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
+	node.kid[0] =
+	    generatePtrNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams, hopsRemaining - 1);
+	node.kid[1] = generateNode<T>(ast, reader, depth - 1, budget, loopDepth, breakDepth, numParams);
 	const int idx = static_cast<int>(ast.nodes.size());
 	ast.nodes.push_back(node);
 	return idx;
@@ -782,13 +815,17 @@ void print(const Ast& ast, int idx, std::string& out) {
 		out += "mem";
 		return;
 	case Kind::PtrAdd:
-		out += "(mem + idx(";
+		out += "(";
 		print<T>(ast, n.kid[0], out);
+		out += " + idx(";
+		print<T>(ast, n.kid[1], out);
 		out += "))";
 		return;
 	case Kind::PtrSub:
-		out += "(mem_end - idx(";
+		out += "(";
 		print<T>(ast, n.kid[0], out);
+		out += " - idx(";
+		print<T>(ast, n.kid[1], out);
 		out += "))";
 		return;
 	default:

--- a/nautilus/test/fuzz/EvalNative.hpp
+++ b/nautilus/test/fuzz/EvalNative.hpp
@@ -142,13 +142,15 @@ int clampTripCount(T raw) {
 }
 
 /// Reduce a raw pointer-offset value of type T to a defined index in
-/// [0, BUFFER_ELEMS), via the identical reinterpret-then-modulo recipe as
-/// clampTripCount, just against BUFFER_ELEMS instead of LOOP_MAX_TRIPS + 1.
-/// Shared verbatim (mod constant aside) with clampBufferIndexTraced in
-/// EvalNautilus.hpp so a pointer built from the same raw offset always lands
-/// on the same buffer slot on both the native and traced sides.
+/// [0, modulus), via the identical reinterpret-then-modulo recipe as
+/// clampTripCount. `modulus` need not be a compile-time constant: a nested
+/// pointer-domain hop (see evalNativePtr) derives it at runtime from however
+/// much room is actually left before the buffer edge. Shared verbatim (mod
+/// constant/runtime-ness aside) with clampIndexModTraced in EvalNautilus.hpp
+/// so a pointer built from the same raw offset always lands on the same
+/// buffer slot on both the native and traced sides.
 template <typename T>
-int clampBufferIndex(T raw) {
+int clampIndexMod(T raw, int modulus) {
 	uint64_t u;
 	if constexpr (std::is_floating_point_v<T>) {
 		u = clampFloatToInt<T, uint64_t>(raw);
@@ -159,7 +161,15 @@ int clampBufferIndex(T raw) {
 	} else {
 		u = static_cast<uint64_t>(static_cast<std::make_unsigned_t<T>>(raw));
 	}
-	return static_cast<int>(u % static_cast<uint64_t>(BUFFER_ELEMS));
+	return static_cast<int>(u % static_cast<uint64_t>(modulus));
+}
+
+/// Reduce a raw pointer-offset value of type T to a defined index in
+/// [0, BUFFER_ELEMS) -- the fixed-modulus case of clampIndexMod, used by the
+/// innermost (bare-`PtrBase`-anchored) pointer-domain hop.
+template <typename T>
+int clampBufferIndex(T raw) {
+	return clampIndexMod<T>(raw, BUFFER_ELEMS);
 }
 
 /// Mutable per-evaluation scratch state, separate from the read-only kernel
@@ -203,17 +213,40 @@ template <typename T>
 T evalNativeCall(const Ast& ast, const Node& n, std::span<const T> args, EvalContext<T>& ctx);
 
 /// Evaluate a pointer-domain node (Kind::PtrBase/PtrAdd/PtrSub, see Ast.hpp)
-/// to a buffer index. Always in [0, BUFFER_ELEMS) by construction --
-/// generatePtrNode never nests, so there is no "current pointer" state to
-/// track, just a single offset off of index 0 or BUFFER_ELEMS - 1.
+/// to a buffer index. Always in [0, BUFFER_ELEMS) by construction.
+///
+/// When kid[0] is a bare Kind::PtrBase leaf (the common, original single-hop
+/// shape), this reduces to exactly the historical fixed-anchor formulas:
+/// PtrAdd anchors at index 0 and PtrSub at BUFFER_ELEMS - 1, each spanning the
+/// full buffer via clampBufferIndex. When kid[0] is itself a nested
+/// PtrAdd/PtrSub (generatePtrNode may nest up to PTR_MAX_HOPS deep), its
+/// index is evaluated recursively -- always already in [0, BUFFER_ELEMS) by
+/// induction -- and this hop's offset is instead reduced modulo however much
+/// room is actually left between that index and the relevant buffer edge
+/// (clampIndexMod with a runtime-computed modulus), so the composed index
+/// can never escape [0, BUFFER_ELEMS) regardless of nesting depth.
 template <typename T>
 int evalNativePtr(const Ast& ast, int idx, std::span<const T> args, EvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
-	case Kind::PtrAdd:
-		return clampBufferIndex<T>(evalNativeGeneric<T>(ast, n.kid[0], args, ctx));
-	case Kind::PtrSub:
-		return (BUFFER_ELEMS - 1) - clampBufferIndex<T>(evalNativeGeneric<T>(ast, n.kid[0], args, ctx));
+	case Kind::PtrAdd: {
+		const T rawOffset = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
+		if (ast.nodes[n.kid[0]].kind == Kind::PtrBase) {
+			return clampBufferIndex<T>(rawOffset);
+		}
+		const int baseIndex = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		const int capacity = BUFFER_ELEMS - baseIndex; // room left below the buffer's upper edge, always >= 1
+		return baseIndex + clampIndexMod<T>(rawOffset, capacity);
+	}
+	case Kind::PtrSub: {
+		const T rawOffset = evalNativeGeneric<T>(ast, n.kid[1], args, ctx);
+		if (ast.nodes[n.kid[0]].kind == Kind::PtrBase) {
+			return (BUFFER_ELEMS - 1) - clampBufferIndex<T>(rawOffset);
+		}
+		const int baseIndex = evalNativePtr<T>(ast, n.kid[0], args, ctx);
+		const int capacity = baseIndex + 1; // room left above index 0, always >= 1
+		return baseIndex - clampIndexMod<T>(rawOffset, capacity);
+	}
 	case Kind::PtrBase:
 	default:
 		return 0;

--- a/nautilus/test/fuzz/EvalNautilus.hpp
+++ b/nautilus/test/fuzz/EvalNautilus.hpp
@@ -152,20 +152,32 @@ void applyProbabilityHint(const Node& n, val<bool>& cond) {
 	}
 }
 
-/// Traced mirror of EvalNative.hpp's clampBufferIndex: same recipe as
-/// clampTripCountTraced, just against BUFFER_ELEMS instead of
-/// LOOP_MAX_TRIPS + 1, so a pointer built from the same raw offset lands on
-/// the same buffer slot as the native oracle.
+/// Traced mirror of EvalNative.hpp's clampIndexMod: same recipe as
+/// clampTripCountTraced, just against a caller-supplied modulus instead of a
+/// fixed LOOP_MAX_TRIPS + 1. `modulus` is itself a traced value (not
+/// necessarily a compile-time constant): a nested pointer-domain hop (see
+/// evalNautilusPtr) derives it at runtime from however much room is actually
+/// left before the buffer edge, exactly like the native oracle's runtime
+/// `capacity`.
 template <typename T>
-val<int32_t> clampBufferIndexTraced(TracedValue<T> raw) {
+val<int32_t> clampIndexModTraced(TracedValue<T> raw, val<uint64_t> modulus) {
 	TracedValue<uint64_t> u(uint64_t(0));
 	if constexpr (std::is_floating_point_v<T>) {
 		u = clampFloatToIntTraced<T, uint64_t>(raw);
 	} else {
 		u = static_cast<TracedValue<uint64_t>>(static_cast<TracedValue<std::make_unsigned_t<T>>>(raw));
 	}
-	TracedValue<uint64_t> index = u % TracedValue<uint64_t>(uint64_t(BUFFER_ELEMS));
+	TracedValue<uint64_t> index = u % modulus;
 	return static_cast<val<int32_t>>(index);
+}
+
+/// Traced mirror of EvalNative.hpp's clampBufferIndex: the fixed-modulus
+/// (BUFFER_ELEMS) case of clampIndexModTraced, used by the innermost
+/// (bare-`PtrBase`-anchored) pointer-domain hop, so a pointer built from the
+/// same raw offset lands on the same buffer slot as the native oracle.
+template <typename T>
+val<int32_t> clampBufferIndexTraced(TracedValue<T> raw) {
+	return clampIndexModTraced<T>(raw, val<uint64_t>(uint64_t(BUFFER_ELEMS)));
 }
 
 /// Mutable per-evaluation scratch state mirroring EvalNative.hpp's
@@ -206,11 +218,37 @@ template <typename T>
 TracedValue<T> evalNautilusCall(const Ast& ast, const Node& n, std::span<const TracedValue<T>> args,
                                 TracedEvalContext<T>& ctx);
 
+/// Result of evaluating a pointer-domain node: the real val<T*> (for
+/// Load/Store/PtrToInt/Ptr-comparisons to consume) plus its buffer index
+/// (always in [0, BUFFER_ELEMS), tracked alongside the pointer purely so an
+/// outer, nested hop can derive its own safe clamp modulus without
+/// re-deriving it from the pointer itself -- val<T*> has no pointer-minus-
+/// pointer operator to recover an index from a bare val<T*>).
+template <typename T>
+struct PtrEvalResult {
+	val<T*> ptr;
+	val<int32_t> index;
+};
+
 /// Traced mirror of EvalNative.hpp's evalNativePtr: evaluates a
 /// pointer-domain node to a real val<T*>, using the exact same
 /// operator+/operator- val<T*> arithmetic under test.
+///
+/// When kid[0] is a bare Kind::PtrBase leaf (the common, original single-hop
+/// shape), this reduces to exactly the historical fixed-anchor formulas:
+/// PtrAdd off ctx.basePtr, PtrSub off ctx.lastPtr, each spanning the full
+/// buffer via clampBufferIndexTraced. When kid[0] is itself a nested
+/// PtrAdd/PtrSub (generatePtrNode may nest up to PTR_MAX_HOPS deep), it is
+/// evaluated recursively -- its index always already in [0, BUFFER_ELEMS) by
+/// induction -- and this hop's offset is instead reduced modulo however much
+/// room is actually left between that index and the relevant buffer edge
+/// (clampIndexModTraced with a runtime-computed val<uint64_t> modulus), so
+/// the composed pointer can never escape the buffer regardless of nesting
+/// depth -- exercising val<T*>::operator+/- chained hop-over-hop on a
+/// pointer that is itself the result of a prior traced pointer operation.
 template <typename T>
-val<T*> evalNautilusPtr(const Ast& ast, int idx, std::span<const TracedValue<T>> args, TracedEvalContext<T>& ctx) {
+PtrEvalResult<T> evalNautilusPtr(const Ast& ast, int idx, std::span<const TracedValue<T>> args,
+                                 TracedEvalContext<T>& ctx) {
 	const Node& n = ast.nodes[idx];
 	switch (n.kind) {
 	case Kind::PtrAdd:
@@ -222,19 +260,33 @@ val<T*> evalNautilusPtr(const Ast& ast, int idx, std::span<const TracedValue<T>>
 			// exist) is never instantiated.
 			__builtin_unreachable();
 		} else {
-			val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusGeneric<T>(ast, n.kid[0], args, ctx));
-			return ctx.basePtr + off;
+			TracedValue<T> rawOffset = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
+			if (ast.nodes[n.kid[0]].kind == Kind::PtrBase) {
+				val<int32_t> off = clampBufferIndexTraced<T>(rawOffset);
+				return {ctx.basePtr + off, off};
+			}
+			PtrEvalResult<T> inner = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+			val<uint64_t> capacity = static_cast<val<uint64_t>>(val<int32_t>(int32_t(BUFFER_ELEMS)) - inner.index);
+			val<int32_t> off = clampIndexModTraced<T>(rawOffset, capacity);
+			return {inner.ptr + off, inner.index + off};
 		}
 	case Kind::PtrSub:
 		if constexpr (std::is_same_v<T, bool>) {
 			__builtin_unreachable();
 		} else {
-			val<int32_t> off = clampBufferIndexTraced<T>(evalNautilusGeneric<T>(ast, n.kid[0], args, ctx));
-			return ctx.lastPtr - off;
+			TracedValue<T> rawOffset = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
+			if (ast.nodes[n.kid[0]].kind == Kind::PtrBase) {
+				val<int32_t> off = clampBufferIndexTraced<T>(rawOffset);
+				return {ctx.lastPtr - off, val<int32_t>(int32_t(BUFFER_ELEMS - 1)) - off};
+			}
+			PtrEvalResult<T> inner = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+			val<uint64_t> capacity = static_cast<val<uint64_t>>(inner.index + val<int32_t>(int32_t(1)));
+			val<int32_t> off = clampIndexModTraced<T>(rawOffset, capacity);
+			return {inner.ptr - off, inner.index - off};
 		}
 	case Kind::PtrBase:
 	default:
-		return ctx.basePtr;
+		return {ctx.basePtr, val<int32_t>(int32_t(0))};
 	}
 }
 
@@ -445,12 +497,12 @@ TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, std::span<const Trac
 			return castThroughTraced<T>(evalNautilusGeneric<T>(ast, n.kid[0], args, ctx), static_cast<TypeId>(n.imm));
 		}
 	case Kind::Load: {
-		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx).ptr;
 		TracedValue<T> v = *p;
 		return v;
 	}
 	case Kind::Store: {
-		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx).ptr;
 		TracedValue<T> v = evalNautilusGeneric<T>(ast, n.kid[1], args, ctx);
 		*p = v;
 		return v;
@@ -462,7 +514,7 @@ TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, std::span<const Trac
 			// excludes bool), so this must never be instantiated for T=bool.
 			__builtin_unreachable();
 		} else {
-			return static_cast<TracedValue<T>>(evalNautilusPtr<T>(ast, n.kid[0], args, ctx));
+			return static_cast<TracedValue<T>>(evalNautilusPtr<T>(ast, n.kid[0], args, ctx).ptr);
 		}
 	case Kind::PtrEq:
 	case Kind::PtrNe:
@@ -470,8 +522,8 @@ TracedValue<T> evalNautilusGeneric(const Ast& ast, int idx, std::span<const Trac
 	case Kind::PtrLe:
 	case Kind::PtrGt:
 	case Kind::PtrGe: {
-		val<T*> a = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
-		val<T*> b = evalNautilusPtr<T>(ast, n.kid[1], args, ctx);
+		val<T*> a = evalNautilusPtr<T>(ast, n.kid[0], args, ctx).ptr;
+		val<T*> b = evalNautilusPtr<T>(ast, n.kid[1], args, ctx).ptr;
 		val<bool> cmp = comparePtrTraced<T>(n.kind, a, b);
 		return select(cmp, TracedValue<T>(T(1)), TracedValue<T>(T(0)));
 	}
@@ -623,7 +675,7 @@ TracedValue<T> evalNautilusCall(const Ast& ast, const Node& n, std::span<const T
 		invoke(&calleeVoidNoop<T>, v[0], v[1]);
 		return v[0];
 	default: { // ptrSwap: kid[0] is the pointer-domain kid, v[0] is the value written.
-		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx);
+		val<T*> p = evalNautilusPtr<T>(ast, n.kid[0], args, ctx).ptr;
 		return invoke(&calleePtrSwap<T>, p, v[0]);
 	}
 	}

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -255,6 +255,13 @@ arithmetic, comparisons, casts, and loads/stores are fuzzed identically to
 the rest of the value domain -- following the same well-defined-by-construction
 principle as everything else here.
 
+This domain still deliberately simplifies two other surfaces raised in
+nebulastream/nautilus#357: there is one buffer of one element type `T` (no
+type-punned/mixed-width access), and no aliasing between distinct pointers
+(there's only ever one buffer to point into). Compounding pointer arithmetic
+(the third surface #357 identifies) is covered below; the other two are
+left as follow-up work.
+
 * **`Load`/`Store`**: `kid[0]` (both) is a *pointer-domain* node (see below),
   `kid[1]` (`Store` only) is a value-domain node. `Load` yields `*ptr`; `Store`
   writes through the pointer and yields the stored value, i.e. the value of
@@ -270,17 +277,40 @@ principle as everything else here.
   value-domain comparisons.
 * **Pointer-domain nodes** (`PtrBase`/`PtrAdd`/`PtrSub`, `generatePtrNode` in
   `Ast.hpp`): never chosen as the AST root or by the value-domain generator
-  directly -- only ever a kid of one of the nodes above. Deliberately never
-  nest (`PtrAdd`'s own child is always a *value*-domain offset expression,
-  never another pointer-domain node), so every pointer this can produce is
-  directly `base + clampBufferIndex(x)` or `end - clampBufferIndex(x)` for
-  some single offset expression `x` -- always an in-bounds buffer index by
-  construction, with no need to reason about compounding offsets across
-  hops. `clampBufferIndex`/`clampBufferIndexTraced` reduce the raw offset the
-  same reinterpret-to-unsigned-then-modulo way as `Loop`'s trip count, just
-  modulo `BUFFER_ELEMS` -- exercising real `val<T*>::operator+`/`operator-`
-  (scaled by `sizeof(T)`) while staying safe regardless of what value the
-  offset expression evaluates to.
+  directly -- only ever a kid of one of the nodes above. `PtrAdd`/`PtrSub`
+  each take two kids: `kid[0]` is a *nested pointer-domain* node (either the
+  `PtrBase` leaf, or -- up to `PTR_MAX_HOPS` deep -- another `PtrAdd`/
+  `PtrSub`), `kid[1]` is the value-domain offset expression. When `kid[0]` is
+  the bare `PtrBase` leaf (the common, single-hop shape), this reduces to
+  exactly `base + clampBufferIndex(x)` or `end - clampBufferIndex(x)` as
+  before, via `clampBufferIndex`/`clampBufferIndexTraced` (the same
+  reinterpret-to-unsigned-then-modulo recipe as `Loop`'s trip count, just
+  modulo `BUFFER_ELEMS`).
+
+  When `kid[0]` is itself a nested `PtrAdd`/`PtrSub` (**compounding pointer
+  arithmetic**, e.g. `(base + i) - j`), the outer hop's offset is instead
+  reduced modulo however much room is *actually left* between the inner
+  pointer's index and the relevant buffer edge --
+  `clampIndexMod`/`clampIndexModTraced` (`EvalNative.hpp`/`EvalNautilus.hpp`),
+  the generalization of `clampBufferIndex`/`clampBufferIndexTraced` to a
+  caller-supplied (possibly runtime-computed) modulus instead of the fixed
+  `BUFFER_ELEMS`. Concretely: `PtrAdd` on a nested pointer whose index is
+  already known (by induction) to be in `[0, BUFFER_ELEMS)` computes
+  `capacity = BUFFER_ELEMS - innerIndex` and adds `offset mod capacity`, so
+  the result stays `<= BUFFER_ELEMS - 1`; `PtrSub` mirrors this with
+  `capacity = innerIndex + 1` and subtracts, so the result stays `>= 0`.
+  Because `capacity` is derived from the *actual* (data-dependent) inner
+  index rather than a per-hop generation-time bound, the in-bounds invariant
+  holds inductively for a chain of *any* length -- `PTR_MAX_HOPS` (currently
+  2, i.e. one level of nesting beyond the original single hop) only bounds
+  generation cost/tree size, not soundness. On the traced side, each hop's
+  index is threaded alongside its `val<T*>` (`PtrEvalResult<T>` in
+  `EvalNautilus.hpp`) purely so an outer hop can compute its own capacity
+  without a pointer-minus-pointer operator (which `val<T*>` doesn't have);
+  the pointer itself is built by chaining real `val<T*>::operator+`/
+  `operator-` calls, one per hop, so a nested pointer genuinely exercises
+  pointer arithmetic applied to the *result* of a prior pointer operation,
+  not just a recomputed final index.
 * **Buffer lifecycle**: the harness declares the buffer once per
   `checkOneTyped<T>` call and resets its contents (not its storage) to the
   same initial values before the native-oracle run and before each backend


### PR DESCRIPTION
## Summary

Addresses one of the three gaps in #357 ("compounding pointer arithmetic"): `generatePtrNode` (`Ast.hpp`) previously never nested — every pointer-domain expression was exactly `base + clampBufferIndex(x)` or `end - clampBufferIndex(x)` for a single offset `x`. `PtrAdd`/`PtrSub` now take a nested pointer-domain node as `kid[0]` (in addition to the value-domain offset at `kid[1]`), bounded to `PTR_MAX_HOPS` (2) hops, so generated programs can contain `(base + i) - j`-shaped pointers.

* **Soundness is depth-independent.** Each hop derives its clamp modulus from however much room is *actually* left between the inner (already-proven in-bounds) pointer's index and the relevant buffer edge — `clampIndexMod`/`clampIndexModTraced` (`EvalNative.hpp`/`EvalNautilus.hpp`), generalized from the old fixed-`BUFFER_ELEMS`-modulus `clampBufferIndex`/`clampBufferIndexTraced` to accept a caller-supplied (possibly runtime-computed) modulus. The in-bounds invariant holds inductively for a chain of any length; `PTR_MAX_HOPS` only bounds generation cost/tree size, not correctness.
* **The single-hop case is unchanged.** When `kid[0]` resolves to the bare `PtrBase` leaf, both evaluators fall back to exactly the original fixed-anchor formulas, so existing coverage/corpus behavior for the common case is preserved.
* **The traced side chains real pointer arithmetic.** `evalNautilusPtr` now returns `{val<T*>, val<int32_t> index}` (`PtrEvalResult<T>`) — the index is threaded alongside the pointer purely so an outer hop can compute its own capacity without a pointer-minus-pointer operator (which `val<T*>` doesn't have). The pointer itself is built by chaining real `val<T*>::operator+`/`operator-` calls, one per hop, so a nested pointer genuinely exercises pointer arithmetic applied to the *result* of a prior traced pointer operation.

`README.md`'s "Memory and pointer domain" section is updated to describe this, and now also calls out the two other #357 surfaces (type-punned/mixed-width access, multi-buffer aliasing) as still-open follow-up work.

## Verification

Built `nautilus-fuzz-replay` (Release, MLIR backend disabled to keep the build fast; interpreter/cpp/bc/tbc/asmjit backends enabled) and ran:
- the built-in 2000-input smoke corpus — clean (only the four documented pre-existing tracer/IR exceptions tolerated, same as before this change)
- `--survey 5000` — 604 findings, all confirmed to fall into the same four pre-existing categories (no new mismatch or exception class); spot-checked example programs confirm nested pointer expressions like `((mem + idx(p0)) - idx(...))` are actually being generated and differentially checked across every backend.

## Test plan

- [x] `nautilus-fuzz-replay` (Release) smoke corpus (2000 inputs) — clean
- [x] `nautilus-fuzz-replay --survey 5000` — no new finding classes; nested pointer expressions confirmed present
- [x] Changed files pass `clang-format-18 --dry-run -Werror`
- [ ] CI (MLIR/GCC/Clang matrix, sanitizers) — pending


---
_Generated by [Claude Code](https://claude.ai/code/session_01EY4rcaoirMM2NF65pXZqRZ)_