### PR TITLE
Guard BC register allocator against 16-bit overflow (#385)

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -4,7 +4,9 @@
 #include "nautilus/compiler/backends/bc/ByteCode.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
 #include "nautilus/exceptions/NotImplementedException.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
 #include <cassert>
+#include <climits>
 #include <utility>
 
 namespace nautilus::compiler::bc {
@@ -94,6 +96,13 @@ BCLoweringProvider::lower(std::shared_ptr<ir::IRGraph> ir, const std::string& fu
 	return ctx.process();
 }
 
+short BCLoweringProvider::RegisterProvider::allocNewRegister() {
+	if (currentRegister == SHRT_MAX) {
+		throw RuntimeException("BC backend register file exhausted (32767); reduce kernel size or enable IR passes");
+	}
+	return currentRegister++;
+}
+
 short BCLoweringProvider::RegisterProvider::allocRegister() {
 	// Reuse freed registers if available
 	if (!freeList.empty()) {
@@ -102,7 +111,7 @@ short BCLoweringProvider::RegisterProvider::allocRegister() {
 		return reg;
 	}
 	// Otherwise allocate a new register
-	return currentRegister++;
+	return allocNewRegister();
 }
 
 short BCLoweringProvider::RegisterProvider::allocPinnedRegister() {
@@ -110,13 +119,13 @@ short BCLoweringProvider::RegisterProvider::allocPinnedRegister() {
 	// pre-initialised from the default register file on every
 	// invocation and must never be clobbered by another operation
 	// during the run, so the slot cannot be taken from the free list.
-	short reg = currentRegister++;
+	short reg = allocNewRegister();
 	pinned.insert(reg);
 	return reg;
 }
 
 short BCLoweringProvider::RegisterProvider::allocFreshRegister() {
-	return currentRegister++;
+	return allocNewRegister();
 }
 
 void BCLoweringProvider::RegisterProvider::freeRegister(short reg) {

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
@@ -96,6 +96,11 @@ private:
 		}
 
 	private:
+		/// Increment currentRegister, throwing a RuntimeException instead of
+		/// silently overflowing the 16-bit counter once SHRT_MAX registers
+		/// have been allocated.
+		short allocNewRegister();
+
 		short currentRegister = 0;
 		std::vector<short> freeList;
 		std::unordered_set<short> pinned;

--- a/nautilus/test/fuzz/Harness.hpp
+++ b/nautilus/test/fuzz/Harness.hpp
@@ -64,10 +64,10 @@ inline std::vector<Config> configs() {
 		// Individual default-ON optimization passes flipped OFF, each isolating a
 		// distinct lowering path. NOTE: we deliberately do NOT expose a blanket
 		// `ir.runPasses=false` -- that also disables constant folding, and the
-		// resulting unoptimized IR of a large generated program overruns the BC
-		// backend's 16-bit (`short`) register file (see README.md "Known
-		// findings"); these per-pass toggles keep constant folding on, so the IR
-		// stays bounded while still exercising the un-optimized path.
+		// resulting unoptimized IR of a large generated program can exceed the BC
+		// backend's 32767-register limit (see README.md "Config sweep"); these
+		// per-pass toggles keep constant folding on, so the IR stays bounded while
+		// still exercising the un-optimized path.
 		result.push_back({backend, "no-dead-code-elim", [](engine::Options& o) {
 			                  o.setOption("ir.disableDeadCodeElimination", true);
 		                  }});

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -434,9 +434,10 @@ never runs for it and it contributes a single `default` peer.
 These are per-pass toggles that keep constant folding **on**, so the IR stays
 bounded. There is deliberately **no** blanket `ir.runPasses=false` peer:
 disabling the whole pipeline also disables constant folding, and the resulting
-unoptimized IR of a large generated program overruns the BC backend's 16-bit
-register file (see [Known findings](#known-findings)) — a pre-existing
-scalability crash unrelated to the miscompiles this fuzzer hunts.
+unoptimized IR of a large generated program can exceed the BC backend's
+32767-register limit (`BCLoweringProvider::RegisterProvider::allocRegister()`
+throws a `RuntimeException` rather than overflowing) — a scalability limit
+unrelated to the miscompiles this fuzzer hunts.
 
 A finding records **which** permutation disagreed (the `config` field on
 `Finding`, printed by the harness and part of the `--survey` bucket key), so an
@@ -532,24 +533,6 @@ same tweak to `makeEngine(backend, tweak)` (e.g.
 in the regression test, or it will not reproduce.
 
 ## Known findings
-
-The [config sweep](#config-sweep) itself surfaced a pre-existing BC-backend
-scalability crash while it was being built. An early version of the sweep
-included a blanket `ir.runPasses=false` peer; on a large generated `f64`
-arity-4 program (deeply nested `Cast`/`If`/`Loop`), turning the *whole* IR
-pipeline off — constant folding included — leaves an unoptimized IR with tens
-of thousands of live SSA values. The BC backend indexes its register file with
-16-bit `short`s (`OpCode`/`Code::arguments` in
-`compiler/backends/bc/ByteCode.hpp`), so the register index overflows past
-32767 and `BCLoweringProvider::lower` writes out of bounds, corrupting a
-`bc::Code` vector's control block — the process dies in `Code::~Code()` freeing
-a garbage pointer (a SIGSEGV/`free(0x1)`, no differential report). This is a
-BC register-space limit, not a miscompile, and the optimization passes normally
-keep the IR well under it; it is orthogonal to what this fuzzer hunts. The
-sweep therefore does **not** expose `ir.runPasses=false` — it uses per-pass
-toggles that keep constant folding on (see [Config sweep](#config-sweep)) — and
-the BC 16-bit-register limit is left to be fixed (graceful error, or a wider
-index) as a separate change.
 
 On its first run this fuzzer reproduces a real bug: the IR constant-folding pass
 folds unsigned integer comparison/division/modulo/right-shift with **signed**


### PR DESCRIPTION
## Summary

Fixes #385.

`BCLoweringProvider::RegisterProvider` indexed its register file with a 16-bit `short` and just did `currentRegister++` with no overflow guard. Once a program needed more than 32767 live registers (e.g. an unoptimized/`ir.runPasses=false` compile of a very large kernel), the counter wrapped negative (signed overflow) and `BCLoweringProvider::lower` wrote out of bounds through it, corrupting adjacent memory — observed as a delayed, hard-to-diagnose crash rather than a clean error.

- `allocRegister()`, `allocPinnedRegister()`, and `allocFreshRegister()` now share a new private `allocNewRegister()` helper that throws a `RuntimeException` ("BC backend register file exhausted (32767); reduce kernel size or enable IR passes") once `currentRegister` would exceed `SHRT_MAX`, instead of silently overflowing.
- Updated `test/fuzz/README.md` and `test/fuzz/Harness.hpp`: removed the "Known findings" entry describing this as an unfixed pre-existing scalability crash, and updated the remaining "Config sweep" references to describe the register limit as a guarded, catchable condition rather than a memory-corruption crash.

This is the "graceful error" option the issue calls out as the minimal, safe fix (a wider `int32_t` index is the other, larger option and was left out of scope here).

## Verification

- `cmake --build . --target nautilus-execution-tests` (BC backend, MLIR/other backends disabled for a fast local build) builds cleanly and the full execution-test suite passes (7384/7384 assertions).
- Manually verified the fix end-to-end with a throwaway reproducer (a kernel with ~40,960 live values compiled with `bc.registerAllocator=false` to force register-file growth past 32767):
  - **Before** this change: the overflow corrupted unrelated memory, surfacing as a `std::length_error` (`vector::_M_fill_insert`) crash deep in an unrelated `std::vector`.
  - **After** this change: compilation cleanly throws `RuntimeException("BC backend register file exhausted (32767); reduce kernel size or enable IR passes")`.
- Did not add this reproducer as an automated test: crossing the 32767-register threshold takes ~100s of tracing/compilation overhead even in the smallest kernel that reaches it, which is too slow to run by default across the project's CI matrix (GCC 14, Clang 19/21, ASAN, macOS, ARM). This scale of program is exactly what the differential fuzzer's config sweep exists to exercise economically.

## Test plan

- [x] `cmake --build . --target nautilus-execution-tests` succeeds
- [x] Full execution-test suite passes
- [x] `clang-format-18 --dry-run --Werror` clean on both modified source files
- [x] Manually confirmed the fix turns the crash into a catchable `RuntimeException` (before/after reproducer)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ES8AwEx1jFLTvWTorixGCe)_