### PR TITLE
Expose MLIR debug source mode in playground

### DIFF
--- a/tools/playground/runner/driver.cpp
+++ b/tools/playground/runner/driver.cpp
@@ -29,6 +29,7 @@ struct DriverArgs {
 	bool enableLocalCSE = false;
 	bool enableStrengthReduction = false;
 	bool enableDwarf = false;
+	std::string mlirDebugSourceMode = "mlir";
 	int maxPipelineIterations = 4;
 };
 
@@ -48,6 +49,11 @@ DriverArgs parseArgs(int argc, char** argv) {
 			args.enableStrengthReduction = true;
 		} else if (arg == "--enable-dwarf") {
 			args.enableDwarf = true;
+		} else if (arg.starts_with("--mlir-debug-source-mode=")) {
+			args.mlirDebugSourceMode = arg.substr(25);
+			if (args.mlirDebugSourceMode != "mlir" && args.mlirDebugSourceMode != "nautilus-ir") {
+				args.mlirDebugSourceMode = "mlir";
+			}
 		} else if (arg.starts_with("--max-iterations=")) {
 			args.maxPipelineIterations = std::atoi(std::string(arg.substr(17)).c_str());
 			if (args.maxPipelineIterations < 1 || args.maxPipelineIterations > 8) {
@@ -119,6 +125,7 @@ int main(int argc, char** argv) {
 	if (args.enableDwarf) {
 		// Only consumed by the MLIR backend; harmless (ignored) on the others.
 		options.setOption("mlir.debug.enable", true);
+		options.setOption("mlir.debug.source_mode", args.mlirDebugSourceMode);
 	}
 
 	std::vector<playground::StatEntry> statistics;

--- a/tools/playground/runner/entrypoint.sh
+++ b/tools/playground/runner/entrypoint.sh
@@ -58,6 +58,7 @@ DRIVER_ARGS="--backend=$PG_BACKEND --out=/out"
 [ "${PG_ENABLE_LOCAL_CSE:-0}" = "1" ] && DRIVER_ARGS="$DRIVER_ARGS --enable-local-cse"
 [ "${PG_ENABLE_STRENGTH_REDUCTION:-0}" = "1" ] && DRIVER_ARGS="$DRIVER_ARGS --enable-strength-reduction"
 [ "${PG_ENABLE_DWARF:-0}" = "1" ] && DRIVER_ARGS="$DRIVER_ARGS --enable-dwarf"
+[ -n "${PG_MLIR_DEBUG_SOURCE_MODE:-}" ] && DRIVER_ARGS="$DRIVER_ARGS --mlir-debug-source-mode=$PG_MLIR_DEBUG_SOURCE_MODE"
 [ -n "${PG_MAX_ITERATIONS:-}" ] && DRIVER_ARGS="$DRIVER_ARGS --max-iterations=$PG_MAX_ITERATIONS"
 
 # shellcheck disable=SC2086

--- a/tools/playground/server/src/routes/compile.ts
+++ b/tools/playground/server/src/routes/compile.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { config } from '../config.js';
-import { BACKENDS } from '../types.js';
+import { BACKENDS, MLIR_DEBUG_SOURCE_MODES } from '../types.js';
 import { allowRequest } from '../rateLimit.js';
 import { cachedResult, cacheKeyFor, getJob, QueueFullError, submitJob, subscribe } from '../jobs/queue.js';
 import type { Example } from '../examples/index.js';
@@ -15,6 +15,7 @@ const compileSchema = z.object({
 			enableLocalCSE: z.boolean().optional(),
 			enableStrengthReduction: z.boolean().optional(),
 			enableDwarf: z.boolean().optional(),
+			mlirDebugSourceMode: z.enum(MLIR_DEBUG_SOURCE_MODES).optional(),
 			maxPipelineIterations: z.number().int().min(1).max(8).optional(),
 		})
 		.optional(),
@@ -93,7 +94,7 @@ export function registerRoutes(app: FastifyInstance, examples: Example[]): void 
 
 	app.get('/api/meta', async () => ({
 		backends: BACKENDS,
-		passOptions: ['enableLICM', 'enableLocalCSE', 'enableStrengthReduction', 'enableDwarf'],
+		passOptions: ['enableLICM', 'enableLocalCSE', 'enableStrengthReduction', 'enableDwarf', 'mlirDebugSourceMode'],
 		limits: {
 			sourceMaxBytes: config.sourceMaxBytes,
 			maxPipelineIterations: 8,

--- a/tools/playground/server/src/sandbox/dockerRunner.ts
+++ b/tools/playground/server/src/sandbox/dockerRunner.ts
@@ -69,6 +69,9 @@ export async function runInSandbox(jobId: string, source: string, backend: Backe
 	if (options.enableDwarf) {
 		args.push('-e', 'PG_ENABLE_DWARF=1');
 	}
+	if (options.mlirDebugSourceMode !== undefined) {
+		args.push('-e', `PG_MLIR_DEBUG_SOURCE_MODE=${options.mlirDebugSourceMode}`);
+	}
 	if (options.maxPipelineIterations !== undefined) {
 		args.push('-e', `PG_MAX_ITERATIONS=${options.maxPipelineIterations}`);
 	}

--- a/tools/playground/server/src/types.ts
+++ b/tools/playground/server/src/types.ts
@@ -1,11 +1,14 @@
 export const BACKENDS = ['mlir', 'cpp', 'bc', 'tbc', 'asmjit', 'cuda', 'metal'] as const;
 export type Backend = (typeof BACKENDS)[number];
+export const MLIR_DEBUG_SOURCE_MODES = ['mlir', 'nautilus-ir'] as const;
+export type MlirDebugSourceMode = (typeof MLIR_DEBUG_SOURCE_MODES)[number];
 
 export interface CompileOptions {
 	enableLICM?: boolean;
 	enableLocalCSE?: boolean;
 	enableStrengthReduction?: boolean;
 	enableDwarf?: boolean;
+	mlirDebugSourceMode?: MlirDebugSourceMode;
 	maxPipelineIterations?: number;
 }
 

--- a/tools/playground/web/src/api.ts
+++ b/tools/playground/web/src/api.ts
@@ -2,12 +2,15 @@
 
 export const BACKENDS = ['mlir', 'cpp', 'bc', 'tbc', 'asmjit', 'cuda', 'metal'] as const;
 export type Backend = (typeof BACKENDS)[number];
+export const MLIR_DEBUG_SOURCE_MODES = ['mlir', 'nautilus-ir'] as const;
+export type MlirDebugSourceMode = (typeof MLIR_DEBUG_SOURCE_MODES)[number];
 
 export interface CompileOptions {
 	enableLICM?: boolean;
 	enableLocalCSE?: boolean;
 	enableStrengthReduction?: boolean;
 	enableDwarf?: boolean;
+	mlirDebugSourceMode?: MlirDebugSourceMode;
 	maxPipelineIterations?: number;
 }
 

--- a/tools/playground/web/src/components/Toolbar.tsx
+++ b/tools/playground/web/src/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Anchor, Badge, Button, Checkbox, Divider, Group, Popover, Select, Text, Tooltip } from '@mantine/core';
-import { BACKENDS, type Backend, type CompileOptions, type Example } from '../api';
+import { BACKENDS, MLIR_DEBUG_SOURCE_MODES, type Backend, type CompileOptions, type Example } from '../api';
 
 export type StatusKind = 'ready' | 'working' | 'done' | 'failed';
 
@@ -204,6 +204,25 @@ export function Toolbar({
 								disabled={backend !== 'mlir'}
 								checked={options.enableDwarf ?? false}
 								onChange={(e) => onOptionsChange({ ...options, enableDwarf: e.currentTarget.checked })}
+							/>
+						</Tooltip>
+						<Tooltip
+							label="Chooses whether DWARF line numbers point at the emitted MLIR snapshot or a Nautilus IR dump. Requires DWARF debug info."
+							maw={280}
+							multiline
+							withArrow
+						>
+							<Select
+								size="xs"
+								mt={8}
+								label="Debug source mode"
+								disabled={backend !== 'mlir' || !(options.enableDwarf ?? false)}
+								value={options.mlirDebugSourceMode ?? 'mlir'}
+								data={MLIR_DEBUG_SOURCE_MODES.map((mode) => ({ value: mode, label: mode }))}
+								onChange={(value) =>
+									value && onOptionsChange({ ...options, mlirDebugSourceMode: value as CompileOptions['mlirDebugSourceMode'] })
+								}
+								allowDeselect={false}
 							/>
 						</Tooltip>
 					</Popover.Dropdown>


### PR DESCRIPTION
### Motivation
- Allow the playground to control `mlir.debug.source_mode` so users can choose whether DWARF line numbers point at the MLIR snapshot or the Nautilus IR dump (values `mlir` or `nautilus-ir`).

### Description
- Add `MLIR_DEBUG_SOURCE_MODES` and `mlirDebugSourceMode` types to the shared client/server API (`tools/playground/web/src/api.ts` and `tools/playground/server/src/types.ts`).
- Validate and accept `mlirDebugSourceMode` in the compile request schema and expose it in `/api/meta` (`tools/playground/server/src/routes/compile.ts`).
- Thread the option through the sandbox environment by setting `PG_MLIR_DEBUG_SOURCE_MODE` in `dockerRunner.ts` and forwarding it in the runner `entrypoint.sh` as `--mlir-debug-source-mode` to the driver.
- Parse the flag in the C++ driver (`tools/playground/runner/driver.cpp`) and apply it with `options.setOption("mlir.debug.source_mode", ...)` when `mlir.debug.enable` is active.
- Add a UI selector in the playground toolbar under Debug info to choose the debug source mode, enabled only for the `mlir` backend when DWARF debug info is active (`tools/playground/web/src/components/Toolbar.tsx`).

### Testing
- Ran `npm --prefix tools/playground/web ci` and `npm --prefix tools/playground/server ci` and both completed successfully.
- Ran TypeScript checks with `npm --prefix tools/playground/web run typecheck` and `npm --prefix tools/playground/server run typecheck` and they passed.
- Built the web and server artifacts with `npm --prefix tools/playground/web run build` and `npm --prefix tools/playground/server run build` and both builds succeeded.
- Ran `git diff --check` to ensure no whitespace/format issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a1e343ecc8329bff1c4970fe746ec)