### PR TITLE
Fix trace/IR inconsistency in LazyTraceContext::follow (issue #384)

### DIFF
--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -67,8 +67,32 @@ bool ExceptionBasedTraceContext::isFollowing() {
 
 TypedValueRef& ExceptionBasedTraceContext::follow([[maybe_unused]] Op op) {
 	auto& currentOperation = state->executionTrace.getCurrentOperation();
+	auto consumedTag = currentOperation.tag;
 	state->executionTrace.nextOperation();
 	assert(currentOperation.op == op);
+	// traceConstant/traceCopy's globalTagMap-collision branch (see their
+	// definitions below) records a *reconciliation* ASSIGN immediately after
+	// the primary operation, sharing its exact tag, so that a stale value ref
+	// from an earlier, structurally-identical call site is patched to the
+	// freshly recorded value -- folding two recorded operations into a single
+	// traceConstant()/traceCopy() call. A later FOLLOW-mode replay only ever
+	// issues one follow() call per call site, so without this the cursor
+	// would desynchronize from the recorded operation stream by one entry as
+	// soon as it stepped over such a pair, corrupting every subsequent follow()
+	// in the block (see LazyTraceContext::follow, issue #384, for the fuller
+	// writeup -- this is the same defect in this tracer's own copy of the
+	// mechanism). Skip any run of same-tagged reconciliation operations here
+	// to keep the cursor aligned.
+	while (true) {
+		auto& block = state->executionTrace.getCurrentBlock();
+		if (state->executionTrace.currentOperationIndex >= block.operations.size()) {
+			break;
+		}
+		if (!(block.operations[state->executionTrace.currentOperationIndex]->tag == consumedTag)) {
+			break;
+		}
+		state->executionTrace.nextOperation();
+	}
 	return currentOperation.resultRef;
 }
 

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -51,8 +51,30 @@ bool LazyTraceContext::isFollowing() {
 
 TypedValueRef& LazyTraceContext::follow([[maybe_unused]] Op op) {
 	auto& currentOperation = state->executionTrace.getCurrentOperation();
+	auto consumedTag = currentOperation.tag;
 	state->executionTrace.nextOperation();
 	assert(currentOperation.op == op);
+	// traceConstant/traceCopy's globalTagMap-collision branch (see their
+	// definitions below) records a *reconciliation* ASSIGN immediately after
+	// the primary operation, sharing its exact tag, so that a stale value ref
+	// from an earlier, structurally-identical call site is patched to the
+	// freshly recorded value -- folding two recorded operations into a single
+	// traceConstant()/traceCopy() call. A later FOLLOW-mode replay only ever
+	// issues one follow() call per call site, so without this the cursor
+	// would desynchronize from the recorded operation stream by one entry as
+	// soon as it stepped over such a pair, corrupting every subsequent follow()
+	// in the block (this was the root cause of #384). Skip any run of
+	// same-tagged reconciliation operations here to keep the cursor aligned.
+	while (true) {
+		auto& block = state->executionTrace.getCurrentBlock();
+		if (state->executionTrace.currentOperationIndex >= block.operations.size()) {
+			break;
+		}
+		if (!(block.operations[state->executionTrace.currentOperationIndex]->tag == consumedTag)) {
+			break;
+		}
+		state->executionTrace.nextOperation();
+	}
 	return currentOperation.resultRef;
 }
 

--- a/nautilus/test/common/ControlFlowFunctions.hpp
+++ b/nautilus/test/common/ControlFlowFunctions.hpp
@@ -2,6 +2,7 @@
 
 #include "nautilus/function.hpp"
 #include <nautilus/Engine.hpp>
+#include <nautilus/select.hpp>
 
 namespace nautilus::engine {
 
@@ -337,6 +338,51 @@ val<uint64_t> zeroTripLoopMergeThenAddConstant(val<uint64_t> c, val<uint64_t> p)
 		result = acc;
 	}
 	return result + val<uint64_t>(static_cast<uint64_t>(119));
+}
+
+// Every logical reference to `mem` copy-constructs through this single call
+// site, mirroring the differential fuzzer's evalNautilusPtr<T> (which every
+// generated `mem` leaf reaches via the same recursive-descent code
+// regardless of which AST node it belongs to -- see issue #384).
+val<float*> issue384_copyBasePtr(val<float*> mem) {
+	return mem;
+}
+
+// Called from the SAME call site (the loop in issue384_traceFollowDesync
+// below) for both comparisons, differentiated only by a native, untraced
+// `bool` -- mirroring the fuzzer's generic AST evaluator dispatching on a
+// runtime node kind through shared code.
+val<bool> issue384_evalCmp(bool wantEq, val<float*> mem) {
+	val<float*> a = issue384_copyBasePtr(mem);
+	val<float*> b = issue384_copyBasePtr(mem);
+	if (wantEq) {
+		return a == b;
+	}
+	return a != b;
+}
+
+// Regression (differential fuzzer, issue #384): traceConstant/traceCopy's
+// globalTagMap-collision branch (added for issue #95) folds a primary
+// operation plus a same-tagged reconciliation ASSIGN into a single call, but
+// LazyTraceContext::follow() only ever consumed one recorded operation per
+// call when replaying that call site on a later symbolic-execution
+// iteration. The two `issue384_copyBasePtr(mem)` calls below collide onto
+// the same tag (identical call-stack shape, identical alive-variable set),
+// tripping that reconciliation path during recording; the `if` beneath
+// forces a second, FOLLOW-mode trace iteration that replays this code and
+// used to desynchronize the follow() cursor, corrupting every operation
+// after it in the block (a Debug assert in LazyTraceContext::follow, or
+// "std::get: wrong index for variant" in Release).
+val<float> issue384_traceFollowDesync(val<float*> mem, val<float> p0) {
+	val<float> acc = 0.0f;
+	for (int i = 0; i < 2; ++i) {
+		val<bool> flag = issue384_evalCmp(i == 0, mem);
+		acc = acc + select<float>(flag, val<float>(1.0f), val<float>(0.0f));
+	}
+	if (p0 > val<float>(0.0f)) {
+		return acc + val<float>(1.0f);
+	}
+	return acc;
 }
 
 } // namespace nautilus::engine

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -417,6 +417,15 @@ void controlFlowTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(uint64_t(1), uint64_t(23)) == 119); // then-arm: zero-trip loop leaves acc == 0
 	}
 
+	// Regression (differential fuzzer, issue #384): see
+	// issue384_traceFollowDesync in ControlFlowFunctions.hpp.
+	SECTION("issue384_traceFollowDesync") {
+		float buffer[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+		auto f = engine.registerFunction(issue384_traceFollowDesync);
+		REQUIRE(f(buffer, 1.0f) == 2.0f);
+		REQUIRE(f(buffer, -1.0f) == 1.0f);
+	}
+
 	SECTION("chainedIf100") {
 		auto f = engine.registerFunction(chainedIf100);
 		REQUIRE(f(42) == 42);

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -751,17 +751,44 @@ different i64 program of its own, once that checkout's own copy of the
 tolerance-filter bug below is worked around):
 
 4. **Wrong-alternative variant access** (`"std::get: wrong index for
-   variant"`): an internal `std::variant` accessed through the wrong
-   alternative somewhere in the cpp backend's lowering of a `voidReturn`-shaped
-   `i64` kernel (issue #355/#363) whose AST mixes `Kind::If`, a `StaticLoop`,
-   and a `Kind::Call`. In a Debug build (asserts compiled in) the same
-   underlying inconsistency instead trips an earlier
-   `assert(currentOperation.op == op)` in `LazyTraceContext::follow`
-   (`LazyTraceContext.cpp`) before this exception is ever thrown; CI builds
-   Release (`NDEBUG` defined, `pr.yml`), where only this catchable exception is
-   observable, so it does not block CI. Root-causing the variant misuse is out
-   of scope here (it predates and is independent of the bool/enum domains this
-   change adds).
+   variant"`) -- **now fixed** (nebulastream/nautilus#384): an internal
+   `std::variant` accessed through the wrong alternative somewhere in the cpp
+   backend's lowering of a `voidReturn`-shaped `i64` kernel (issue #355/#363)
+   whose AST mixes `Kind::If`, a `StaticLoop`, and a `Kind::Call`. In a Debug
+   build (asserts compiled in) the same underlying inconsistency instead
+   tripped an earlier `assert(currentOperation.op == op)` in
+   `LazyTraceContext::follow` (`LazyTraceContext.cpp`) before this exception
+   was ever thrown; CI built Release (`NDEBUG` defined, `pr.yml`), where only
+   this catchable exception was observable, so it never blocked CI.
+
+   Root cause, confirmed with a minimized reproducer (`f32|arity2`):
+
+   ```
+   (((((i16)(((p0 > ((p0 >= (1.6652564597907199e-37f32 / 3.1431495184364167e-09f32)) ? 1 : 0)) ? 1 : 0)) >= ((loop(count=mix(((mem == mem) ? 1 : 0), ((mem != mem) ? 1 : 0)), init=(f32)((-5.8244682405710905e+27f32 / p1)), body=(0f32 + 0f32)) <= 0f32) ? 1 : 0)) ? 1 : 0) == 0f32) ? 1 : 0)
+   ```
+
+   `traceConstant`/`traceCopy` (`LazyTraceContext.cpp`) each have a
+   globalTagMap-collision branch (added for issue #95) that records a
+   *reconciliation* `ASSIGN` immediately after the primary operation, sharing
+   its exact tag, so that a stale value ref from an earlier,
+   structurally-identical call site is patched to the freshly recorded value
+   -- folding **two** recorded operations into a **single** `traceConstant()`/
+   `traceCopy()` call. Here, evaluating the two bare `mem` leaves of
+   `mem == mem` and `mem != mem` -- both reached via the tracer's generic
+   pointer-domain evaluator (`evalNautilusPtr`, a single shared call site for
+   every `Kind::PtrBase` leaf anywhere in the AST) -- collided onto the same
+   Tag/Snapshot, since both hit the identical call-stack shape with an
+   identical alive-variable footprint. `LazyTraceContext::follow()`, used to
+   replay that call site on the second symbolic-execution iteration
+   (triggered by the outer `If`), only ever consumed **one** recorded
+   operation per call, so it silently drifted one entry behind the recorded
+   operation stream as soon as it stepped over that reconciliation pair --
+   corrupting every subsequent `follow()` in the block. Fixed by having
+   `follow()` recognize a reconciliation operation by its shared tag and
+   transparently skip it, keeping the replay cursor aligned with what was
+   actually recorded. Pinned by `issue384_traceFollowDesync` in
+   `ControlFlowFunctions.hpp`; the smoke corpus no longer tolerates this
+   exception.
 
 Wiring the deterministic corpus into CI for the first time (`fuzz-replay-smoke`,
 nebulastream/nautilus#376) immediately surfaced a fifth pre-existing finding on

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -65,12 +65,12 @@ std::vector<uint8_t> randomBuffer() {
 	return buf;
 }
 
-// Four pre-existing, out-of-scope tracer/IR limitations, all in shared
+// Three pre-existing, out-of-scope tracer/IR limitations, all in shared
 // infrastructure well outside Kind::Call's own lowering or the bool/enum
 // domains this fuzzer also adds (see README.md "Known findings" for the full
 // writeup of each). Widening Kind::Call's generation surface and adding the
 // bool/enum domains both reshuffle the byte-stream enough that the
-// fixed-seed smoke corpus below reaches all four on a combined ~8.5% of
+// fixed-seed smoke corpus below reaches all three on a combined ~8.5% of
 // inputs; `--survey` buckets by backend/type/exact exception text (see the
 // key in survey() below) so every one of them stays individually visible and
 // triageable rather than silently folding into a single backend/type bucket.
@@ -102,16 +102,6 @@ std::vector<uint8_t> randomBuffer() {
 //      Kind::If inside a Kind::Call argument -- the same *class* of
 //      merged-value bookkeeping bug as the already-fixed BC/AsmJit
 //      instances documented below, just a shape those fixes didn't cover.
-//   4. "std::get: wrong index for variant" -- an internal std::variant
-//      accessed through the wrong alternative somewhere in the cpp backend's
-//      lowering of a voidReturn-shaped kernel (issue #355/#363) whose AST
-//      mixes Kind::If, a StaticLoop, and a Kind::Call, all i64 -- unrelated to
-//      bool/enum (see README.md "Known findings"). In a Debug build (asserts
-//      compiled in) the same underlying inconsistency instead trips an
-//      earlier `assert(currentOperation.op == op)` in
-//      LazyTraceContext::follow before this exception is ever thrown; CI
-//      builds Release (NDEBUG), where only this catchable exception is
-//      observable.
 //
 // Finding 5 ("verification of MLIR module failed!") is no longer tolerated: it
 // was a default-constructed `val<bool>` carrying an `i32` trace stamp (its
@@ -120,6 +110,18 @@ std::vector<uint8_t> randomBuffer() {
 // MLIR's own verifier reject the module. Fixed in val_bool.hpp (issue #377) by
 // stamping the default state `Type::b`; the smoke corpus now actively guards
 // against its recurrence.
+//
+// Finding 4 ("std::get: wrong index for variant") is no longer tolerated
+// either: traceConstant/traceCopy's globalTagMap-collision branch (added for
+// issue #95) folds a primary operation plus a same-tagged reconciliation
+// ASSIGN into a single call, but LazyTraceContext::follow() only ever
+// consumed one recorded operation per call when replaying that call site on
+// a later symbolic-execution iteration -- desynchronizing the replay cursor
+// from the recorded operation stream as soon as it stepped over such a pair,
+// corrupting every operation after it in the block. Fixed in
+// LazyTraceContext.cpp (issue #384) by having follow() recognize the
+// reconciliation ASSIGN by its shared tag and transparently skip it; the
+// smoke corpus now actively guards against its recurrence.
 bool isKnownPreExistingFinding(const nautilus::fuzz::Finding& f) {
 	if (!f.exception) {
 		return false;
@@ -130,8 +132,7 @@ bool isKnownPreExistingFinding(const nautilus::fuzz::Finding& f) {
 	// symbols (it always did in this environment) -- match on prefix instead
 	// of exact equality, the same way the "Key $" case already does.
 	return f.what.starts_with("Invalid trace. This is maybe caused by a constant loop.") ||
-	       f.what.starts_with("Invalid trace: no Return operation was recorded.") || f.what.starts_with("Key $") ||
-	       f.what.starts_with("std::get: wrong index for variant");
+	       f.what.starts_with("Invalid trace: no Return operation was recorded.") || f.what.starts_with("Key $");
 }
 
 // Default corpus size for the PR-gate smoke run. Overridable via


### PR DESCRIPTION
## Summary

Fixes #384: a trace/replay desync in the tracer's `follow()` mechanism that surfaced as `std::get: wrong index for variant` on every compiled backend in Release, and `assert(currentOperation.op == op)` in `LazyTraceContext::follow` in Debug.

**Root cause:** `traceConstant`/`traceCopy` each have a `globalTagMap`-collision branch (added for issue #95) that records a *reconciliation* `ASSIGN` immediately after the primary operation, sharing its exact tag, so a stale value ref from an earlier, structurally-identical call site gets patched to the freshly recorded value — folding **two** recorded operations into a **single** `traceConstant()`/`traceCopy()` call. `follow()`, used to replay that call site on a later symbolic-execution iteration, only ever consumed **one** recorded operation per call, silently desynchronizing the replay cursor from the recorded operation stream as soon as it stepped over such a pair — corrupting every subsequent operation in the block.

Reproduced and root-caused with the exact minimized fuzzer input from the issue (`f32|arity2`, mixing `If`/`Loop`/a `Call` around `mem == mem` / `mem != mem`). The identical defect also existed in `ExceptionBasedTraceContext::follow` (the non-default tracer), caught by testing the fix's regression case across both `engine.traceMode` settings — fixed there too.

**Fix:** `follow()` now recognizes a reconciliation operation by its shared tag and transparently skips it, keeping the replay cursor aligned with what was actually recorded.

- `nautilus/src/nautilus/tracing/LazyTraceContext.cpp`
- `nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp`

## Regression test

Added `issue384_traceFollowDesync` (`ControlFlowFunctions.hpp`), wired into `ExecutionTest.cpp`'s `controlFlowTest`: a shared pointer-copy call site evaluated for both `mem == mem` and `mem != mem`, forcing a second FOLLOW-mode trace iteration via an `if`. Verified by hand that it trips the original assert against a pre-fix build and passes against the fix, across every backend and both trace modes.

## Fuzzer README update

Updated `test/fuzz/README.md`'s "Known findings" to mark finding 4 as fixed, and removed its tolerance from `ReplayMain.cpp`'s `isKnownPreExistingFinding` so the smoke corpus now actively guards against recurrence.

## Test plan

- [x] `nautilus-fuzz-replay <58-byte crash input from the issue>` — now passes (previously aborted)
- [x] New regression test verified to trip the pre-fix assert and pass post-fix, across every backend × both trace modes
- [x] Full `nautilus-execution-tests` suite (Debug, MLIR off): 4950/4950 assertions passed (only the pre-existing, unrelated `whileContinue` `SKIP()`, same as on `main`)
- [x] Deterministic CI smoke corpus (`nautilus-fuzz-replay`, 2000 iterations): clean
- [x] Extended 10,000-iteration `--survey`: 5460 findings, all in the two other already-tracked categories, zero `std::get: wrong index for variant` occurrences
- [x] Release `Tracing Benchmark` comparison: no measurable performance regression (fix is O(1) per `follow()` call, compile-time-only, never in the JIT-compiled kernel's runtime path)

https://claude.ai/code/session_018zc4QoaNn7jNUeWv2TUSas