### PR TITLE
Surface server response body on failed MLIR download

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -57,6 +57,15 @@ function(download_file url filename)
             break()
         else ()
             message(STATUS "Error occurred during download: ${ERROR_MESSAGE}")
+            # Servers (e.g. a blocking proxy) often return a small text/JSON body explaining the
+            # failure instead of the requested file; surface it since it is otherwise discarded silently.
+            if (EXISTS ${filename})
+                file(SIZE ${filename} DOWNLOADED_FILE_SIZE)
+                if (DOWNLOADED_FILE_SIZE LESS 4096)
+                    file(READ ${filename} DOWNLOAD_ERROR_BODY)
+                    message(STATUS "Server response: ${DOWNLOAD_ERROR_BODY}")
+                endif ()
+            endif ()
             message(STATUS "Retry attempt ${CURRENT_ITERATION}/${MAX_RETRIES}")
             # Remove created (incomplete) file which failed to get downloaded
             file(REMOVE ${filename})


### PR DESCRIPTION
## Summary

Investigated reports that the MLIR prebuilt-binary download (`cmake/ImportMLIR.cmake` → `download_file()` in `cmake/macros.cmake`) sometimes fails unreliably in Claude Code sessions.

Root cause: in Claude Code's remote/web sessions, outbound GitHub traffic goes through a session-scoped proxy that only allows repos explicitly attached to the session. The MLIR release archives live in a separate repo, `nebulastream/mlir-binaries`, which isn't automatically in scope, so requests for its release assets get blocked with an HTTP 403 whose body explains the problem. `download_file()` correctly detects the HTTP error and retries 3 times before aborting, but it silently discards the response body on each failed attempt (`file(REMOVE ${filename})`), so the actual explanation never reaches the visible CMake output — only a generic "HTTP response code said error".

This PR fixes the diagnostics side of that: `download_file()` now prints the response body (when small, e.g. an error page/JSON) before discarding it, so the real cause of a failed download is visible in the CMake configure output instead of swallowed.

- `cmake/macros.cmake`: on a failed `file(DOWNLOAD)` attempt, read and print the downloaded file's contents (capped at 4KB) before removing it.

## Test plan

- [x] Manually reproduced the failure mode (`file(DOWNLOAD)` against a blocked URL) and confirmed the new code path prints the server's response body instead of only the generic curl error.
- [ ] CI build matrix (format check, GCC/Clang builds) — pending.


---
_Generated by [Claude Code](https://claude.ai/code/session_019DHpdd13hTCbikH2p1Mdps)_