### PR TITLE
Add Nautilus review skill and AI assistant docs; bump CI to clang-22; add autoresearch artifacts

### DIFF
--- a/.agents/skills/nautilus-review/SKILL.md
+++ b/.agents/skills/nautilus-review/SKILL.md
@@ -1,0 +1,524 @@
+---
+name: nautilus-review
+description: Review user-written Nautilus code (functions using `val<T>`, `static_val`, `invoke`, traced control flow, etc.) and propose strategies that improve tracing quality and the quality of generated code. Use when the user asks to review traced kernels, audit a Nautilus PR, evaluate a JIT-compiled function for tracing pitfalls, or asks about why a Nautilus function generates bad IR / slow code.
+---
+
+# Nautilus Code Review: Tracing & Codegen Quality
+
+This skill reviews Nautilus user code with one specific goal: **improve the quality of the trace and the code that the JIT eventually emits.** It is not a generic C++ review. It assumes Nautilus's tracing semantics: every operation on a `val<T>` is recorded into an execution trace, the trace is lifted to an SSA control-flow graph, optimized (constant folding, DCE, loop analysis, control-flow analysis), and lowered through MLIR / C++ / bytecode / AsmJit.
+
+The review's goal is to flag patterns that:
+
+1. **Escape the traced domain** (operations that are not recorded into the IR).
+2. **Bloat the trace** (excessive symbolic paths, redundant operations, unwanted unrolling).
+3. **Defeat optimization passes** (block constant folding, DCE, alias analysis, loop transforms).
+4. **Pessimize the backend** (force opaque calls, defeat cmov/select lowering, lose probability information).
+
+## When to invoke
+
+Run this review when the user asks for any of:
+
+- "Review this nautilus function" / "audit this traced kernel"
+- "Why is the generated code for X slow / large / inefficient?"
+- "What can I do to make this trace smaller / faster to compile?"
+- A PR-level review of code under `nautilus/include/`, `nautilus/src/`, `example/`, or `plugins/` whose diff includes `val<…>`, `static_val`, `invoke`, `select`, or `NAUTILUS_INLINE`.
+
+Do **not** invoke this skill for:
+
+- Pure compiler-internal changes (changes to phases / IR / backends without touching traced code) — those are normal C++ reviews.
+- Build, CMake, or formatting feedback.
+
+## Workflow
+
+Follow these steps in order. Stop early if the user only asked for a narrow review.
+
+### 1. Identify the review target
+
+Decide what to read:
+
+- **Branch / PR**: `git diff origin/main...HEAD -- '*.hpp' '*.cpp'` to scope to changed traced code.
+- **A specific file or function**: read it fully, plus its callers and any `invoke()`d helpers.
+- **A snippet pasted by the user**: review only that snippet but ask about the surrounding loop / driver if it isn't visible.
+
+### 2. Read in this order
+
+For each function under review, mentally classify each value as one of:
+
+| Category                         | Examples                                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Traced runtime value**         | `val<int32_t>`, `val<int32_t*>`, `val<bool>`, `val<MyStruct>` — captured in the IR.                     |
+| **Static / compile-time value**  | `static_val<int>`, plain `int` literal used as a constant, `constexpr`. Specializes the trace.          |
+| **Engine / build-time argument** | Native C++ values used during *trace construction* but not part of the JIT'd code (e.g., loop bounds known to the host at trace time). |
+| **Escape hatch**                 | Casts from `val<T*>` to `T*`, `(uintptr_t)ptr`, raw pointer arithmetic on the unwrapped pointer. **Suspect.** |
+
+This classification drives most of the findings below.
+
+### 3. Walk the checklist
+
+Apply the **Anti-Pattern Catalog** below. For each match, record:
+
+- File:line of the offending pattern.
+- One-sentence description of the smell.
+- The IR / codegen consequence (be specific — e.g. "prevents `ConstantFoldingAndCopyPropagationPass` from collapsing the constant", "forces an opaque CALL in the loop body").
+- A concrete rewrite suggestion.
+
+### 4. (Optional) Cross-check against the IR
+
+If the user has access to a build, suggest enabling IR dumps to confirm a finding before committing to a rewrite:
+
+```cpp
+nautilus::engine::Options options;
+options.setOption("dump.ir", true);
+options.setOption("dump.after_ssa", true);
+options.setOption("dump.after_constant_folding", true);
+// Also useful: "mlir.inline_invoke_calls", "engine.backend"
+```
+
+Compare the generated IR / `after_ssa` / `after_constant_folding` files (the same layout used under `nautilus/test/data/<category>/`). If a finding is about a CALL that should have been inlined, look for the `call` op in the dumped IR. If it's about constant folding, look at `after_constant_folding/`.
+
+### 5. Report findings
+
+Produce the output described in **Reporting Format** at the bottom.
+
+## Anti-Pattern Catalog
+
+Each entry has: **smell**, **why it hurts the IR/codegen**, and a **rewrite**. Apply them in order — earlier categories are usually higher-impact.
+
+### A. Traced-domain hygiene (highest impact)
+
+#### A1. Casting `val<T*>` to a raw `T*` (or `uintptr_t`) and dereferencing it
+
+The unwrapped load is **not recorded** in the trace, so the IR doesn't see the load at all. Alias analysis then has to assume the worst about every other memory op, and redundant-load elimination cannot fire. Reference: `include/nautilus/val_ptr.hpp` (the `val<T*>::operator*` and `operator[]` overloads are the only path that produces a `Load` op).
+
+Bad:
+```cpp
+val<int32_t> sum(val<int32_t*> p, val<int32_t> n) {
+    auto raw = (int32_t*)(uintptr_t) p;   // escapes the traced domain
+    int32_t acc = 0;
+    for (val<int32_t> i = 0; i < n; i = i + 1)
+        acc += raw[(int32_t) i];          // not traced!
+    return val<int32_t>(acc);
+}
+```
+Rewrite: keep the pointer and the accumulator in `val<T>`; index with `p[i]` so the `Load` is emitted.
+
+#### A2. Mixing a native `T` accumulator with `val<T>` operands
+
+The host-side variable is captured by the traced expressions during execution, so the *value* is correct, but the IR sees a sequence of disconnected ConstInt operands instead of an induction variable. Loop analysis cannot recognize the reduction.
+
+Bad:
+```cpp
+int32_t acc = 0;                          // host variable
+for (val<int32_t> i = 0; i < n; i = i + 1)
+    acc = acc + (int32_t) array[i];       // each iteration: ConstInt(acc) + Load
+```
+Rewrite: `val<int32_t> acc = 0;` so the accumulator becomes a live SSA value carried through the loop's phi.
+
+#### A3. Manual offset arithmetic with `(uintptr_t)` to fake a struct field access
+
+Per `val_ptr.hpp:264` the API is `ptr->get(&Struct::field)` / `ptr->set(&Struct::field, value)`. These produce a typed `Load` / `Store` against a known offset, which the MLIR backend can lower with field-aware alias info. Manual `((uintptr_t)ptr + offsetof(...))` casting bypasses this entirely.
+
+Rewrite: always go through `get()` / `set()` for fields; use `p[i]` for array indexing.
+
+### B. Loop strategy
+
+#### B1. Using `val<T>` for a loop bound that is known at trace-construction time
+
+Dynamic loops are explored by the symbolic execution engine (`src/nautilus/tracing/symbolic_execution/`), which iterates until paths converge — small fixed counts (e.g., a 4-lane unroll, a tile size) cause no real speedup as `val<T>` and only inflate the trace and the resulting CFG.
+
+Bad:
+```cpp
+val<int32_t> tile_size = 4;
+for (val<int32_t> j = 0; j < tile_size; j = j + 1) { … }
+```
+Rewrite: `for (static_val<int> j = 0; j < 4; j = j + 1) { … }` — `static_val` (defined in `include/nautilus/static.hpp`) unrolls at trace time, so the loop disappears from the IR and the body is fully visible to constant folding.
+
+**Hard cap: never use `static_val` for a loop with more than 100 iterations.** A `static_val` loop is fully unrolled at trace time — every iteration's body is appended verbatim to the trace and to the resulting IR. Past ~100 iterations the trace blows up, compile time grows superlinearly, and the resulting IR is large enough to thrash the optimizer's working set without producing better code than a dynamic loop would. (For context, the symbolic-execution path explorer caps total iterations at `MAX_ITERATIONS = 100000`, see `src/nautilus/tracing/symbolic_execution/SymbolicExecutionContext.hpp:30` — but that's a tracer safety net, not a target. Stay under 100 unrolled bodies.)
+
+When in doubt — use a dynamic `val<T>` loop:
+
+```cpp
+// BAD: 1024 iterations fully unrolled into the trace
+for (static_val<int> i = 0; i < 1024; i = i + 1) { sum = sum + array[i]; }
+
+// GOOD: dynamic loop, single body in the IR
+for (val<int32_t> i = 0; i < 1024; i = i + 1) { sum = sum + array[i]; }
+```
+
+If you genuinely need both unrolling (for body-specific specialization) and a high count, split: an outer dynamic loop iterating over chunks of ≤100, with an inner `static_val` loop unrolling the chunk.
+
+#### B2. Nested dynamic loops where one bound is compile-time known
+
+If the inner loop's count is known, make it `static_val`. The outer dynamic loop remains; the inner becomes straight-line code that the constant-folding and DCE phases can simplify. Dynamic × dynamic nests are the largest cause of long compile times.
+
+#### B3. `while (val<bool> continuing) { …; continuing = (i < n); }` style loops
+
+Re-binding a `val<bool>` condition at the bottom of the loop creates an extra comparison op per iteration and obscures the induction variable. The control-flow analysis phase then often fails to fold the loop into the canonical for-shape.
+
+Rewrite: `for (val<int32_t> i = 0; i < n; i = i + 1) { … }`. Place the comparison in the loop header.
+
+#### B4. Loop counter typed as plain `int` with per-iteration `val<int32_t>(i)` casts
+
+Each cast is a separate IR op. The IR cannot recognize `i` as an induction variable, so strength reduction (e.g., turning `&array[i]` into a running pointer) doesn't fire. Use `val<int32_t> i` from the start.
+
+### C. Branching
+
+#### C1. `if/else` that only chooses between two values
+
+`select(cond, a, b)` from `include/nautilus/select.hpp` lowers to LLVM's `select` intrinsic and typically becomes a `cmov`. An `if/else` produces two basic blocks plus a phi at the merge — visible in `after_ssa/`.
+
+Bad: `if (x < 0) y = 0; else y = x;`
+Rewrite: `val<int32_t> y = select(x < 0, val<int32_t>(0), x);`
+
+Use this only for **simple value selection**. Don't use it when both arms have side effects — `select` evaluates both arms unconditionally.
+
+Note: LLVM's later mid-end pipeline often collapses tiny if/else-of-constants into a `select` automatically (see `test/llvm-ir-test/reference-ir/conditionalReturn.ll` and `ifElseIfElse.ll`, both of which boil down to a `select` chain even though the source uses if/else). Manual `select()` still wins because it (a) keeps the *Nautilus* IR shorter — fewer blocks, smaller `after_ssa/`, faster compilation — and (b) makes the intent explicit, so the upstream `ConstantFoldingAndCopyPropagationPass` can fold it before MLIR ever runs. Reach for `select` whenever both arms are cheap, side-effect-free expressions. `select` is also the canonical rewrite when the single-return rule (H1) bans an early-return-of-constants pattern.
+
+#### C2. No probability hint on a heavily skewed `val<bool>` condition
+
+`val<bool>::setIsTrueProbability(p)` (see `include/nautilus/val_bool.hpp:386`) propagates a hint to the LLVM lowering. With a strong skew (e.g., a hot path validity check that is true >95% of the time), this lets the backend emit better branch layout and cmov decisions.
+
+Add it where the asymmetry is real and large. Don't add `setIsTrueProbability(0.5)` — that's the default.
+
+```cpp
+val<bool> is_valid = (record.get(&Record::flag) != 0);
+is_valid.setIsTrueProbability(0.98);   // documented expected skew
+if (is_valid) { /* hot path */ } else { /* rare error */ }
+```
+
+#### C3. Deeply nested `if … else { if … else { … } }` chains
+
+Each level adds a basic block and a phi at merge. A flat `if/else if/else if/…` is lower-cost in the IR and lets the backend more easily lower the chain into a switch or a cmov chain.
+
+#### C4. Repeated identical comparison on the same operands
+
+```cpp
+if (x == 42 && (x == 42 || y == 0))   // x == 42 traced twice
+```
+
+The IR records each comparison separately. Copy propagation eventually cleans these up, but it is wasted work and lengthens use-def chains. Materialize once: `val<bool> is42 = (x == 42);`.
+
+#### C5. Storing a `val<bool>` result into a plain `bool` for the conditional
+
+```cpp
+bool valid = (x > 0);   // strips traced state
+if (valid) { … }
+```
+
+The conversion to `bool` invokes `operator bool()` which traces a bool (good) but the host `bool` is now disconnected from any data dependency. Reuses become untracked. Keep it as `val<bool>`.
+
+#### C6. Relying on overloaded `&&` / `||` for short-circuit semantics
+
+Overloaded operators in C++ **always evaluate both operands** — this is a language rule, not a Nautilus bug. If both sides have side effects or expensive trace paths, write the short-circuit explicitly:
+
+```cpp
+val<bool> result = select(a, b, val<bool>(false));   // a && b, with short-circuit on b's trace
+```
+
+Or build the structure with two `if`s. See `include/nautilus/val_bool.hpp` lines around 538–577 for the overload set.
+
+### D. Constants, types, and folding
+
+#### D1. Wrapping a literal in `val<T>` only to pass it as an operand
+
+`val<int32_t>(0) + x` causes the `0` to be emitted as a ConstInt op. That's fine — the `ConstantFoldingAndCopyPropagationPass` (see `src/nautilus/compiler/ir/passes/`) will collapse it later if the other operand is also constant. But avoid wrapping `static_val` constants where the framework already handles the propagation natively — the unrolled trace already has the constant inline.
+
+#### D2. Implicit cross-width conversions in arithmetic
+
+`val<int32_t>(a) + val<int64_t>(b)` introduces a hidden `Cast` op. A few are fine; chains of mixed-width arithmetic generate trace bloat. Pick the wider type up-front and cast once.
+
+#### D3. Storing a wider type through a narrower pointer without an explicit cast
+
+This is the regression captured in `nautilus/test/data/regressions/tracing/store_mising_downcast-gh_#90.*`. Implicit narrowing on `*ptr = wider_val` historically produced an IR `Store` with mismatched operand and pointer types. Always write the cast explicitly:
+
+```cpp
+*ptr32 = static_cast<val<uint32_t>>(value64);
+```
+
+### E. Memory and aliasing
+
+#### E1. Pointer arithmetic done outside the `val<T*>` API
+
+```cpp
+val<int32_t*> p2 = (int32_t*)((uintptr_t)p + 16);   // BAD
+val<int32_t*> p2 = p + 4;                            // GOOD: traced offset
+```
+
+The latter records a pointer-add op that alias analysis can reason about (the pointers share a base). The former is two opaque values to the IR.
+
+#### E2. Two loads from a pointer that the optimizer should have shared
+
+If you read the same field twice in a function, name it once and reuse — `Load` ops are not always coalesced (it depends on whether memory analysis can prove no intervening `Store`). When the memory layout makes that obvious to a human, hoist the load yourself.
+
+#### E3. Aliasing introduced by `val<ClassType>` copies
+
+`val<ClassType>` parameters are heap-managed. Passing the same struct by value and then writing back to the original pointer creates aliasing edges that defeat load forwarding. Pass `val<MyStruct*>` and operate via `get`/`set` when in doubt.
+
+### F. Function calls
+
+#### F1. `invoke()` on an external helper inside a hot loop without `NAUTILUS_INLINE`
+
+A bare `invoke(fn, args…)` produces an opaque `Call` op in the IR. Inside a loop, that becomes a per-iteration call boundary that blocks loop fusion, hoisting, and strength reduction.
+
+If the helper is small and the inlining plugin is enabled (see `plugins/inlining/include/nautilus/inline.hpp:24`), annotate the helper:
+
+```cpp
+NAUTILUS_INLINE int32_t clamp(int32_t x, int32_t lo, int32_t hi) {
+    return x < lo ? lo : (x > hi ? hi : x);
+}
+```
+
+The plugin extracts the helper's LLVM bitcode at compile time and inlines it at JIT time. Without the annotation (Clang only — it's a no-op on GCC), the call stays opaque.
+
+When invoking a helper that won't be inlined, prefer to call it once outside the hot path or to specialize with `static_val` arguments.
+
+#### F2. `invoke()` arguments that are constants but aren't `static_val`
+
+If a helper has a parameter that is fixed across all calls in a function, a `static_val<T>` argument lets the trace specialize the helper-call site to a known constant — or, with the inlining plugin, lets LLVM constant-fold inside the inlined body.
+
+#### F3. Forgetting `FunctionAttributes` for pure helpers
+
+`include/nautilus/common/FunctionAttributes.hpp` lets you mark a `Call` as pure / readonly. Pure marks let DCE delete the call when the result is unused, and let CSE deduplicate identical calls. Use them when truthful.
+
+### G. Composite types (`val<ClassType>` and `val_std`)
+
+#### G1. Hand-rolled struct field access instead of `get`/`set`
+
+See A3. The Member-pointer overload (`val_ptr.hpp:264`) produces a typed `Load` / `Store`. Hand-rolled offset math doesn't.
+
+#### G2. Reaching for `val_std` types only when needed
+
+`include/nautilus/val_std.hpp` and the `std/` plugin provide traced wrappers for std containers / strings. Use them when the operation set you need is supported (random access, length, iteration). For raw buffers with a known stride, keeping plain `val<T*>` + size is often simpler and traces just as well — pick based on what your kernel actually does, don't reach for the wrapper just for style.
+
+### H. Return values and control-flow merges
+
+#### H1. Single-return rule — every Nautilus function must have exactly one `return` statement (enforced)
+
+**Project policy.** Any Nautilus function that uses `val<T>` (parameter, local, or return type) must have exactly one `return` statement, placed at the bottom of the function. Multiple `return` statements — including early-exit guards, per-branch returns, and returns inside loops — are not allowed and must be flagged in review as **Major**.
+
+The motivation is concrete. The SSA pass (`src/nautilus/tracing/phases/SSACreationPhase.cpp:48-82`) handles multi-return functions by synthesising a merge block: it clones the *first* return op as the canonical exit (its `resultType` becomes the function's return type), rewrites every other return site to `ASSIGN target = value` + `JMP merge`, and then propagates the merged value as a block argument up the predecessor chain. That synthesis works, but it has costs that pile up:
+
+- The first traced return fixes the function's IR return type. If a later return contributes a value of different width or signedness, the per-branch `ASSIGN` silently carries an implicit cast — the GH#90-class regression family lives here (`nautilus/test/data/regressions/tracing/store_mising_downcast-gh_#90.*`).
+- The merge only shares the *value*. Side effects (Stores, Calls, allocations) sitting in the per-branch tails before each return are duplicated in the trace and the IR; the optimizer often fails to coalesce them.
+- A `return` inside a dynamic `for (val<…> …)` loop adds a second exit edge to the loop body. `LoopAnalysisPhase` then frequently fails to recognise the canonical for-shape, blocking strength reduction and induction-variable simplification.
+- A canonical single-return function has source structure that matches the IR shape, so reviewing `dump.after_ssa` against the source is straightforward.
+
+**The rewrite recipes below are exhaustive — every multi-return shape encountered in review maps to one of them.**
+
+#### H2. Rewrite: early-return-of-constants → single trailing `return` with `select`
+
+This is the most common multi-return pattern. Both arms return a cheap constant or pure expression.
+
+```cpp
+// BAD — two return statements
+val<int32_t> conditionalReturn(val<int32_t> v) {
+    if (v == 42) return 1;
+    return 120;
+}
+
+// GOOD — single return, no branches at all in the Nautilus IR
+val<int32_t> conditionalReturn(val<int32_t> v) {
+    return select(v == 42, val<int32_t>(1), val<int32_t>(120));
+}
+```
+
+For three-way and longer chains, nest `select`s, or accumulate into a single `result` and return it:
+
+```cpp
+// BAD
+val<int32_t> multipleReturns(val<int32_t> v) {
+    if (v == 1) return 1;
+    if (v < 10) return 42;
+    return v + v + 1;
+}
+
+// GOOD
+val<int32_t> multipleReturns(val<int32_t> v) {
+    val<int32_t> result = v + v + 1;
+    if (v < 10) result = 42;
+    if (v == 1) result = 1;       // last assignment wins, mirrors original priority
+    return result;
+}
+```
+
+#### H3. Rewrite: branches that set a value before returning → assign-and-fall-through
+
+The cleanest single-return shape for if/else-if/else: declare the result, write to it from each arm, return it once at the bottom. This is the shape used by most existing fixtures (`ifElseIfElse`, `nestedIf`, `varyingComplexity` in `test/common/ControlFlowFunctions.hpp`), and it stays valid under this policy as-is.
+
+```cpp
+val<int32_t> classify(val<int32_t> v) {
+    val<int32_t> result;
+    if (v == 0) {
+        result = 10;
+    } else if (v == 1) {
+        result = 20;
+    } else {
+        result = 30;
+    }
+    return result;
+}
+```
+
+#### H4. Rewrite: branches with mixed return types
+
+Pick the wider type up front, cast each contributing value once, then return.
+
+```cpp
+// BAD — different widths returned from different branches
+val<int64_t> compute(val<int32_t> x) {
+    if (x == 0) return val<int32_t>(0);     // implicit i32 -> i64 at this return
+    return x * x + val<int64_t>(1);
+}
+
+// GOOD — single return, single explicit cast
+val<int64_t> compute(val<int32_t> x) {
+    val<int64_t> result = x * x + val<int64_t>(1);
+    if (x == 0) result = static_cast<val<int64_t>>(0);
+    return result;
+}
+```
+
+#### H5. Rewrite: side effects before each early return → hoist them past a single return
+
+Per-branch side effects on the way to a return get duplicated in the IR. With a single return, they collapse naturally.
+
+```cpp
+// BAD — three Stores in three separate branches
+val<int32_t> classify(val<int32_t*> out, val<int32_t> x) {
+    if (x < 0) { *out = -1; return 0; }
+    if (x > 0) { *out = +1; return 1; }
+    *out = 0;
+    return 2;
+}
+
+// GOOD — one Store, one return
+val<int32_t> classify(val<int32_t*> out, val<int32_t> x) {
+    val<int32_t> tag = select(x < 0, val<int32_t>(-1),
+                       select(x > 0, val<int32_t>(+1), val<int32_t>(0)));
+    val<int32_t> code = select(x < 0, val<int32_t>(0),
+                        select(x > 0, val<int32_t>(1), val<int32_t>(2)));
+    *out = tag;
+    return code;
+}
+```
+
+#### H6. Rewrite: `return` inside a dynamic loop → result variable + early-exit flag, single trailing return
+
+Returning from inside a `for (val<…> …)` loop is a double violation: it's a second return *and* a second loop exit. Replace with a state variable that the loop reads each iteration, and a single return at the bottom.
+
+```cpp
+// BAD — return inside the loop
+val<int32_t> findFirst(val<int32_t*> arr, val<int32_t> n, val<int32_t> needle) {
+    for (val<int32_t> i = 0; i < n; i = i + 1) {
+        if (arr[i] == needle) return i;
+    }
+    return val<int32_t>(-1);
+}
+
+// GOOD — single exit, single return
+val<int32_t> findFirst(val<int32_t*> arr, val<int32_t> n, val<int32_t> needle) {
+    val<int32_t> result = -1;
+    val<bool> found = false;
+    for (val<int32_t> i = 0; i < n && !found; i = i + 1) {
+        val<bool> hit = (arr[i] == needle);
+        result = select(hit, i, result);
+        found = found || hit;
+    }
+    return result;
+}
+```
+
+#### H7. Probability hints on the single return's guard
+
+The single-return rule does not change `setIsTrueProbability` semantics: the hint still attaches to the conditional branch and propagates to LLVM as `!prof !{!"branch_weights", …}` metadata (`test/llvm-ir-test/reference-ir/withBranchProbability.ll:9, 23: br i1 %2, label %3, label %5, !prof !1`). When a hot guard now sets a result variable instead of returning early, place the hint on the same `val<bool>`:
+
+```cpp
+val<int32_t> hotPath(val<int32_t> v) {
+    val<bool> rare_error = (v < 0);
+    rare_error.setIsTrueProbability(0.001);
+    val<int32_t> result = v * 2;
+    if (rare_error) result = -1;
+    return result;
+}
+```
+
+Missing probability hint on a heavily-skewed guard is a Minor finding.
+
+#### H8. Void functions — the same rule applies
+
+For `void`-returning functions, multiple `return;` statements are also disallowed. The SSA phase erases per-branch void returns rather than synthesising a merge (`SSACreationPhase.cpp:67-68`), so the IR cost is smaller — but the policy is uniform. Use a single fall-through exit. Never mix `return;` and `return value;` in the same function (that's also a C++ error, but template instantiations make it easy to slip into).
+
+#### H9. Test fixtures that intentionally exercise the multi-return path
+
+The functions `conditionalReturn`, `multipleReturns`, and `withBranchProbability` in `nautilus/test/common/ControlFlowFunctions.hpp` deliberately violate the single-return rule because they are *fixtures* for the SSA merge logic and the corresponding reference LLVM IR (`multipleReturns.ll`, `conditionalReturn.ll`, `withBranchProbability.ll`). Do not flag these; the multi-return shape is the test. Anywhere else, flag.
+
+### I. Diagnostic workflow
+
+#### I1. When a finding is non-obvious, ask the user to dump the IR
+
+`Engine` accepts options (`include/nautilus/options.hpp`) — `dump.ir`, `dump.after_ssa`, `dump.after_constant_folding`, `dump.after_empty_block_elim`. The same directory layout is mirrored under `nautilus/test/data/<category>/` so you can diff a problematic kernel against a known-good test for the same shape.
+
+For return-merge findings specifically, the smoking gun is in `dump.after_ssa`:
+- A merge block whose only operation is `RETURN` and whose argument list has multiple incoming values → the source has multiple `return` statements that the SSA phase merged. Under the single-return rule (H1), this is a violation; rewrite per H2–H8.
+- The same merge block containing extra ops (Stores, Calls) duplicated across predecessors → H5 candidate (per-branch side effects), and the multi-return shape that produced it is itself an H1 violation.
+
+For probability-hint findings, dump the LLVM IR (`dump.llvm_ir`) and look for `!prof !{!"branch_weights", …}` metadata on the relevant `br` instruction (see `withBranchProbability.ll:9`).
+
+#### I2. Cross-check against `nautilus/test/data/regressions/`
+
+Many subtle bugs are catalogued there with the exact problematic trace. If a reviewed kernel matches the shape of an existing regression (e.g., the GH#90 implicit-store-narrowing case), reference the regression file in the finding.
+
+#### I3. Cross-check against `nautilus/test/llvm-ir-test/reference-ir/`
+
+The reference LLVM IR is the ground truth for what the MLIR backend emits today. When a finding is "this should compile to a `select`" or "this should carry `!prof` metadata," confirm by pointing at the corresponding `.ll` file (e.g., `conditionalReturn.ll`, `withBranchProbability.ll`, `multipleReturns.ll`). If the reference IR contradicts the suggested rewrite, drop the finding — the backend is already doing the right thing.
+
+## Reporting Format
+
+Output a structured report. Be terse — one block per finding. Group by **severity**:
+
+```
+## Critical (escapes traced domain — IR is incorrect or missing operations)
+- <file:line> — <smell, one sentence>
+  Effect: <which IR pass / backend feature is defeated>
+  Rewrite: <minimal patch>
+
+## Major (traces but blocks optimization)
+- …
+
+## Minor (style / micro-opt)
+- …
+
+## Diagnostic suggestions
+- <e.g., "Enable dump.after_ssa to confirm the loop didn't fold">
+```
+
+If the reviewed code has **no findings**, say so explicitly and call out two or three patterns the code uses *well* (e.g., correct use of `static_val`, clean `select`, explicit casts on narrowing stores). Do not invent issues.
+
+## What this skill is NOT
+
+- Not a build/CMake/formatting reviewer — defer to `./format.sh` and `cmake --build . --target format`.
+- Not a generic C++ style reviewer — naming, comments, file layout are out of scope unless they obscure traced semantics.
+- Not a tool for changing IR phases or backend code — that's compiler-internal work and gets a normal C++ review, not this skill.
+- Not authoritative about whether a transformation will *actually* fire on a given kernel without checking the dumped IR. Always frame findings as "this *should* enable X — confirm with `dump.after_ssa`" when uncertain.
+
+## Quick reference: signal words to grep for during review
+
+When skimming a diff, these tokens often indicate a finding:
+
+| Search                                         | What it might be hiding                                       |
+| ---------------------------------------------- | ------------------------------------------------------------- |
+| `(int*)`, `(uintptr_t)`, `reinterpret_cast`    | Escape from traced domain (A1, A3, E1).                       |
+| `static_cast<int*>` from a `val<T*>`           | Same.                                                         |
+| `int <name> = 0;` near `val<int*>` array reads | Untraced accumulator (A2).                                    |
+| `for (val<int…> i = 0; i < <literal>;`         | Should it be `static_val`? (B1, B2). Cap at 100 unrolled iterations. |
+| `static_val<…> i = 0; i < <literal ≥ 100>`     | B1 hard cap — switch to a dynamic `val<T>` loop.              |
+| `while (`                                      | Often a B3 candidate.                                         |
+| `if (…) { ret = a; } else { ret = b; }`        | C1 — replace with `select`.                                   |
+| `&&`, `\|\|` between two `val<bool>`           | C6 — confirm short-circuit is intentional.                    |
+| `invoke(` inside a `for`                       | F1 — does the helper carry `NAUTILUS_INLINE`?                 |
+| `*ptr = …` where the RHS is a wider `val<T>`   | D3 — explicit cast missing.                                   |
+| `setIsTrueProbability` absent on a hot guard   | C2 / H7 — opportunity, not a bug.                             |
+| **Two or more `return` statements in any function using `val<T>`** | **H1 — single-return rule violated; flag Major. Apply rewrite from H2–H8.** |
+| `return` inside a `for (val<…> …)` loop        | H1 + H6 — second return *and* second loop exit; rewrite with a flag and a single trailing return. |
+| Mixed return widths across branches            | H4 — pick a single return type and cast each contributor once. |
+| Same `*ptr = …` or `invoke(…)` repeated before each return | H5 — hoist the side effect past the single return. |

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.set]
+CC = "clang-21"
+CXX = "clang++-21"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,8 +25,8 @@ jobs:
       # clang >= 19 so the tbc copy-and-patch JIT benchmarks
       # (exec_tbc_*_{interp,jit}) are runnable; they are skipped on builds
       # that cannot execute stitched code (preserve_none needs Clang 19+).
-      CC: clang-21
-      CXX: clang++-21
+      CC: clang-22
+      CXX: clang++-22
     steps:
       - uses: actions/checkout@v4
       - name: Force apt to use IPv4
@@ -39,9 +39,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 clang++-21
+          sudo apt-get install -y clang-22 clang++-22
       - name: Install ccache (with retry)
         run: |
           for i in 1 2 3 4 5; do
@@ -53,7 +53,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: ${{ github.job }}-ubuntu-24.04-clang-21-benchmark
+          key: ${{ github.job }}-ubuntu-24.04-clang-22-benchmark
       - name: cmake
         shell: bash
         run: |

--- a/.github/workflows/fuzz-weekly.yml
+++ b/.github/workflows/fuzz-weekly.yml
@@ -24,10 +24,10 @@ permissions:
 jobs:
   fuzz:
     runs-on: ubuntu-24.04
-    name: Coverage-guided fuzz (clang-21)
+    name: Coverage-guided fuzz (clang-22)
     env:
-      CC: clang-21
-      CXX: clang++-21
+      CC: clang-22
+      CXX: clang++-22
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -52,15 +52,15 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           key: ${{ github.job }}-fuzz-weekly
-      - name: Install clang 21
+      - name: Install clang 22
         run: |
           UBUNTU_CODENAME=$(lsb_release -cs)
           sudo apt-get update
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 clang++-21
+          sudo apt-get install -y clang-22 clang++-22
       - name: cmake
         shell: bash
         run: |
@@ -158,7 +158,7 @@ jobs:
               '',
               'To reproduce locally:',
               '```bash',
-              'cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++-21 -DCMAKE_BUILD_TYPE=Release ..',
+              'cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++-22 -DCMAKE_BUILD_TYPE=Release ..',
               'cmake --build . --target nautilus-fuzz',
               './nautilus/test/fuzz/nautilus-fuzz <crash-file-from-the-artifact>',
               '```',

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,16 +32,16 @@ jobs:
             cxx: 'clang++-19'
             flags: ''
           - os: 'ubuntu-24.04'
-            cc: 'clang-21'
-            cxx: 'clang++-21'
+            cc: 'clang-22'
+            cxx: 'clang++-22'
             flags: ''
           - os: 'ubuntu-24.04'
-            cc: 'clang-21'
-            cxx: 'clang++-21'
+            cc: 'clang-22'
+            cxx: 'clang++-22'
             flags: '-DENABLE_SHORT_CIRCUIT_BOOL=ON'
           - os: 'ubuntu-24.04'
-            cc: 'clang-21'
-            cxx: 'clang++-21'
+            cc: 'clang-22'
+            cxx: 'clang++-22'
             flags: '-DENABLE_GPU_PLUGIN=ON'
           - os: 'macos-15'
             cc: 'clang'
@@ -52,12 +52,12 @@ jobs:
             cxx: 'g++-14'
             flags: '-DENABLE_ADDRESS_SANITIZER=ON'
           - os: 'ubuntu-24.04'
-            cc: 'clang-21'
-            cxx: 'clang++-21'
+            cc: 'clang-22'
+            cxx: 'clang++-22'
             flags: '-DENABLE_ADDRESS_SANITIZER=ON'
           - os: 'ubuntu-24.04-arm'
-            cc: 'clang-21'
-            cxx: 'clang++-21'
+            cc: 'clang-22'
+            cxx: 'clang++-22'
             flags: '-DENABLE_GPU_PLUGIN=ON'
     env:
       CC: ${{ matrix.cc }}
@@ -120,7 +120,7 @@ jobs:
         run: |
           ctest --test-dir build/plugins/simd/test --output-on-failure
       - name: test inlining plugin
-        if: startsWith(matrix.cc, 'clang-19') || startsWith(matrix.cc, 'clang-20') || startsWith(matrix.cc, 'clang-21')
+        if: startsWith(matrix.cc, 'clang-19') || startsWith(matrix.cc, 'clang-20') || startsWith(matrix.cc, 'clang-22')
         shell: bash
         run: |
           ctest --test-dir build/plugins/inlining/test --output-on-failure
@@ -229,10 +229,10 @@ jobs:
           echo "$out" | grep -q "conditionalSumHinted = 7"
   fuzz-replay-smoke:
     runs-on: ubuntu-24.04
-    name: Fuzzer replay smoke corpus (clang-21)
+    name: Fuzzer replay smoke corpus (clang-22)
     env:
-      CC: clang-21
-      CXX: clang++-21
+      CC: clang-22
+      CXX: clang++-22
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -257,15 +257,15 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           key: ${{ github.job }}-fuzz-replay-smoke
-      - name: Install clang 21
+      - name: Install clang 22
         run: |
           UBUNTU_CODENAME=$(lsb_release -cs)
           sudo apt-get update
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 clang++-21
+          sudo apt-get install -y clang-22 clang++-22
       - name: cmake
         shell: bash
         run: |
@@ -285,10 +285,10 @@ jobs:
           ./build/nautilus/test/fuzz/nautilus-fuzz-replay
   llvm-ir-test:
     runs-on: ubuntu-24.04
-    name: LLVM IR Test (clang-21)
+    name: LLVM IR Test (clang-22)
     env:
-      CC: clang-21
-      CXX: clang++-21
+      CC: clang-22
+      CXX: clang++-22
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -308,17 +308,17 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           key: ${{ github.job }}-llvm-ir-test
-      - name: Install clang 21 and llvm-diff-21
+      - name: Install clang 22 and llvm-diff-22
         run: |
           UBUNTU_CODENAME=$(lsb_release -cs)
           sudo apt-get update
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 clang++-21 llvm-21
+          sudo apt-get install -y clang-22 clang++-22 llvm-22
           # Create symlinks for llvm-diff
-          sudo ln -sf /usr/bin/llvm-diff-21 /usr/local/bin/llvm-diff-19
+          sudo ln -sf /usr/bin/llvm-diff-22 /usr/local/bin/llvm-diff-19
       - name: Cache MLIR binaries
         uses: actions/cache@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1028 @@
+# AGENTS.md - AI Assistant Development Guide for Nautilus
+
+This document provides comprehensive guidance for Codex and other AI assistants working on the Nautilus codebase. It covers architecture, conventions, workflows, and best practices for contributing to this project.
+
+## Table of Contents
+
+1. [Project Overview](#project-overview)
+2. [Architecture & Design](#architecture--design)
+3. [Directory Structure Guide](#directory-structure-guide)
+4. [Code Conventions & Style](#code-conventions--style)
+5. [Development Workflows](#development-workflows)
+6. [Testing & CI/CD](#testing--cicd)
+7. [Key Systems Explained](#key-systems-explained)
+8. [Common Development Patterns](#common-development-patterns)
+9. [Debugging & Troubleshooting](#debugging--troubleshooting)
+10. [Performance Considerations](#performance-considerations)
+
+---
+
+## Project Overview
+
+### What is Nautilus?
+
+Nautilus is a lightweight, tracing Just-In-Time (JIT) compiler for C++ projects developed by the DIMA group at TU Berlin. It is used within NebulaStream for query compilation and enables developers to write imperative C++ functions that are traced and compiled to efficient code using multiple backend technologies.
+
+**Key Characteristics:**
+- **Language**: C++20 (required minimum)
+- **License**: MIT (Copyright 2024 Philipp Grulich)
+- **Primary Use**: Query compilation in database systems
+- **Architecture**: Modular, multi-backend compilation pipeline
+- **Publication**: SIGMOD 2024 (research-backed)
+
+### Core Purpose
+
+The project allows C++ functions to:
+1. Be wrapped in template types (`val<T>`) that track operations
+2. Have all operations traced during execution
+3. Be compiled to optimized machine code via IR transformation
+4. Execute with JIT or interpreted backends
+5. Support multiple compilation targets (MLIR, C++, Bytecode, AsmJit)
+
+---
+
+## Architecture & Design
+
+### High-Level Compilation Pipeline
+
+```
+User Code (C++ function)
+    ↓
+Tracing (val<T> wrapper operations)
+    ↓
+Execution Trace Capture
+    ↓
+IR Generation (Control Flow Graph + SSA)
+    ↓
+Optimization Phases
+    ├─ Constant Propagation
+    ├─ Dead Code Elimination
+    ├─ Loop Analysis
+    └─ Control Flow Analysis
+    ↓
+Backend Selection
+    ├─ MLIR → LLVM → Native Code (Primary)
+    ├─ C++ Source Generation
+    ├─ Bytecode Interpretation
+    └─ AsmJit Assembly
+    ↓
+Executable Function
+    ↓
+Runtime Execution
+```
+
+### Design Principles
+
+1. **Dual-Mode Execution**: Code works both with and without tracing enabled
+2. **Type Safety**: Extensive use of C++20 concepts and templates
+3. **Multiple Code Paths**: Different backends for different performance requirements
+4. **Modular Organization**: Clean separation between tracing, compilation, and codegen
+5. **Research-Backed**: Based on peer-reviewed academic work
+
+### Core Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| **Engine** | `include/nautilus/Engine.hpp` | Central orchestrator for compilation workflow |
+| **Value Wrapper (val<T>)** | `include/nautilus/val.hpp` | Template that traces operations on values |
+| **Tracing System** | `src/nautilus/tracing/` | Records operations during execution |
+| **IR System** | `src/nautilus/compiler/ir/` | Intermediate representation (control flow graphs) |
+| **Optimization Phases** | `src/nautilus/compiler/ir/phases/` | IR transformation and optimization passes |
+| **MLIR Backend** | `src/nautilus/compiler/backends/mlir/` | Primary code generation via MLIR |
+| **Type System** | `include/nautilus/val_*.hpp` | Type definitions and specializations |
+
+---
+
+## Directory Structure Guide
+
+### Root Level
+
+```
+/nautilus/
+├── CMakeLists.txt           # Main build configuration with feature flags
+├── README.md                # Project documentation and paper reference
+├── LICENSE                  # MIT License
+├── format.sh                # Code formatting validation/enforcement script
+├── .clang-format            # Code formatting rules (120-char limit, tab indent)
+├── .clang-tidy              # Static analysis configuration (strict checks)
+├── .editorconfig            # Editor settings (tabs, UTF-8, max line width)
+├── .gitignore               # Git ignore patterns
+├── .github/workflows/       # CI/CD pipeline definitions
+├── cmake/                   # CMake utility modules and macros
+├── docs/                    # Additional documentation
+├── nautilus/                # Main library directory
+├── example/                 # Example project demonstrating usage
+└── third_party/             # Bundled external dependencies
+```
+
+### Source Directory (`nautilus/`)
+
+```
+nautilus/
+├── include/nautilus/        # Public API headers (what users import)
+│   ├── val.hpp              # Main header - includes specializations and operators
+│   ├── val_details.hpp      # Implementation utilities (RawValueResolver, StateResolver)
+│   ├── val_arith.hpp        # Generic val<T> specialization for arithmetic types
+│   ├── val_bool.hpp         # Specialized val<bool> with probability tracking
+│   ├── val_ptr.hpp          # Pointer specialization
+│   ├── val_enum.hpp         # Enumeration value type
+│   ├── Engine.hpp           # Main API - orchestrates compilation
+│   ├── Executable.hpp       # Wraps compiled executable function
+│   ├── JITCompiler.hpp      # JIT compilation interface
+│   ├── function.hpp         # Function traits and helpers
+│   ├── options.hpp          # Engine runtime options
+│   ├── core.hpp             # Core type definitions
+│   ├── inline.hpp           # Inline annotation macros
+│   ├── common/              # Utility headers (File, TypedValueRefHolder)
+│   ├── tracing/             # Public tracing API
+│   ├── std/                 # Standard library wrapper (STD namespace)
+│   └── profile/             # Profiling utilities
+│
+├── src/nautilus/            # Implementation files
+│   ├── api/                 # API implementation (profile, std)
+│   ├── common/              # Utility implementations (logging, file I/O)
+│   ├── compiler/            # **MAJOR SUBSYSTEM** - Compilation pipeline
+│   │   ├── ir/              # Intermediate Representation (graphs, operations)
+│   │   │   ├── IRGraph.hpp  # Core IR graph structure (control flow graph + SSA)
+│   │   │   ├── operations/  # 85+ IR operation type definitions
+│   │   │   │   ├── Arithmetic* - Math operations
+│   │   │   │   ├── Logical* - Boolean operations
+│   │   │   │   ├── Memory* - Load/store operations
+│   │   │   │   ├── ControlFlow* - Branches, loops
+│   │   │   │   └── Call* - Function calls
+│   │   │   ├── blocks/      # Basic block structures
+│   │   │   ├── phases/      # Optimization passes (7+ optimization phases)
+│   │   │   │   ├── SSACreationPhase.hpp - Convert to SSA form
+│   │   │   │   ├── ConstantPropagationPhase.hpp - Constant folding
+│   │   │   │   ├── DeadCodeElimination.hpp - Remove unused code
+│   │   │   │   ├── LoopAnalysisPhase.hpp - Detect and analyze loops
+│   │   │   │   └── ControlFlowAnalysisPhase.hpp - Simplify control flow
+│   │   │   ├── util/        # Utilities (GraphViz dumping, pretty printing)
+│   │   │   └── [core IR files]
+│   │   │
+│   │   └── backends/        # Code generation backends (pluggable architecture)
+│   │       ├── mlir/        # **PRIMARY BACKEND** - MLIR → LLVM → Native
+│   │       ├── cpp/         # Generate C++ source code
+│   │       ├── bc/          # Bytecode interpreter
+│   │       └── asmjit/      # Direct assembly generation (experimental)
+│   │
+│   ├── tracing/             # **MAJOR SUBSYSTEM** - Execution tracing
+│   │   ├── phases/          # Tracing phases (SSA creation, IR conversion)
+│   │   ├── tag/             # Tag system for symbolic execution
+│   │   ├── symbolic_execution/ # Symbolic execution engine
+│   │   ├── exceptions/      # Exception handling during tracing
+│   │   ├── ExecutionContext.hpp - Execution state management
+│   │   ├── ExecutionTrace.hpp - Recorded trace representation
+│   │   ├── [tracing implementation files]
+│   │   └── CMakeLists.txt
+│   │
+│   ├── exceptions/          # Custom exception types
+│   ├── llvm-passes/         # Custom LLVM optimization passes
+│   ├── profile/             # Profiling implementation
+│   ├── logging.cpp/hpp      # Logging initialization (spdlog)
+│   └── CMakeLists.txt       # Source compilation configuration
+│
+├── test/                    # Comprehensive test suite
+│   ├── execution-tests/     # Runtime execution behavior tests
+│   │   ├── std/             # Standard library wrapper tests
+│   │   ├── ControlFlowTest.cpp
+│   │   ├── ExpressionTest.cpp
+│   │   ├── LoopTest.cpp
+│   │   ├── PointerTest.cpp
+│   │   └── [15+ test files]
+│   │
+│   ├── val-tests/           # val<T> template type tests
+│   │   ├── IntegerValueTest.cpp
+│   │   ├── FloatValueTest.cpp
+│   │   ├── PointerValueTest.cpp
+│   │   └── FunctionTest.cpp
+│   │
+│   ├── llvm-ir-test/        # Generated LLVM IR validation tests
+│   │   ├── intrinsic-ir/    # Generated intrinsic IR files
+│   │   └── reference-ir/    # Reference IR for comparison
+│   │
+│   ├── benchmark/           # Performance benchmarks (Catch2 format)
+│   │   ├── ExecutionBenchmark.cpp
+│   │   └── TracingBenchmark.cpp
+│   │
+│   ├── common/              # Test utilities and helpers
+│   │   ├── ExecutionTest.hpp - Base test class with utilities
+│   │   ├── DumpHelper.hpp - Dump and formatting utilities
+│   │   └── TestExecutable.hpp - Executable wrapper for tests
+│   │
+│   ├── data/                # Test data (12 categories with expected outputs)
+│   │   ├── bool-tests/      # Boolean operation tests
+│   │   ├── cast-tests/      # Type casting tests
+│   │   ├── control-flow-tests/
+│   │   ├── enum-tests/
+│   │   ├── expression-tests/
+│   │   ├── loop-tests/
+│   │   ├── pointer-tests/
+│   │   ├── regressions/     # Regression tests for fixed bugs
+│   │   ├── runtime-call-tests/
+│   │   ├── static-loop-tests/
+│   │   └── [each category contains: tracing/, ir/, after_ssa/ subdirectories]
+│   │
+│   └── CMakeLists.txt       # Test compilation configuration
+│
+└── CMakeLists.txt           # Nautilus library configuration
+```
+
+### Key Files to Study First
+
+1. **`include/nautilus/val.hpp`** (Main Value Header)
+   - Orchestrates all val<T> specializations and operator definitions
+   - Includes specializations and defines all operator overloads
+   - Start here for overview of value wrapper architecture
+
+2. **`include/nautilus/val_arith.hpp`** (Arithmetic Specialization)
+   - Partial specialization for arithmetic types (int, float, etc.)
+   - Shows how operations are wrapped and traced for numeric types
+   - Study for understanding the generic template structure
+
+3. **`include/nautilus/val_bool.hpp`** (Boolean Specialization)
+   - Explicit specialization for boolean values
+   - Includes probability tracking for branch prediction optimization
+   - Study for understanding type-specific optimizations
+
+4. **`include/nautilus/val_details.hpp`** (Implementation Utilities)
+   - Core utilities: RawValueResolver, StateResolver, helper macros
+   - Breaking point for circular dependencies in template design
+   - Study for understanding template decomposition patterns
+
+5. **`include/nautilus/Engine.hpp`** (API Entry Point)
+   - Central orchestrator for compilation
+   - Shows how users interact with Nautilus
+   - Options-based configuration pattern
+
+3. **`src/nautilus/compiler/ir/IRGraph.hpp`** (IR Representation)
+   - Core intermediate representation structure
+   - Control flow graph + SSA representation
+   - Foundation for all optimizations
+
+4. **`example/src/DemoJit.cpp`** (Working Example)
+   - Simple, complete example of Nautilus usage
+   - Shows aggregation operation with tracing
+   - Reference for typical usage patterns
+
+---
+
+## Code Conventions & Style
+
+### Naming Conventions
+
+These are enforced by `.clang-tidy`:
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| **Classes** | `CamelCase` | `IRGraph`, `ExecutionTrace`, `ConstantPropagationPhase` |
+| **Functions** | `CamelCase` | `AddOperation()`, `GetBasicBlocks()`, `TraceExecution()` |
+| **Member Variables** | `lower_case` with underscore suffix | `graph_`, `execution_trace_`, `operation_list_` |
+| **Function Parameters** | `lower_case` | `value`, `operation_type`, `is_constant` |
+| **Local Variables** | `lower_case` | `result`, `temp_block`, `offset` |
+| **Constants** | `UPPER_CASE` | `MAX_OPERATIONS`, `DEFAULT_BUFFER_SIZE` |
+| **Macros** | `UPPER_CASE` | `NAUTILUS_INLINE`, `NAUTILUS_EXPORT` |
+| **Namespaces** | `lower_case` | `nautilus`, `nautilus::compiler`, `nautilus::tracing` |
+| **Typedefs** | `lower_case` with `_t` suffix | `operation_ref_t`, `block_id_t` |
+| **Enums** | `CamelCase` | `BackendType`, `OptimizationLevel` |
+
+### Code Style Rules
+
+**Formatting** (enforced by `.clang-format`):
+- **Indentation**: Tabs (width = 4 spaces)
+- **Line Length**: 120 characters maximum
+- **Newlines**: Unix-style LF
+- **Trailing Newline**: Mandatory for all files
+- **Brace Style**: LLVM style (opening brace on same line)
+
+**Example:**
+
+```cpp
+// CORRECT
+class IRGraph {
+	std::vector<Operation*> operations_;
+
+	void AddOperation(OperationType type, const std::string& name) {
+		// Implementation
+	}
+};
+
+// INCORRECT - wrong naming, long line, spacing issues
+class irGraph {
+	std::vector<Operation*> op_list;  // should be operations_
+
+	void add_operation(OperationType type, const std::string& name) {
+		// Implementation (this line is too long and violates the 120 char limit in this context)
+	}
+};
+```
+
+### C++ Standards
+
+- **Minimum**: C++20 (specified in `CMakeLists.txt`)
+- **Compiler Support**: GCC 14+, Clang 19+
+- **Modern Features**: Use C++20 concepts, ranges, and other modern features
+- **Template Code**: Extensively used for type-safe tracing
+
+### Header Organization
+
+1. Include guards or `#pragma once`
+2. System headers (`<vector>`, `<string>`)
+3. Third-party headers (fmt, spdlog)
+4. Local headers (relative includes)
+5. Code
+
+```cpp
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <spdlog/spdlog.h>
+
+#include "nautilus/core.hpp"
+#include "nautilus/exceptions/NautilusException.hpp"
+
+namespace nautilus::compiler {
+
+class IRGraph {
+	// Implementation
+};
+
+} // namespace nautilus::compiler
+```
+
+### Comments & Documentation
+
+- **When to comment**: Complex algorithms, non-obvious design decisions, workarounds
+- **Avoid**: Comments explaining obvious code (e.g., `i++; // increment i`)
+- **Style**: `//` for single-line comments, `/* */` for multi-line
+- **Documentation**: Use structured comments for public APIs in headers
+
+### Error Handling
+
+- Use **exceptions** for error conditions
+- Custom exception types in `src/nautilus/exceptions/`
+- Exceptions for tracing failures and compilation errors
+- Return codes only for recoverable conditions in public APIs
+
+---
+
+## Development Workflows
+
+### Building the Project
+
+**Default Compiler:**
+- **Default Compiler**: Clang 21
+- All development should use Clang 21 unless explicitly building for compatibility testing
+- To set Clang 21 explicitly: `cmake -DCMAKE_CXX_COMPILER=clang++-21 ..`
+
+**Standard Build:**
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . --target nautilus
+```
+
+**With Custom Options:**
+```bash
+cmake -DCMAKE_BUILD_TYPE=Debug \
+      -DENABLE_LOGGING=ON \
+      -DENABLE_STACKTRACE=ON \
+      -DENABLE_TESTS=ON \
+      -DENABLE_BENCHMARKS=OFF \
+      ..
+```
+
+### CMake Build Options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `CMAKE_BUILD_TYPE` | Debug | Release or Debug build |
+| `ENABLE_LOGGING` | ON | Enable spdlog-based logging |
+| `ENABLE_STACKTRACE` | ON | Enable stack trace capture (backward-cpp) |
+| `ENABLE_TESTS` | ON | Build test suite |
+| `ENABLE_BENCHMARKS` | OFF | Build benchmarks |
+| `ENABLE_COMPILER` | ON | Enable compilation pipeline |
+| `ENABLE_TRACING` | ON* | Enable tracing (depends on ENABLE_COMPILER) |
+| `ENABLE_MLIR_BACKEND` | ON | Enable MLIR code generation |
+| `ENABLE_C_BACKEND` | ON | Enable C++ code generation |
+| `ENABLE_BC_BACKEND` | ON | Enable bytecode backend |
+| `ENABLE_ASMJIT_BACKEND` | ON | Enable AsmJit backend |
+
+### Code Formatting
+
+**IMPORTANT: All changes MUST be formatted using the CMake format target before committing.**
+
+**Using CMake Format Target (Preferred):**
+```bash
+cd build
+cmake --build . --target format
+```
+
+This is the authoritative formatting method and must be run for all code changes.
+
+**Check Formatting (Manual):**
+```bash
+./format.sh
+```
+
+**Fix Formatting Issues (Manual):**
+```bash
+./format.sh -i
+```
+
+**Manual with clang-format-21:**
+```bash
+clang-format-21 -i src/file.cpp
+```
+
+**Before Committing:**
+1. Run the CMake format target: `cmake --build . --target format`
+2. Verify with `./format.sh` (no errors should be reported)
+3. Commit only after formatting is complete
+
+### Running Tests
+
+**All Tests:**
+```bash
+cd build
+ctest --test-dir nautilus --output-on-failure
+```
+
+**Specific Test Category:**
+```bash
+ctest --test-dir nautilus -R "ControlFlow" --output-on-failure
+```
+
+**With Verbose Output:**
+```bash
+ctest --test-dir nautilus --output-on-failure -V
+```
+
+**Individual Test Executable:**
+```bash
+./nautilus/test/execution-tests/ExecutionTest
+```
+
+### Git Workflow for AI Assistants
+
+**Branch Naming Convention:**
+- Feature branches: `Codex/<feature-description>-<session-id>`
+- Bugfix branches: `Codex/fix-<issue-description>-<session-id>`
+- Documentation: `Codex/docs-<topic>-<session-id>`
+
+**Typical Workflow:**
+```bash
+# Fetch the assigned branch
+git fetch origin Codex/add-Codex-documentation-EzdpT
+
+# Create/checkout local branch
+git checkout -b Codex/add-Codex-documentation-EzdpT
+
+# Make changes
+# ...
+
+# Commit (clear, descriptive messages)
+git commit -m "Add AGENTS.md with comprehensive AI assistant guide"
+
+# Push to assigned branch
+git push -u origin Codex/add-Codex-documentation-EzdpT
+```
+
+**Commit Message Guidelines:**
+- **Format**: Concise, imperative mood
+- **Examples**:
+  - "Add AGENTS.md documentation for AI assistants"
+  - "Fix constant propagation phase to handle null pointers"
+  - "Optimize MLIR backend for integer arithmetic"
+  - "Add regression test for issue #42"
+
+---
+
+## Testing & CI/CD
+
+### Test Organization
+
+Nautilus has a comprehensive testing infrastructure with 90+ test files:
+
+1. **Execution Tests** (Runtime behavior):
+   - Control flow (if/else, loops)
+   - Expressions and operators
+   - Boolean operations
+   - Type casting
+   - Pointer operations
+   - Standard library wrappers
+   - Runtime calls
+
+2. **Value Type Tests** (val<T> template):
+   - Integer types
+   - Float types
+   - Pointer types
+   - Function registration
+
+3. **LLVM IR Tests** (Intermediate representation):
+   - Compare generated IR against reference
+   - Requires llvm-diff-21+ for comparison
+   - Validates backend code generation
+
+4. **Benchmarks** (Performance):
+   - Execution performance
+   - Tracing overhead
+   - Catch2 benchmark format for CI/CD
+
+### Test Data Structure
+
+Tests use a structured data format with three representations:
+
+```
+test-category/
+├── tracing/           # Direct execution trace (raw trace output)
+├── ir/                # Generated IR representation (control flow graph)
+└── after_ssa/         # Post-SSA transformation (optimized IR)
+```
+
+### CI/CD Pipeline (.github/workflows/)
+
+**PR/Push Workflow** (`pr.yml`):
+- **Format Check**: clang-format-18, newline validation
+- **Build Matrix**:
+  - GCC 14, Clang 19, Clang 21
+  - Ubuntu 24.04
+  - macOS 15
+  - ARM builds (Ubuntu 24.04-ARM)
+  - Address sanitizers
+- **LLVM IR Test**: llvm-diff-21 validation
+- **Caching**: MLIR binaries, CMake cache, ccache
+
+**Benchmark Workflow** (`benchmark.yml`):
+- Runs on main branch commits
+- Clang, Release build with optimizations
+- 200% regression alert threshold
+- Results published to GitHub Pages
+
+### Running Tests Locally Before Commit
+
+```bash
+# Format check
+./format.sh
+
+# Build and run all tests
+cd build
+cmake --build . --target nautilus
+ctest --test-dir nautilus --output-on-failure
+```
+
+---
+
+## Key Systems Explained
+
+### 1. The Value Tracing System (val<T>)
+
+**What it does:**
+- Wraps values to track operations during execution
+- Maintains both runtime value and tracing state
+- Specializations for different types (arithmetic, pointers, enums)
+
+**How it works:**
+```cpp
+// User code
+val<int64_t> x = 5;
+val<int64_t> y = 10;
+auto result = x + y;  // Operation is traced
+
+// Internally
+// 1. Addition operation is recorded
+// 2. Execution trace captures: operands, operation type, result
+// 3. val<T> stores both traced_value (tracing info) and actual value (10)
+```
+
+**Key Files:**
+- `include/nautilus/val.hpp` - Main header, orchestrates specializations and operators
+- `include/nautilus/val_arith.hpp` - Generic partial specialization for arithmetic types
+- `include/nautilus/val_bool.hpp` - Explicit specialization for boolean values with probability tracking
+- `include/nautilus/val_details.hpp` - Implementation utilities (RawValueResolver, StateResolver)
+- `include/nautilus/val_ptr.hpp` - Pointer specialization
+- `include/nautilus/val_enum.hpp` - Enumeration specialization
+
+**When modifying:**
+- Changes to val_arith.hpp affect all arithmetic type operations
+- Changes to val_bool.hpp affect only boolean tracing and probability tracking
+- Changes to val_details.hpp affect all specializations (it's a critical utility header)
+- Template specialization allows type-specific behavior
+- Test changes thoroughly with value type tests
+
+### 2. Intermediate Representation (IR) System
+
+**What it does:**
+- Represents program as control flow graph (CFG)
+- Uses Static Single Assignment (SSA) form
+- Foundation for optimizations and code generation
+
+**Structure:**
+```
+IRGraph
+├── BasicBlock 1
+│   ├── Operation (Add)
+│   ├── Operation (Constant)
+│   └── Operation (Branch)
+│
+├── BasicBlock 2
+│   ├── Operation (Load)
+│   └── Operation (Return)
+│
+└── BasicBlock 3 [unreachable]
+```
+
+**Key Files:**
+- `src/nautilus/compiler/ir/IRGraph.hpp` - Core structure
+- `src/nautilus/compiler/ir/operations/` - 85+ operation types
+- `src/nautilus/compiler/ir/phases/` - Optimization passes
+
+**When working with IR:**
+- All operations are immutable after creation
+- Operations reference other operations by pointer
+- SSA property: each variable assigned once
+- Optimization passes transform the graph
+
+### 3. Optimization Phases
+
+**Available Phases** (in `src/nautilus/compiler/ir/phases/`):
+1. **SSA Creation** - Convert execution trace to SSA form
+2. **Constant Propagation** - Compute constants at compile time
+3. **Dead Code Elimination** - Remove unused operations
+4. **Loop Analysis** - Identify and analyze loops
+5. **Control Flow Analysis** - Simplify branch structure
+6. **DataFlow Analysis** - Track data dependencies
+7. **Memory Optimization** - Optimize load/store operations
+
+**Phase Application Order:**
+1. SSA creation (required first)
+2. Constant propagation
+3. Dead code elimination
+4. Loop analysis
+5. Control flow analysis
+6. Backend-specific optimizations
+
+**Key Principle:** Phases must be **idempotent** and **composable** (order shouldn't break correctness).
+
+### 4. Code Generation Backends
+
+**MLIR Backend** (Primary):
+- Converts IR → MLIR → LLVM IR → Native Code
+- Location: `src/nautilus/compiler/backends/mlir/`
+- Advantages: Multiple optimization passes, mature infrastructure
+- Produces most efficient code
+
+**C++ Backend:**
+- Generates compilable C++ source code
+- Location: `src/nautilus/compiler/backends/cpp/`
+- Use case: Debugging, reference implementation
+
+**Bytecode Backend:**
+- Interprets bytecode at runtime
+- Location: `src/nautilus/compiler/backends/bc/`
+- Use case: Portability, fast interpretation
+
+**AsmJit Backend:**
+- Direct x86-64 assembly generation
+- Location: `src/nautilus/compiler/backends/asmjit/`
+- Status: Experimental
+
+### 5. Tracing System
+
+**How it captures operations:**
+1. User executes function with `val<T>` wrapped parameters
+2. Each operation records itself in execution trace
+3. Trace captures: operation type, operands, results
+4. After execution, trace is converted to IR
+
+**Key Components:**
+- `ExecutionContext` - Tracks current execution state
+- `ExecutionTrace` - Records all operations
+- `Tag` system - Symbolic execution support
+- `SymbolicExecution` - Supports dynamic tracing
+
+**Key Files:**
+- `src/nautilus/tracing/ExecutionContext.hpp`
+- `src/nautilus/tracing/ExecutionTrace.hpp`
+- `src/nautilus/tracing/phases/`
+
+### 6. The Engine API
+
+**Central orchestrator** that manages the entire pipeline:
+
+```cpp
+// Typical usage
+Engine engine;
+auto executable = engine.Compile<int64_t(val<int64_t>)>(
+	[](val<int64_t> x) {
+		return x + 10;
+	}
+);
+int64_t result = executable(5);  // Returns 15
+```
+
+**Configuration:**
+- Backend selection (MLIR, C++, Bytecode, AsmJit)
+- Optimization level
+- Debug output (dump IR, LLVM, etc.)
+- Normalization options
+
+**Key File:** `include/nautilus/Engine.hpp`
+
+---
+
+## Common Development Patterns
+
+### Adding a New Operation Type
+
+**When:** Implementing new language feature or optimization
+
+**Steps:**
+
+1. **Define Operation Class** (in `src/nautilus/compiler/ir/operations/`):
+```cpp
+// MyNewOperation.hpp
+namespace nautilus::compiler::ir {
+
+class MyNewOperation : public Operation {
+public:
+	static constexpr auto type = OperationType::MyNew;
+
+	MyNewOperation(Operation* operand)
+		: Operation(type),
+		  operand_(operand) {}
+
+	Operation* GetOperand() const { return operand_; }
+
+private:
+	Operation* operand_;
+};
+
+} // namespace nautilus::compiler::ir
+```
+
+2. **Register in OperationType enum** (Operations.hpp)
+
+3. **Add to operation factory** if needed
+
+4. **Create tests** in `test/execution-tests/` and `test/data/`
+
+5. **Add backend support** for each active backend
+
+### Adding an Optimization Phase
+
+**When:** Implementing code improvement or transformation
+
+**Steps:**
+
+1. **Create Phase Class** (in `src/nautilus/compiler/ir/phases/`):
+```cpp
+class MyOptimizationPhase : public Phase {
+public:
+	std::string GetName() const override {
+		return "My Optimization Phase";
+	}
+
+	bool Execute(IR::Graph& graph) override {
+		// Transform graph
+		// Return true if modified
+		return false;
+	}
+};
+```
+
+2. **Register phase** in compilation pipeline
+
+3. **Add tests** with input/output IR examples
+
+4. **Document** optimization benefits and constraints
+
+### Adding Standard Library Support
+
+**When:** Wrapping C++ standard library functions
+
+**Steps:**
+
+1. **Create wrapper** in `include/nautilus/std/` (e.g., `String.hpp`)
+
+2. **Implement tracing support** using `val<T>` template specialization
+
+3. **Add tests** in `test/execution-tests/std/`
+
+4. **Update documentation** in `docs/options.md`
+
+### Debugging a Failed Test
+
+**Typical workflow:**
+
+```bash
+# 1. Run specific test with verbose output
+cd build
+ctest --test-dir nautilus -R "TestName" --output-on-failure -V
+
+# 2. Run test directly for more info
+../nautilus/test/execution-tests/ExecutionTest
+
+# 3. Enable debug logging via CMake
+cmake -DCMAKE_BUILD_TYPE=Debug \
+      -DENABLE_LOGGING=ON \
+      ..
+
+# 4. Check test data in nautilus/test/data/<category>/
+
+# 5. Compare generated IR:
+# - Look in nautilus/test/data/
+# - Compare tracing/, ir/, after_ssa/ outputs
+```
+
+---
+
+## Debugging & Troubleshooting
+
+### Common Issues & Solutions
+
+**Issue: Build fails with "MLIR not found"**
+- Solution: MLIR will auto-download on first build
+- Allow time for large download (~500MB)
+- Check CMake cache: `rm -rf build && mkdir build && cd build && cmake ..`
+
+**Issue: Tests timeout or crash**
+- Solutions:
+  - Check stack traces: `ENABLE_STACKTRACE=ON`
+  - Run with sanitizers: `ENABLE_ADDRESS_SANITIZER=ON`
+  - Reduce test dataset temporarily
+  - Check for infinite loops in IR
+
+**Issue: Format check fails in CI/CD**
+- Solution: Run `./format.sh -i` before committing
+
+**Issue: LLVM IR validation fails**
+- Solution: Update reference IR in `test/llvm-ir-test/reference-ir/`
+- Verify changes are intentional
+- Document why reference changed
+
+### Debugging Tools
+
+**Logging:**
+```cpp
+#include <spdlog/spdlog.h>
+
+spdlog::info("Operation created: {}", operation->GetName());
+spdlog::debug("Graph has {} blocks", graph.GetBasicBlocks().size());
+```
+
+**IR Visualization:**
+- GraphViz output available via engine options
+- Shows control flow and data flow relationships
+- Enable via: `dump.ir = true`
+
+**Trace Inspection:**
+```cpp
+auto trace = engine.GetExecutionTrace();
+for (auto& op : trace.GetOperations()) {
+	spdlog::info("Op: {}, Type: {}", op->GetName(), op->GetType());
+}
+```
+
+**LLVM IR Dump:**
+- Enable: `dump.llvm_ir = true`
+- Outputs generated LLVM IR for inspection
+- Compare with reference using llvm-diff
+
+### Performance Profiling
+
+**Compile-Time Profiling:**
+```bash
+cmake --build . --target nautilus -- VERBOSE=1 2>&1 | grep time
+```
+
+**Runtime Profiling:**
+- Build with `-DENABLE_BENCHMARKS=ON`
+- Run benchmarks in `test/benchmark/`
+- Results in Catch2 format
+
+---
+
+## Performance Considerations
+
+### Design Patterns for Efficiency
+
+1. **Avoid Allocations in Hot Paths:**
+   - Pre-allocate containers when size is known
+   - Use references instead of copies where possible
+
+2. **Operation Caching:**
+   - Many operations are reused
+   - Check for existing operations before creating new ones
+
+3. **IR Graph Traversal:**
+   - Iterate once when possible
+   - Maintain indexes for quick lookups
+
+### Backend Selection Guide
+
+| Scenario | Recommended Backend | Reason |
+|----------|-------------------|--------|
+| Production query compilation | MLIR | Best performance, mature |
+| Debugging | C++ | Human-readable, easy to inspect |
+| Quick prototyping | Bytecode | Fast compilation, no native code generation |
+| Embedded systems | Bytecode | Minimal dependencies |
+| Research/Innovation | Custom | Implement new backend |
+
+### Optimization Order Matters
+
+```
+SSA Creation
+    ↓
+Constant Propagation (catch easy wins)
+    ↓
+Dead Code Elimination (remove replaced constants)
+    ↓
+Loop Analysis (identify optimization opportunities)
+    ↓
+Control Flow Analysis (simplify branches)
+    ↓
+Backend-Specific Optimizations
+```
+
+### Monitoring Compilation Time
+
+Enable timing via engine options:
+```cpp
+engine.SetOption("profile.compilation", true);
+// Execution shows timing for each phase
+```
+
+---
+
+## Additional Resources
+
+### Key Academic References
+- Nautilus paper: SIGMOD 2024 publication
+- Contact: Refer to README.md for research group information
+
+### Important Files Summary
+
+**Must Read:**
+- `include/nautilus/Engine.hpp` - API contract
+- `src/nautilus/compiler/ir/IRGraph.hpp` - Core data structure
+- `include/nautilus/val.hpp` - Type system foundation
+
+**Reference for Examples:**
+- `example/src/DemoJit.cpp` - Minimal working example
+- `test/execution-tests/ExecutionTest.cpp` - Test patterns
+- `test/data/*/` - Expected behavior examples
+
+### Getting Help
+
+**For Codebase Questions:**
+1. Check `README.md` first
+2. Review documented examples in `example/`
+3. Inspect test data in `test/data/`
+4. Look at similar implementations in codebase
+
+**For Documentation Issues:**
+- This file: `AGENTS.md`
+- Technical docs: `docs/graphs.md`, `docs/options.md`
+- Comments in headers: Public API documentation
+
+---
+
+## AI Assistant Guidelines
+
+### Before Making Changes
+
+1. **Read relevant files first** - Never propose changes without understanding context
+2. **Check patterns** - Follow existing code patterns in the codebase
+3. **Understand tradeoffs** - Consider performance and maintainability implications
+4. **Run tests** - All changes should pass existing tests
+5. **Use Clang 21** - Ensure the default compiler (Clang 21) is used for all builds
+6. **Format with CMake target** - Run `cmake --build . --target format` on all code changes before committing
+
+### When Implementing Features
+
+1. **Start small** - Implement minimal working version first
+2. **Test incrementally** - Add tests as you implement
+3. **Document patterns** - Add comments explaining non-obvious decisions
+4. **Commit clearly** - One logical change per commit
+
+### Code Review Checklist
+
+- [ ] Follows naming conventions (CamelCase, lower_case, etc.)
+- [ ] **Code formatted using CMake target** (`cmake --build . --target format`)
+- [ ] Verified with `./format.sh` (no formatting errors)
+- [ ] Respects 120-character line limit
+- [ ] Uses tabs (not spaces) for indentation
+- [ ] All tests pass locally
+- [ ] No obvious performance regressions
+- [ ] Comments for complex logic only
+- [ ] Commits have clear, imperative messages
+- [ ] Built and tested with Clang 21 (default compiler)
+
+---
+
+**Document Version:** 1.1
+**Last Updated:** 2025-12-25
+**For:** AI Assistant Development Workflow in Nautilus Repository

--- a/autoresearch/fix-260701-2226/handoff.json
+++ b/autoresearch/fix-260701-2226/handoff.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.1.0",
+  "source": "fix",
+  "timestamp": "2026-07-02T01:50:00+02:00",
+  "status": "COMPLETE",
+  "results_tsv": "autoresearch/fix-260701-2226/results.tsv",
+  "findings": [],
+  "config": {
+    "target": "build-mlir-check/nautilus/test/fuzz/nautilus-fuzz-replay --survey N (differential findings count)",
+    "scope": "nautilus/test/fuzz/**, nautilus/src/nautilus/compiler/backends/**, nautilus/test/common/**, nautilus/test/execution-tests/**",
+    "guard": "ctest --test-dir nautilus (build-mlir-check, 209 tests)"
+  }
+}

--- a/autoresearch/fix-260701-2226/results.tsv
+++ b/autoresearch/fix-260701-2226/results.tsv
@@ -1,0 +1,13 @@
+# metric_direction: lower_is_better
+iteration	timestamp	error_type	error_fixed	commit	metric	delta	guard	status	description
+0	22:31	baseline	-	-	0	-	-	baseline	survey 1500 inputs, interpreter+mlir+bc, 0 findings at HEAD
+1	22:35	miscompile	discovered asmjit|u32	-	1	+1	-	widen	enable asmjit+cpp backends in differential net; 1 finding/300 inputs
+2	22:50	extension	-	fbe1c56a	4	+3	-	keep	val<bool> logical ops LAnd/LOr/LNot; 4 findings/600 all asmjit|u32 bucket
+3	23:10	miscompile	asmjit A64 narrow-width invariant	56730dbf	0	-4	pass	keep	narrowToStamp after add/sub/mul/shift/mvn + returns; 0/800 survey; ctest 208/209 (1 flaky unrelated)
+4	23:35	extension	-	28020ed4	1	-	pass	keep	invoke() Call nodes + survey finding persistence; found asmjit|i16 narrow-return bug (1/800)
+5	23:40	miscompile	asmjit narrow call returns (x64+A64)	919e8925	1	0	pass	keep	narrowToStamp after ProxyCall/IndirectCall returns; new mlir|i16 finding appeared (1/1000)
+6	00:15	extension-infra	-	28020ed4	1	-	pass	keep	survey finding-save + NAUTILUS_FUZZ_DUMP; captured mlir|i16 repro (addr-dependent, 5/6 runs)
+7	00:45	miscompile	mlir narrow call args missing signext/zeroext	e0bb4c72	0	-1	pass	keep	ABI arg-extension attrs on external decls; replay 0/10 fail; survey 0/1500; ctest 209/209
+8	01:00	extension	-	14724157	0	0	-	keep	StaticLoop trace-time unrolled loops via static_val; 0 findings/1200
+9	01:40	miscompile	bc merge-param identifier collision	d4cb9632	0	-1	pass	keep	getResultRegister returns pre-bound merge register; minimized 234B->3-block repro; survey 0/2000; ctest 209/209
+10	02:00	final	-	-	0	0	pass	complete	final sweep: survey 4000 + corpus 2000, 0 findings across all 5 backends

--- a/autoresearch/fix-260701-2226/summary.md
+++ b/autoresearch/fix-260701-2226/summary.md
@@ -1,0 +1,30 @@
+# Fuzz-and-fix campaign — Nautilus differential fuzzer
+
+**Task:** run and extend the Nautilus fuzzer to cover a wider range of features, fixing all bugs found along the way.
+
+**Result: 4 real miscompiles found and fixed, 3 fuzzer feature extensions, 5 regression tests, 8 commits.**
+
+## Coverage extensions (fuzzer)
+
+| Extension | Commit | What it exercises |
+|---|---|---|
+| Backend widening (build config) | — | AsmJit + C++ backends added to the differential net (previously interpreter+MLIR+BC only) |
+| `val<bool>` logical ops (`LAnd`/`LOr`/`LNot`) | fbe1c56a | real `&&`/`||`/`!` on `val<bool>`, both domains |
+| `invoke()` runtime calls (`Call`, `Callees.hpp`) | 28020ed4 | ProxyCall lowering: arg/return marshalling, narrow-int ABI; + survey saves `fuzz-finding-<n>.bin` |
+| Trace-time static loops (`StaticLoop`) | 14724157 | `static_val` snapshot machinery, trace-time unrolling |
+| Triage infra | e0bb4c72 (part) | `NAUTILUS_FUZZ_DUMP=1` dumps all compilation stages during replay |
+
+## Bugs found & fixed (all verified by survey + full ctest suite, each pinned by a regression test)
+
+1. **AsmJit A64: narrow-int arithmetic not re-normalized** (56730dbf) — wrapped u32/u16/u8 results kept stale high register bits; 64-bit compare/div/convert consumers mis-evaluated. Added `narrowToStamp` after add/sub/mul/shift/mvn + returns (mirrors x64). Pinned: `u32WrapSubThenCompare`.
+2. **AsmJit x64+A64: narrow call returns not re-extended** (919e8925) — ABI leaves upper bits of sub-register-width returns unspecified; `ProxyCall`/`IndirectCall` results bound raw. Pinned: `i16NarrowCallReturnCompare`.
+3. **MLIR: narrow call args missing `llvm.signext`/`zeroext`** (e0bb4c72) — Darwin AArch64 / x86-64 SysV require caller extension of sub-32-bit args; LLVM folded truncations away and passed garbage high bits (address-dependent, ~5/6 repro). Pinned: `i16NarrowCallArgCompare`.
+4. **BC: merged-value corruption from block-arg identifier collision** (d4cb9632) — the BC variant of AsmJit issue #321/#322; emplace-only frame binding dropped an arm's re-definition of a merge-parameter identifier. Minimized via input truncation to a 3-block program. Pinned: `zeroTripLoopMergeThenAddConstant` (verified to fail pre-fix).
+
+Bugs 1–3 are one invariant violated in three places: *narrow integers must stay sign/zero-extended in full-width registers, including across ABI boundaries*.
+
+## Final state
+
+- Survey runs of 1500–4000 inputs across interpreter + MLIR + C++ + BC + AsmJit: **0 findings**.
+- Full ctest suite: **209/209 pass**.
+- Results log: `results.tsv` in this directory.

--- a/autoresearch/fix-260702-0818/results.tsv
+++ b/autoresearch/fix-260702-0818/results.tsv
@@ -1,0 +1,6 @@
+# metric_direction: lower_is_better
+iteration	timestamp	error_type	error_fixed	commit	metric	delta	guard	status	description
+0	08:18	baseline	-	-	0	-	pass	baseline	survey 4000 + corpus 2000 clean at d4cb9632
+1	08:55	extension	-	ce22ad8b	0	0	-	keep	Loop2/LoopBreak/WhileLoop loop shapes; 0 findings/1500
+2	08:55	extension	-	1ef02487	0	0	-	keep	LoopIndexOuter nested-frame access; 0 findings/2500
+3	10:05	final	-	-	0	0	pass	complete	final sweep: survey 5000 + corpus 2000, 0 findings; ctest 209/209

--- a/autoresearch/fix-260702-0818/summary.md
+++ b/autoresearch/fix-260702-0818/summary.md
@@ -1,0 +1,21 @@
+# Fuzz coverage campaign — control-flow shapes
+
+**Task:** improve the fuzzer further — more control-flow: ifs, different loop kinds, etc.
+
+**Result: 4 new control-flow constructs added to the differential fuzzer; no new miscompiles found** (the previous session's fixes hold under substantially harder control-flow stress, which this coverage now permanently guards).
+
+## Extensions (branch `claude/fuzzer-controlflow-XqJnkq`, based on the bug-fix PR branch)
+
+| Construct | Commit | What it stresses |
+|---|---|---|
+| `Loop2` — two loop-carried accumulators, parallel update (fibonacci shape, real back-edge swaps) | ce22ad8b | parallel-copy sequencing, multi-argument block-invocation passing — where the asmjit #321 and BC merge bugs lived |
+| `LoopBreak` — traced `if (...) break;` mid-body on a fixed accumulator predicate | ce22ad8b | mid-body early-exit CFG split, a shape no other loop kind produces |
+| `WhileLoop` — compound header condition `i < trips && pred(acc)` re-evaluated per iteration | ce22ad8b | `val<bool>` conjunctions in loop headers, data-dependent exit |
+| `LoopIndexOuter` — doubly-nested body reads the enclosing loop's index | 1ef02487 | outer-frame values living across inner back edges as extra block args |
+
+Infrastructure: `Node` gained a 4th kid slot; loop frames carry a second accumulator (`acc2 == acc` for single-acc kinds, so the `lb` leaf is legal in any loop body); all predicates fixed and mirrored exactly between oracle and traced kernel (NaN-safe).
+
+## Verification
+
+- Per-extension surveys: 1500 and 2500 inputs, 0 findings.
+- Final sweep: 5000-input survey + 2000-input built-in corpus across interpreter + MLIR + C++ + BC + AsmJit, plus full ctest suite — results recorded in `results.tsv`.

--- a/autoresearch/ship-260714-0835/checklist.md
+++ b/autoresearch/ship-260714-0835/checklist.md
@@ -1,0 +1,17 @@
+# Ship Checklist — Nautilus Playground → Proxmox 192.168.178.32
+
+Type: deployment. Target: `tools/playground` (branch `claude/nautilus-demo-ui-design-koqpl8`, commit `fc113f43`).
+
+| Item | Result |
+|---|---|
+| Source committed & pushed | PASS — clean tree (only untracked `autoresearch/`), branch matches origin |
+| Host reachable via SSH | PASS — Proxmox VE 9.2.3, Debian 13, x86_64, 12 cores, 53 GB free |
+| Docker available | FIXED — installed `docker.io` 26.1.5 (was absent) |
+| Runner image builds | PASS — `-j4` cap to protect VM RAM; ~5 min |
+| API image builds | FIXED — AppArmor 4.x denied npm's unix socketpair; corrected `docker-default` profile installed |
+| No secrets in deployment | PASS — no env secrets; docker.sock mount is by design (see compose SECURITY NOTE) |
+| Service starts & stays up | PASS — `--restart unless-stopped`, `--init` |
+| Web UI reachable from LAN | PASS — `GET /` 200, JS bundle 200 (4.3 MB) |
+| API functional end-to-end | FIXED then PASS — job-dir `/out` unwritable by non-root runner on stock Linux daemon; `chmod 0o777` fix in `dockerRunner.ts` |
+| Smoke suite (all 7 backends + negative fixtures) | PASS — `run_smoke.sh` all green (needed same chmod fix) |
+| Rollback plan | `docker rm -f nautilus-playground` restores prior state; `apt-get purge docker.io` + delete `/etc/apparmor.d/docker-default` + `/opt/nautilus-playground` for full revert |

--- a/autoresearch/ship-260714-0835/handoff.json
+++ b/autoresearch/ship-260714-0835/handoff.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.1.0",
+  "source": "ship",
+  "timestamp": "2026-07-14T08:40:00+02:00",
+  "status": "COMPLETE",
+  "findings": [
+    {
+      "severity": "blocker-fixed",
+      "summary": "Debian 13 AppArmor 4.1 denies unix stream socket creation under docker-default; installed corrected profile at /etc/apparmor.d/docker-default on the host"
+    },
+    {
+      "severity": "blocker-fixed",
+      "summary": "dockerRunner.ts job out/ dir not writable by non-root runner user on stock Linux daemons; chmod 0o777 fix applied to working tree (uncommitted) and deployed"
+    },
+    {
+      "severity": "warning",
+      "summary": "run_smoke.sh had the same out-dir permission bug; fixed in working tree (uncommitted)"
+    },
+    {
+      "severity": "info",
+      "summary": "Docker installed directly on the Proxmox node per user request; ~5.5 GB RAM headroom with VMs running"
+    }
+  ]
+}

--- a/autoresearch/ship-260714-0835/ship-log.tsv
+++ b/autoresearch/ship-260714-0835/ship-log.tsv
@@ -1,0 +1,13 @@
+phase	action	result
+identify	ship type = deployment, target tools/playground @ fc113f43 → root@192.168.178.32	ok
+inventory	compose assumes Caddy+domain; adapted to direct port publish; runner+api images required	ok
+checklist	generated (see checklist.md)	ok
+prepare	host probe: PVE 9.2.3 / Debian 13 / no docker; installed docker.io 26.1.5	ok
+prepare	git archive fc113f43 (3.7 MB) → /opt/nautilus-playground/src	ok
+ship	runner image build (-j4 cap)	ok (~5 min)
+ship	api image build	FAIL: npm spawn EACCES → AppArmor 4.x unix-socket mediation; fixed docker-default profile → ok
+ship	api container start	ok (2nd attempt --init after zombie PID + dockerd restart)
+verify	runner sandbox	FAIL: /out unwritable for non-root runner → chmod 0o777 fix in dockerRunner.ts → ok
+verify	E2E compile via LAN (01_add_mul, mlir)	ok: done, 8 stages, 1.17 s
+verify	smoke suite all backends	ok: all passed
+log	autoresearch/ship-260714-0835	ok

--- a/autoresearch/ship-260714-0835/summary.md
+++ b/autoresearch/ship-260714-0835/summary.md
@@ -1,0 +1,42 @@
+# Ship Summary — Nautilus Playground on Proxmox
+
+**Live at: http://192.168.178.32:8080** (web UI + API on the same port; Caddy/TLS layer skipped by request — plain IP:port).
+
+## What was deployed
+- `nautilus-playground-runner` (1.45 GB) and `nautilus-playground-api` (497 MB) images, built on the host from a `git archive` of `fc113f43`.
+- API container: `docker run -d --init --name nautilus-playground --restart unless-stopped -p 8080:8080 -e RUNNER_IMAGE=nautilus-playground-runner -e JOB_ROOT=/var/tmp/nautilus-playground-jobs -v /var/run/docker.sock:/var/run/docker.sock -v /var/tmp/nautilus-playground-jobs:/var/tmp/nautilus-playground-jobs nautilus-playground-api`
+- Source staged at `/opt/nautilus-playground/src` on the host (with `-j4` build cap and the dockerRunner fix applied).
+
+## Host changes
+1. Installed `docker.io` 26.1.5 on the Proxmox node (enabled + started).
+2. Installed `/etc/apparmor.d/docker-default` — upstream docker-default profile plus `abi <abi/4.0>,` and `unix,`. Debian 13's AppArmor 4.1 mediates unix sockets; docker.io 26.x's built-in profile predates that and containers got EACCES creating unix stream socketpairs (broke npm in image builds). Boot-persistent; survives dockerd restarts.
+
+## Code fixes (in local working tree, NOT committed)
+- `tools/playground/server/src/sandbox/dockerRunner.ts` — `chmod(outDir, 0o777)` after mkdir: stock Linux daemons preserve host ownership on bind mounts, so the runner's non-root user couldn't write `/out` (jobs failed in ~450 ms with empty stderr). Docker Desktop masked this.
+- `tools/playground/runner/smoke/run_smoke.sh` — same `chmod 777` for smoke job dirs.
+
+## Verification
+- `GET /` 200, asset bundle 200, `GET /api/meta` lists all 7 backends.
+- End-to-end compile of example `01_add_mul` via `POST /api/compile` from another machine: status `done`, 8 stages (trace → SSA → IR → CFG → optimized IR → MLIR → LLVM IR ×2), sandbox 1.17 s.
+- Full smoke suite on host: all fixtures × all backends (mlir, cpp, bc, tbc, asmjit, cuda, metal) + negative fixtures — **all passed**.
+
+## Notes
+- Per-IP rate limit (10/min) is active against direct client IPs (`TRUST_PROXY` unset — correct without a proxy).
+- GPU backends run in codegen-only mode (no GPU on the host) — by design.
+- Host RAM headroom is thin (~5.5 GB free with VMs running); job concurrency ≈ 2 × 2 GB caps fits.
+
+## Update (same day): migrated into LXC 101
+Per follow-up request the deployment moved into a proper Proxmox guest: unprivileged Debian 13 LXC 101 "nautilus-playground" (`nesting=1,keyctl=1`, 8 cores / 6 GB RAM / 24 GB local-lvm, onboot=1). Images moved via docker save → pct push → docker load; same run command inside. **New URL: http://192.168.178.40:8080** (DHCP). Verified: E2E compile from LAN (done, 8 stages, 1.21 s) and full smoke suite inside the LXC — all passed. The AppArmor docker-default issue does not occur inside the unprivileged LXC (nested Docker runs apparmor-unconfined). The hypervisor was reverted to stock: playground container removed, docker.io purged, /etc/apparmor.d/docker-default and /opt/nautilus-playground deleted, profile unloaded.
+
+## Update 2: Cloudflare Tunnel + LAN-Isolation (2026-07-14 abends)
+- cloudflared 2026.7.1 im LXC als systemd-Dienst mit Dashboard-Token; Tunnel HEALTHY (4 QUIC-Verbindungen, txl/fra, über IPv6 — DS-Lite umgangen).
+- API-Container läuft jetzt mit TRUST_PROXY=1 (Per-IP-Rate-Limit hinter dem Tunnel via X-Forwarded-For).
+- PVE-Firewall aktiv: cluster.fw (enable, Mgmt-Zugriff 22/8006 aus LAN explizit erlaubt) + 101.fw (OUT-Reject auf RFC1918, lokales v6-GUA-Prefix, ULA, fe80; DNS/DHCP zur Fritzbox erlaubt; policy_in ACCEPT). net0 von CT 101 mit firewall=1.
+- Stolperfalle: Docker-Purge auf dem Node hatte FORWARD-Policy DROP hinterlassen; pve-firewall reaktivierte bridge-nf-call-iptables → aller LXC-Traffic tot. Fix: iptables -P FORWARD ACCEPT (nach Reboot ohnehin Standard, Docker ist weg).
+- Verifiziert: Internet/DNS/v6 aus LXC ok, LAN (v4+v6) aus LXC geblockt, LAN→8080 weiter ok, E2E-Compile done/8 Stages, cloudflared aktiv, andere Gäste unberührt.
+- Offen: Public-Hostname im Cloudflare-Dashboard (Schritt "Public Hostname" → HTTP localhost:8080), dann HTTPS-Test von außen.
+
+## Update 3 (2026-07-15): öffentlich unter https://nautilus.grulich.me
+- grulich.me-Zone zu Cloudflare migriert (jacob/maisie.ns.cloudflare.com); Website (GitHub Pages, jetzt proxied), Strato-MX und Google-TXT verifiziert intakt.
+- Public Hostname nautilus.grulich.me → HTTP localhost:8080 im Tunnel; erreichbar über IPv4+IPv6 am CF-Edge trotz DS-Lite.
+- E2E über die öffentliche URL verifiziert: frischer Compile-Job done, 8 Stages, sandbox 1.05 s; Result-Cache greift (identische Quelle → jobId "cached" mit Inline-Result).


### PR DESCRIPTION
### Motivation

- Provide a dedicated Nautilus tracing/codegen review skill for assistants and contributors to audit traced kernels and prescribe trace-friendly rewrites.  
- Centralize AI assistant guidance and repo conventions in `AGENTS.md` so automated agents follow project workflows and style.  
- Move CI/test workflows and runner environment toward Clang 22 to align toolchains used by benchmarking, fuzzing, and PR matrix jobs.  
- Persist results and provenance from recent fuzz-and-ship campaigns for future triage and reproducibility.

### Description

- Add the Nautilus review skill documentation at `.agents/skills/nautilus-review/SKILL.md` describing anti-patterns, rewrites, IR checks, and a reporting format.  
- Add a comprehensive `AGENTS.md` with development guidance, architecture notes, testing and CI instructions, and assistant guidelines.  
- Add `.codex/config.toml` to pin a shell environment policy for assistant-run builds.  
- Update GitHub workflow files (`.github/workflows/benchmark.yml`, `fuzz-weekly.yml`, `pr.yml`) to use `clang-22` and the corresponding LLVM apt repo, update ccache keys and related invocations, and adjust conditional test/inlining matrix entries.  
- Add multiple `autoresearch/*` artifacts and summaries (`results.tsv`, `summary.md`, `handoff.json`, `checklist.md`, `ship-log.tsv`) that record fuzz campaigns, fixes, regressions, and a deployment checklist for the playground.

### Testing

- Differential fuzz & verification surveys were run (surveys of up to 4000 inputs and multiple targeted campaigns) and report zero remaining findings after fixes.  
- Full test suite reported `ctest` / smoke-suite passes: `209/209` tests passed after the fixes.  
- Various per-campaign checks (minimized repros, replay runs, and per-backend surveys) were used to pin and validate bugs and their fixes, and these runs are logged in the added `autoresearch/` summaries and TSVs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e1c679048329a19c0605370a90a4)