### PR TITLE
Mention AsmJit and tiered compilation in README; fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nautilus
 
-[![Build Nautilus](https://github.com/nebulastream/nautilus/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/nebulastream/nautilus/actions/workflows/build.yml)
+[![PR](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml)
 [![Playground](https://img.shields.io/badge/try_it-playground-blue)](https://nautilus.grulich.me)
 
 **Nautilus is a lightweight, tracing just-in-time (JIT) compiler for C++.**
@@ -41,6 +41,13 @@ SIGMOD 2024 paper (see [Publication](#publication) below).
   - **Bytecode**: interprets directly, optionally accelerated by a
     copy-and-patch JIT that stitches together pre-compiled machine-code
     stencils, for very low compilation latency.
+  - **AsmJit**: emits x86-64/AArch64 assembly directly for very fast
+    compilation with no external codegen dependency.
+- **Tiered compilation by default.** A function starts running immediately on
+  a fast tier-0 backend (AsmJit, bytecode, or the interpreter) while a
+  higher-quality tier-1 backend (typically MLIR) compiles in the background
+  and transparently takes over once ready, so callers get low latency without
+  giving up peak throughput.
 - **Optimizing IR pipeline.** Traced code passes through an SSA-based IR with
   constant propagation, dead code elimination, loop analysis, and
   control-flow simplification before reaching a backend.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nautilus
 
-[![PR](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml)
+[![Build](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml)
 [![Playground](https://img.shields.io/badge/try_it-playground-blue)](https://nautilus.grulich.me)
 
 **Nautilus is a lightweight, tracing just-in-time (JIT) compiler for C++.**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ SIGMOD 2024 paper (see [Publication](#publication) below).
 
 - **Write ordinary C++.** Loops, branches, and expressions over `val<T>`
   values look and read like normal C++: no separate DSL or code-generation
-  templates to learn.
+  templates to learn. Because it's just C++, you can step through and debug
+  the traced function directly with a regular debugger before it's ever
+  compiled.
 - **Trace once, compile anywhere.** A single traced function can target
   multiple backends without changes to its source:
   - **MLIR**: lowers through MLIR/LLVM to native machine code for maximum


### PR DESCRIPTION
## Summary

- Follow-up to the README restructure in #398 (already merged).
- Added the missing **AsmJit backend** to the "Why Nautilus?" backend list.
- Added a **"Tiered compilation by default"** bullet explaining that Nautilus starts a function on a fast tier-0 backend (AsmJit/bytecode/interpreter) and transparently promotes it to a higher-quality tier-1 backend (typically MLIR) in the background, per `TieredJITCompiler`/`TieredCompiler.cpp`.
- Fixed the top build badge: it pointed at a nonexistent `workflows/build.yml`. The actual CI workflow is `.github/workflows/pr.yml` (named "PR"), so the badge now points there.

## Test plan

- N/A – documentation-only change, no build/test impact.
- Verified `.github/workflows/pr.yml` exists and is named "PR" (`name: PR`), matching the new badge URL.


---
_Generated by [Claude Code](https://claude.ai/code/session_011XBdzPH4SWp1YhKiEYydeX)_