### PR TITLE
[fuzzer] Audit known findings against current main; cross-link them to tracking issues #381-#385

### DIFF
--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -549,7 +549,7 @@ keep the IR well under it; it is orthogonal to what this fuzzer hunts. The
 sweep therefore does **not** expose `ir.runPasses=false` — it uses per-pass
 toggles that keep constant folding on (see [Config sweep](#config-sweep)) — and
 the BC 16-bit-register limit is left to be fixed (graceful error, or a wider
-index) as a separate change.
+index) as a separate change, tracked in nebulastream/nautilus#385.
 
 On its first run this fuzzer reproduces a real bug: the IR constant-folding pass
 folds unsigned integer comparison/division/modulo/right-shift with **signed**
@@ -702,7 +702,7 @@ backend/type bucket) for future investigation.
    shapes being reachable reintroduces the collision on unrelated trees
    elsewhere in the corpus -- i.e. the byte-stream *shift* from having more
    `Kind::Call` diversity is what surfaces it, not anything specific to a
-   given new callee's own marshalling.
+   given new callee's own marshalling. Tracked in nebulastream/nautilus#381.
 2. **Empty return list** (`"Invalid trace: no Return operation was
    recorded."`, hardened from a crash): a kernel combining `Kind::If` with a
    pointer `Store` and two nested `nautilus::invoke()` calls (concretely:
@@ -721,7 +721,7 @@ backend/type bucket) for future investigation.
    own "a trivial kernel crashes the same way through an ad hoc harness"
    caveat and making this specific defect resistant to standalone
    minimization; it is only reliably reproduced through the real fuzz/replay
-   harness's deeper call stack.
+   harness's deeper call stack. Tracked in nebulastream/nautilus#382.
 3. **Merged-value Frame lookup miss** (`"Key $N does not exists in frame."`):
    a `Frame<K,V>` (`compiler/Frame.hpp`, shared by the cpp/bc/asmjit lowering
    providers) lookup miss for an SSA value merged across two `Kind::If` arms,
@@ -731,7 +731,11 @@ backend/type bucket) for future investigation.
    BC/AsmJit fix above, just a control-flow shape neither `getResultRegister`
    nor `bindResult` covers -- worth a maintainer's attention alongside it, but
    root-causing and fixing the shared `Frame<K,V>` lookup path is out of
-   scope for this Call-coverage expansion.
+   scope for this Call-coverage expansion. Tracked in
+   nebulastream/nautilus#383 (which also records that later byte-stream
+   reshuffles moved this finding out of the deterministic corpus's reach --
+   a 10000-input `--survey` on current `main` no longer hits it, while the
+   other tolerated findings all still fire).
 
 Adding `val<bool>`/`val<enum>` as generated domains (see "Bool domain"/"Enum
 domain" above) immediately surfaced four more latent bugs, all fixed by this
@@ -778,7 +782,11 @@ tolerance-filter bug below is worked around):
    Release (`NDEBUG` defined, `pr.yml`), where only this catchable exception is
    observable, so it does not block CI. Root-causing the variant misuse is out
    of scope here (it predates and is independent of the bool/enum domains this
-   change adds).
+   change adds). Tracked in nebulastream/nautilus#384, which also corrects the
+   scope: a later audit showed it is not cpp-specific -- every affected
+   program fails identically on all four compiled backends under every config
+   permutation, pointing at shared tracing/IR infrastructure (consistent with
+   the Debug-build assert living in `LazyTraceContext::follow`).
 
 Wiring the deterministic corpus into CI for the first time (`fuzz-replay-smoke`,
 nebulastream/nautilus#376) immediately surfaced a fifth pre-existing finding on

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -87,7 +87,7 @@ std::vector<uint8_t> randomBuffer() {
 //      call sites* a tracing evaluator takes to reach an `if` -- not on
 //      which logical AST node it is -- so two unrelated Kind::If nodes
 //      reached via the same shape of recursive descent can collide onto the
-//      same Tag.
+//      same Tag. Tracked in issue #381.
 //   2. "Invalid trace: no Return operation was recorded." -- some traced
 //      kernels combining Kind::If with a pointer Store and nested
 //      nautilus::invoke() calls complete tracing without ever recording a
@@ -95,13 +95,15 @@ std::vector<uint8_t> randomBuffer() {
 //      front() on that empty list (undefined behavior, a real crash) -- now
 //      hardened (see SSACreationPhase.cpp) to throw this catchable exception
 //      instead. The underlying "why is the Return missing" tracing defect is
-//      still open.
+//      still open; tracked in issue #382.
 //   3. "Key $N does not exists in frame." -- a Frame<K,V> (compiler/Frame.hpp,
 //      shared by the cpp/bc/asmjit lowering providers) lookup miss for an
 //      SSA value merged across two Kind::If arms, reachable with nested
 //      Kind::If inside a Kind::Call argument -- the same *class* of
 //      merged-value bookkeeping bug as the already-fixed BC/AsmJit
 //      instances documented below, just a shape those fixes didn't cover.
+//      Tracked in issue #383 (currently latent: later byte-stream reshuffles
+//      moved it out of this deterministic corpus's reach).
 //   4. "std::get: wrong index for variant" -- an internal std::variant
 //      accessed through the wrong alternative somewhere in the cpp backend's
 //      lowering of a voidReturn-shaped kernel (issue #355/#363) whose AST
@@ -111,7 +113,8 @@ std::vector<uint8_t> randomBuffer() {
 //      earlier `assert(currentOperation.op == op)` in
 //      LazyTraceContext::follow before this exception is ever thrown; CI
 //      builds Release (NDEBUG), where only this catchable exception is
-//      observable.
+//      observable. Tracked in issue #384 (not actually cpp-specific: every
+//      affected program fails identically on all four compiled backends).
 //   5. "verification of MLIR module failed!" -- a `u16`/`mixed`-shape kernel
 //      whose AST nests a control-flow `Kind::If` inside a larger boolean
 //      arithmetic expression reaches MLIRLoweringProvider's `cf.cond_br`


### PR DESCRIPTION
## Summary

Docs/comments-only change accompanying an audit of the fuzzer's "Known findings" (`nautilus/test/fuzz/README.md`) against current `main` (d25f722). Each still-relevant pre-existing finding now has a dedicated GitHub issue, and the README + `ReplayMain.cpp`'s tolerance-filter comment reference them — the same way finding 5 already references #377.

## Audit method and results

Built `nautilus-fuzz-replay` (`-DENABLE_FUZZER_REPLAY=ON`, Release, Clang 18, x86-64, MLIR backend off) and ran `--survey 10000` over the deterministic corpus (a superset of the 2000-input CI smoke corpus). 5660 findings, **zero value mismatches** (the miscompile classes previously fixed — #312 signed folding, signed-zero negation, AsmJit narrow-width invariants, MLIR call-arg extension, BC merge registers — all stay fixed). Every finding is one of the known tolerated exceptions:

| Known finding | Status | Issue |
|---|---|---|
| 1. Tag/Snapshot collision (`"Invalid trace. This is maybe caused by a constant loop."`) | **Still reproduces**: 268/10000 programs (~2.7%), all compiled backends × all configs; smallest examples are control-flow-free (`min(0f64, 0f64)`) | #381 (new) |
| 2. Missing Return operation (`"Invalid trace: no Return operation was recorded."`) | **Still reproduces**: 3/10000 programs, all backends × configs | #382 (new) |
| 3. Merged-value Frame lookup miss (`"Key $N does not exists in frame."`) | **Not reproduced** in current fixed-seed corpus (byte-stream drift since #365/#366/#368/#374, not a fix); code path unchanged — tracked as latent | #383 (new) |
| 4. Wrong-alternative variant access (`"std::get: wrong index for variant"`) | **Still reproduces**: 12/10000 programs — and **not cpp-specific** as the README previously said: identical failure on asmjit/bc/cpp/tbc under every config, pointing at shared tracing (`LazyTraceContext::follow` assert in Debug) | #384 (new) |
| 5. MLIR `cf.cond_br` i32 condition | Already tracked (not re-checked here; MLIR was off in this build) | #377 (existing) |
| BC 16-bit register-file overflow (config-sweep section) | Confirmed unguarded by inspection: `RegisterProvider::allocRegister()` is `currentRegister++` on a `short` with no bound | #385 (new) |

## Changes

- `nautilus/test/fuzz/README.md`: add issue references to findings 1–4 and the BC register-limit paragraph; record the finding-3 corpus-drift status and the finding-4 scope correction.
- `nautilus/test/fuzz/ReplayMain.cpp`: same issue references in the `isKnownPreExistingFinding` comment block. Comments only — no behavior change.

## Test plan

- [x] `clang-format-18 --dry-run --Werror` clean on `ReplayMain.cpp` (the repo-wide `format.sh` failures are pre-existing in `plugins/gpu/test/data`, unrelated).
- [x] No code change; `nautilus-fuzz-replay` built and ran before/after identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6jVVRLC7tEHJUZs7VPSYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6jVVRLC7tEHJUZs7VPSYe)_