### PR TITLE
Fix tracer dropping Return when a repeated tag assigns a different target

### DIFF
--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -251,9 +251,46 @@ TypedValueRef& ExceptionBasedTraceContext::traceNautilusFunctionPtr(const Nautil
 
 void ExceptionBasedTraceContext::traceAssignment(const TypedValueRef& target, const TypedValueRef& source,
                                                  Type resultType) {
-	traceOperation(ASSIGN, [&](Snapshot& tag) -> TypedValueRef& {
-		return state->executionTrace.addAssignmentOperation(tag, target, source, resultType);
-	});
+	if (isFollowing()) {
+		follow(ASSIGN);
+		return;
+	}
+	auto tag = recordSnapshot();
+	auto& trace = state->executionTrace;
+
+	// Tag identity is purely a call-stack return-address chain (TagRecorder.cpp),
+	// so a tag match here does not by itself prove this ASSIGN is a genuine
+	// control-flow re-entry (a loop back-edge or an if/else merge point): the
+	// identical call-stack shape, with an identical alive-variable footprint,
+	// can also be reached while assigning a *different* target -- e.g. two
+	// structurally-identical sibling arguments of the same call (`f(0, x, 0)`)
+	// evaluated by the same argument-evaluation loop, or two slots of the same
+	// array assigned via the same loop body. Distinguish the two by checking
+	// whether the operation already recorded at this tag assigned the same
+	// target: if not, this is an unrelated assignment that merely collided,
+	// so record it fresh instead of forcing a bogus merge that would discard
+	// everything traced afterwards (issue #382). This mirrors how traceCopy
+	// already reconciles instead of merging when a repeated call site's
+	// *source* legitimately differs (issue #95/#384). Same defect and same
+	// fix as LazyTraceContext::traceAssignment -- this tracer keeps its own
+	// copy of the mechanism.
+	const operation_identifier* existing = nullptr;
+	if (auto it = trace.globalTagMap.find(tag); it != trace.globalTagMap.end()) {
+		existing = &it->second;
+	} else if (auto localIt = trace.localTagMap.find(tag); localIt != trace.localTagMap.end()) {
+		existing = &localIt->second;
+	}
+	if (existing != nullptr) {
+		auto* existingOp = trace.getBlocks()[existing->blockIndex]->operations[existing->operationIndex];
+		if (existingOp->op != ASSIGN || existingOp->resultRef.ref != target.ref) {
+			trace.addAssignmentOperation(tag, target, source, resultType);
+			return;
+		}
+	}
+	if (!trace.checkTag(tag)) {
+		throw TraceTerminationException();
+	}
+	trace.addAssignmentOperation(tag, target, source, resultType);
 }
 
 void ExceptionBasedTraceContext::traceReturnOperation(Type resultType, const TypedValueRef& ref) {

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -258,9 +258,45 @@ void LazyTraceContext::traceAssignment(const TypedValueRef& target, const TypedV
 	if (paused_) {
 		return;
 	}
-	traceOperation(ASSIGN, [&](Snapshot& tag) -> TypedValueRef& {
-		return state->executionTrace.addAssignmentOperation(tag, target, source, resultType);
-	});
+	if (isFollowing()) {
+		follow(ASSIGN);
+		return;
+	}
+	auto tag = recordSnapshot();
+	auto& trace = state->executionTrace;
+
+	// Tag identity is purely a call-stack return-address chain (TagRecorder.cpp),
+	// so a tag match here does not by itself prove this ASSIGN is a genuine
+	// control-flow re-entry (a loop back-edge or an if/else merge point): the
+	// identical call-stack shape, with an identical alive-variable footprint,
+	// can also be reached while assigning a *different* target -- e.g. two
+	// structurally-identical sibling arguments of the same call (`f(0, x, 0)`)
+	// evaluated by the same argument-evaluation loop, or two slots of the same
+	// array assigned via the same loop body. Distinguish the two by checking
+	// whether the operation already recorded at this tag assigned the same
+	// target: if not, this is an unrelated assignment that merely collided,
+	// so record it fresh instead of forcing a bogus merge that would discard
+	// everything traced afterwards (issue #382). This mirrors how traceCopy
+	// already reconciles instead of merging when a repeated call site's
+	// *source* legitimately differs (issue #95/#384).
+	const operation_identifier* existing = nullptr;
+	if (auto it = trace.globalTagMap.find(tag); it != trace.globalTagMap.end()) {
+		existing = &it->second;
+	} else if (auto localIt = trace.localTagMap.find(tag); localIt != trace.localTagMap.end()) {
+		existing = &localIt->second;
+	}
+	if (existing != nullptr) {
+		auto* existingOp = trace.getBlocks()[existing->blockIndex]->operations[existing->operationIndex];
+		if (existingOp->op != ASSIGN || existingOp->resultRef.ref != target.ref) {
+			trace.addAssignmentOperation(tag, target, source, resultType);
+			return;
+		}
+	}
+	if (!trace.checkTag(tag)) {
+		paused_ = true;
+		return;
+	}
+	trace.addAssignmentOperation(tag, target, source, resultType);
 }
 
 void LazyTraceContext::traceReturnOperation(Type resultType, const TypedValueRef& ref) {

--- a/nautilus/test/common/ControlFlowFunctions.hpp
+++ b/nautilus/test/common/ControlFlowFunctions.hpp
@@ -385,4 +385,43 @@ val<float> issue384_traceFollowDesync(val<float*> mem, val<float> p0) {
 	return acc;
 }
 
+uint32_t issue382_sum3(uint32_t a, uint32_t b, uint32_t c) {
+	return a + b + c;
+}
+
+// Regression (differential fuzzer, issue #382): a native, untraced `for` loop
+// populates a fixed-size array of `val<uint32_t>` slots -- mirroring the
+// differential fuzzer's evalNautilusCall<T>, which populates a call's
+// argument array through the exact same loop-body call site regardless of
+// which argument index is being evaluated. Slots 0 and 2 are assigned the
+// same literal-zero constant; slot 1's assignment is preceded by a real
+// traced `if` (with a pointer Store in its body) that slots 0/2 don't go
+// through. Tag identity is purely a call-stack return-address chain
+// (TagRecorder.cpp) plus the alive-variable footprint, so slot 2's
+// assignment reaches the identical tag already recorded for slot 0's
+// assignment -- despite writing to a *different* target. Before the fix,
+// LazyTraceContext::traceAssignment treated any tag match as a genuine
+// control-flow re-entry and forced a control-flow merge back into the if's
+// own condition block, discarding the call and the return that should have
+// followed; SSACreationPhase::getReturnBlock then found no Return operation
+// at all ("Invalid trace: no Return operation was recorded.").
+val<int8_t> issue382_siblingArgAssignCollision(val<uint32_t*> mem, val<uint32_t> p0) {
+	val<uint32_t> args[3] = {val<uint32_t>(0u), val<uint32_t>(0u), val<uint32_t>(0u)};
+	for (int i = 0; i < 3; ++i) {
+		val<uint32_t> value = val<uint32_t>(0u);
+		if (i == 1) {
+			val<bool> cond = p0 != val<uint32_t>(0u);
+			val<uint32_t> branchValue = val<uint32_t>(0u);
+			if (cond) {
+				branchValue = val<uint32_t>(0u);
+			}
+			*mem = branchValue;
+			value = branchValue;
+		}
+		args[i] = value;
+	}
+	val<uint32_t> result = invoke(issue382_sum3, args[0], args[1], args[2]);
+	return static_cast<val<int8_t>>(result);
+}
+
 } // namespace nautilus::engine

--- a/nautilus/test/execution-tests/ExecutionTest.cpp
+++ b/nautilus/test/execution-tests/ExecutionTest.cpp
@@ -426,6 +426,15 @@ void controlFlowTest(engine::NautilusEngine& engine) {
 		REQUIRE(f(buffer, -1.0f) == 1.0f);
 	}
 
+	// Regression (differential fuzzer, issue #382): see
+	// issue382_siblingArgAssignCollision in ControlFlowFunctions.hpp.
+	SECTION("issue382_siblingArgAssignCollision") {
+		uint32_t buffer[1] = {0};
+		auto f = engine.registerFunction(issue382_siblingArgAssignCollision);
+		REQUIRE(f(buffer, 0u) == 0);
+		REQUIRE(f(buffer, 7u) == 0);
+	}
+
 	SECTION("chainedIf100") {
 		auto f = engine.registerFunction(chainedIf100);
 		REQUIRE(f(42) == 42);

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -654,16 +654,17 @@ byte-stream enough that the fixed-seed smoke corpus (`nautilus-fuzz-replay`,
 no arguments) now reaches the *exact* call-stack-depth artifact predicted
 above -- this time through the **real** fuzz harness, not an ad hoc one --
 plus two further pre-existing defects, on a combined ~6.5% of the 2000-input
-corpus (129 findings via `--survey 2000`). All three were in shared
-tracer/IR infrastructure well outside `Kind::Call`'s own lowering (the actual
-subject of this expansion); the smoke corpus tolerated their diagnosed
-exception strings (see `isKnownPreExistingFinding` in `ReplayMain.cpp`)
-without treating them as pass/fail signal, while any other exception, or any
-value mismatch, still aborted the smoke corpus immediately, and `--survey`
-kept every occurrence individually visible (bucketed by backend/type/exact
+corpus (129 findings via `--survey 2000`). These were in shared tracer/IR
+infrastructure well outside `Kind::Call`'s own lowering (the actual subject
+of this expansion); the smoke corpus tolerated their diagnosed exception
+strings (see `isKnownPreExistingFinding` in `ReplayMain.cpp`) without
+treating them as pass/fail signal, while any other exception, or any value
+mismatch, still aborted the smoke corpus immediately, and `--survey` kept
+every occurrence individually visible (bucketed by backend/type/exact
 exception text, not merged into one backend/type bucket) for future
-investigation. One of the three (finding 2 below) is now fixed and no longer
-tolerated.
+investigation. The two still open are listed below (a third, "no Return
+operation was recorded", was fixed in nebulastream/nautilus#382 and is no
+longer tolerated or tracked here).
 
 1. **Tag/Snapshot collision** (`"Invalid trace. This is maybe caused by a
    constant loop."`, ~126 of the 129 findings): the exact fragility the
@@ -687,45 +688,7 @@ tolerated.
    elsewhere in the corpus -- i.e. the byte-stream *shift* from having more
    `Kind::Call` diversity is what surfaces it, not anything specific to a
    given new callee's own marshalling.
-2. **Empty return list** (`"Invalid trace: no Return operation was
-   recorded."`) -- **now fixed** (nebulastream/nautilus#382): a kernel
-   combining `Kind::If` with a pointer `Store` and two nested
-   `nautilus::invoke()` calls (concretely: `narrowReturn(A, mix(p0 -
-   (Store(...) + ptrSwap(mem, if(...))), B))`) completed tracing without
-   ever recording a `Return` operation. `SSACreationPhase::getReturnBlock`
-   (`SSACreationPhase.cpp`) called `.front()` on that empty list --
-   undefined behavior, a real segfault on every compiled backend, first
-   hardened to throw a catchable `RuntimeException` instead of reading past
-   the end of the vector, and later root-caused and fixed outright.
-
-   Root cause, minimized down to `(i8)((sum3(0u32, ((uintptr_t)(mem) +
-   (*(mem) = if(0u32 != 0, 0u32, 0u32))), 0u32) + 0u32))`: `Tag` identity is
-   purely a call-stack return-address chain (`TagRecorder.cpp`) plus an
-   alive-variable footprint hash, so it carries no information about *which
-   variable* an operation touches. `evalNautilusCall`'s argument-evaluation
-   loop (`v[i] = evalNautilusGeneric(...)`) assigns each call argument
-   through the same loop-body call site; when two sibling arguments are
-   structurally identical (here, `sum3`'s literal-zero argument 0 and
-   argument 2), the second assignment reaches the identical tag already
-   recorded for the first -- despite writing to a *different* target array
-   slot. `LazyTraceContext::traceAssignment` (and its twin in
-   `ExceptionBasedTraceContext`) treated any tag match as a genuine
-   control-flow re-entry and forced a bogus merge back into the `if`'s own
-   condition block, discarding the call and the return that should have
-   followed. Fixed by comparing the target ref against the operation
-   already recorded at the matched tag: a mismatch means the collision is
-   coincidental, not a real revisit, so the assignment is now recorded
-   normally instead of merged -- mirroring how `traceConstant`/`traceCopy`
-   already reconcile instead of merging when a repeated call site's
-   *source* legitimately differs (issue #95/#384). A standalone
-   minimization attempt (a small hand-written kernel with the same
-   `if`/`Store`/nested-`invoke()` shape) used to reproduce the unrelated
-   `TagRecorder` call-stack-depth artifact from finding 1 instead of this
-   bug; that caveat no longer matters now that the underlying defect itself
-   is fixed. Pinned by `issue382_siblingArgAssignCollision` in
-   `ControlFlowFunctions.hpp`; the smoke corpus no longer tolerates this
-   exception.
-3. **Merged-value Frame lookup miss** (`"Key $N does not exists in frame."`):
+2. **Merged-value Frame lookup miss** (`"Key $N does not exists in frame."`):
    a `Frame<K,V>` (`compiler/Frame.hpp`, shared by the cpp/bc/asmjit lowering
    providers) lookup miss for an SSA value merged across two `Kind::If` arms,
    reachable with a `Kind::If` nested inside a `Kind::Call` argument (e.g.
@@ -764,13 +727,13 @@ kernel using the affected path failed deterministically, so these were
 Rebasing this change onto the `Call`-coverage expansion above (which also
 restricted bool to a smaller shape menu, since `mixed`/`narrowReturn` need a
 Cast neither backend supports for bool -- see "Bool domain") reshuffled the
-byte-stream once more and surfaced a fourth pre-existing, `bool`/`enum`-
+byte-stream once more and surfaced a third pre-existing, `bool`/`enum`-
 unrelated defect (confirmed via a bisection against a clean checkout of the
 pre-rebase `main`: the exact same finding reproduces there too, through a
 different i64 program of its own, once that checkout's own copy of the
 tolerance-filter bug below is worked around):
 
-4. **Wrong-alternative variant access** (`"std::get: wrong index for
+3. **Wrong-alternative variant access** (`"std::get: wrong index for
    variant"`) -- **now fixed** (nebulastream/nautilus#384): an internal
    `std::variant` accessed through the wrong alternative somewhere in the cpp
    backend's lowering of a `voidReturn`-shaped `i64` kernel (issue #355/#363)
@@ -811,11 +774,11 @@ tolerance-filter bug below is worked around):
    exception.
 
 Wiring the deterministic corpus into CI for the first time (`fuzz-replay-smoke`,
-nebulastream/nautilus#376) immediately surfaced a fifth pre-existing finding on
+nebulastream/nautilus#376) immediately surfaced a fourth pre-existing finding on
 the very first CI run -- confirmed independent of that PR (reproduces from a
 clean `main` checkout the same way):
 
-5. **MLIR module verification failure** (`"verification of MLIR module
+4. **MLIR module verification failure** (`"verification of MLIR module
    failed!"`) -- **now fixed** (nebulastream/nautilus#377): a `u16`/`mixed`-shape
    kernel --
    ```
@@ -840,7 +803,7 @@ clean `main` checkout the same way):
    (exercised across every backend by `BoolExecutionTest.cpp`), and the smoke
    corpus no longer tolerates this exception.
 
-Investigating finding 4 above also caught the tolerance filter itself in
+Investigating finding 3 above also caught the tolerance filter itself in
 `ReplayMain.cpp`'s `isKnownPreExistingFinding` failing silently: it compared
 `Finding::what` against findings 1-3's bare messages with exact (`==`)
 equality, but `RuntimeException` (`exceptions/RuntimeException.cpp`)

--- a/nautilus/test/fuzz/README.md
+++ b/nautilus/test/fuzz/README.md
@@ -654,15 +654,16 @@ byte-stream enough that the fixed-seed smoke corpus (`nautilus-fuzz-replay`,
 no arguments) now reaches the *exact* call-stack-depth artifact predicted
 above -- this time through the **real** fuzz harness, not an ad hoc one --
 plus two further pre-existing defects, on a combined ~6.5% of the 2000-input
-corpus (129 findings via `--survey 2000`). All three are in shared
+corpus (129 findings via `--survey 2000`). All three were in shared
 tracer/IR infrastructure well outside `Kind::Call`'s own lowering (the actual
-subject of this expansion), so the smoke corpus tolerates exactly these three
-diagnosed exception strings (see `isKnownPreExistingFinding` in
-`ReplayMain.cpp`) without treating them as pass/fail signal; any other
-exception, or any value mismatch, still aborts the smoke corpus immediately,
-and `--survey` keeps every occurrence of all three individually visible
-(bucketed by backend/type/exact exception text, not merged into one
-backend/type bucket) for future investigation.
+subject of this expansion); the smoke corpus tolerated their diagnosed
+exception strings (see `isKnownPreExistingFinding` in `ReplayMain.cpp`)
+without treating them as pass/fail signal, while any other exception, or any
+value mismatch, still aborted the smoke corpus immediately, and `--survey`
+kept every occurrence individually visible (bucketed by backend/type/exact
+exception text, not merged into one backend/type bucket) for future
+investigation. One of the three (finding 2 below) is now fixed and no longer
+tolerated.
 
 1. **Tag/Snapshot collision** (`"Invalid trace. This is maybe caused by a
    constant loop."`, ~126 of the 129 findings): the exact fragility the
@@ -687,24 +688,43 @@ backend/type bucket) for future investigation.
    `Kind::Call` diversity is what surfaces it, not anything specific to a
    given new callee's own marshalling.
 2. **Empty return list** (`"Invalid trace: no Return operation was
-   recorded."`, hardened from a crash): a kernel combining `Kind::If` with a
-   pointer `Store` and two nested `nautilus::invoke()` calls (concretely:
-   `narrowReturn(A, mix(p0 - (Store(...) + ptrSwap(mem, if(...))), B))`)
-   completed tracing without ever recording a `Return` operation.
-   `SSACreationPhase::getReturnBlock` (`SSACreationPhase.cpp`) called
-   `.front()` on that empty list -- undefined behavior, a real segfault on
-   every compiled backend, reproduced deterministically via
-   `nautilus-fuzz-replay` and isolated with `gdb`. Hardened here: an empty
-   return list now throws a catchable `RuntimeException` instead of reading
-   past the end of the vector. The underlying "why does this trace shape
-   never record a Return" defect is still open -- a standalone minimization
-   attempt (a small hand-written kernel with the same `if`/`Store`/nested-
-   `invoke()` shape) reproduced the unrelated `TagRecorder` call-stack-depth
-   artifact from finding 1 instead of this bug, confirming that artifact's
-   own "a trivial kernel crashes the same way through an ad hoc harness"
-   caveat and making this specific defect resistant to standalone
-   minimization; it is only reliably reproduced through the real fuzz/replay
-   harness's deeper call stack.
+   recorded."`) -- **now fixed** (nebulastream/nautilus#382): a kernel
+   combining `Kind::If` with a pointer `Store` and two nested
+   `nautilus::invoke()` calls (concretely: `narrowReturn(A, mix(p0 -
+   (Store(...) + ptrSwap(mem, if(...))), B))`) completed tracing without
+   ever recording a `Return` operation. `SSACreationPhase::getReturnBlock`
+   (`SSACreationPhase.cpp`) called `.front()` on that empty list --
+   undefined behavior, a real segfault on every compiled backend, first
+   hardened to throw a catchable `RuntimeException` instead of reading past
+   the end of the vector, and later root-caused and fixed outright.
+
+   Root cause, minimized down to `(i8)((sum3(0u32, ((uintptr_t)(mem) +
+   (*(mem) = if(0u32 != 0, 0u32, 0u32))), 0u32) + 0u32))`: `Tag` identity is
+   purely a call-stack return-address chain (`TagRecorder.cpp`) plus an
+   alive-variable footprint hash, so it carries no information about *which
+   variable* an operation touches. `evalNautilusCall`'s argument-evaluation
+   loop (`v[i] = evalNautilusGeneric(...)`) assigns each call argument
+   through the same loop-body call site; when two sibling arguments are
+   structurally identical (here, `sum3`'s literal-zero argument 0 and
+   argument 2), the second assignment reaches the identical tag already
+   recorded for the first -- despite writing to a *different* target array
+   slot. `LazyTraceContext::traceAssignment` (and its twin in
+   `ExceptionBasedTraceContext`) treated any tag match as a genuine
+   control-flow re-entry and forced a bogus merge back into the `if`'s own
+   condition block, discarding the call and the return that should have
+   followed. Fixed by comparing the target ref against the operation
+   already recorded at the matched tag: a mismatch means the collision is
+   coincidental, not a real revisit, so the assignment is now recorded
+   normally instead of merged -- mirroring how `traceConstant`/`traceCopy`
+   already reconcile instead of merging when a repeated call site's
+   *source* legitimately differs (issue #95/#384). A standalone
+   minimization attempt (a small hand-written kernel with the same
+   `if`/`Store`/nested-`invoke()` shape) used to reproduce the unrelated
+   `TagRecorder` call-stack-depth artifact from finding 1 instead of this
+   bug; that caveat no longer matters now that the underlying defect itself
+   is fixed. Pinned by `issue382_siblingArgAssignCollision` in
+   `ControlFlowFunctions.hpp`; the smoke corpus no longer tolerates this
+   exception.
 3. **Merged-value Frame lookup miss** (`"Key $N does not exists in frame."`):
    a `Frame<K,V>` (`compiler/Frame.hpp`, shared by the cpp/bc/asmjit lowering
    providers) lookup miss for an SSA value merged across two `Kind::If` arms,

--- a/nautilus/test/fuzz/ReplayMain.cpp
+++ b/nautilus/test/fuzz/ReplayMain.cpp
@@ -65,12 +65,12 @@ std::vector<uint8_t> randomBuffer() {
 	return buf;
 }
 
-// Three pre-existing, out-of-scope tracer/IR limitations, all in shared
+// Two pre-existing, out-of-scope tracer/IR limitations, both in shared
 // infrastructure well outside Kind::Call's own lowering or the bool/enum
 // domains this fuzzer also adds (see README.md "Known findings" for the full
 // writeup of each). Widening Kind::Call's generation surface and adding the
 // bool/enum domains both reshuffle the byte-stream enough that the
-// fixed-seed smoke corpus below reaches all three on a combined ~8.5% of
+// fixed-seed smoke corpus below reaches both on a combined ~8.5% of
 // inputs; `--survey` buckets by backend/type/exact exception text (see the
 // key in survey() below) so every one of them stays individually visible and
 // triageable rather than silently folding into a single backend/type bucket.
@@ -88,20 +88,31 @@ std::vector<uint8_t> randomBuffer() {
 //      which logical AST node it is -- so two unrelated Kind::If nodes
 //      reached via the same shape of recursive descent can collide onto the
 //      same Tag.
-//   2. "Invalid trace: no Return operation was recorded." -- some traced
-//      kernels combining Kind::If with a pointer Store and nested
-//      nautilus::invoke() calls complete tracing without ever recording a
-//      Return operation; SSACreationPhase::getReturnBlock used to call
-//      front() on that empty list (undefined behavior, a real crash) -- now
-//      hardened (see SSACreationPhase.cpp) to throw this catchable exception
-//      instead. The underlying "why is the Return missing" tracing defect is
-//      still open.
-//   3. "Key $N does not exists in frame." -- a Frame<K,V> (compiler/Frame.hpp,
+//   2. "Key $N does not exists in frame." -- a Frame<K,V> (compiler/Frame.hpp,
 //      shared by the cpp/bc/asmjit lowering providers) lookup miss for an
 //      SSA value merged across two Kind::If arms, reachable with nested
 //      Kind::If inside a Kind::Call argument -- the same *class* of
 //      merged-value bookkeeping bug as the already-fixed BC/AsmJit
 //      instances documented below, just a shape those fixes didn't cover.
+//
+// Finding "Invalid trace: no Return operation was recorded." is no longer
+// tolerated either (issue #382): LazyTraceContext::traceAssignment's generic
+// tag-collision handling treated *any* tag match as a genuine control-flow
+// re-entry, but Tag identity is purely a call-stack return-address chain
+// (TagRecorder.cpp) plus the alive-variable footprint -- it says nothing
+// about which variable is being assigned. Two structurally-identical
+// sibling call arguments (e.g. `sum3(0, x, 0)`, both literal-zero) evaluated
+// by the same argument-evaluation loop reach the identical tag while
+// assigning *different* targets (two different array slots), which was
+// wrongly folded into a bogus control-flow merge -- discarding every
+// operation traced afterwards, including the call and the return. Fixed in
+// LazyTraceContext.cpp by comparing the target ref against the operation
+// already recorded at that tag: a mismatch means the collision is
+// coincidental, not a real revisit, so the assignment is now recorded
+// normally instead of merged, mirroring how traceCopy already reconciles
+// instead of merging when a repeated call site's source legitimately
+// differs (issue #95/#384). The smoke corpus now actively guards against
+// its recurrence.
 //
 // Finding 5 ("verification of MLIR module failed!") is no longer tolerated: it
 // was a default-constructed `val<bool>` carrying an `i32` trace stamp (its
@@ -131,8 +142,7 @@ bool isKnownPreExistingFinding(const nautilus::fuzz::Finding& f) {
 	// exactly one of these strings when ENABLE_STACKTRACE actually resolves
 	// symbols (it always did in this environment) -- match on prefix instead
 	// of exact equality, the same way the "Key $" case already does.
-	return f.what.starts_with("Invalid trace. This is maybe caused by a constant loop.") ||
-	       f.what.starts_with("Invalid trace: no Return operation was recorded.") || f.what.starts_with("Key $");
+	return f.what.starts_with("Invalid trace. This is maybe caused by a constant loop.") || f.what.starts_with("Key $");
 }
 
 // Default corpus size for the PR-gate smoke run. Overridable via


### PR DESCRIPTION
## Summary

Fixes #382.

Root cause: `Tag` identity (`TagRecorder.cpp`) is purely a call-stack return-address chain, combined with an alive-variable footprint hash. It carries no information about *which variable* an operation touches. `LazyTraceContext::traceAssignment` (and its twin in `ExceptionBasedTraceContext`) treated *any* tag match as proof of a genuine control-flow re-entry (a loop back-edge or an if/else merge) and unconditionally forced a control-flow merge via `ExecutionTrace::processControlFlowMerge`.

That assumption breaks when the identical call-stack shape is reached while assigning a *different* target — e.g. two structurally-identical sibling arguments of the same call (`f(0, x, 0)`, both literal zero) populated by the same argument-evaluation loop, or two slots of the same array assigned via the same loop body. The bogus merge discards every operation traced afterwards on that path, including the call and the eventual `Return` — which is exactly why `SSACreationPhase::getReturnBlock` found an empty return list for the shapes described in the issue (`Kind::If` + a pointer `Store` + nested `nautilus::invoke()`).

I reproduced this with the differential fuzzer (`nautilus-fuzz-replay --survey`), used `gdb`/targeted logging to isolate the exact colliding pair of trace operations, and minimized the repro down to:

```
(i8)((sum3(0u32, ((uintptr_t)(mem) + (*(mem) = if(0u32 != 0, 0u32, 0u32))), 0u32) + 0u32))
```

Both `sum3`'s argument 0 and argument 2 are literal-zero constants assigned via the same loop-body call site (`evalNautilusCall`'s `v[i] = evalNautilusGeneric(...)`); the identical tag collides across the two array slots and gets misread as a revisit of argument 0's own assignment.

## Fix

`traceAssignment` (both trace contexts) now checks whether the operation already recorded at a matched tag assigned the *same* target ref:
- Same target → genuine revisit (loop/merge) → unchanged behavior (`checkTag` → `processControlFlowMerge`).
- Different target → coincidental collision → record the assignment normally instead of merging.

This mirrors the existing `traceCopy` reconciliation added for issue #95/#384, which already draws the same distinction for copy-construction's *source* ref.

Also updates `test/fuzz/ReplayMain.cpp`'s `isKnownPreExistingFinding` to drop the now-fixed `"Invalid trace: no Return operation was recorded."` tolerance entry, per the issue's own pointer.

## Test plan

- [x] Added `issue382_siblingArgAssignCollision` (`test/common/ControlFlowFunctions.hpp`) + a `controlFlowTest` section in `ExecutionTest.cpp`; confirmed it reproduces the exact failure on the pre-fix code (reverted the fix, saw both `lazyTracing`/`exceptionBasedTracing` variants fail with the reported exception) and passes after the fix.
- [x] Full `ctest --test-dir nautilus` suite (337 tests) passes.
- [x] Plugin test suites (std, simd, specialization, inlining) pass.
- [x] `nautilus-fuzz-replay` deterministic smoke corpus (2000 inputs) passes with zero tolerated findings for this bucket.
- [x] `nautilus-fuzz-replay --survey 10000`: the `"Invalid trace: no Return operation was recorded."` bucket is gone (was reproducing on ~0.25%+ of surveyed inputs); the only remaining findings are the already-separately-tracked `"Invalid trace. This is maybe caused by a constant loop."` bucket (a same-block collision, a different and still-open tag-identity issue, not in scope here).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TiikoVoUFVAuCzFMuvjnez)_