### PR TITLE
Add benchmark trends link and badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/nebulastream/nautilus/actions/workflows/pr.yml)
 [![Playground](https://img.shields.io/badge/try_it-playground-blue)](https://nautilus.grulich.me)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-trends-brightgreen)](https://nebulastream.github.io/nautilus/dev/bench/#/trends/trace)
 
 **Nautilus is a lightweight, tracing just-in-time (JIT) compiler for C++.**
 Write imperative C++ using `val<T>` wrapper types, and Nautilus traces the
@@ -16,6 +17,8 @@ query compiler of the data management system
 SIGMOD 2024 paper (see [Publication](#publication) below).
 
 ▶ **[Try Nautilus in your browser: no setup required](https://nautilus.grulich.me)**
+
+📈 **[Track Nautilus benchmark trends](https://nebulastream.github.io/nautilus/dev/bench/#/trends/trace)**
 
 ## Contents
 


### PR DESCRIPTION
### Motivation
- Add a prominent link to the Nautilus benchmark trends page so readers can quickly access performance trends.

### Description
- Updated `README.md` to add a "Benchmarks" badge linking to https://nebulastream.github.io/nautilus/dev/bench/#/trends/trace and inserted a prominent introductory text link to the same page.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a493000548329b29c1423d62df22c)