### PR TITLE
Run LLVM IR CI with clang 22

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -285,10 +285,10 @@ jobs:
           ./build/nautilus/test/fuzz/nautilus-fuzz-replay
   llvm-ir-test:
     runs-on: ubuntu-24.04
-    name: LLVM IR Test (clang-21)
+    name: LLVM IR Test (clang-22)
     env:
-      CC: clang-21
-      CXX: clang++-21
+      CC: clang-22
+      CXX: clang++-22
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -308,17 +308,17 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           key: ${{ github.job }}-llvm-ir-test
-      - name: Install clang 21 and llvm-diff-21
+      - name: Install clang 22 and llvm-diff-22
         run: |
           UBUNTU_CODENAME=$(lsb_release -cs)
           sudo apt-get update
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 clang++-21 llvm-21
+          sudo apt-get install -y clang-22 clang++-22 llvm-22
           # Create symlinks for llvm-diff
-          sudo ln -sf /usr/bin/llvm-diff-21 /usr/local/bin/llvm-diff-19
+          sudo ln -sf /usr/bin/llvm-diff-22 /usr/local/bin/llvm-diff-19
       - name: Cache MLIR binaries
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
### Motivation
- Move the LLVM IR comparison job to use a newer compiler toolchain so the CI runs the llvm-ir tests under `clang-22`/`clang++-22` instead of `clang-21`.

### Description
- Update the `llvm-ir-test` job in `.github/workflows/pr.yml` to advertise `name: LLVM IR Test (clang-22)` and set `CC`/`CXX` to `clang-22`/`clang++-22`.
- Change the installation step to add the LLVM 22 apt repository and install `clang-22`, `clang++-22`, and `llvm-22`.
- Point the existing `llvm-diff` shim to `llvm-diff-22` by creating a symlink at `/usr/local/bin/llvm-diff-19` to `/usr/bin/llvm-diff-22` so existing test plumbing remains compatible.

### Testing
- Ran `git diff --check` which produced no whitespace or diff errors and committed the updated workflow file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e1c679048329a19c0605370a90a4)