### PR TITLE
Fix val<bool> default constructor stamping its trace state i32 instead of i1 (#377)

### DIFF
--- a/nautilus/include/nautilus/val_bool.hpp
+++ b/nautilus/include/nautilus/val_bool.hpp
@@ -170,14 +170,17 @@ public:
 	/// Default constructor.
 	///
 	/// Initializes the boolean value to false with default probability 0.5.
-	/// If tracing is enabled, records a constant 0 (false) in the trace.
+	/// If tracing is enabled, records a boolean `false` constant in the trace.
+	/// The literal must be a `bool` (not an `int`) so the traced state is
+	/// stamped `Type::b`; seeding it from an `int` `0` would stamp it `i32`
+	/// and feed a non-`i1` operand into the MLIR backend's `cf.cond_br`.
 	///
 	/// # Example
 	/// ```cpp
 	/// val<bool> b;  // b = false, probability = 0.5
 	/// ```
 #ifdef ENABLE_TRACING
-	val() : state(tracing::traceConstant(0)), value(false) {
+	val() : state(tracing::traceConstant(false)), value(false) {
 	}
 #else
 	val() {

--- a/nautilus/test/common/BoolOperations.hpp
+++ b/nautilus/test/common/BoolOperations.hpp
@@ -47,6 +47,26 @@ val<bool> boolIfElse(val<bool> x, val<bool> z) {
 	}
 }
 
+// Regression for #377: a default-constructed val<bool> must carry a boolean
+// (i1) trace stamp, not i32. The default constructor used to seed its initial
+// `false` state through an `int` literal (traceConstant(0)), which stamped the
+// value i32 instead of Type::b. Branching on such a value then fed a non-i1
+// operand into the MLIR backend's `cf.cond_br`, and MLIR's own verifier
+// rejected the module ("operand #0 must be 1-bit signless integer, but got
+// 'i32'"). This mirrors the loop break/continue signal shape the differential
+// fuzzer first hit: a default-constructed val<bool>, conditionally assigned,
+// then used as a branch condition.
+val<bool> defaultConstructedBoolBranch(val<int32_t> x) {
+	val<bool> flag;
+	if (x == 42) {
+		flag = true;
+	}
+	if (flag) {
+		return true;
+	}
+	return false;
+}
+
 val<bool> eval(val<bool> x, val<bool> z) {
 	return x == z;
 }

--- a/nautilus/test/execution-tests/BoolExecutionTest.cpp
+++ b/nautilus/test/execution-tests/BoolExecutionTest.cpp
@@ -77,6 +77,15 @@ void boolTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(true, false) == false);
 	}
 
+	// Regression for #377: default-constructed val<bool> used as a branch
+	// condition must lower to an i1 in the MLIR backend (was stamped i32).
+	SECTION("defaultConstructedBoolBranch") {
+		auto f = engine.registerFunction(defaultConstructedBoolBranch);
+		REQUIRE(f(42) == true);
+		REQUIRE(f(0) == false);
+		REQUIRE(f(7) == false);
+	}
+
 	SECTION("boolNestedFunction") {
 		auto f = engine.registerFunction(boolNestedFunction);
 		REQUIRE(f(true, true) == true);

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -786,17 +786,29 @@ the very first CI run -- confirmed independent of that PR (reproduces from a
 clean `main` checkout the same way):
 
 5. **MLIR module verification failure** (`"verification of MLIR module
-   failed!"`): a `u16`/`mixed`-shape kernel --
+   failed!"`) -- **now fixed** (nebulastream/nautilus#377): a `u16`/`mixed`-shape
+   kernel --
    ```
    ((((((mem + idx(39420u16)) + idx((i64)(if(p1 != 0, p1, p2)))) <= (mem + idx((uintptr_t)((mem + idx(60247u16)))))) ? 1 : 0) * ((((mem < mem) ? 1 : 0) == p0) ? 1 : 0)) - ((mem <= (mem - idx((while(init=(p1 << 3044u16), cond=cont(cond=3715u16, value=29463u16), body=(*(mem) = p2)) ^ 11218u16)))) ? 1 : 0))
    ```
-   -- reaches `MLIRLoweringProvider`'s `cf.cond_br` emission
+   -- reached `MLIRLoweringProvider`'s `cf.cond_br` emission
    (`resolveOperand(ifOp->getValue(), frame)`) with an `i32` operand where MLIR
-   requires `i1`, so MLIR's own verifier rejects the module before LLVM
-   lowering ever runs (`'cf.cond_br' op operand #0 must be 1-bit signless
-   integer, but got 'i32'`). Root-causing exactly which sub-expression's
-   condition loses its `Type::b` stamp on the way to the branch is out of
-   scope for a CI-wiring change; tracked in nebulastream/nautilus#377.
+   requires `i1`, so MLIR's own verifier rejected the module before LLVM
+   lowering ever ran (`'cf.cond_br' op operand #0 must be 1-bit signless
+   integer, but got 'i32'`). Root cause: `val<bool>`'s **default constructor**
+   (`include/nautilus/val_bool.hpp`) seeded its initial `false` state via an
+   `int` literal -- `tracing::traceConstant(0)` deduces `T = int`, so the
+   constant was stamped `Type::i32` rather than `Type::b`, giving every
+   default-constructed `val<bool>` an `i32` trace state. The `while` body's
+   `cont` (`Kind::LoopContinue`) drives the enclosing loop's default-constructed
+   `val<bool>` break/continue signal (`TracedLoopSignal` in `EvalNautilus.hpp`),
+   so the `if (signal)` post-body check branched on that mis-stamped `i32`.
+   Fixed by seeding the default state with a `bool` literal
+   (`tracing::traceConstant(false)`), matching how `val(bool)` and
+   `val_arith.hpp`'s `traceConstant<raw_type>(0)` already stamp their constants.
+   Pinned by `defaultConstructedBoolBranch` in `test/common/BoolOperations.hpp`
+   (exercised across every backend by `BoolExecutionTest.cpp`), and the smoke
+   corpus no longer tolerates this exception.
 
 Investigating finding 4 above also caught the tolerance filter itself in
 `ReplayMain.cpp`'s `isKnownPreExistingFinding` failing silently: it compared

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -112,16 +112,14 @@ std::vector<uint8_t> randomBuffer() {
 //      LazyTraceContext::follow before this exception is ever thrown; CI
 //      builds Release (NDEBUG), where only this catchable exception is
 //      observable.
-//   5. "verification of MLIR module failed!" -- a `u16`/`mixed`-shape kernel
-//      whose AST nests a control-flow `Kind::If` inside a larger boolean
-//      arithmetic expression reaches MLIRLoweringProvider's `cf.cond_br`
-//      emission with an `i32` operand instead of the required `i1`; MLIR's
-//      own verifier rejects the module before LLVM lowering ever runs. First
-//      surfaced when the `fuzz-replay-smoke` CI job (#376) executed this
-//      corpus in CI for the first time -- confirmed pre-existing (reproduces
-//      from a clean checkout), not introduced by that PR. Root-causing which
-//      sub-expression loses its `Type::b` stamp on the way to the branch is
-//      tracked in issue #377.
+//
+// Finding 5 ("verification of MLIR module failed!") is no longer tolerated: it
+// was a default-constructed `val<bool>` carrying an `i32` trace stamp (its
+// initial `false` was seeded via an `int` literal, `traceConstant(0)`), which
+// reached MLIRLoweringProvider's `cf.cond_br` as a non-`i1` operand and made
+// MLIR's own verifier reject the module. Fixed in val_bool.hpp (issue #377) by
+// stamping the default state `Type::b`; the smoke corpus now actively guards
+// against its recurrence.
 bool isKnownPreExistingFinding(const nautilus::fuzz::Finding& f) {
 	if (!f.exception) {
 		return false;
@@ -133,8 +131,7 @@ bool isKnownPreExistingFinding(const nautilus::fuzz::Finding& f) {
 	// of exact equality, the same way the "Key $" case already does.
 	return f.what.starts_with("Invalid trace. This is maybe caused by a constant loop.") ||
 	       f.what.starts_with("Invalid trace: no Return operation was recorded.") || f.what.starts_with("Key $") ||
-	       f.what.starts_with("std::get: wrong index for variant") ||
-	       f.what.starts_with("verification of MLIR module failed!");
+	       f.what.starts_with("std::get: wrong index for variant");
 }
 
 // Default corpus size for the PR-gate smoke run. Overridable via


### PR DESCRIPTION
## Summary

Fixes #377 — the MLIR backend rejected modules with `'cf.cond_br' op operand #0 must be 1-bit signless integer, but got 'i32'`.

**Root cause.** `val<bool>`'s default constructor seeded its initial `false` trace state via `tracing::traceConstant(0)`. The `0` literal is an **`int`**, so the template `traceConstant(T&&)` deduced `T = int` and `TypeResolver<int>::to_type()` stamped the constant `Type::i32` instead of `Type::b`. Every default-constructed `val<bool>` therefore carried an i32 trace state.

When such a value is used as a branch condition, `MLIRLoweringProvider::visitIf` emits a `cf.cond_br` whose condition operand is that i32 stamp, and MLIR's own verifier rejects the module before LLVM lowering ever runs. The differential fuzzer's built-in corpus hit this through the loop `break`/`continue` signals (`TracedLoopSignal`'s default-constructed `val<bool>` members), whose `if (signal)` post-body check branches on the mis-stamped value — matching the issue's `while(... cont(...) ...)` reproducer.

**Fix.** Seed the default state with a `bool` literal — `tracing::traceConstant(false)` — so `T` deduces to `bool` and the constant is stamped `Type::b`. This matches how `val(bool)` and `val_arith.hpp`'s `traceConstant<raw_type>(0)` already stamp their constants.

## Changes

- `include/nautilus/val_bool.hpp`: `traceConstant(0)` → `traceConstant(false)` in the default constructor (+ doc comment explaining the invariant).
- `test/common/BoolOperations.hpp` + `test/execution-tests/BoolExecutionTest.cpp`: new `defaultConstructedBoolBranch` regression (a default-constructed `val<bool>`, conditionally assigned, then used as a branch condition), exercised across every backend.
- `test/fuzz/ReplayMain.cpp` + `test/fuzz/README.md`: the smoke corpus no longer tolerates the `"verification of MLIR module failed!"` finding, so it now actively guards against a regression; README "Known findings" entry updated to reflect the fix.

## Verification

Dumped the generated IR for the regression kernel before/after the fix:

- **Before:** `CONST $2 0 :i32` → control-flow-merge phi `B5($2:i32)` → `CMP $7 $2 …` (the exact i32-into-`cf.cond_br` MLIR rejects).
- **After:** `CONST $2 false :bool` → phi `B5($2:bool)` → `CMP $7 $2 …` (i1).

Full `nautilus-execution-tests` suite passes (bc/tbc/interpreter build; MLIR-gated tests skipped locally as the backend was not built), and the fuzzer replay smoke driver builds and runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wUdzkNbj2Cw7uMsjXHoZm

---
_Generated by [Claude Code](https://claude.ai/code/session_012wUdzkNbj2Cw7uMsjXHoZm)_