### PR TITLE
Fix Debug link failure: compile MLIRJit.cpp with -fno-rtti to match LLVM

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/mlir/jit/CMakeLists.txt
+++ b/nautilus/src/nautilus/compiler/backends/mlir/jit/CMakeLists.txt
@@ -2,3 +2,23 @@ add_source_files(nautilus
         MLIRJit.cpp
         PackFunctionArguments.cpp
 )
+
+# MLIRJit drives llvm::orc::LLJIT directly; ORC's error types (e.g.
+# llvm::ErrorInfo<llvm::orc::JITDylibDefunct, llvm::ErrorInfoBase>) reference
+# the typeinfo of llvm::ErrorInfoBase. MLIR itself is built with -fno-rtti,
+# so its libraries do not export that typeinfo. Match the flag for this one TU
+# so the emitted vtable does not reference the missing typeinfo.
+# The nautilus target's sources are aggregated globally via add_source_files
+# and compiled from nautilus/CMakeLists.txt, so the DIRECTORY scope must
+# be the one that owns the target.  Compute that path relative to this
+# file so the property also resolves when the example sub-project is
+# the top-level CMake project (in which case CMAKE_SOURCE_DIR is
+# example/, not the nautilus repo root).
+get_filename_component(_nautilus_target_dir
+        "${CMAKE_CURRENT_LIST_DIR}/../../../../../.."
+        ABSOLUTE)
+set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/MLIRJit.cpp
+        DIRECTORY ${_nautilus_target_dir}
+        PROPERTIES COMPILE_OPTIONS -fno-rtti
+)


### PR DESCRIPTION
## Problem

Building `main` in **Debug** mode fails to link the CTest executables with:

```
Undefined symbols for architecture arm64:
  "typeinfo for llvm::ErrorInfoBase", referenced from:
      typeinfo for llvm::ErrorInfo<llvm::orc::JITDylibDefunct, llvm::ErrorInfoBase> in libnautilus.a[86](MLIRJit.cpp.o)
```

Release builds link fine; only Debug fails.

## Root cause

- The prebuilt MLIR/LLVM 22.1.8 is compiled with `-fno-rtti` (confirmed via `LLVM_ENABLE_RTTI OFF` in `LLVMConfig.cmake`), so its libraries never export `typeinfo for llvm::ErrorInfoBase`.
- `MLIRJit.cpp` drives `llvm::orc::LLJIT` directly and instantiates ORC error types like `llvm::ErrorInfo<llvm::orc::JITDylibDefunct, llvm::ErrorInfoBase>`. Compiled **with** RTTI (the default), the emitted vtable/typeinfo references the base typeinfo that LLVM does not export, producing an undefined symbol at link time in Debug builds.

## Fix

Compile `MLIRJit.cpp` with `-fno-rtti` so it does not reference the missing typeinfo. This mirrors the existing per-TU pattern already used for `EmitDbgValuePass.cpp` in `nautilus/src/nautilus/compiler/backends/mlir/debug/CMakeLists.txt` (which subclasses `mlir::Pass`, also built `-fno-rtti`).

A blanket `-fno-rtti` for the whole library is not viable because `val_concepts.hpp` uses `typeid` in the `is_val` concept used by `Engine.hpp`.

## Verification

- Fresh Debug build (`/usr/bin/clang++`, `cmake-build-debug`) now links `nautilus-execution-tests` successfully.
- Full Debug ctest run: 378/379 passed; the 1 failure (`Debug info: per-block DILexicalBlock scoping...`) is a pre-existing flaky test that passes in isolation and under repeated re-runs — unrelated to this change.
- Release build still links cleanly.
- The fix also resolves the existing `cmake-build-debug` after reconfiguration.