### PR TITLE
Make LLVM IR generation deterministic across hosts

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/mlir/LLVMIROptimizer.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/LLVMIROptimizer.cpp
@@ -38,8 +38,22 @@ std::function<llvm::Error(llvm::Module*)> LLVMIROptimizer::getLLVMOptimizerPipel
 		// Currently, we do not increase the sizeLevel requirement of the
 		// optimizingTransformer beyond 0.
 		constexpr int SIZE_LEVEL = 0;
-		// Create A target-specific target machine for the host
+		// Create A target-specific target machine for the host. The `mlir.targetCpu`
+		// option pins the CPU (and drops the host feature set) so IR-generation and
+		// optimization decisions — most visibly the LLVM loop vectorizer's width —
+		// are deterministic across machines. This is what the LLVM IR reference
+		// tests rely on; without the pin, a runner with AVX-512 vectorizes wider
+		// than one without, so the generated IR differs run to run.
 		auto tmBuilderOrError = llvm::orc::JITTargetMachineBuilder::detectHost();
+		const std::string pinnedCpu = options.getOptionOrDefault<std::string>("mlir.targetCpu", "");
+		if (!pinnedCpu.empty()) {
+			tmBuilderOrError->setCPU(pinnedCpu);
+			// Pin an explicit baseline feature set (rather than leaving the
+			// host's) so TTI-driven decisions are deterministic. A non-empty
+			// feature string also keeps the reference-IR normalizer's
+			// target-features stripping effective.
+			tmBuilderOrError->setFeatures("+64bit,+sse2");
+		}
 		auto targetMachine = tmBuilderOrError->createTargetMachine();
 		llvm::TargetMachine* targetMachinePtr = targetMachine->get();
 		// With debug info active, lower the codegen opt level to `Less`

--- a/nautilus/test/llvm-ir-test/LLVMIRTestUtil.hpp
+++ b/nautilus/test/llvm-ir-test/LLVMIRTestUtil.hpp
@@ -44,6 +44,12 @@ void testLLVMIR(const std::string& functionName, Func func, bool enableIntrinsic
 	options.setOption("dump.path", dumpPath);
 	options.setOption("engine.normalizeFunctionNames", true);
 	options.setOption("mlir.enableIntrinsics", enableIntrinsics);
+	// Pin a fixed target CPU (and drop the host feature set) so the LLVM loop
+	// vectorizer and other TTI-driven transforms produce the same IR on every
+	// machine. detectHost() would otherwise make the generated IR depend on
+	// whether the runner happens to have AVX-512 (see LLVMIROptimizer.cpp),
+	// making these reference tests flaky across heterogeneous CI runners.
+	options.setOption("mlir.targetCpu", "x86-64");
 
 	if (extraOptions) {
 		extraOptions(options);

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyBytesFunction_with_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyBytesFunction_with_intrinsics.ll
@@ -18,7 +18,7 @@ define ptr @_mlir_ciface_execute(ptr returned writeonly %0, ptr readonly %1, i64
 ; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memmove.p0.p0.i64(ptr writeonly, ptr readonly, i64, i1 immarg) #1
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -35,7 +35,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -54,7 +54,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 
 attributes #0 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) }
 attributes #1 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { mustprogress nofree norecurse nounwind willreturn }
+attributes #2 = { mustprogress nofree norecurse nounwind willreturn memory(readwrite) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyBytesFunction_without_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyBytesFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define ptr @execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
 }
 
-; Function Attrs: memory(readwrite)
 define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
@@ -18,7 +16,7 @@ define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare ptr @runtimeFunc0(ptr, ptr, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyFunction_with_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyFunction_with_intrinsics.ll
@@ -18,7 +18,7 @@ define ptr @_mlir_ciface_execute(ptr returned writeonly %0, ptr readonly %1, i64
 ; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memmove.p0.p0.i64(ptr writeonly, ptr readonly, i64, i1 immarg) #1
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -35,7 +35,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -54,7 +54,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 
 attributes #0 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) }
 attributes #1 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { mustprogress nofree norecurse nounwind willreturn }
+attributes #2 = { mustprogress nofree norecurse nounwind willreturn memory(readwrite) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyFunction_without_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memcpyFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define ptr @execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
 }
 
-; Function Attrs: memory(readwrite)
 define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
@@ -18,7 +16,7 @@ define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare ptr @runtimeFunc0(ptr, ptr, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveFunction_with_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveFunction_with_intrinsics.ll
@@ -18,7 +18,7 @@ define ptr @_mlir_ciface_execute(ptr returned writeonly %0, ptr readonly %1, i64
 ; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memmove.p0.p0.i64(ptr writeonly, ptr readonly, i64, i1 immarg) #1
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -35,7 +35,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -54,7 +54,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 
 attributes #0 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) }
 attributes #1 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { mustprogress nofree norecurse nounwind willreturn }
+attributes #2 = { mustprogress nofree norecurse nounwind willreturn memory(readwrite) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveFunction_without_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define ptr @execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
 }
 
-; Function Attrs: memory(readwrite)
 define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
@@ -18,7 +16,7 @@ define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare ptr @runtimeFunc0(ptr, ptr, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveOverlapFunction_with_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveOverlapFunction_with_intrinsics.ll
@@ -18,7 +18,7 @@ define ptr @_mlir_ciface_execute(ptr returned writeonly %0, ptr readonly %1, i64
 ; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memmove.p0.p0.i64(ptr writeonly, ptr readonly, i64, i1 immarg) #1
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -35,7 +35,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -54,7 +54,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 
 attributes #0 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) }
 attributes #1 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { mustprogress nofree norecurse nounwind willreturn }
+attributes #2 = { mustprogress nofree norecurse nounwind willreturn memory(readwrite) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveOverlapFunction_without_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memmoveOverlapFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define ptr @execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
 }
 
-; Function Attrs: memory(readwrite)
 define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, ptr %1, i64 %2)
   ret ptr %4
@@ -18,7 +16,7 @@ define ptr @_mlir_ciface_execute(ptr %0, ptr %1, i64 %2) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare ptr @runtimeFunc0(ptr, ptr, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memsetFunction_with_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memsetFunction_with_intrinsics.ll
@@ -20,7 +20,7 @@ define ptr @_mlir_ciface_execute(ptr returned writeonly %0, i32 %1, i64 %2) loca
 ; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr writeonly, i8, i64, i1 immarg) #1
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -38,7 +38,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -58,7 +58,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 
 attributes #0 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: write, inaccessiblemem: readwrite) }
 attributes #1 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { mustprogress nofree norecurse nounwind willreturn }
+attributes #2 = { mustprogress nofree norecurse nounwind willreturn memory(readwrite) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memsetFunction_without_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memsetFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define ptr @execute(ptr %0, i32 %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, i32 %1, i64 %2)
   ret ptr %4
 }
 
-; Function Attrs: memory(readwrite)
 define ptr @_mlir_ciface_execute(ptr %0, i32 %1, i64 %2) local_unnamed_addr #0 {
   %4 = tail call ptr @runtimeFunc0(ptr %0, i32 %1, i64 %2)
   ret ptr %4
@@ -18,7 +16,7 @@ define ptr @_mlir_ciface_execute(ptr %0, i32 %1, i64 %2) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare ptr @runtimeFunc0(ptr, i32, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memsetZeroFunction_with_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memsetZeroFunction_with_intrinsics.ll
@@ -18,7 +18,7 @@ define ptr @_mlir_ciface_execute(ptr returned writeonly %0, i64 %1) local_unname
 ; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr writeonly, i8, i64, i1 immarg) #1
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -32,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(readwrite)
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
@@ -48,7 +48,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 
 attributes #0 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: write, inaccessiblemem: readwrite) }
 attributes #1 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { mustprogress nofree norecurse nounwind willreturn }
+attributes #2 = { mustprogress nofree norecurse nounwind willreturn memory(readwrite) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/intrinsic-ir/memsetZeroFunction_without_intrinsics.ll
+++ b/nautilus/test/llvm-ir-test/intrinsic-ir/memsetZeroFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define ptr @execute(ptr %0, i64 %1) local_unnamed_addr #0 {
   %3 = tail call ptr @runtimeFunc0(ptr %0, i32 0, i64 %1)
   ret ptr %3
 }
 
-; Function Attrs: memory(readwrite)
 define ptr @_mlir_ciface_execute(ptr %0, i64 %1) local_unnamed_addr #0 {
   %3 = tail call ptr @runtimeFunc0(ptr %0, i32 0, i64 %1)
   ret ptr %3
@@ -18,7 +16,7 @@ define ptr @_mlir_ciface_execute(ptr %0, i64 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare ptr @runtimeFunc0(ptr, i32, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/andCondition.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/andCondition.ll
@@ -8,8 +8,8 @@ define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp eq i32 %0, 8
   %4 = icmp eq i32 %1, 1
   %5 = and i1 %3, %4
-  %spec.select = select i1 %5, i32 15, i32 1
-  ret i32 %spec.select
+  %6 = select i1 %5, i32 15, i32 1
+  ret i32 %6
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
@@ -17,8 +17,8 @@ define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp eq i32 %0, 8
   %4 = icmp eq i32 %1, 1
   %5 = and i1 %3, %4
-  %spec.select.i = select i1 %5, i32 15, i32 1
-  ret i32 %spec.select.i
+  %6 = select i1 %5, i32 15, i32 1
+  ret i32 %6
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = icmp eq i32 %3, 8
   %8 = icmp eq i32 %6, 1
   %9 = and i1 %7, %8
-  %spec.select.i = select i1 %9, i32 15, i32 1
-  %10 = getelementptr i8, ptr %0, i64 16
-  %11 = load ptr, ptr %10, align 8
-  store i32 %spec.select.i, ptr %11, align 4
+  %10 = select i1 %9, i32 15, i32 1
+  %11 = getelementptr i8, ptr %0, i64 16
+  %12 = load ptr, ptr %11, align 8
+  store i32 %10, ptr %12, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = icmp eq i32 %3, 8
   %8 = icmp eq i32 %6, 1
   %9 = and i1 %7, %8
-  %spec.select.i.i = select i1 %9, i32 15, i32 1
-  %10 = getelementptr i8, ptr %0, i64 16
-  %11 = load ptr, ptr %10, align 8
-  store i32 %spec.select.i.i, ptr %11, align 4
+  %10 = select i1 %9, i32 15, i32 1
+  %11 = getelementptr i8, ptr %0, i64 16
+  %12 = load ptr, ptr %11, align 8
+  store i32 %10, ptr %12, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/callCountFuncCall.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/callCountFuncCall.ll
@@ -3,22 +3,20 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i1 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i1 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i1 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i1 %0)
   ret i32 %2
 }
 
 ; Function Attrs: memory(readwrite)
-declare i32 @runtimeFunc0(i1) local_unnamed_addr #1
+declare i32 @runtimeFunc0(i1 zeroext) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i1, ptr %2, align 1
   %4 = tail call i32 @runtimeFunc0(i1 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i1, ptr %2, align 1
   %4 = tail call i32 @runtimeFunc0(i1 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/callEnumClassFunction.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/callEnumClassFunction.ll
@@ -3,22 +3,20 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i8 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i8 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i8 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i8 %0)
   ret i32 %2
 }
 
 ; Function Attrs: memory(readwrite)
-declare i32 @runtimeFunc0(i8) local_unnamed_addr #1
+declare i32 @runtimeFunc0(i8 zeroext) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i8, ptr %2, align 1
   %4 = tail call i32 @runtimeFunc0(i8 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i8, ptr %2, align 1
   %4 = tail call i32 @runtimeFunc0(i8 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/callEnumFunction.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/callEnumFunction.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/callSameFunction.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/callSameFunction.ll
@@ -3,14 +3,12 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0, i32 %0)
   %3 = tail call i32 @runtimeFunc0(i32 %2, i32 %2)
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0, i32 %0)
   %3 = tail call i32 @runtimeFunc0(i32 %2, i32 %2)
@@ -20,7 +18,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3, i32 %3)
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3, i32 %3)
@@ -42,7 +40,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/callTwoFunctions.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/callTwoFunctions.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   %4 = tail call i32 @runtimeFunc1(i32 %0, i32 %1)
@@ -11,7 +10,6 @@ define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   ret i32 %5
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   %4 = tail call i32 @runtimeFunc1(i32 %0, i32 %1)
@@ -25,7 +23,7 @@ declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc1(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -40,7 +38,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -55,7 +53,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/castCustomClass.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/castCustomClass.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(ptr) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/compoundAssignment.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/compoundAssignment.ll
@@ -6,15 +6,15 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 5
-  %spec.select = select i1 %2, i32 15, i32 10
-  ret i32 %spec.select
+  %3 = select i1 %2, i32 15, i32 10
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 5
-  %spec.select.i = select i1 %2, i32 15, i32 10
-  ret i32 %spec.select.i
+  %3 = select i1 %2, i32 15, i32 10
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -22,10 +22,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 5
-  %spec.select.i = select i1 %4, i32 15, i32 10
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %spec.select.i, ptr %6, align 4
+  %5 = select i1 %4, i32 15, i32 10
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 
@@ -34,10 +34,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 5
-  %spec.select.i.i = select i1 %4, i32 15, i32 10
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %spec.select.i.i, ptr %6, align 4
+  %5 = select i1 %4, i32 15, i32 10
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/compoundStatements.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/compoundStatements.ll
@@ -6,15 +6,15 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 5
-  %spec.select = select i1 %2, i32 2, i32 0
-  ret i32 %spec.select
+  %3 = select i1 %2, i32 2, i32 0
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 5
-  %spec.select.i = select i1 %2, i32 2, i32 0
-  ret i32 %spec.select.i
+  %3 = select i1 %2, i32 2, i32 0
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -22,10 +22,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 5
-  %spec.select.i = select i1 %4, i32 2, i32 0
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %spec.select.i, ptr %6, align 4
+  %5 = select i1 %4, i32 2, i32 0
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 
@@ -34,10 +34,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 5
-  %spec.select.i.i = select i1 %4, i32 2, i32 0
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %spec.select.i.i, ptr %6, align 4
+  %5 = select i1 %4, i32 2, i32 0
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/directCallComplexFunction.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/directCallComplexFunction.ll
@@ -3,14 +3,12 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call double @runtimeFunc0(i32 %0, i32 %1)
   %4 = fptosi double %3 to i32
   ret i32 %4
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call double @runtimeFunc0(i32 %0, i32 %1)
   %4 = fptosi double %3 to i32
@@ -20,7 +18,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare double @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -48,7 +46,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/directCallWithNestedCalls.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/directCallWithNestedCalls.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/dynCastCall.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/dynCastCall.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(ptr) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/factorial.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/factorial.ll
@@ -6,200 +6,110 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 1
-  br i1 %2, label %iter.check, label %._crit_edge
+  br i1 %2, label %.lr.ph.preheader, label %._crit_edge
 
-iter.check:                                       ; preds = %1
+.lr.ph.preheader:                                 ; preds = %1
   %3 = add nsw i32 %0, -1
-  %min.iters.check = icmp ult i32 %0, 5
-  br i1 %min.iters.check, label %.lr.ph.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %0, 9
+  br i1 %min.iters.check, label %.lr.ph.preheader5, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check4 = icmp ult i32 %0, 33
-  br i1 %min.iters.check4, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, -32
+vector.ph:                                        ; preds = %.lr.ph.preheader
+  %n.vec = and i32 %3, -8
   %4 = sub i32 %0, %n.vec
-  %broadcast.splatinsert = insertelement <8 x i32> poison, i32 %0, i64 0
-  %broadcast.splat = shufflevector <8 x i32> %broadcast.splatinsert, <8 x i32> poison, <8 x i32> zeroinitializer
-  %induction = add nsw <8 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3, i32 -4, i32 -5, i32 -6, i32 -7>
+  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %0, i64 0
+  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
+  %induction = add nsw <4 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3>
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %5, %vector.body ]
-  %vec.phi5 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %6, %vector.body ]
-  %vec.phi6 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %7, %vector.body ]
-  %vec.phi7 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %8, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 -8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 -16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 -24)
-  %5 = mul <8 x i32> %vec.ind, %vec.phi
-  %6 = mul <8 x i32> %step.add, %vec.phi5
-  %7 = mul <8 x i32> %step.add.2, %vec.phi6
-  %8 = mul <8 x i32> %step.add.3, %vec.phi7
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 -32)
-  %9 = icmp eq i32 %index.next, %n.vec
-  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !1
+  %vec.ind = phi <4 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %5, %vector.body ]
+  %vec.phi4 = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %6, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 -4)
+  %5 = mul <4 x i32> %vec.ind, %vec.phi
+  %6 = mul <4 x i32> %step.add, %vec.phi4
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 -8)
+  %7 = icmp eq i32 %index.next, %n.vec
+  br i1 %7, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = mul <8 x i32> %6, %5
-  %bin.rdx8 = mul <8 x i32> %7, %bin.rdx
-  %bin.rdx9 = mul <8 x i32> %8, %bin.rdx8
-  %10 = tail call i32 @llvm.vector.reduce.mul.v8i32(<8 x i32> %bin.rdx9)
+  %bin.rdx = mul <4 x i32> %6, %5
+  %8 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader5
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = sub i32 %0, %n.vec
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %4, %vec.epilog.iter.check ], [ %0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %10, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %n.vec11 = and i32 %3, -4
-  %11 = sub i32 %0, %n.vec11
-  %12 = insertelement <4 x i32> <i32 poison, i32 1, i32 1, i32 1>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert12 = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat13 = shufflevector <4 x i32> %broadcast.splatinsert12, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction14 = add nsw <4 x i32> %broadcast.splat13, <i32 0, i32 -1, i32 -2, i32 -3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index15 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next18, %vec.epilog.vector.body ]
-  %vec.ind16 = phi <4 x i32> [ %induction14, %vec.epilog.ph ], [ %vec.ind.next19, %vec.epilog.vector.body ]
-  %vec.phi17 = phi <4 x i32> [ %12, %vec.epilog.ph ], [ %13, %vec.epilog.vector.body ]
-  %13 = mul <4 x i32> %vec.ind16, %vec.phi17
-  %index.next18 = add nuw i32 %index15, 4
-  %vec.ind.next19 = add nsw <4 x i32> %vec.ind16, splat (i32 -4)
-  %14 = icmp eq i32 %index.next18, %n.vec11
-  br i1 %14, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !5
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %15 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %13)
-  %cmp.n20 = icmp eq i32 %3, %n.vec11
-  br i1 %cmp.n20, label %._crit_edge, label %.lr.ph.preheader
-
-.lr.ph.preheader:                                 ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ %0, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %11, %vec.epilog.middle.block ]
-  %.ph23 = phi i32 [ 1, %iter.check ], [ %10, %vec.epilog.iter.check ], [ %15, %vec.epilog.middle.block ]
+.lr.ph.preheader5:                                ; preds = %.lr.ph.preheader, %middle.block
+  %.ph = phi i32 [ %0, %.lr.ph.preheader ], [ %4, %middle.block ]
+  %.ph6 = phi i32 [ 1, %.lr.ph.preheader ], [ %8, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader, %.lr.ph
-  %16 = phi i32 [ %19, %.lr.ph ], [ %.ph, %.lr.ph.preheader ]
-  %17 = phi i32 [ %18, %.lr.ph ], [ %.ph23, %.lr.ph.preheader ]
-  %18 = mul i32 %16, %17
-  %19 = add nsw i32 %16, -1
-  %20 = icmp samesign ugt i32 %16, 2
-  br i1 %20, label %.lr.ph, label %._crit_edge, !llvm.loop !6
+.lr.ph:                                           ; preds = %.lr.ph.preheader5, %.lr.ph
+  %9 = phi i32 [ %12, %.lr.ph ], [ %.ph, %.lr.ph.preheader5 ]
+  %10 = phi i32 [ %11, %.lr.ph ], [ %.ph6, %.lr.ph.preheader5 ]
+  %11 = mul i32 %9, %10
+  %12 = add nsw i32 %9, -1
+  %13 = icmp samesign ugt i32 %9, 2
+  br i1 %13, label %.lr.ph, label %._crit_edge, !llvm.loop !4
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa = phi i32 [ 1, %1 ], [ %15, %vec.epilog.middle.block ], [ %10, %middle.block ], [ %18, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %1
+  %.lcssa = phi i32 [ 1, %1 ], [ %8, %middle.block ], [ %11, %.lr.ph ]
   ret i32 %.lcssa
 }
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 1
-  br i1 %2, label %iter.check, label %execute.exit
+  br i1 %2, label %.lr.ph.i.preheader, label %execute.exit
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.preheader:                               ; preds = %1
   %3 = add nsw i32 %0, -1
-  %min.iters.check = icmp ult i32 %0, 5
-  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %0, 9
+  br i1 %min.iters.check, label %.lr.ph.i.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %0, 33
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, -32
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %3, -8
   %4 = sub i32 %0, %n.vec
-  %broadcast.splatinsert = insertelement <8 x i32> poison, i32 %0, i64 0
-  %broadcast.splat = shufflevector <8 x i32> %broadcast.splatinsert, <8 x i32> poison, <8 x i32> zeroinitializer
-  %induction = add nsw <8 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3, i32 -4, i32 -5, i32 -6, i32 -7>
+  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %0, i64 0
+  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
+  %induction = add nsw <4 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3>
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %5, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %6, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %7, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %8, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 -8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 -16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 -24)
-  %5 = mul <8 x i32> %vec.phi, %vec.ind
-  %6 = mul <8 x i32> %vec.phi2, %step.add
-  %7 = mul <8 x i32> %vec.phi3, %step.add.2
-  %8 = mul <8 x i32> %vec.phi4, %step.add.3
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 -32)
-  %9 = icmp eq i32 %index.next, %n.vec
-  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !7
+  %vec.ind = phi <4 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %5, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %6, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 -4)
+  %5 = mul <4 x i32> %vec.phi, %vec.ind
+  %6 = mul <4 x i32> %vec.phi1, %step.add
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 -8)
+  %7 = icmp eq i32 %index.next, %n.vec
+  br i1 %7, label %middle.block, label %vector.body, !llvm.loop !5
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = mul <8 x i32> %6, %5
-  %bin.rdx5 = mul <8 x i32> %7, %bin.rdx
-  %bin.rdx6 = mul <8 x i32> %8, %bin.rdx5
-  %10 = tail call i32 @llvm.vector.reduce.mul.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = mul <4 x i32> %6, %5
+  %8 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = sub i32 %0, %n.vec
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %4, %vec.epilog.iter.check ], [ %0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %10, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, -4
-  %11 = sub i32 %0, %n.vec8
-  %12 = insertelement <4 x i32> <i32 poison, i32 1, i32 1, i32 1>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert9 = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat10 = shufflevector <4 x i32> %broadcast.splatinsert9, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction11 = add nsw <4 x i32> %broadcast.splat10, <i32 0, i32 -1, i32 -2, i32 -3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index12 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next15, %vec.epilog.vector.body ]
-  %vec.ind13 = phi <4 x i32> [ %induction11, %vec.epilog.ph ], [ %vec.ind.next16, %vec.epilog.vector.body ]
-  %vec.phi14 = phi <4 x i32> [ %12, %vec.epilog.ph ], [ %13, %vec.epilog.vector.body ]
-  %13 = mul <4 x i32> %vec.phi14, %vec.ind13
-  %index.next15 = add nuw i32 %index12, 4
-  %vec.ind.next16 = add nsw <4 x i32> %vec.ind13, splat (i32 -4)
-  %14 = icmp eq i32 %index.next15, %n.vec8
-  br i1 %14, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !8
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %15 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %13)
-  %cmp.n17 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n17, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ %0, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %11, %vec.epilog.middle.block ]
-  %.ph20 = phi i32 [ 1, %iter.check ], [ %10, %vec.epilog.iter.check ], [ %15, %vec.epilog.middle.block ]
+.lr.ph.i.preheader2:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ %0, %.lr.ph.i.preheader ], [ %4, %middle.block ]
+  %.ph3 = phi i32 [ 1, %.lr.ph.i.preheader ], [ %8, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %16 = phi i32 [ %19, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %17 = phi i32 [ %18, %.lr.ph.i ], [ %.ph20, %.lr.ph.i.preheader ]
-  %18 = mul i32 %17, %16
-  %19 = add nsw i32 %16, -1
-  %20 = icmp samesign ugt i32 %16, 2
-  br i1 %20, label %.lr.ph.i, label %execute.exit, !llvm.loop !9
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader2, %.lr.ph.i
+  %9 = phi i32 [ %12, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader2 ]
+  %10 = phi i32 [ %11, %.lr.ph.i ], [ %.ph3, %.lr.ph.i.preheader2 ]
+  %11 = mul i32 %10, %9
+  %12 = add nsw i32 %9, -1
+  %13 = icmp samesign ugt i32 %9, 2
+  br i1 %13, label %.lr.ph.i, label %execute.exit, !llvm.loop !6
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 1, %1 ], [ %15, %vec.epilog.middle.block ], [ %10, %middle.block ], [ %18, %.lr.ph.i ]
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 1, %1 ], [ %8, %middle.block ], [ %11, %.lr.ph.i ]
   ret i32 %.lcssa.i
 }
 
@@ -208,103 +118,58 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 1
-  br i1 %4, label %iter.check, label %execute.exit
+  br i1 %4, label %.lr.ph.i.preheader, label %execute.exit
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.preheader:                               ; preds = %1
   %5 = add nsw i32 %3, -1
-  %min.iters.check = icmp ult i32 %3, 5
-  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %3, 9
+  br i1 %min.iters.check, label %.lr.ph.i.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 33
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %5, 28
-  %n.vec = and i32 %5, -32
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %5, -8
   %6 = sub i32 %3, %n.vec
-  %broadcast.splatinsert = insertelement <8 x i32> poison, i32 %3, i64 0
-  %broadcast.splat = shufflevector <8 x i32> %broadcast.splatinsert, <8 x i32> poison, <8 x i32> zeroinitializer
-  %induction = add nsw <8 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3, i32 -4, i32 -5, i32 -6, i32 -7>
+  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %3, i64 0
+  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
+  %induction = add nsw <4 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3>
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %7, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %8, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %9, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %10, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 -8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 -16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 -24)
-  %7 = mul <8 x i32> %vec.phi, %vec.ind
-  %8 = mul <8 x i32> %vec.phi2, %step.add
-  %9 = mul <8 x i32> %vec.phi3, %step.add.2
-  %10 = mul <8 x i32> %vec.phi4, %step.add.3
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 -32)
-  %11 = icmp eq i32 %index.next, %n.vec
-  br i1 %11, label %middle.block, label %vector.body, !llvm.loop !10
+  %vec.ind = phi <4 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %7, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %8, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 -4)
+  %7 = mul <4 x i32> %vec.phi, %vec.ind
+  %8 = mul <4 x i32> %vec.phi1, %step.add
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 -8)
+  %9 = icmp eq i32 %index.next, %n.vec
+  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !7
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = mul <8 x i32> %8, %7
-  %bin.rdx5 = mul <8 x i32> %9, %bin.rdx
-  %bin.rdx6 = mul <8 x i32> %10, %bin.rdx5
-  %12 = tail call i32 @llvm.vector.reduce.mul.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = mul <4 x i32> %8, %7
+  %10 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %5, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = sub i32 %3, %n.vec
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %6, %vec.epilog.iter.check ], [ %3, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %12, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %5, -4
-  %13 = sub i32 %3, %n.vec8
-  %14 = insertelement <4 x i32> <i32 poison, i32 1, i32 1, i32 1>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert9 = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat10 = shufflevector <4 x i32> %broadcast.splatinsert9, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction11 = add nsw <4 x i32> %broadcast.splat10, <i32 0, i32 -1, i32 -2, i32 -3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index12 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next15, %vec.epilog.vector.body ]
-  %vec.ind13 = phi <4 x i32> [ %induction11, %vec.epilog.ph ], [ %vec.ind.next16, %vec.epilog.vector.body ]
-  %vec.phi14 = phi <4 x i32> [ %14, %vec.epilog.ph ], [ %15, %vec.epilog.vector.body ]
-  %15 = mul <4 x i32> %vec.phi14, %vec.ind13
-  %index.next15 = add nuw i32 %index12, 4
-  %vec.ind.next16 = add nsw <4 x i32> %vec.ind13, splat (i32 -4)
-  %16 = icmp eq i32 %index.next15, %n.vec8
-  br i1 %16, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !11
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %17 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %15)
-  %cmp.n17 = icmp eq i32 %5, %n.vec8
-  br i1 %cmp.n17, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ %3, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %13, %vec.epilog.middle.block ]
-  %.ph20 = phi i32 [ 1, %iter.check ], [ %12, %vec.epilog.iter.check ], [ %17, %vec.epilog.middle.block ]
+.lr.ph.i.preheader2:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ %3, %.lr.ph.i.preheader ], [ %6, %middle.block ]
+  %.ph3 = phi i32 [ 1, %.lr.ph.i.preheader ], [ %10, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %18 = phi i32 [ %21, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %19 = phi i32 [ %20, %.lr.ph.i ], [ %.ph20, %.lr.ph.i.preheader ]
-  %20 = mul i32 %19, %18
-  %21 = add nsw i32 %18, -1
-  %22 = icmp samesign ugt i32 %18, 2
-  br i1 %22, label %.lr.ph.i, label %execute.exit, !llvm.loop !12
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader2, %.lr.ph.i
+  %11 = phi i32 [ %14, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader2 ]
+  %12 = phi i32 [ %13, %.lr.ph.i ], [ %.ph3, %.lr.ph.i.preheader2 ]
+  %13 = mul i32 %12, %11
+  %14 = add nsw i32 %11, -1
+  %15 = icmp samesign ugt i32 %11, 2
+  br i1 %15, label %.lr.ph.i, label %execute.exit, !llvm.loop !8
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 1, %1 ], [ %17, %vec.epilog.middle.block ], [ %12, %middle.block ], [ %20, %.lr.ph.i ]
-  %23 = getelementptr i8, ptr %0, i64 8
-  %24 = load ptr, ptr %23, align 8
-  store i32 %.lcssa.i, ptr %24, align 4
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 1, %1 ], [ %10, %middle.block ], [ %13, %.lr.ph.i ]
+  %16 = getelementptr i8, ptr %0, i64 8
+  %17 = load ptr, ptr %16, align 8
+  store i32 %.lcssa.i, ptr %17, align 4
   ret void
 }
 
@@ -313,108 +178,60 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 1
-  br i1 %4, label %iter.check, label %_mlir_ciface_execute.exit
+  br i1 %4, label %.lr.ph.i.i.preheader, label %_mlir_ciface_execute.exit
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.i.preheader:                             ; preds = %1
   %5 = add nsw i32 %3, -1
-  %min.iters.check = icmp ult i32 %3, 5
-  br i1 %min.iters.check, label %.lr.ph.i.i.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %3, 9
+  br i1 %min.iters.check, label %.lr.ph.i.i.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 33
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %5, 28
-  %n.vec = and i32 %5, -32
+vector.ph:                                        ; preds = %.lr.ph.i.i.preheader
+  %n.vec = and i32 %5, -8
   %6 = sub i32 %3, %n.vec
-  %broadcast.splatinsert = insertelement <8 x i32> poison, i32 %3, i64 0
-  %broadcast.splat = shufflevector <8 x i32> %broadcast.splatinsert, <8 x i32> poison, <8 x i32> zeroinitializer
-  %induction = add nsw <8 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3, i32 -4, i32 -5, i32 -6, i32 -7>
+  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %3, i64 0
+  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
+  %induction = add nsw <4 x i32> %broadcast.splat, <i32 0, i32 -1, i32 -2, i32 -3>
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %7, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %8, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %9, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ splat (i32 1), %vector.ph ], [ %10, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 -8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 -16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 -24)
-  %7 = mul <8 x i32> %vec.phi, %vec.ind
-  %8 = mul <8 x i32> %vec.phi2, %step.add
-  %9 = mul <8 x i32> %vec.phi3, %step.add.2
-  %10 = mul <8 x i32> %vec.phi4, %step.add.3
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 -32)
-  %11 = icmp eq i32 %index.next, %n.vec
-  br i1 %11, label %middle.block, label %vector.body, !llvm.loop !13
+  %vec.ind = phi <4 x i32> [ %induction, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %7, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ splat (i32 1), %vector.ph ], [ %8, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 -4)
+  %7 = mul <4 x i32> %vec.phi, %vec.ind
+  %8 = mul <4 x i32> %vec.phi1, %step.add
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 -8)
+  %9 = icmp eq i32 %index.next, %n.vec
+  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !9
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = mul <8 x i32> %8, %7
-  %bin.rdx5 = mul <8 x i32> %9, %bin.rdx
-  %bin.rdx6 = mul <8 x i32> %10, %bin.rdx5
-  %12 = tail call i32 @llvm.vector.reduce.mul.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = mul <4 x i32> %8, %7
+  %10 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %5, %n.vec
-  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = sub i32 %3, %n.vec
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %6, %vec.epilog.iter.check ], [ %3, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %12, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %5, -4
-  %13 = sub i32 %3, %n.vec8
-  %14 = insertelement <4 x i32> <i32 poison, i32 1, i32 1, i32 1>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert9 = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat10 = shufflevector <4 x i32> %broadcast.splatinsert9, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction11 = add nsw <4 x i32> %broadcast.splat10, <i32 0, i32 -1, i32 -2, i32 -3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index12 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next15, %vec.epilog.vector.body ]
-  %vec.ind13 = phi <4 x i32> [ %induction11, %vec.epilog.ph ], [ %vec.ind.next16, %vec.epilog.vector.body ]
-  %vec.phi14 = phi <4 x i32> [ %14, %vec.epilog.ph ], [ %15, %vec.epilog.vector.body ]
-  %15 = mul <4 x i32> %vec.phi14, %vec.ind13
-  %index.next15 = add nuw i32 %index12, 4
-  %vec.ind.next16 = add nsw <4 x i32> %vec.ind13, splat (i32 -4)
-  %16 = icmp eq i32 %index.next15, %n.vec8
-  br i1 %16, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !14
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %17 = tail call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %15)
-  %cmp.n17 = icmp eq i32 %5, %n.vec8
-  br i1 %cmp.n17, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
-
-.lr.ph.i.i.preheader:                             ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ %3, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %13, %vec.epilog.middle.block ]
-  %.ph20 = phi i32 [ 1, %iter.check ], [ %12, %vec.epilog.iter.check ], [ %17, %vec.epilog.middle.block ]
+.lr.ph.i.i.preheader2:                            ; preds = %.lr.ph.i.i.preheader, %middle.block
+  %.ph = phi i32 [ %3, %.lr.ph.i.i.preheader ], [ %6, %middle.block ]
+  %.ph3 = phi i32 [ 1, %.lr.ph.i.i.preheader ], [ %10, %middle.block ]
   br label %.lr.ph.i.i
 
-.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader, %.lr.ph.i.i
-  %18 = phi i32 [ %21, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader ]
-  %19 = phi i32 [ %20, %.lr.ph.i.i ], [ %.ph20, %.lr.ph.i.i.preheader ]
-  %20 = mul i32 %19, %18
-  %21 = add nsw i32 %18, -1
-  %22 = icmp samesign ugt i32 %18, 2
-  br i1 %22, label %.lr.ph.i.i, label %_mlir_ciface_execute.exit, !llvm.loop !15
+.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader2, %.lr.ph.i.i
+  %11 = phi i32 [ %14, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader2 ]
+  %12 = phi i32 [ %13, %.lr.ph.i.i ], [ %.ph3, %.lr.ph.i.i.preheader2 ]
+  %13 = mul i32 %12, %11
+  %14 = add nsw i32 %11, -1
+  %15 = icmp samesign ugt i32 %11, 2
+  br i1 %15, label %.lr.ph.i.i, label %_mlir_ciface_execute.exit, !llvm.loop !10
 
-_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i.i = phi i32 [ 1, %1 ], [ %17, %vec.epilog.middle.block ], [ %12, %middle.block ], [ %20, %.lr.ph.i.i ]
-  %23 = getelementptr i8, ptr %0, i64 8
-  %24 = load ptr, ptr %23, align 8
-  store i32 %.lcssa.i.i, ptr %24, align 4
+_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %1
+  %.lcssa.i.i = phi i32 [ 1, %1 ], [ %10, %middle.block ], [ %13, %.lr.ph.i.i ]
+  %16 = getelementptr i8, ptr %0, i64 8
+  %17 = load ptr, ptr %16, align 8
+  store i32 %.lcssa.i.i, ptr %17, align 4
   ret void
 }
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.mul.v8i32(<8 x i32>) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.mul.v4i32(<4 x i32>) #2
@@ -429,15 +246,10 @@ attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !1 = distinct !{!1, !2, !3}
 !2 = !{!"llvm.loop.isvectorized", i32 1}
 !3 = !{!"llvm.loop.unroll.runtime.disable"}
-!4 = !{!"branch_weights", i32 4, i32 28}
+!4 = distinct !{!4, !3, !2}
 !5 = distinct !{!5, !2, !3}
 !6 = distinct !{!6, !3, !2}
 !7 = distinct !{!7, !2, !3}
-!8 = distinct !{!8, !2, !3}
-!9 = distinct !{!9, !3, !2}
-!10 = distinct !{!10, !2, !3}
-!11 = distinct !{!11, !2, !3}
-!12 = distinct !{!12, !3, !2}
-!13 = distinct !{!13, !2, !3}
-!14 = distinct !{!14, !2, !3}
-!15 = distinct !{!15, !3, !2}
+!8 = distinct !{!8, !3, !2}
+!9 = distinct !{!9, !2, !3}
+!10 = distinct !{!10, !3, !2}

--- a/nautilus/test/llvm-ir-test/reference-ir/fibonacci.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/fibonacci.ll
@@ -5,8 +5,8 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
-  %.not2 = icmp slt i32 %0, 2
-  br i1 %.not2, label %._crit_edge, label %.lr.ph
+  %.not1 = icmp slt i32 %0, 2
+  br i1 %.not1, label %._crit_edge, label %.lr.ph
 
 .lr.ph:                                           ; preds = %1, %.lr.ph
   %2 = phi i32 [ %4, %.lr.ph ], [ 0, %1 ]
@@ -24,8 +24,8 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
-  %.not2.i = icmp slt i32 %0, 2
-  br i1 %.not2.i, label %execute.exit, label %.lr.ph.i
+  %.not1.i = icmp slt i32 %0, 2
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i
 
 .lr.ph.i:                                         ; preds = %1, %.lr.ph.i
   %2 = phi i32 [ %4, %.lr.ph.i ], [ 0, %1 ]
@@ -45,8 +45,8 @@ execute.exit:                                     ; preds = %.lr.ph.i, %1
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
-  %.not2.i = icmp slt i32 %3, 2
-  br i1 %.not2.i, label %execute.exit, label %.lr.ph.i
+  %.not1.i = icmp slt i32 %3, 2
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i
 
 .lr.ph.i:                                         ; preds = %1, %.lr.ph.i
   %4 = phi i32 [ %6, %.lr.ph.i ], [ 0, %1 ]
@@ -69,8 +69,8 @@ execute.exit:                                     ; preds = %.lr.ph.i, %1
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
-  %.not2.i.i = icmp slt i32 %3, 2
-  br i1 %.not2.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i
+  %.not1.i.i = icmp slt i32 %3, 2
+  br i1 %.not1.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i
 
 .lr.ph.i.i:                                       ; preds = %1, %.lr.ph.i.i
   %4 = phi i32 [ %6, %.lr.ph.i.i ], [ 0, %1 ]

--- a/nautilus/test/llvm-ir-test/reference-ir/ifInsideLoop.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/ifInsideLoop.ll
@@ -6,202 +6,110 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 0
-  br i1 %2, label %iter.check, label %._crit_edge
+  br i1 %2, label %.lr.ph.preheader, label %._crit_edge
 
-iter.check:                                       ; preds = %1
-  %min.iters.check = icmp ult i32 %0, 4
-  br i1 %min.iters.check, label %.lr.ph.preheader, label %vector.main.loop.iter.check
+.lr.ph.preheader:                                 ; preds = %1
+  %min.iters.check = icmp ult i32 %0, 8
+  br i1 %min.iters.check, label %.lr.ph.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %0, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %0, 28
-  %n.vec = and i32 %0, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader
+  %n.vec = and i32 %0, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %14, %vector.body ]
-  %3 = and <8 x i32> %vec.ind, splat (i32 1)
-  %4 = and <8 x i32> %vec.ind, splat (i32 1)
-  %5 = and <8 x i32> %vec.ind, splat (i32 1)
-  %6 = and <8 x i32> %vec.ind, splat (i32 1)
-  %7 = xor <8 x i32> %3, splat (i32 1)
-  %8 = xor <8 x i32> %4, splat (i32 1)
-  %9 = xor <8 x i32> %5, splat (i32 1)
-  %10 = xor <8 x i32> %6, splat (i32 1)
-  %11 = add <8 x i32> %7, %vec.phi
-  %12 = add <8 x i32> %8, %vec.phi2
-  %13 = add <8 x i32> %9, %vec.phi3
-  %14 = add <8 x i32> %10, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %15 = icmp eq i32 %index.next, %n.vec
-  br i1 %15, label %middle.block, label %vector.body, !llvm.loop !1
+  %vec.ind = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
+  %3 = and <4 x i32> %vec.ind, splat (i32 1)
+  %4 = and <4 x i32> %vec.ind, splat (i32 1)
+  %5 = xor <4 x i32> %3, splat (i32 1)
+  %6 = xor <4 x i32> %4, splat (i32 1)
+  %7 = add <4 x i32> %5, %vec.phi
+  %8 = add <4 x i32> %6, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %9 = icmp eq i32 %index.next, %n.vec
+  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %12, %11
-  %bin.rdx5 = add <8 x i32> %13, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %14, %bin.rdx5
-  %16 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %8, %7
+  %10 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %0, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %bc.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %16, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %0, 2147483644
-  %17 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = or disjoint <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %bc.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %17, %vec.epilog.ph ], [ %20, %vec.epilog.vector.body ]
-  %18 = and <4 x i32> %vec.ind10, splat (i32 1)
-  %19 = xor <4 x i32> %18, splat (i32 1)
-  %20 = add <4 x i32> %19, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add nuw nsw <4 x i32> %vec.ind10, splat (i32 4)
-  %21 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %21, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !5
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %22 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %20)
-  %cmp.n14 = icmp eq i32 %0, %n.vec8
-  br i1 %cmp.n14, label %._crit_edge, label %.lr.ph.preheader
-
-.lr.ph.preheader:                                 ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec8, %vec.epilog.middle.block ]
-  %.ph17 = phi i32 [ 0, %iter.check ], [ %16, %vec.epilog.iter.check ], [ %22, %vec.epilog.middle.block ]
+.lr.ph.preheader2:                                ; preds = %.lr.ph.preheader, %middle.block
+  %.ph = phi i32 [ 0, %.lr.ph.preheader ], [ %n.vec, %middle.block ]
+  %.ph3 = phi i32 [ 0, %.lr.ph.preheader ], [ %10, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader, %.lr.ph
-  %23 = phi i32 [ %27, %.lr.ph ], [ %.ph, %.lr.ph.preheader ]
-  %24 = phi i32 [ %spec.select, %.lr.ph ], [ %.ph17, %.lr.ph.preheader ]
-  %25 = and i32 %23, 1
-  %26 = xor i32 %25, 1
-  %spec.select = add i32 %26, %24
-  %27 = add nuw nsw i32 %23, 1
-  %exitcond.not = icmp eq i32 %27, %0
-  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !6
+.lr.ph:                                           ; preds = %.lr.ph.preheader2, %.lr.ph
+  %11 = phi i32 [ %15, %.lr.ph ], [ %.ph, %.lr.ph.preheader2 ]
+  %12 = phi i32 [ %spec.select, %.lr.ph ], [ %.ph3, %.lr.ph.preheader2 ]
+  %13 = and i32 %11, 1
+  %14 = xor i32 %13, 1
+  %spec.select = add i32 %14, %12
+  %15 = add nuw nsw i32 %11, 1
+  %exitcond.not = icmp eq i32 %15, %0
+  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !4
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa = phi i32 [ 0, %1 ], [ %22, %vec.epilog.middle.block ], [ %16, %middle.block ], [ %spec.select, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %1
+  %.lcssa = phi i32 [ 0, %1 ], [ %10, %middle.block ], [ %spec.select, %.lr.ph ]
   ret i32 %.lcssa
 }
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 0
-  br i1 %2, label %iter.check, label %execute.exit
+  br i1 %2, label %.lr.ph.i.preheader, label %execute.exit
 
-iter.check:                                       ; preds = %1
-  %min.iters.check = icmp ult i32 %0, 4
-  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+.lr.ph.i.preheader:                               ; preds = %1
+  %min.iters.check = icmp ult i32 %0, 8
+  br i1 %min.iters.check, label %.lr.ph.i.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %0, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %0, 28
-  %n.vec = and i32 %0, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %0, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %14, %vector.body ]
-  %3 = and <8 x i32> %vec.ind, splat (i32 1)
-  %4 = and <8 x i32> %vec.ind, splat (i32 1)
-  %5 = and <8 x i32> %vec.ind, splat (i32 1)
-  %6 = and <8 x i32> %vec.ind, splat (i32 1)
-  %7 = xor <8 x i32> %3, splat (i32 1)
-  %8 = xor <8 x i32> %4, splat (i32 1)
-  %9 = xor <8 x i32> %5, splat (i32 1)
-  %10 = xor <8 x i32> %6, splat (i32 1)
-  %11 = add <8 x i32> %7, %vec.phi
-  %12 = add <8 x i32> %8, %vec.phi2
-  %13 = add <8 x i32> %9, %vec.phi3
-  %14 = add <8 x i32> %10, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %15 = icmp eq i32 %index.next, %n.vec
-  br i1 %15, label %middle.block, label %vector.body, !llvm.loop !7
+  %vec.ind = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
+  %3 = and <4 x i32> %vec.ind, splat (i32 1)
+  %4 = and <4 x i32> %vec.ind, splat (i32 1)
+  %5 = xor <4 x i32> %3, splat (i32 1)
+  %6 = xor <4 x i32> %4, splat (i32 1)
+  %7 = add <4 x i32> %5, %vec.phi
+  %8 = add <4 x i32> %6, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %9 = icmp eq i32 %index.next, %n.vec
+  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !5
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %12, %11
-  %bin.rdx5 = add <8 x i32> %13, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %14, %bin.rdx5
-  %16 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %8, %7
+  %10 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %0, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %bc.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %16, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %0, 2147483644
-  %17 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = or disjoint <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %bc.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %17, %vec.epilog.ph ], [ %20, %vec.epilog.vector.body ]
-  %18 = and <4 x i32> %vec.ind10, splat (i32 1)
-  %19 = xor <4 x i32> %18, splat (i32 1)
-  %20 = add <4 x i32> %19, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add nuw nsw <4 x i32> %vec.ind10, splat (i32 4)
-  %21 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %21, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !8
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %22 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %20)
-  %cmp.n14 = icmp eq i32 %0, %n.vec8
-  br i1 %cmp.n14, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec8, %vec.epilog.middle.block ]
-  %.ph17 = phi i32 [ 0, %iter.check ], [ %16, %vec.epilog.iter.check ], [ %22, %vec.epilog.middle.block ]
+.lr.ph.i.preheader2:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ 0, %.lr.ph.i.preheader ], [ %n.vec, %middle.block ]
+  %.ph3 = phi i32 [ 0, %.lr.ph.i.preheader ], [ %10, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %23 = phi i32 [ %27, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %24 = phi i32 [ %spec.select.i, %.lr.ph.i ], [ %.ph17, %.lr.ph.i.preheader ]
-  %25 = and i32 %23, 1
-  %26 = xor i32 %25, 1
-  %spec.select.i = add i32 %26, %24
-  %27 = add nuw nsw i32 %23, 1
-  %exitcond.not.i = icmp eq i32 %27, %0
-  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !9
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader2, %.lr.ph.i
+  %11 = phi i32 [ %15, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader2 ]
+  %12 = phi i32 [ %spec.select.i, %.lr.ph.i ], [ %.ph3, %.lr.ph.i.preheader2 ]
+  %13 = and i32 %11, 1
+  %14 = xor i32 %13, 1
+  %spec.select.i = add i32 %14, %12
+  %15 = add nuw nsw i32 %11, 1
+  %exitcond.not.i = icmp eq i32 %15, %0
+  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !6
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %22, %vec.epilog.middle.block ], [ %16, %middle.block ], [ %spec.select.i, %.lr.ph.i ]
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %10, %middle.block ], [ %spec.select.i, %.lr.ph.i ]
   ret i32 %.lcssa.i
 }
 
@@ -210,104 +118,58 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 0
-  br i1 %4, label %iter.check, label %execute.exit
+  br i1 %4, label %.lr.ph.i.preheader, label %execute.exit
 
-iter.check:                                       ; preds = %1
-  %min.iters.check = icmp ult i32 %3, 4
-  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+.lr.ph.i.preheader:                               ; preds = %1
+  %min.iters.check = icmp ult i32 %3, 8
+  br i1 %min.iters.check, label %.lr.ph.i.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %3, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %14, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %15, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %16, %vector.body ]
-  %5 = and <8 x i32> %vec.ind, splat (i32 1)
-  %6 = and <8 x i32> %vec.ind, splat (i32 1)
-  %7 = and <8 x i32> %vec.ind, splat (i32 1)
-  %8 = and <8 x i32> %vec.ind, splat (i32 1)
-  %9 = xor <8 x i32> %5, splat (i32 1)
-  %10 = xor <8 x i32> %6, splat (i32 1)
-  %11 = xor <8 x i32> %7, splat (i32 1)
-  %12 = xor <8 x i32> %8, splat (i32 1)
-  %13 = add <8 x i32> %9, %vec.phi
-  %14 = add <8 x i32> %10, %vec.phi2
-  %15 = add <8 x i32> %11, %vec.phi3
-  %16 = add <8 x i32> %12, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %17 = icmp eq i32 %index.next, %n.vec
-  br i1 %17, label %middle.block, label %vector.body, !llvm.loop !10
+  %vec.ind = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
+  %5 = and <4 x i32> %vec.ind, splat (i32 1)
+  %6 = and <4 x i32> %vec.ind, splat (i32 1)
+  %7 = xor <4 x i32> %5, splat (i32 1)
+  %8 = xor <4 x i32> %6, splat (i32 1)
+  %9 = add <4 x i32> %7, %vec.phi
+  %10 = add <4 x i32> %8, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %11 = icmp eq i32 %index.next, %n.vec
+  br i1 %11, label %middle.block, label %vector.body, !llvm.loop !7
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %14, %13
-  %bin.rdx5 = add <8 x i32> %15, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %16, %bin.rdx5
-  %18 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %10, %9
+  %12 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %bc.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %18, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, 2147483644
-  %19 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = or disjoint <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %bc.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %19, %vec.epilog.ph ], [ %22, %vec.epilog.vector.body ]
-  %20 = and <4 x i32> %vec.ind10, splat (i32 1)
-  %21 = xor <4 x i32> %20, splat (i32 1)
-  %22 = add <4 x i32> %21, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add nuw nsw <4 x i32> %vec.ind10, splat (i32 4)
-  %23 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %23, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !11
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %24 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %22)
-  %cmp.n14 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n14, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec8, %vec.epilog.middle.block ]
-  %.ph17 = phi i32 [ 0, %iter.check ], [ %18, %vec.epilog.iter.check ], [ %24, %vec.epilog.middle.block ]
+.lr.ph.i.preheader2:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ 0, %.lr.ph.i.preheader ], [ %n.vec, %middle.block ]
+  %.ph3 = phi i32 [ 0, %.lr.ph.i.preheader ], [ %12, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %25 = phi i32 [ %29, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %26 = phi i32 [ %spec.select.i, %.lr.ph.i ], [ %.ph17, %.lr.ph.i.preheader ]
-  %27 = and i32 %25, 1
-  %28 = xor i32 %27, 1
-  %spec.select.i = add i32 %28, %26
-  %29 = add nuw nsw i32 %25, 1
-  %exitcond.not.i = icmp eq i32 %29, %3
-  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !12
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader2, %.lr.ph.i
+  %13 = phi i32 [ %17, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader2 ]
+  %14 = phi i32 [ %spec.select.i, %.lr.ph.i ], [ %.ph3, %.lr.ph.i.preheader2 ]
+  %15 = and i32 %13, 1
+  %16 = xor i32 %15, 1
+  %spec.select.i = add i32 %16, %14
+  %17 = add nuw nsw i32 %13, 1
+  %exitcond.not.i = icmp eq i32 %17, %3
+  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !8
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %24, %vec.epilog.middle.block ], [ %18, %middle.block ], [ %spec.select.i, %.lr.ph.i ]
-  %30 = getelementptr i8, ptr %0, i64 8
-  %31 = load ptr, ptr %30, align 8
-  store i32 %.lcssa.i, ptr %31, align 4
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %12, %middle.block ], [ %spec.select.i, %.lr.ph.i ]
+  %18 = getelementptr i8, ptr %0, i64 8
+  %19 = load ptr, ptr %18, align 8
+  store i32 %.lcssa.i, ptr %19, align 4
   ret void
 }
 
@@ -316,109 +178,60 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 0
-  br i1 %4, label %iter.check, label %_mlir_ciface_execute.exit
+  br i1 %4, label %.lr.ph.i.i.preheader, label %_mlir_ciface_execute.exit
 
-iter.check:                                       ; preds = %1
-  %min.iters.check = icmp ult i32 %3, 4
-  br i1 %min.iters.check, label %.lr.ph.i.i.preheader, label %vector.main.loop.iter.check
+.lr.ph.i.i.preheader:                             ; preds = %1
+  %min.iters.check = icmp ult i32 %3, 8
+  br i1 %min.iters.check, label %.lr.ph.i.i.preheader2, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.i.preheader
+  %n.vec = and i32 %3, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %14, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %15, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %16, %vector.body ]
-  %5 = and <8 x i32> %vec.ind, splat (i32 1)
-  %6 = and <8 x i32> %vec.ind, splat (i32 1)
-  %7 = and <8 x i32> %vec.ind, splat (i32 1)
-  %8 = and <8 x i32> %vec.ind, splat (i32 1)
-  %9 = xor <8 x i32> %5, splat (i32 1)
-  %10 = xor <8 x i32> %6, splat (i32 1)
-  %11 = xor <8 x i32> %7, splat (i32 1)
-  %12 = xor <8 x i32> %8, splat (i32 1)
-  %13 = add <8 x i32> %9, %vec.phi
-  %14 = add <8 x i32> %10, %vec.phi2
-  %15 = add <8 x i32> %11, %vec.phi3
-  %16 = add <8 x i32> %12, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %17 = icmp eq i32 %index.next, %n.vec
-  br i1 %17, label %middle.block, label %vector.body, !llvm.loop !13
+  %vec.ind = phi <4 x i32> [ <i32 0, i32 1, i32 2, i32 3>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
+  %5 = and <4 x i32> %vec.ind, splat (i32 1)
+  %6 = and <4 x i32> %vec.ind, splat (i32 1)
+  %7 = xor <4 x i32> %5, splat (i32 1)
+  %8 = xor <4 x i32> %6, splat (i32 1)
+  %9 = add <4 x i32> %7, %vec.phi
+  %10 = add <4 x i32> %8, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %11 = icmp eq i32 %index.next, %n.vec
+  br i1 %11, label %middle.block, label %vector.body, !llvm.loop !9
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %14, %13
-  %bin.rdx5 = add <8 x i32> %15, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %16, %bin.rdx5
-  %18 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %10, %9
+  %12 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader2
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %bc.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %18, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, 2147483644
-  %19 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = or disjoint <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %bc.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %19, %vec.epilog.ph ], [ %22, %vec.epilog.vector.body ]
-  %20 = and <4 x i32> %vec.ind10, splat (i32 1)
-  %21 = xor <4 x i32> %20, splat (i32 1)
-  %22 = add <4 x i32> %21, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add nuw nsw <4 x i32> %vec.ind10, splat (i32 4)
-  %23 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %23, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !14
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %24 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %22)
-  %cmp.n14 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n14, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
-
-.lr.ph.i.i.preheader:                             ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec8, %vec.epilog.middle.block ]
-  %.ph17 = phi i32 [ 0, %iter.check ], [ %18, %vec.epilog.iter.check ], [ %24, %vec.epilog.middle.block ]
+.lr.ph.i.i.preheader2:                            ; preds = %.lr.ph.i.i.preheader, %middle.block
+  %.ph = phi i32 [ 0, %.lr.ph.i.i.preheader ], [ %n.vec, %middle.block ]
+  %.ph3 = phi i32 [ 0, %.lr.ph.i.i.preheader ], [ %12, %middle.block ]
   br label %.lr.ph.i.i
 
-.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader, %.lr.ph.i.i
-  %25 = phi i32 [ %29, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader ]
-  %26 = phi i32 [ %spec.select.i.i, %.lr.ph.i.i ], [ %.ph17, %.lr.ph.i.i.preheader ]
-  %27 = and i32 %25, 1
-  %28 = xor i32 %27, 1
-  %spec.select.i.i = add i32 %28, %26
-  %29 = add nuw nsw i32 %25, 1
-  %exitcond.not.i.i = icmp eq i32 %29, %3
-  br i1 %exitcond.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !15
+.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader2, %.lr.ph.i.i
+  %13 = phi i32 [ %17, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader2 ]
+  %14 = phi i32 [ %spec.select.i.i, %.lr.ph.i.i ], [ %.ph3, %.lr.ph.i.i.preheader2 ]
+  %15 = and i32 %13, 1
+  %16 = xor i32 %15, 1
+  %spec.select.i.i = add i32 %16, %14
+  %17 = add nuw nsw i32 %13, 1
+  %exitcond.not.i.i = icmp eq i32 %17, %3
+  br i1 %exitcond.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !10
 
-_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %24, %vec.epilog.middle.block ], [ %18, %middle.block ], [ %spec.select.i.i, %.lr.ph.i.i ]
-  %30 = getelementptr i8, ptr %0, i64 8
-  %31 = load ptr, ptr %30, align 8
-  store i32 %.lcssa.i.i, ptr %31, align 4
+_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %1
+  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %12, %middle.block ], [ %spec.select.i.i, %.lr.ph.i.i ]
+  %18 = getelementptr i8, ptr %0, i64 8
+  %19 = load ptr, ptr %18, align 8
+  store i32 %.lcssa.i.i, ptr %19, align 4
   ret void
 }
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #2
@@ -433,15 +246,10 @@ attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !1 = distinct !{!1, !2, !3}
 !2 = !{!"llvm.loop.isvectorized", i32 1}
 !3 = !{!"llvm.loop.unroll.runtime.disable"}
-!4 = !{!"branch_weights", i32 4, i32 28}
+!4 = distinct !{!4, !3, !2}
 !5 = distinct !{!5, !2, !3}
 !6 = distinct !{!6, !3, !2}
 !7 = distinct !{!7, !2, !3}
-!8 = distinct !{!8, !2, !3}
-!9 = distinct !{!9, !3, !2}
-!10 = distinct !{!10, !2, !3}
-!11 = distinct !{!11, !2, !3}
-!12 = distinct !{!12, !3, !2}
-!13 = distinct !{!13, !2, !3}
-!14 = distinct !{!14, !2, !3}
-!15 = distinct !{!15, !3, !2}
+!8 = distinct !{!8, !3, !2}
+!9 = distinct !{!9, !2, !3}
+!10 = distinct !{!10, !3, !2}

--- a/nautilus/test/llvm-ir-test/reference-ir/ifThenCondition.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/ifThenCondition.ll
@@ -6,15 +6,15 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 42
-  %spec.select = select i1 %2, i32 44, i32 43
-  ret i32 %spec.select
+  %3 = select i1 %2, i32 44, i32 43
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 42
-  %spec.select.i = select i1 %2, i32 44, i32 43
-  ret i32 %spec.select.i
+  %3 = select i1 %2, i32 44, i32 43
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -22,10 +22,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 42
-  %spec.select.i = select i1 %4, i32 44, i32 43
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %spec.select.i, ptr %6, align 4
+  %5 = select i1 %4, i32 44, i32 43
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 
@@ -34,10 +34,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 42
-  %spec.select.i.i = select i1 %4, i32 44, i32 43
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %spec.select.i.i, ptr %6, align 4
+  %5 = select i1 %4, i32 44, i32 43
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/ifThenElseCondition.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/ifThenElseCondition.ll
@@ -6,15 +6,15 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 42
-  %. = select i1 %2, i32 44, i32 85
-  ret i32 %.
+  %3 = select i1 %2, i32 44, i32 85
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 42
-  %..i = select i1 %2, i32 44, i32 85
-  ret i32 %..i
+  %3 = select i1 %2, i32 44, i32 85
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -22,10 +22,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 42
-  %..i = select i1 %4, i32 44, i32 85
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %..i, ptr %6, align 4
+  %5 = select i1 %4, i32 44, i32 85
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 
@@ -34,10 +34,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 42
-  %..i.i = select i1 %4, i32 44, i32 85
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %..i.i, ptr %6, align 4
+  %5 = select i1 %4, i32 44, i32 85
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/incrementFuncCallFiveTimesWithModRef.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/incrementFuncCallFiveTimesWithModRef.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i1 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i1 %0)
   %3 = tail call i32 @runtimeFunc0(i1 false)
@@ -13,7 +12,6 @@ define signext i32 @execute(i1 %0) local_unnamed_addr #0 {
   ret i32 %6
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i1 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i1 %0)
   %3 = tail call i32 @runtimeFunc0(i1 false)
@@ -24,9 +22,9 @@ define signext i32 @_mlir_ciface_execute(i1 %0) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: memory(readwrite)
-declare i32 @runtimeFunc0(i1) local_unnamed_addr #1
+declare i32 @runtimeFunc0(i1 zeroext) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i1, ptr %2, align 1
   %4 = tail call i32 @runtimeFunc0(i1 %3)
@@ -40,7 +38,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i1, ptr %2, align 1
   %4 = tail call i32 @runtimeFunc0(i1 %3)
@@ -54,7 +52,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/incrementFuncCallFiveTimesWithRef.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/incrementFuncCallFiveTimesWithRef.ll
@@ -18,7 +18,7 @@ define signext i32 @_mlir_ciface_execute(i1 %0) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: nofree memory(read)
-declare i32 @runtimeFunc0(i1) local_unnamed_addr #1
+declare i32 @runtimeFunc0(i1 zeroext) local_unnamed_addr #1
 
 ; Function Attrs: nofree memory(readwrite, inaccessiblemem: read)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {

--- a/nautilus/test/llvm-ir-test/reference-ir/isPrime.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/isPrime.ll
@@ -9,11 +9,11 @@ define noundef i1 @execute(i32 %0) local_unnamed_addr #0 {
   br i1 %2, label %.loopexit, label %.preheader
 
 .preheader:                                       ; preds = %1
-  %.not2 = icmp samesign ult i32 %0, 4
-  br i1 %.not2, label %.loopexit, label %.lr.ph
+  %.not1 = icmp samesign ult i32 %0, 4
+  br i1 %.not1, label %.loopexit, label %.lr.ph
 
 .loopexit:                                        ; preds = %4, %.lr.ph, %.preheader, %1
-  %3 = phi i1 [ false, %1 ], [ true, %.preheader ], [ %.not5.not, %.lr.ph ], [ %.not5.not, %4 ]
+  %3 = phi i1 [ false, %1 ], [ true, %.preheader ], [ %.not4.not, %.lr.ph ], [ %.not4.not, %4 ]
   ret i1 %3
 
 4:                                                ; preds = %.lr.ph
@@ -25,8 +25,8 @@ define noundef i1 @execute(i32 %0) local_unnamed_addr #0 {
 .lr.ph:                                           ; preds = %.preheader, %4
   %7 = phi i32 [ %5, %4 ], [ 2, %.preheader ]
   %8 = srem i32 %0, %7
-  %.not5.not = icmp ne i32 %8, 0
-  br i1 %.not5.not, label %4, label %.loopexit
+  %.not4.not = icmp ne i32 %8, 0
+  br i1 %.not4.not, label %4, label %.loopexit
 }
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
@@ -35,8 +35,8 @@ define noundef i1 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   br i1 %2, label %execute.exit, label %.preheader.i
 
 .preheader.i:                                     ; preds = %1
-  %.not2.i = icmp samesign ult i32 %0, 4
-  br i1 %.not2.i, label %execute.exit, label %.lr.ph.i
+  %.not1.i = icmp samesign ult i32 %0, 4
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i
 
 3:                                                ; preds = %.lr.ph.i
   %4 = add i32 %6, 1
@@ -47,11 +47,11 @@ define noundef i1 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 .lr.ph.i:                                         ; preds = %.preheader.i, %3
   %6 = phi i32 [ %4, %3 ], [ 2, %.preheader.i ]
   %7 = srem i32 %0, %6
-  %.not5.i.not.not = icmp ne i32 %7, 0
-  br i1 %.not5.i.not.not, label %3, label %execute.exit
+  %.not4.i.not.not = icmp ne i32 %7, 0
+  br i1 %.not4.i.not.not, label %3, label %execute.exit
 
 execute.exit:                                     ; preds = %3, %.lr.ph.i, %1, %.preheader.i
-  %8 = phi i1 [ false, %1 ], [ true, %.preheader.i ], [ %.not5.i.not.not, %.lr.ph.i ], [ %.not5.i.not.not, %3 ]
+  %8 = phi i1 [ false, %1 ], [ true, %.preheader.i ], [ %.not4.i.not.not, %.lr.ph.i ], [ %.not4.i.not.not, %3 ]
   ret i1 %8
 }
 
@@ -63,8 +63,8 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   br i1 %4, label %execute.exit, label %.preheader.i
 
 .preheader.i:                                     ; preds = %1
-  %.not2.i = icmp samesign ult i32 %3, 4
-  br i1 %.not2.i, label %execute.exit, label %.lr.ph.i
+  %.not1.i = icmp samesign ult i32 %3, 4
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i
 
 5:                                                ; preds = %.lr.ph.i
   %6 = add i32 %8, 1
@@ -75,11 +75,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
 .lr.ph.i:                                         ; preds = %.preheader.i, %5
   %8 = phi i32 [ %6, %5 ], [ 2, %.preheader.i ]
   %9 = srem i32 %3, %8
-  %.not5.i.not.not = icmp ne i32 %9, 0
-  br i1 %.not5.i.not.not, label %5, label %execute.exit
+  %.not4.i.not.not = icmp ne i32 %9, 0
+  br i1 %.not4.i.not.not, label %5, label %execute.exit
 
 execute.exit:                                     ; preds = %5, %.lr.ph.i, %1, %.preheader.i
-  %10 = phi i1 [ false, %1 ], [ true, %.preheader.i ], [ %.not5.i.not.not, %.lr.ph.i ], [ %.not5.i.not.not, %5 ]
+  %10 = phi i1 [ false, %1 ], [ true, %.preheader.i ], [ %.not4.i.not.not, %.lr.ph.i ], [ %.not4.i.not.not, %5 ]
   %11 = getelementptr i8, ptr %0, i64 8
   %12 = load ptr, ptr %11, align 8
   store i1 %10, ptr %12, align 1
@@ -94,8 +94,8 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   br i1 %4, label %_mlir_ciface_execute.exit, label %.preheader.i.i
 
 .preheader.i.i:                                   ; preds = %1
-  %.not2.i.i = icmp samesign ult i32 %3, 4
-  br i1 %.not2.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i
+  %.not1.i.i = icmp samesign ult i32 %3, 4
+  br i1 %.not1.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i
 
 5:                                                ; preds = %.lr.ph.i.i
   %6 = add i32 %8, 1
@@ -106,11 +106,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
 .lr.ph.i.i:                                       ; preds = %.preheader.i.i, %5
   %8 = phi i32 [ %6, %5 ], [ 2, %.preheader.i.i ]
   %9 = srem i32 %3, %8
-  %.not5.i.not.i.not.not = icmp ne i32 %9, 0
-  br i1 %.not5.i.not.i.not.not, label %5, label %_mlir_ciface_execute.exit
+  %.not4.i.not.i.not.not = icmp ne i32 %9, 0
+  br i1 %.not4.i.not.i.not.not, label %5, label %_mlir_ciface_execute.exit
 
 _mlir_ciface_execute.exit:                        ; preds = %5, %.lr.ph.i.i, %1, %.preheader.i.i
-  %10 = phi i1 [ false, %1 ], [ true, %.preheader.i.i ], [ %.not5.i.not.i.not.not, %.lr.ph.i.i ], [ %.not5.i.not.i.not.not, %5 ]
+  %10 = phi i1 [ false, %1 ], [ true, %.preheader.i.i ], [ %.not4.i.not.i.not.not, %.lr.ph.i.i ], [ %.not4.i.not.i.not.not, %5 ]
   %11 = getelementptr i8, ptr %0, i64 8
   %12 = load ptr, ptr %11, align 8
   store i1 %10, ptr %12, align 1

--- a/nautilus/test/llvm-ir-test/reference-ir/lambdaRuntimeFunction.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/lambdaRuntimeFunction.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/loopDirectCall.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/loopDirectCall.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %0, 0
   br i1 %3, label %.lr.ph, label %._crit_edge
@@ -21,7 +20,6 @@ define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   ret i32 %.lcssa
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %0, 0
   br i1 %3, label %.lr.ph.i, label %execute.exit
@@ -42,7 +40,7 @@ execute.exit:                                     ; preds = %.lr.ph.i, %2
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -67,7 +65,7 @@ execute.exit:                                     ; preds = %.lr.ph.i, %1
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -92,7 +90,6 @@ _mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %1
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/loopDirectCall2.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/loopDirectCall2.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0()
   %3 = sext i32 %2 to i64
@@ -23,7 +22,6 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   ret i32 %.lcssa
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0()
   %3 = sext i32 %2 to i64
@@ -49,7 +47,7 @@ declare i32 @runtimeFunc0() local_unnamed_addr #1
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc1(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0()
@@ -73,7 +71,7 @@ execute.exit:                                     ; preds = %.lr.ph.i, %1
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0()
@@ -97,7 +95,6 @@ _mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %1
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionConditional.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionConditional.ll
@@ -18,7 +18,7 @@ define signext i32 @_mlir_ciface_conditionalHelper(i32 %0) local_unnamed_addr #0
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 10
-  %3 = add nuw i32 %0, 100
+  %3 = add i32 %0, 100
   %spec.select = select i1 %2, i32 %3, i32 %0
   ret i32 %spec.select
 }
@@ -26,7 +26,7 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 10
-  %3 = add nuw i32 %0, 100
+  %3 = add i32 %0, 100
   %spec.select.i = select i1 %2, i32 %3, i32 %0
   ret i32 %spec.select.i
 }
@@ -58,7 +58,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 10
-  %5 = add nuw i32 %3, 100
+  %5 = add i32 %3, 100
   %spec.select.i = select i1 %4, i32 %5, i32 %3
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
@@ -71,7 +71,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 10
-  %5 = add nuw i32 %3, 100
+  %5 = add i32 %3, 100
   %spec.select.i.i = select i1 %4, i32 %5, i32 %3
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8

--- a/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionMultiple.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionMultiple.ll
@@ -4,30 +4,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @subtract5(i32 %0) local_unnamed_addr #0 {
-  %2 = add i32 %0, -5
-  ret i32 %2
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @_mlir_ciface_subtract5(i32 %0) local_unnamed_addr #0 {
-  %2 = add i32 %0, -5
-  ret i32 %2
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @multiply2(i32 %0) local_unnamed_addr #0 {
-  %2 = shl i32 %0, 1
-  ret i32 %2
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @_mlir_ciface_multiply2(i32 %0) local_unnamed_addr #0 {
-  %2 = shl i32 %0, 1
-  ret i32 %2
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @add10(i32 %0) local_unnamed_addr #0 {
   %2 = add i32 %0, 10
   ret i32 %2
@@ -53,48 +29,28 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   ret i32 %3
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_subtract5(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = add i32 %3, -5
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
-  ret void
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @multiply2(i32 %0) local_unnamed_addr #0 {
+  %2 = shl i32 %0, 1
+  ret i32 %2
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_subtract5(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = add i32 %3, -5
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
-  ret void
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_multiply2(i32 %0) local_unnamed_addr #0 {
+  %2 = shl i32 %0, 1
+  ret i32 %2
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_multiply2(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = shl i32 %3, 1
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
-  ret void
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @subtract5(i32 %0) local_unnamed_addr #0 {
+  %2 = add i32 %0, -5
+  ret i32 %2
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_multiply2(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = shl i32 %3, 1
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
-  ret void
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_subtract5(i32 %0) local_unnamed_addr #0 {
+  %2 = add i32 %0, -5
+  ret i32 %2
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -140,6 +96,50 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
   store i32 %5, ptr %7, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_multiply2(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_multiply2(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_subtract5(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = add i32 %3, -5
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_subtract5(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = add i32 %3, -5
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionMultipleResults.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionMultipleResults.ll
@@ -4,18 +4,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @multiply(i32 %0, i32 %1) local_unnamed_addr #0 {
-  %3 = mul i32 %1, %0
-  ret i32 %3
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @_mlir_ciface_multiply(i32 %0, i32 %1) local_unnamed_addr #0 {
-  %3 = mul i32 %1, %0
-  ret i32 %3
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0, i32 %1, i32 %2) local_unnamed_addr #0 {
   %4 = mul i32 %1, %0
   %5 = mul i32 %4, %1
@@ -31,32 +19,16 @@ define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1, i32 %2) local_unnamed_a
   ret i32 %6
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_multiply(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = getelementptr i8, ptr %0, i64 8
-  %5 = load ptr, ptr %4, align 8
-  %6 = load i32, ptr %5, align 4
-  %7 = mul i32 %6, %3
-  %8 = getelementptr i8, ptr %0, i64 16
-  %9 = load ptr, ptr %8, align 8
-  store i32 %7, ptr %9, align 4
-  ret void
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @multiply(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = mul i32 %1, %0
+  ret i32 %3
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_multiply(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = getelementptr i8, ptr %0, i64 8
-  %5 = load ptr, ptr %4, align 8
-  %6 = load i32, ptr %5, align 4
-  %7 = mul i32 %6, %3
-  %8 = getelementptr i8, ptr %0, i64 16
-  %9 = load ptr, ptr %8, align 8
-  store i32 %7, ptr %9, align 4
-  ret void
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_multiply(i32 %0, i32 %1) local_unnamed_addr #0 {
+  %3 = mul i32 %1, %0
+  ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -94,6 +66,34 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %13 = getelementptr i8, ptr %0, i64 24
   %14 = load ptr, ptr %13, align 8
   store i32 %12, ptr %14, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_multiply(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load i32, ptr %5, align 4
+  %7 = mul i32 %6, %3
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_multiply(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr i8, ptr %0, i64 8
+  %5 = load ptr, ptr %4, align 8
+  %6 = load i32, ptr %5, align 4
+  %7 = mul i32 %6, %3
+  %8 = getelementptr i8, ptr %0, i64 16
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionNested.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionNested.ll
@@ -4,6 +4,20 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
+  %2 = shl i32 %0, 1
+  %3 = add i32 %2, 5
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
+  %2 = shl i32 %0, 1
+  %3 = add i32 %2, 5
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @inner(i32 %0) local_unnamed_addr #0 {
   %2 = shl i32 %0, 1
   ret i32 %2
@@ -29,18 +43,28 @@ define signext i32 @_mlir_ciface_outer(i32 %0) local_unnamed_addr #0 {
   ret i32 %3
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
-  %2 = shl i32 %0, 1
-  %3 = add i32 %2, 5
-  ret i32 %3
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = add i32 %4, 5
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
+  ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
-  %2 = shl i32 %0, 1
-  %3 = add i32 %2, 5
-  ret i32 %3
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = shl i32 %3, 1
+  %5 = add i32 %4, 5
+  %6 = getelementptr i8, ptr %0, i64 8
+  %7 = load ptr, ptr %6, align 8
+  store i32 %5, ptr %7, align 4
+  ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -79,30 +103,6 @@ define void @_mlir_outer(ptr readonly %0) local_unnamed_addr #1 {
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
 define void @_mlir__mlir_ciface_outer(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = shl i32 %3, 1
-  %5 = add i32 %4, 5
-  %6 = getelementptr i8, ptr %0, i64 8
-  %7 = load ptr, ptr %6, align 8
-  store i32 %5, ptr %7, align 4
-  ret void
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = shl i32 %3, 1
-  %5 = add i32 %4, 5
-  %6 = getelementptr i8, ptr %0, i64 8
-  %7 = load ptr, ptr %6, align 8
-  store i32 %5, ptr %7, align 4
-  ret void
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = shl i32 %3, 1

--- a/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionRecursiveStyle.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionRecursiveStyle.ll
@@ -4,6 +4,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
+  %2 = add i32 %0, 3
+  ret i32 %2
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
+  %2 = add i32 %0, 3
+  ret i32 %2
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @recursiveHelper(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %1, 0
   %4 = zext i1 %3 to i32
@@ -19,16 +31,26 @@ define signext i32 @_mlir_ciface_recursiveHelper(i32 %0, i32 %1) local_unnamed_a
   ret i32 %spec.select.i
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
-  %2 = add i32 %0, 3
-  ret i32 %2
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = add i32 %3, 3
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
-  %2 = add i32 %0, 3
-  ret i32 %2
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load i32, ptr %2, align 4
+  %4 = add i32 %3, 3
+  %5 = getelementptr i8, ptr %0, i64 8
+  %6 = load ptr, ptr %5, align 8
+  store i32 %4, ptr %6, align 4
+  ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -60,28 +82,6 @@ define void @_mlir__mlir_ciface_recursiveHelper(ptr readonly %0) local_unnamed_a
   %9 = getelementptr i8, ptr %0, i64 16
   %10 = load ptr, ptr %9, align 8
   store i32 %spec.select.i.i, ptr %10, align 4
-  ret void
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = add i32 %3, 3
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
-  ret void
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load i32, ptr %2, align 4
-  %4 = add i32 %3, 3
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionVoid.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nautilusFunctionVoid.ll
@@ -4,22 +4,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
-define void @voidHelper(ptr %0) local_unnamed_addr #0 {
-  %2 = load i32, ptr %0, align 4
-  %3 = add i32 %2, 10
-  store i32 %3, ptr %0, align 4
-  ret void
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
-define void @_mlir_ciface_voidHelper(ptr %0) local_unnamed_addr #0 {
-  %2 = load i32, ptr %0, align 4
-  %3 = add i32 %2, 10
-  store i32 %3, ptr %0, align 4
-  ret void
-}
-
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
   %2 = load i32, ptr %0, align 4
   %3 = add i32 %2, 10
@@ -35,23 +19,19 @@ define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
   ret i32 %3
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_voidHelper(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load ptr, ptr %2, align 8
-  %4 = load i32, ptr %3, align 4
-  %5 = add i32 %4, 10
-  store i32 %5, ptr %3, align 4
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
+define void @voidHelper(ptr %0) local_unnamed_addr #0 {
+  %2 = load i32, ptr %0, align 4
+  %3 = add i32 %2, 10
+  store i32 %3, ptr %0, align 4
   ret void
 }
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_voidHelper(ptr readonly %0) local_unnamed_addr #1 {
-  %2 = load ptr, ptr %0, align 8
-  %3 = load ptr, ptr %2, align 8
-  %4 = load i32, ptr %3, align 4
-  %5 = add i32 %4, 10
-  store i32 %5, ptr %3, align 4
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
+define void @_mlir_ciface_voidHelper(ptr %0) local_unnamed_addr #0 {
+  %2 = load i32, ptr %0, align 4
+  %3 = add i32 %2, 10
+  store i32 %3, ptr %0, align 4
   ret void
 }
 
@@ -78,6 +58,26 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
   store i32 %5, ptr %7, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir_voidHelper(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = load i32, ptr %3, align 4
+  %5 = add i32 %4, 10
+  store i32 %5, ptr %3, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
+define void @_mlir__mlir_ciface_voidHelper(ptr readonly %0) local_unnamed_addr #1 {
+  %2 = load ptr, ptr %0, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = load i32, ptr %3, align 4
+  %5 = add i32 %4, 10
+  store i32 %5, ptr %3, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/nestedLambdaRuntimeFunction.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nestedLambdaRuntimeFunction.ll
@@ -3,14 +3,12 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   %3 = tail call i32 @runtimeFunc1(i32 %2)
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   %3 = tail call i32 @runtimeFunc1(i32 %2)
@@ -23,7 +21,7 @@ declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc1(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -45,7 +43,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/nestedSumLoop.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/nestedSumLoop.ll
@@ -5,13 +5,13 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
-._crit_edge5:
+._crit_edge2:
   %1 = mul i32 %0, %0
   %2 = mul i32 %1, 10
   %3 = or disjoint i32 %2, 1
   %.inv = icmp slt i32 %0, 1
-  %.lcssa4 = select i1 %.inv, i32 1, i32 %3
-  ret i32 %.lcssa4
+  %.lcssa1 = select i1 %.inv, i32 1, i32 %3
+  ret i32 %.lcssa1
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
@@ -20,8 +20,8 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %3 = mul i32 %2, %0
   %4 = or disjoint i32 %3, 1
   %.inv.i = icmp slt i32 %0, 1
-  %.lcssa4.i = select i1 %.inv.i, i32 1, i32 %4
-  ret i32 %.lcssa4.i
+  %.lcssa1.i = select i1 %.inv.i, i32 1, i32 %4
+  ret i32 %.lcssa1.i
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
@@ -32,10 +32,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %5 = mul i32 %4, %3
   %6 = or disjoint i32 %5, 1
   %.inv.i = icmp slt i32 %3, 1
-  %.lcssa4.i = select i1 %.inv.i, i32 1, i32 %6
+  %.lcssa1.i = select i1 %.inv.i, i32 1, i32 %6
   %7 = getelementptr i8, ptr %0, i64 8
   %8 = load ptr, ptr %7, align 8
-  store i32 %.lcssa4.i, ptr %8, align 4
+  store i32 %.lcssa1.i, ptr %8, align 4
   ret void
 }
 
@@ -47,10 +47,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %5 = mul i32 %4, %3
   %6 = or disjoint i32 %5, 1
   %.inv.i.i = icmp slt i32 %3, 1
-  %.lcssa4.i.i = select i1 %.inv.i.i, i32 1, i32 %6
+  %.lcssa1.i.i = select i1 %.inv.i.i, i32 1, i32 %6
   %7 = getelementptr i8, ptr %0, i64 8
   %8 = load ptr, ptr %7, align 8
-  store i32 %.lcssa4.i.i, ptr %8, align 4
+  store i32 %.lcssa1.i.i, ptr %8, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/orCondition.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/orCondition.ll
@@ -5,33 +5,33 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
-  %switch.selectcmp.case1 = icmp eq i32 %0, 8
-  %switch.selectcmp.case2 = icmp eq i32 %0, 1
-  %switch.selectcmp = or i1 %switch.selectcmp.case1, %switch.selectcmp.case2
-  %2 = select i1 %switch.selectcmp, i32 15, i32 1
-  ret i32 %2
+  %2 = icmp eq i32 %0, 8
+  %3 = icmp eq i32 %0, 1
+  %4 = or i1 %2, %3
+  %5 = select i1 %4, i32 15, i32 1
+  ret i32 %5
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
-  %switch.selectcmp.case1.i = icmp eq i32 %0, 8
-  %switch.selectcmp.case2.i = icmp eq i32 %0, 1
-  %switch.selectcmp.i = or i1 %switch.selectcmp.case1.i, %switch.selectcmp.case2.i
-  %2 = select i1 %switch.selectcmp.i, i32 15, i32 1
-  ret i32 %2
+  %2 = icmp eq i32 %0, 8
+  %3 = icmp eq i32 %0, 1
+  %4 = or i1 %2, %3
+  %5 = select i1 %4, i32 15, i32 1
+  ret i32 %5
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
-  %switch.selectcmp.case1.i = icmp eq i32 %3, 8
-  %switch.selectcmp.case2.i = icmp eq i32 %3, 1
-  %switch.selectcmp.i = or i1 %switch.selectcmp.case1.i, %switch.selectcmp.case2.i
-  %4 = select i1 %switch.selectcmp.i, i32 15, i32 1
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
+  %4 = icmp eq i32 %3, 8
+  %5 = icmp eq i32 %3, 1
+  %6 = or i1 %4, %5
+  %7 = select i1 %6, i32 15, i32 1
+  %8 = getelementptr i8, ptr %0, i64 8
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
   ret void
 }
 
@@ -39,13 +39,13 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
-  %switch.selectcmp.case1.i.i = icmp eq i32 %3, 8
-  %switch.selectcmp.case2.i.i = icmp eq i32 %3, 1
-  %switch.selectcmp.i.i = or i1 %switch.selectcmp.case1.i.i, %switch.selectcmp.case2.i.i
-  %4 = select i1 %switch.selectcmp.i.i, i32 15, i32 1
-  %5 = getelementptr i8, ptr %0, i64 8
-  %6 = load ptr, ptr %5, align 8
-  store i32 %4, ptr %6, align 4
+  %4 = icmp eq i32 %3, 8
+  %5 = icmp eq i32 %3, 1
+  %6 = or i1 %4, %5
+  %7 = select i1 %6, i32 15, i32 1
+  %8 = getelementptr i8, ptr %0, i64 8
+  %9 = load ptr, ptr %8, align 8
+  store i32 %7, ptr %9, align 4
   ret void
 }
 

--- a/nautilus/test/llvm-ir-test/reference-ir/passCustomClass.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/passCustomClass.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(ptr) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/shiftRight_int32.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/shiftRight_int32.ll
@@ -10,13 +10,13 @@ define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #1 {
+define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = ashr i32 %0, %1
   ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -30,7 +30,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,8 +44,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/reference-ir/shiftRight_int64.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/shiftRight_int64.ll
@@ -10,13 +10,13 @@ define signext i64 @execute(i64 %0, i64 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #1 {
+define signext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #0 {
   %3 = ashr i64 %0, %1
   ret i64 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -30,7 +30,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,8 +44,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/reference-ir/shiftRight_int8.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/shiftRight_int8.ll
@@ -13,7 +13,7 @@ define signext i8 @execute(i8 %0, i8 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define signext i8 @_mlir_ciface_execute(i8 %0, i8 %1) local_unnamed_addr #1 {
+define signext i8 @_mlir_ciface_execute(i8 %0, i8 %1) local_unnamed_addr #0 {
   %3 = sext i8 %0 to i32
   %4 = zext nneg i8 %1 to i32
   %5 = ashr i32 %3, %4
@@ -22,7 +22,7 @@ define signext i8 @_mlir_ciface_execute(i8 %0, i8 %1) local_unnamed_addr #1 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i8, ptr %2, align 1
   %4 = getelementptr i8, ptr %0, i64 8
@@ -39,7 +39,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i8, ptr %2, align 1
   %4 = getelementptr i8, ptr %0, i64 8
@@ -56,8 +56,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/reference-ir/shiftRight_uint32.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/shiftRight_uint32.ll
@@ -10,13 +10,13 @@ define zeroext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define zeroext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #1 {
+define zeroext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = lshr i32 %0, %1
   ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -30,7 +30,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,8 +44,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/reference-ir/shiftRight_uint64.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/shiftRight_uint64.ll
@@ -10,13 +10,13 @@ define zeroext i64 @execute(i64 %0, i64 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define zeroext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #1 {
+define zeroext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #0 {
   %3 = lshr i64 %0, %1
   ret i64 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -30,7 +30,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,8 +44,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/reference-ir/shiftRight_uint8.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/shiftRight_uint8.ll
@@ -13,7 +13,7 @@ define zeroext i8 @execute(i8 %0, i8 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-define zeroext i8 @_mlir_ciface_execute(i8 %0, i8 %1) local_unnamed_addr #1 {
+define zeroext i8 @_mlir_ciface_execute(i8 %0, i8 %1) local_unnamed_addr #0 {
   %3 = zext i8 %0 to i32
   %4 = zext nneg i8 %1 to i32
   %5 = lshr i32 %3, %4
@@ -22,7 +22,7 @@ define zeroext i8 @_mlir_ciface_execute(i8 %0, i8 %1) local_unnamed_addr #1 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i8, ptr %2, align 1
   %4 = getelementptr i8, ptr %0, i64 8
@@ -39,7 +39,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none)
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i8, ptr %2, align 1
   %4 = getelementptr i8, ptr %0, i64 8
@@ -56,8 +56,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
 }
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-attributes #2 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none) }
 
 !llvm.module.flags = !{!0}
 

--- a/nautilus/test/llvm-ir-test/reference-ir/simpleDirectCall.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/simpleDirectCall.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/specializeType.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/specializeType.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(ptr %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(ptr) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = tail call i32 @runtimeFunc0(ptr %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/staticConstIterator.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/staticConstIterator.ll
@@ -6,9 +6,9 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 1
-  %spec.select = zext i1 %2 to i32
-  %3 = icmp sgt i32 %0, 2
-  %4 = select i1 %3, i32 2, i32 %spec.select
+  %3 = zext i1 %2 to i32
+  %4 = icmp sgt i32 %0, 2
+  %spec.select = select i1 %4, i32 2, i32 %3
   %5 = icmp sgt i32 %0, 3
   %6 = zext i1 %5 to i32
   %7 = icmp sgt i32 %0, 4
@@ -17,16 +17,16 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %10 = zext i1 %9 to i32
   %11 = add nuw nsw i32 %8, %6
   %12 = add nuw nsw i32 %11, %10
-  %13 = add nuw nsw i32 %12, %4
+  %13 = add nuw nsw i32 %12, %spec.select
   ret i32 %13
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 1
-  %spec.select.i = zext i1 %2 to i32
-  %3 = icmp sgt i32 %0, 2
-  %4 = select i1 %3, i32 2, i32 %spec.select.i
+  %3 = zext i1 %2 to i32
+  %4 = icmp sgt i32 %0, 2
+  %spec.select.i = select i1 %4, i32 2, i32 %3
   %5 = icmp sgt i32 %0, 3
   %6 = zext i1 %5 to i32
   %7 = icmp sgt i32 %0, 4
@@ -35,7 +35,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %10 = zext i1 %9 to i32
   %11 = add nuw nsw i32 %8, %6
   %12 = add nuw nsw i32 %11, %10
-  %13 = add nuw nsw i32 %12, %4
+  %13 = add nuw nsw i32 %12, %spec.select.i
   ret i32 %13
 }
 
@@ -44,9 +44,9 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 1
-  %spec.select.i = zext i1 %4 to i32
-  %5 = icmp sgt i32 %3, 2
-  %6 = select i1 %5, i32 2, i32 %spec.select.i
+  %5 = zext i1 %4 to i32
+  %6 = icmp sgt i32 %3, 2
+  %spec.select.i = select i1 %6, i32 2, i32 %5
   %7 = icmp sgt i32 %3, 3
   %8 = zext i1 %7 to i32
   %9 = icmp sgt i32 %3, 4
@@ -55,7 +55,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %12 = zext i1 %11 to i32
   %13 = add nuw nsw i32 %10, %8
   %14 = add nuw nsw i32 %13, %12
-  %15 = add nuw nsw i32 %14, %6
+  %15 = add nuw nsw i32 %14, %spec.select.i
   %16 = getelementptr i8, ptr %0, i64 8
   %17 = load ptr, ptr %16, align 8
   store i32 %15, ptr %17, align 4
@@ -67,9 +67,9 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 1
-  %spec.select.i.i = zext i1 %4 to i32
-  %5 = icmp sgt i32 %3, 2
-  %6 = select i1 %5, i32 2, i32 %spec.select.i.i
+  %5 = zext i1 %4 to i32
+  %6 = icmp sgt i32 %3, 2
+  %spec.select.i.i = select i1 %6, i32 2, i32 %5
   %7 = icmp sgt i32 %3, 3
   %8 = zext i1 %7 to i32
   %9 = icmp sgt i32 %3, 4
@@ -78,7 +78,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %12 = zext i1 %11 to i32
   %13 = add nuw nsw i32 %10, %8
   %14 = add nuw nsw i32 %13, %12
-  %15 = add nuw nsw i32 %14, %6
+  %15 = add nuw nsw i32 %14, %spec.select.i.i
   %16 = getelementptr i8, ptr %0, i64 8
   %17 = load ptr, ptr %16, align 8
   store i32 %15, ptr %17, align 4

--- a/nautilus/test/llvm-ir-test/reference-ir/staticIterator.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/staticIterator.ll
@@ -6,9 +6,9 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 1
-  %spec.select = zext i1 %2 to i32
-  %3 = icmp sgt i32 %0, 2
-  %4 = select i1 %3, i32 2, i32 %spec.select
+  %3 = zext i1 %2 to i32
+  %4 = icmp sgt i32 %0, 2
+  %spec.select = select i1 %4, i32 2, i32 %3
   %5 = icmp sgt i32 %0, 3
   %6 = zext i1 %5 to i32
   %7 = icmp sgt i32 %0, 4
@@ -17,16 +17,16 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %10 = zext i1 %9 to i32
   %11 = add nuw nsw i32 %8, %6
   %12 = add nuw nsw i32 %11, %10
-  %13 = add nuw nsw i32 %12, %4
+  %13 = add nuw nsw i32 %12, %spec.select
   ret i32 %13
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 1
-  %spec.select.i = zext i1 %2 to i32
-  %3 = icmp sgt i32 %0, 2
-  %4 = select i1 %3, i32 2, i32 %spec.select.i
+  %3 = zext i1 %2 to i32
+  %4 = icmp sgt i32 %0, 2
+  %spec.select.i = select i1 %4, i32 2, i32 %3
   %5 = icmp sgt i32 %0, 3
   %6 = zext i1 %5 to i32
   %7 = icmp sgt i32 %0, 4
@@ -35,7 +35,7 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %10 = zext i1 %9 to i32
   %11 = add nuw nsw i32 %8, %6
   %12 = add nuw nsw i32 %11, %10
-  %13 = add nuw nsw i32 %12, %4
+  %13 = add nuw nsw i32 %12, %spec.select.i
   ret i32 %13
 }
 
@@ -44,9 +44,9 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 1
-  %spec.select.i = zext i1 %4 to i32
-  %5 = icmp sgt i32 %3, 2
-  %6 = select i1 %5, i32 2, i32 %spec.select.i
+  %5 = zext i1 %4 to i32
+  %6 = icmp sgt i32 %3, 2
+  %spec.select.i = select i1 %6, i32 2, i32 %5
   %7 = icmp sgt i32 %3, 3
   %8 = zext i1 %7 to i32
   %9 = icmp sgt i32 %3, 4
@@ -55,7 +55,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %12 = zext i1 %11 to i32
   %13 = add nuw nsw i32 %10, %8
   %14 = add nuw nsw i32 %13, %12
-  %15 = add nuw nsw i32 %14, %6
+  %15 = add nuw nsw i32 %14, %spec.select.i
   %16 = getelementptr i8, ptr %0, i64 8
   %17 = load ptr, ptr %16, align 8
   store i32 %15, ptr %17, align 4
@@ -67,9 +67,9 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 1
-  %spec.select.i.i = zext i1 %4 to i32
-  %5 = icmp sgt i32 %3, 2
-  %6 = select i1 %5, i32 2, i32 %spec.select.i.i
+  %5 = zext i1 %4 to i32
+  %6 = icmp sgt i32 %3, 2
+  %spec.select.i.i = select i1 %6, i32 2, i32 %5
   %7 = icmp sgt i32 %3, 3
   %8 = zext i1 %7 to i32
   %9 = icmp sgt i32 %3, 4
@@ -78,7 +78,7 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %12 = zext i1 %11 to i32
   %13 = add nuw nsw i32 %10, %8
   %14 = add nuw nsw i32 %13, %12
-  %15 = add nuw nsw i32 %14, %6
+  %15 = add nuw nsw i32 %14, %spec.select.i.i
   %16 = getelementptr i8, ptr %0, i64 8
   %17 = load ptr, ptr %16, align 8
   store i32 %15, ptr %17, align 4

--- a/nautilus/test/llvm-ir-test/reference-ir/staticLoopWithDynamicLoop.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/staticLoopWithDynamicLoop.ll
@@ -10,80 +10,50 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
 
 .lr.ph.preheader:                                 ; preds = %1
   %3 = icmp ult i32 %0, 7
-  br i1 %3, label %switch.lookup, label %iter.check
+  br i1 %3, label %switch.lookup, label %.lr.ph.preheader34
 
-iter.check:                                       ; preds = %.lr.ph.preheader
+.lr.ph.preheader34:                               ; preds = %.lr.ph.preheader
   %4 = add nsw i32 %0, -6
-  %min.iters.check = icmp ult i32 %4, 4
-  br i1 %min.iters.check, label %.lr.ph.preheader50, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %4, 8
+  br i1 %min.iters.check, label %.lr.ph.preheader37, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check36 = icmp ult i32 %4, 32
-  br i1 %min.iters.check36, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %4, 28
-  %n.vec = and i32 %4, -32
+vector.ph:                                        ; preds = %.lr.ph.preheader34
+  %n.vec = and i32 %4, -8
+  %5 = or disjoint i32 %n.vec, 6
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %reduced.phi = phi <8 x i32> [ <i32 180, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, %vector.ph ], [ %bin.rdx41, %vector.body ]
-  %bin.rdx41 = add <8 x i32> %reduced.phi, splat (i32 132)
-  %index.next = add nuw i32 %index, 32
-  %5 = icmp eq i32 %index.next, %n.vec
-  br i1 %5, label %middle.block, label %vector.body, !llvm.loop !1
+  %reduced.phi = phi <4 x i32> [ <i32 180, i32 0, i32 0, i32 0>, %vector.ph ], [ %bin.rdx, %vector.body ]
+  %bin.rdx = add <4 x i32> %reduced.phi, splat (i32 66)
+  %index.next = add nuw i32 %index, 8
+  %6 = icmp eq i32 %index.next, %n.vec
+  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %6 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx41)
+  %7 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %4, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader37
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 6
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader50, label %vec.epilog.ph, !prof !5
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %6, %vec.epilog.iter.check ], [ 180, %vector.main.loop.iter.check ]
-  %n.vec43 = and i32 %4, -4
-  %7 = add i32 %n.vec43, 6
-  %8 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index44 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next46, %vec.epilog.vector.body ]
-  %vec.phi45 = phi <4 x i32> [ %8, %vec.epilog.ph ], [ %9, %vec.epilog.vector.body ]
-  %9 = add <4 x i32> %vec.phi45, splat (i32 33)
-  %index.next46 = add nuw i32 %index44, 4
-  %10 = icmp eq i32 %index.next46, %n.vec43
-  br i1 %10, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !6
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %11 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %9)
-  %cmp.n47 = icmp eq i32 %4, %n.vec43
-  br i1 %cmp.n47, label %._crit_edge, label %.lr.ph.preheader50
-
-.lr.ph.preheader50:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 6, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %7, %vec.epilog.middle.block ]
-  %.ph51 = phi i32 [ 180, %iter.check ], [ %6, %vec.epilog.iter.check ], [ %11, %vec.epilog.middle.block ]
+.lr.ph.preheader37:                               ; preds = %.lr.ph.preheader34, %middle.block
+  %.ph = phi i32 [ 6, %.lr.ph.preheader34 ], [ %5, %middle.block ]
+  %.ph38 = phi i32 [ 180, %.lr.ph.preheader34 ], [ %7, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader50, %.lr.ph
-  %12 = phi i32 [ %15, %.lr.ph ], [ %.ph, %.lr.ph.preheader50 ]
-  %13 = phi i32 [ %14, %.lr.ph ], [ %.ph51, %.lr.ph.preheader50 ]
-  %14 = add i32 %13, 33
-  %15 = add nuw nsw i32 %12, 1
-  %exitcond.not = icmp eq i32 %15, %0
-  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !7
+.lr.ph:                                           ; preds = %.lr.ph.preheader37, %.lr.ph
+  %8 = phi i32 [ %11, %.lr.ph ], [ %.ph, %.lr.ph.preheader37 ]
+  %9 = phi i32 [ %10, %.lr.ph ], [ %.ph38, %.lr.ph.preheader37 ]
+  %10 = add i32 %9, 33
+  %11 = add nuw nsw i32 %8, 1
+  %exitcond.not = icmp eq i32 %11, %0
+  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !5
 
 switch.lookup:                                    ; preds = %.lr.ph.preheader
-  %16 = mul nuw nsw i32 %0, 30
+  %12 = mul nuw nsw i32 %0, 30
   br label %._crit_edge
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %switch.lookup, %1
-  %.lcssa = phi i32 [ 0, %1 ], [ %16, %switch.lookup ], [ %11, %vec.epilog.middle.block ], [ %6, %middle.block ], [ %14, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %switch.lookup, %1
+  %.lcssa = phi i32 [ 0, %1 ], [ %12, %switch.lookup ], [ %7, %middle.block ], [ %10, %.lr.ph ]
   ret i32 %.lcssa
 }
 
@@ -167,9 +137,6 @@ _mlir_ciface_execute.exit:                        ; preds = %1, %.lr.ph.i.prehea
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #3
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #3
 
 attributes #0 = { nofree norecurse nosync nounwind memory(none) }
@@ -184,6 +151,4 @@ attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !2 = !{!"llvm.loop.peeled.count", i32 6}
 !3 = !{!"llvm.loop.isvectorized", i32 1}
 !4 = !{!"llvm.loop.unroll.runtime.disable"}
-!5 = !{!"branch_weights", i32 4, i32 28}
-!6 = distinct !{!6, !2, !3, !4}
-!7 = distinct !{!7, !2, !4, !3}
+!5 = distinct !{!5, !2, !4, !3}

--- a/nautilus/test/llvm-ir-test/reference-ir/staticLoopWithDynamicLoopPostIncrement.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/staticLoopWithDynamicLoopPostIncrement.ll
@@ -10,80 +10,50 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
 
 .lr.ph.preheader:                                 ; preds = %1
   %3 = icmp ult i32 %0, 7
-  br i1 %3, label %switch.lookup, label %iter.check
+  br i1 %3, label %switch.lookup, label %.lr.ph.preheader34
 
-iter.check:                                       ; preds = %.lr.ph.preheader
+.lr.ph.preheader34:                               ; preds = %.lr.ph.preheader
   %4 = add nsw i32 %0, -6
-  %min.iters.check = icmp ult i32 %4, 4
-  br i1 %min.iters.check, label %.lr.ph.preheader50, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %4, 8
+  br i1 %min.iters.check, label %.lr.ph.preheader37, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check36 = icmp ult i32 %4, 32
-  br i1 %min.iters.check36, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %4, 28
-  %n.vec = and i32 %4, -32
+vector.ph:                                        ; preds = %.lr.ph.preheader34
+  %n.vec = and i32 %4, -8
+  %5 = or disjoint i32 %n.vec, 6
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %reduced.phi = phi <8 x i32> [ <i32 180, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, %vector.ph ], [ %bin.rdx41, %vector.body ]
-  %bin.rdx41 = add <8 x i32> %reduced.phi, splat (i32 132)
-  %index.next = add nuw i32 %index, 32
-  %5 = icmp eq i32 %index.next, %n.vec
-  br i1 %5, label %middle.block, label %vector.body, !llvm.loop !1
+  %reduced.phi = phi <4 x i32> [ <i32 180, i32 0, i32 0, i32 0>, %vector.ph ], [ %bin.rdx, %vector.body ]
+  %bin.rdx = add <4 x i32> %reduced.phi, splat (i32 66)
+  %index.next = add nuw i32 %index, 8
+  %6 = icmp eq i32 %index.next, %n.vec
+  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %6 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx41)
+  %7 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %4, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader37
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 6
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader50, label %vec.epilog.ph, !prof !5
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %6, %vec.epilog.iter.check ], [ 180, %vector.main.loop.iter.check ]
-  %n.vec43 = and i32 %4, -4
-  %7 = add i32 %n.vec43, 6
-  %8 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index44 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next46, %vec.epilog.vector.body ]
-  %vec.phi45 = phi <4 x i32> [ %8, %vec.epilog.ph ], [ %9, %vec.epilog.vector.body ]
-  %9 = add <4 x i32> %vec.phi45, splat (i32 33)
-  %index.next46 = add nuw i32 %index44, 4
-  %10 = icmp eq i32 %index.next46, %n.vec43
-  br i1 %10, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !6
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %11 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %9)
-  %cmp.n47 = icmp eq i32 %4, %n.vec43
-  br i1 %cmp.n47, label %._crit_edge, label %.lr.ph.preheader50
-
-.lr.ph.preheader50:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 6, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %7, %vec.epilog.middle.block ]
-  %.ph51 = phi i32 [ 180, %iter.check ], [ %6, %vec.epilog.iter.check ], [ %11, %vec.epilog.middle.block ]
+.lr.ph.preheader37:                               ; preds = %.lr.ph.preheader34, %middle.block
+  %.ph = phi i32 [ 6, %.lr.ph.preheader34 ], [ %5, %middle.block ]
+  %.ph38 = phi i32 [ 180, %.lr.ph.preheader34 ], [ %7, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader50, %.lr.ph
-  %12 = phi i32 [ %15, %.lr.ph ], [ %.ph, %.lr.ph.preheader50 ]
-  %13 = phi i32 [ %14, %.lr.ph ], [ %.ph51, %.lr.ph.preheader50 ]
-  %14 = add i32 %13, 33
-  %15 = add nuw nsw i32 %12, 1
-  %exitcond.not = icmp eq i32 %15, %0
-  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !7
+.lr.ph:                                           ; preds = %.lr.ph.preheader37, %.lr.ph
+  %8 = phi i32 [ %11, %.lr.ph ], [ %.ph, %.lr.ph.preheader37 ]
+  %9 = phi i32 [ %10, %.lr.ph ], [ %.ph38, %.lr.ph.preheader37 ]
+  %10 = add i32 %9, 33
+  %11 = add nuw nsw i32 %8, 1
+  %exitcond.not = icmp eq i32 %11, %0
+  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !5
 
 switch.lookup:                                    ; preds = %.lr.ph.preheader
-  %16 = mul nuw nsw i32 %0, 30
+  %12 = mul nuw nsw i32 %0, 30
   br label %._crit_edge
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %switch.lookup, %1
-  %.lcssa = phi i32 [ 0, %1 ], [ %16, %switch.lookup ], [ %11, %vec.epilog.middle.block ], [ %6, %middle.block ], [ %14, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %switch.lookup, %1
+  %.lcssa = phi i32 [ 0, %1 ], [ %12, %switch.lookup ], [ %7, %middle.block ], [ %10, %.lr.ph ]
   ret i32 %.lcssa
 }
 
@@ -167,9 +137,6 @@ _mlir_ciface_execute.exit:                        ; preds = %1, %.lr.ph.i.prehea
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #3
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #3
 
 attributes #0 = { nofree norecurse nosync nounwind memory(none) }
@@ -184,6 +151,4 @@ attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !2 = !{!"llvm.loop.peeled.count", i32 6}
 !3 = !{!"llvm.loop.isvectorized", i32 1}
 !4 = !{!"llvm.loop.unroll.runtime.disable"}
-!5 = !{!"branch_weights", i32 4, i32 28}
-!6 = distinct !{!6, !2, !3, !4}
-!7 = distinct !{!7, !2, !4, !3}
+!5 = distinct !{!5, !2, !4, !3}

--- a/nautilus/test/llvm-ir-test/reference-ir/staticLoopWithDynamicLoopPreIncrement.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/staticLoopWithDynamicLoopPreIncrement.ll
@@ -10,80 +10,50 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
 
 .lr.ph.preheader:                                 ; preds = %1
   %3 = icmp ult i32 %0, 7
-  br i1 %3, label %switch.lookup, label %iter.check
+  br i1 %3, label %switch.lookup, label %.lr.ph.preheader34
 
-iter.check:                                       ; preds = %.lr.ph.preheader
+.lr.ph.preheader34:                               ; preds = %.lr.ph.preheader
   %4 = add nsw i32 %0, -6
-  %min.iters.check = icmp ult i32 %4, 4
-  br i1 %min.iters.check, label %.lr.ph.preheader50, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %4, 8
+  br i1 %min.iters.check, label %.lr.ph.preheader37, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check36 = icmp ult i32 %4, 32
-  br i1 %min.iters.check36, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %4, 28
-  %n.vec = and i32 %4, -32
+vector.ph:                                        ; preds = %.lr.ph.preheader34
+  %n.vec = and i32 %4, -8
+  %5 = or disjoint i32 %n.vec, 6
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %reduced.phi = phi <8 x i32> [ <i32 180, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, %vector.ph ], [ %bin.rdx41, %vector.body ]
-  %bin.rdx41 = add <8 x i32> %reduced.phi, splat (i32 132)
-  %index.next = add nuw i32 %index, 32
-  %5 = icmp eq i32 %index.next, %n.vec
-  br i1 %5, label %middle.block, label %vector.body, !llvm.loop !1
+  %reduced.phi = phi <4 x i32> [ <i32 180, i32 0, i32 0, i32 0>, %vector.ph ], [ %bin.rdx, %vector.body ]
+  %bin.rdx = add <4 x i32> %reduced.phi, splat (i32 66)
+  %index.next = add nuw i32 %index, 8
+  %6 = icmp eq i32 %index.next, %n.vec
+  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %6 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx41)
+  %7 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %4, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader37
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 6
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader50, label %vec.epilog.ph, !prof !5
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %6, %vec.epilog.iter.check ], [ 180, %vector.main.loop.iter.check ]
-  %n.vec43 = and i32 %4, -4
-  %7 = add i32 %n.vec43, 6
-  %8 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index44 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next46, %vec.epilog.vector.body ]
-  %vec.phi45 = phi <4 x i32> [ %8, %vec.epilog.ph ], [ %9, %vec.epilog.vector.body ]
-  %9 = add <4 x i32> %vec.phi45, splat (i32 33)
-  %index.next46 = add nuw i32 %index44, 4
-  %10 = icmp eq i32 %index.next46, %n.vec43
-  br i1 %10, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !6
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %11 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %9)
-  %cmp.n47 = icmp eq i32 %4, %n.vec43
-  br i1 %cmp.n47, label %._crit_edge, label %.lr.ph.preheader50
-
-.lr.ph.preheader50:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 6, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %7, %vec.epilog.middle.block ]
-  %.ph51 = phi i32 [ 180, %iter.check ], [ %6, %vec.epilog.iter.check ], [ %11, %vec.epilog.middle.block ]
+.lr.ph.preheader37:                               ; preds = %.lr.ph.preheader34, %middle.block
+  %.ph = phi i32 [ 6, %.lr.ph.preheader34 ], [ %5, %middle.block ]
+  %.ph38 = phi i32 [ 180, %.lr.ph.preheader34 ], [ %7, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader50, %.lr.ph
-  %12 = phi i32 [ %15, %.lr.ph ], [ %.ph, %.lr.ph.preheader50 ]
-  %13 = phi i32 [ %14, %.lr.ph ], [ %.ph51, %.lr.ph.preheader50 ]
-  %14 = add i32 %13, 33
-  %15 = add nuw nsw i32 %12, 1
-  %exitcond.not = icmp eq i32 %15, %0
-  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !7
+.lr.ph:                                           ; preds = %.lr.ph.preheader37, %.lr.ph
+  %8 = phi i32 [ %11, %.lr.ph ], [ %.ph, %.lr.ph.preheader37 ]
+  %9 = phi i32 [ %10, %.lr.ph ], [ %.ph38, %.lr.ph.preheader37 ]
+  %10 = add i32 %9, 33
+  %11 = add nuw nsw i32 %8, 1
+  %exitcond.not = icmp eq i32 %11, %0
+  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !5
 
 switch.lookup:                                    ; preds = %.lr.ph.preheader
-  %16 = mul nuw nsw i32 %0, 30
+  %12 = mul nuw nsw i32 %0, 30
   br label %._crit_edge
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %switch.lookup, %1
-  %.lcssa = phi i32 [ 0, %1 ], [ %16, %switch.lookup ], [ %11, %vec.epilog.middle.block ], [ %6, %middle.block ], [ %14, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %switch.lookup, %1
+  %.lcssa = phi i32 [ 0, %1 ], [ %12, %switch.lookup ], [ %7, %middle.block ], [ %10, %.lr.ph ]
   ret i32 %.lcssa
 }
 
@@ -167,9 +137,6 @@ _mlir_ciface_execute.exit:                        ; preds = %1, %.lr.ph.i.prehea
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #3
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #3
 
 attributes #0 = { nofree norecurse nosync nounwind memory(none) }
@@ -184,6 +151,4 @@ attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !2 = !{!"llvm.loop.peeled.count", i32 6}
 !3 = !{!"llvm.loop.isvectorized", i32 1}
 !4 = !{!"llvm.loop.unroll.runtime.disable"}
-!5 = !{!"branch_weights", i32 4, i32 28}
-!6 = distinct !{!6, !2, !3, !4}
-!7 = distinct !{!7, !2, !4, !3}
+!5 = distinct !{!5, !2, !4, !3}

--- a/nautilus/test/llvm-ir-test/reference-ir/sumArray.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/sumArray.ll
@@ -6,196 +6,112 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: nofree norecurse nosync nounwind memory(argmem: read)
 define signext i32 @execute(ptr readonly %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %1, 0
-  br i1 %3, label %iter.check, label %._crit_edge
+  br i1 %3, label %.lr.ph.preheader, label %._crit_edge
 
-iter.check:                                       ; preds = %2
+.lr.ph.preheader:                                 ; preds = %2
   %wide.trip.count = zext nneg i32 %1 to i64
-  %min.iters.check = icmp ult i32 %1, 4
-  br i1 %min.iters.check, label %.lr.ph.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %1, 8
+  br i1 %min.iters.check, label %.lr.ph.preheader7, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check5 = icmp ult i32 %1, 32
-  br i1 %min.iters.check5, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i64 %wide.trip.count, 28
-  %n.vec = and i64 %wide.trip.count, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader
+  %n.vec = and i64 %wide.trip.count, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
-  %vec.phi6 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
-  %vec.phi7 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %vec.phi8 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %vec.phi5 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
   %4 = shl nuw nsw i64 %index, 2
   %5 = getelementptr i8, ptr %0, i64 %4
-  %6 = getelementptr i8, ptr %5, i64 32
-  %7 = getelementptr i8, ptr %5, i64 64
-  %8 = getelementptr i8, ptr %5, i64 96
-  %wide.load = load <8 x i32>, ptr %5, align 4
-  %wide.load9 = load <8 x i32>, ptr %6, align 4
-  %wide.load10 = load <8 x i32>, ptr %7, align 4
-  %wide.load11 = load <8 x i32>, ptr %8, align 4
-  %9 = add <8 x i32> %wide.load, %vec.phi
-  %10 = add <8 x i32> %wide.load9, %vec.phi6
-  %11 = add <8 x i32> %wide.load10, %vec.phi7
-  %12 = add <8 x i32> %wide.load11, %vec.phi8
-  %index.next = add nuw i64 %index, 32
-  %13 = icmp eq i64 %index.next, %n.vec
-  br i1 %13, label %middle.block, label %vector.body, !llvm.loop !1
+  %6 = getelementptr i8, ptr %5, i64 16
+  %wide.load = load <4 x i32>, ptr %5, align 4
+  %wide.load6 = load <4 x i32>, ptr %6, align 4
+  %7 = add <4 x i32> %wide.load, %vec.phi
+  %8 = add <4 x i32> %wide.load6, %vec.phi5
+  %index.next = add nuw i64 %index, 8
+  %9 = icmp eq i64 %index.next, %n.vec
+  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %10, %9
-  %bin.rdx12 = add <8 x i32> %11, %bin.rdx
-  %bin.rdx13 = add <8 x i32> %12, %bin.rdx12
-  %14 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx13)
+  %bin.rdx = add <4 x i32> %8, %7
+  %10 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i64 %n.vec, %wide.trip.count
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader7
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i64 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i64 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %14, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec15 = and i64 %wide.trip.count, 2147483644
-  %15 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index16 = phi i64 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next19, %vec.epilog.vector.body ]
-  %vec.phi17 = phi <4 x i32> [ %15, %vec.epilog.ph ], [ %18, %vec.epilog.vector.body ]
-  %16 = shl nuw nsw i64 %index16, 2
-  %17 = getelementptr i8, ptr %0, i64 %16
-  %wide.load18 = load <4 x i32>, ptr %17, align 4
-  %18 = add <4 x i32> %wide.load18, %vec.phi17
-  %index.next19 = add nuw i64 %index16, 4
-  %19 = icmp eq i64 %index.next19, %n.vec15
-  br i1 %19, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !5
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %20 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %18)
-  %cmp.n20 = icmp eq i64 %n.vec15, %wide.trip.count
-  br i1 %cmp.n20, label %._crit_edge, label %.lr.ph.preheader
-
-.lr.ph.preheader:                                 ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %indvars.iv.ph = phi i64 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec15, %vec.epilog.middle.block ]
-  %.ph = phi i32 [ 0, %iter.check ], [ %14, %vec.epilog.iter.check ], [ %20, %vec.epilog.middle.block ]
+.lr.ph.preheader7:                                ; preds = %.lr.ph.preheader, %middle.block
+  %indvars.iv.ph = phi i64 [ 0, %.lr.ph.preheader ], [ %n.vec, %middle.block ]
+  %.ph = phi i32 [ 0, %.lr.ph.preheader ], [ %10, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader, %.lr.ph
-  %indvars.iv = phi i64 [ %indvars.iv.next, %.lr.ph ], [ %indvars.iv.ph, %.lr.ph.preheader ]
-  %21 = phi i32 [ %25, %.lr.ph ], [ %.ph, %.lr.ph.preheader ]
-  %22 = shl nuw nsw i64 %indvars.iv, 2
-  %23 = getelementptr i8, ptr %0, i64 %22
-  %24 = load i32, ptr %23, align 4
-  %25 = add i32 %24, %21
+.lr.ph:                                           ; preds = %.lr.ph.preheader7, %.lr.ph
+  %indvars.iv = phi i64 [ %indvars.iv.next, %.lr.ph ], [ %indvars.iv.ph, %.lr.ph.preheader7 ]
+  %11 = phi i32 [ %15, %.lr.ph ], [ %.ph, %.lr.ph.preheader7 ]
+  %12 = shl nuw nsw i64 %indvars.iv, 2
+  %13 = getelementptr i8, ptr %0, i64 %12
+  %14 = load i32, ptr %13, align 4
+  %15 = add i32 %14, %11
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, %wide.trip.count
-  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !6
+  br i1 %exitcond.not, label %._crit_edge, label %.lr.ph, !llvm.loop !4
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %2
-  %.lcssa = phi i32 [ 0, %2 ], [ %20, %vec.epilog.middle.block ], [ %14, %middle.block ], [ %25, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %2
+  %.lcssa = phi i32 [ 0, %2 ], [ %10, %middle.block ], [ %15, %.lr.ph ]
   ret i32 %.lcssa
 }
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(argmem: read)
 define signext i32 @_mlir_ciface_execute(ptr readonly %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %1, 0
-  br i1 %3, label %iter.check, label %execute.exit
+  br i1 %3, label %.lr.ph.preheader.i, label %execute.exit
 
-iter.check:                                       ; preds = %2
+.lr.ph.preheader.i:                               ; preds = %2
   %wide.trip.count.i = zext nneg i32 %1 to i64
-  %min.iters.check = icmp ult i32 %1, 4
-  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %1, 8
+  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %1, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i64 %wide.trip.count.i, 28
-  %n.vec = and i64 %wide.trip.count.i, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader.i
+  %n.vec = and i64 %wide.trip.count.i, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
   %4 = shl nuw nsw i64 %index, 2
   %5 = getelementptr i8, ptr %0, i64 %4
-  %6 = getelementptr i8, ptr %5, i64 32
-  %7 = getelementptr i8, ptr %5, i64 64
-  %8 = getelementptr i8, ptr %5, i64 96
-  %wide.load = load <8 x i32>, ptr %5, align 4
-  %wide.load5 = load <8 x i32>, ptr %6, align 4
-  %wide.load6 = load <8 x i32>, ptr %7, align 4
-  %wide.load7 = load <8 x i32>, ptr %8, align 4
-  %9 = add <8 x i32> %wide.load, %vec.phi
-  %10 = add <8 x i32> %wide.load5, %vec.phi2
-  %11 = add <8 x i32> %wide.load6, %vec.phi3
-  %12 = add <8 x i32> %wide.load7, %vec.phi4
-  %index.next = add nuw i64 %index, 32
-  %13 = icmp eq i64 %index.next, %n.vec
-  br i1 %13, label %middle.block, label %vector.body, !llvm.loop !7
+  %6 = getelementptr i8, ptr %5, i64 16
+  %wide.load = load <4 x i32>, ptr %5, align 4
+  %wide.load2 = load <4 x i32>, ptr %6, align 4
+  %7 = add <4 x i32> %wide.load, %vec.phi
+  %8 = add <4 x i32> %wide.load2, %vec.phi1
+  %index.next = add nuw i64 %index, 8
+  %9 = icmp eq i64 %index.next, %n.vec
+  br i1 %9, label %middle.block, label %vector.body, !llvm.loop !5
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %10, %9
-  %bin.rdx8 = add <8 x i32> %11, %bin.rdx
-  %bin.rdx9 = add <8 x i32> %12, %bin.rdx8
-  %14 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx9)
+  %bin.rdx = add <4 x i32> %8, %7
+  %10 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i64 %n.vec, %wide.trip.count.i
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i64 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i64 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %14, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec11 = and i64 %wide.trip.count.i, 2147483644
-  %15 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index12 = phi i64 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next15, %vec.epilog.vector.body ]
-  %vec.phi13 = phi <4 x i32> [ %15, %vec.epilog.ph ], [ %18, %vec.epilog.vector.body ]
-  %16 = shl nuw nsw i64 %index12, 2
-  %17 = getelementptr i8, ptr %0, i64 %16
-  %wide.load14 = load <4 x i32>, ptr %17, align 4
-  %18 = add <4 x i32> %wide.load14, %vec.phi13
-  %index.next15 = add nuw i64 %index12, 4
-  %19 = icmp eq i64 %index.next15, %n.vec11
-  br i1 %19, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !8
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %20 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %18)
-  %cmp.n16 = icmp eq i64 %n.vec11, %wide.trip.count.i
-  br i1 %cmp.n16, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %indvars.iv.i.ph = phi i64 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec11, %vec.epilog.middle.block ]
-  %.ph = phi i32 [ 0, %iter.check ], [ %14, %vec.epilog.iter.check ], [ %20, %vec.epilog.middle.block ]
+.lr.ph.i.preheader:                               ; preds = %.lr.ph.preheader.i, %middle.block
+  %indvars.iv.i.ph = phi i64 [ 0, %.lr.ph.preheader.i ], [ %n.vec, %middle.block ]
+  %.ph = phi i32 [ 0, %.lr.ph.preheader.i ], [ %10, %middle.block ]
   br label %.lr.ph.i
 
 .lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
   %indvars.iv.i = phi i64 [ %indvars.iv.next.i, %.lr.ph.i ], [ %indvars.iv.i.ph, %.lr.ph.i.preheader ]
-  %21 = phi i32 [ %25, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %22 = shl nuw nsw i64 %indvars.iv.i, 2
-  %23 = getelementptr i8, ptr %0, i64 %22
-  %24 = load i32, ptr %23, align 4
-  %25 = add i32 %24, %21
+  %11 = phi i32 [ %15, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
+  %12 = shl nuw nsw i64 %indvars.iv.i, 2
+  %13 = getelementptr i8, ptr %0, i64 %12
+  %14 = load i32, ptr %13, align 4
+  %15 = add i32 %14, %11
   %indvars.iv.next.i = add nuw nsw i64 %indvars.iv.i, 1
   %exitcond.not.i = icmp eq i64 %indvars.iv.next.i, %wide.trip.count.i
-  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !9
+  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !6
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %2
-  %.lcssa.i = phi i32 [ 0, %2 ], [ %20, %vec.epilog.middle.block ], [ %14, %middle.block ], [ %25, %.lr.ph.i ]
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %2
+  %.lcssa.i = phi i32 [ 0, %2 ], [ %10, %middle.block ], [ %15, %.lr.ph.i ]
   ret i32 %.lcssa.i
 }
 
@@ -207,101 +123,59 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %5 = load ptr, ptr %4, align 8
   %6 = load i32, ptr %5, align 4
   %7 = icmp sgt i32 %6, 0
-  br i1 %7, label %iter.check, label %execute.exit
+  br i1 %7, label %.lr.ph.preheader.i, label %execute.exit
 
-iter.check:                                       ; preds = %1
+.lr.ph.preheader.i:                               ; preds = %1
   %wide.trip.count.i = zext nneg i32 %6 to i64
-  %min.iters.check = icmp ult i32 %6, 4
-  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %6, 8
+  br i1 %min.iters.check, label %.lr.ph.i.preheader, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %6, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i64 %wide.trip.count.i, 28
-  %n.vec = and i64 %wide.trip.count.i, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader.i
+  %n.vec = and i64 %wide.trip.count.i, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %14, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %15, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %16, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
   %8 = shl nuw nsw i64 %index, 2
   %9 = getelementptr i8, ptr %3, i64 %8
-  %10 = getelementptr i8, ptr %9, i64 32
-  %11 = getelementptr i8, ptr %9, i64 64
-  %12 = getelementptr i8, ptr %9, i64 96
-  %wide.load = load <8 x i32>, ptr %9, align 4
-  %wide.load5 = load <8 x i32>, ptr %10, align 4
-  %wide.load6 = load <8 x i32>, ptr %11, align 4
-  %wide.load7 = load <8 x i32>, ptr %12, align 4
-  %13 = add <8 x i32> %wide.load, %vec.phi
-  %14 = add <8 x i32> %wide.load5, %vec.phi2
-  %15 = add <8 x i32> %wide.load6, %vec.phi3
-  %16 = add <8 x i32> %wide.load7, %vec.phi4
-  %index.next = add nuw i64 %index, 32
-  %17 = icmp eq i64 %index.next, %n.vec
-  br i1 %17, label %middle.block, label %vector.body, !llvm.loop !10
+  %10 = getelementptr i8, ptr %9, i64 16
+  %wide.load = load <4 x i32>, ptr %9, align 4
+  %wide.load2 = load <4 x i32>, ptr %10, align 4
+  %11 = add <4 x i32> %wide.load, %vec.phi
+  %12 = add <4 x i32> %wide.load2, %vec.phi1
+  %index.next = add nuw i64 %index, 8
+  %13 = icmp eq i64 %index.next, %n.vec
+  br i1 %13, label %middle.block, label %vector.body, !llvm.loop !7
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %14, %13
-  %bin.rdx8 = add <8 x i32> %15, %bin.rdx
-  %bin.rdx9 = add <8 x i32> %16, %bin.rdx8
-  %18 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx9)
+  %bin.rdx = add <4 x i32> %12, %11
+  %14 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i64 %n.vec, %wide.trip.count.i
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i64 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i64 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %18, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec11 = and i64 %wide.trip.count.i, 2147483644
-  %19 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index12 = phi i64 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next15, %vec.epilog.vector.body ]
-  %vec.phi13 = phi <4 x i32> [ %19, %vec.epilog.ph ], [ %22, %vec.epilog.vector.body ]
-  %20 = shl nuw nsw i64 %index12, 2
-  %21 = getelementptr i8, ptr %3, i64 %20
-  %wide.load14 = load <4 x i32>, ptr %21, align 4
-  %22 = add <4 x i32> %wide.load14, %vec.phi13
-  %index.next15 = add nuw i64 %index12, 4
-  %23 = icmp eq i64 %index.next15, %n.vec11
-  br i1 %23, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !11
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %24 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %22)
-  %cmp.n16 = icmp eq i64 %n.vec11, %wide.trip.count.i
-  br i1 %cmp.n16, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %indvars.iv.i.ph = phi i64 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec11, %vec.epilog.middle.block ]
-  %.ph = phi i32 [ 0, %iter.check ], [ %18, %vec.epilog.iter.check ], [ %24, %vec.epilog.middle.block ]
+.lr.ph.i.preheader:                               ; preds = %.lr.ph.preheader.i, %middle.block
+  %indvars.iv.i.ph = phi i64 [ 0, %.lr.ph.preheader.i ], [ %n.vec, %middle.block ]
+  %.ph = phi i32 [ 0, %.lr.ph.preheader.i ], [ %14, %middle.block ]
   br label %.lr.ph.i
 
 .lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
   %indvars.iv.i = phi i64 [ %indvars.iv.next.i, %.lr.ph.i ], [ %indvars.iv.i.ph, %.lr.ph.i.preheader ]
-  %25 = phi i32 [ %29, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %26 = shl nuw nsw i64 %indvars.iv.i, 2
-  %27 = getelementptr i8, ptr %3, i64 %26
-  %28 = load i32, ptr %27, align 4
-  %29 = add i32 %28, %25
+  %15 = phi i32 [ %19, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
+  %16 = shl nuw nsw i64 %indvars.iv.i, 2
+  %17 = getelementptr i8, ptr %3, i64 %16
+  %18 = load i32, ptr %17, align 4
+  %19 = add i32 %18, %15
   %indvars.iv.next.i = add nuw nsw i64 %indvars.iv.i, 1
   %exitcond.not.i = icmp eq i64 %indvars.iv.next.i, %wide.trip.count.i
-  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !12
+  br i1 %exitcond.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !8
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %24, %vec.epilog.middle.block ], [ %18, %middle.block ], [ %29, %.lr.ph.i ]
-  %30 = getelementptr i8, ptr %0, i64 16
-  %31 = load ptr, ptr %30, align 8
-  store i32 %.lcssa.i, ptr %31, align 4
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %14, %middle.block ], [ %19, %.lr.ph.i ]
+  %20 = getelementptr i8, ptr %0, i64 16
+  %21 = load ptr, ptr %20, align 8
+  store i32 %.lcssa.i, ptr %21, align 4
   ret void
 }
 
@@ -313,106 +187,61 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %5 = load ptr, ptr %4, align 8
   %6 = load i32, ptr %5, align 4
   %7 = icmp sgt i32 %6, 0
-  br i1 %7, label %iter.check, label %_mlir_ciface_execute.exit
+  br i1 %7, label %.lr.ph.preheader.i.i, label %_mlir_ciface_execute.exit
 
-iter.check:                                       ; preds = %1
+.lr.ph.preheader.i.i:                             ; preds = %1
   %wide.trip.count.i.i = zext nneg i32 %6 to i64
-  %min.iters.check = icmp ult i32 %6, 4
-  br i1 %min.iters.check, label %.lr.ph.i.i.preheader, label %vector.main.loop.iter.check
+  %min.iters.check = icmp ult i32 %6, 8
+  br i1 %min.iters.check, label %.lr.ph.i.i.preheader, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %6, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i64 %wide.trip.count.i.i, 28
-  %n.vec = and i64 %wide.trip.count.i.i, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader.i.i
+  %n.vec = and i64 %wide.trip.count.i.i, 2147483640
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %14, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %15, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %16, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
   %8 = shl nuw nsw i64 %index, 2
   %9 = getelementptr i8, ptr %3, i64 %8
-  %10 = getelementptr i8, ptr %9, i64 32
-  %11 = getelementptr i8, ptr %9, i64 64
-  %12 = getelementptr i8, ptr %9, i64 96
-  %wide.load = load <8 x i32>, ptr %9, align 4
-  %wide.load5 = load <8 x i32>, ptr %10, align 4
-  %wide.load6 = load <8 x i32>, ptr %11, align 4
-  %wide.load7 = load <8 x i32>, ptr %12, align 4
-  %13 = add <8 x i32> %wide.load, %vec.phi
-  %14 = add <8 x i32> %wide.load5, %vec.phi2
-  %15 = add <8 x i32> %wide.load6, %vec.phi3
-  %16 = add <8 x i32> %wide.load7, %vec.phi4
-  %index.next = add nuw i64 %index, 32
-  %17 = icmp eq i64 %index.next, %n.vec
-  br i1 %17, label %middle.block, label %vector.body, !llvm.loop !13
+  %10 = getelementptr i8, ptr %9, i64 16
+  %wide.load = load <4 x i32>, ptr %9, align 4
+  %wide.load2 = load <4 x i32>, ptr %10, align 4
+  %11 = add <4 x i32> %wide.load, %vec.phi
+  %12 = add <4 x i32> %wide.load2, %vec.phi1
+  %index.next = add nuw i64 %index, 8
+  %13 = icmp eq i64 %index.next, %n.vec
+  br i1 %13, label %middle.block, label %vector.body, !llvm.loop !9
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %14, %13
-  %bin.rdx8 = add <8 x i32> %15, %bin.rdx
-  %bin.rdx9 = add <8 x i32> %16, %bin.rdx8
-  %18 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx9)
+  %bin.rdx = add <4 x i32> %12, %11
+  %14 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i64 %n.vec, %wide.trip.count.i.i
-  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %min.epilog.iters.check = icmp eq i64 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i64 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %18, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec11 = and i64 %wide.trip.count.i.i, 2147483644
-  %19 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index12 = phi i64 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next15, %vec.epilog.vector.body ]
-  %vec.phi13 = phi <4 x i32> [ %19, %vec.epilog.ph ], [ %22, %vec.epilog.vector.body ]
-  %20 = shl nuw nsw i64 %index12, 2
-  %21 = getelementptr i8, ptr %3, i64 %20
-  %wide.load14 = load <4 x i32>, ptr %21, align 4
-  %22 = add <4 x i32> %wide.load14, %vec.phi13
-  %index.next15 = add nuw i64 %index12, 4
-  %23 = icmp eq i64 %index.next15, %n.vec11
-  br i1 %23, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !14
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %24 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %22)
-  %cmp.n16 = icmp eq i64 %n.vec11, %wide.trip.count.i.i
-  br i1 %cmp.n16, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
-
-.lr.ph.i.i.preheader:                             ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %indvars.iv.i.i.ph = phi i64 [ 0, %iter.check ], [ %n.vec, %vec.epilog.iter.check ], [ %n.vec11, %vec.epilog.middle.block ]
-  %.ph = phi i32 [ 0, %iter.check ], [ %18, %vec.epilog.iter.check ], [ %24, %vec.epilog.middle.block ]
+.lr.ph.i.i.preheader:                             ; preds = %.lr.ph.preheader.i.i, %middle.block
+  %indvars.iv.i.i.ph = phi i64 [ 0, %.lr.ph.preheader.i.i ], [ %n.vec, %middle.block ]
+  %.ph = phi i32 [ 0, %.lr.ph.preheader.i.i ], [ %14, %middle.block ]
   br label %.lr.ph.i.i
 
 .lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader, %.lr.ph.i.i
   %indvars.iv.i.i = phi i64 [ %indvars.iv.next.i.i, %.lr.ph.i.i ], [ %indvars.iv.i.i.ph, %.lr.ph.i.i.preheader ]
-  %25 = phi i32 [ %29, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader ]
-  %26 = shl nuw nsw i64 %indvars.iv.i.i, 2
-  %27 = getelementptr i8, ptr %3, i64 %26
-  %28 = load i32, ptr %27, align 4
-  %29 = add i32 %28, %25
+  %15 = phi i32 [ %19, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader ]
+  %16 = shl nuw nsw i64 %indvars.iv.i.i, 2
+  %17 = getelementptr i8, ptr %3, i64 %16
+  %18 = load i32, ptr %17, align 4
+  %19 = add i32 %18, %15
   %indvars.iv.next.i.i = add nuw nsw i64 %indvars.iv.i.i, 1
   %exitcond.not.i.i = icmp eq i64 %indvars.iv.next.i.i, %wide.trip.count.i.i
-  br i1 %exitcond.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !15
+  br i1 %exitcond.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !10
 
-_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %24, %vec.epilog.middle.block ], [ %18, %middle.block ], [ %29, %.lr.ph.i.i ]
-  %30 = getelementptr i8, ptr %0, i64 16
-  %31 = load ptr, ptr %30, align 8
-  store i32 %.lcssa.i.i, ptr %31, align 4
+_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %1
+  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %14, %middle.block ], [ %19, %.lr.ph.i.i ]
+  %20 = getelementptr i8, ptr %0, i64 16
+  %21 = load ptr, ptr %20, align 8
+  store i32 %.lcssa.i.i, ptr %21, align 4
   ret void
 }
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #2
@@ -427,15 +256,10 @@ attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !1 = distinct !{!1, !2, !3}
 !2 = !{!"llvm.loop.isvectorized", i32 1}
 !3 = !{!"llvm.loop.unroll.runtime.disable"}
-!4 = !{!"branch_weights", i32 4, i32 28}
+!4 = distinct !{!4, !3, !2}
 !5 = distinct !{!5, !2, !3}
 !6 = distinct !{!6, !3, !2}
 !7 = distinct !{!7, !2, !3}
-!8 = distinct !{!8, !2, !3}
-!9 = distinct !{!9, !3, !2}
-!10 = distinct !{!10, !2, !3}
-!11 = distinct !{!11, !2, !3}
-!12 = distinct !{!12, !3, !2}
-!13 = distinct !{!13, !2, !3}
-!14 = distinct !{!14, !2, !3}
-!15 = distinct !{!15, !3, !2}
+!8 = distinct !{!8, !3, !2}
+!9 = distinct !{!9, !2, !3}
+!10 = distinct !{!10, !3, !2}

--- a/nautilus/test/llvm-ir-test/reference-ir/sumOfNumbers.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/sumOfNumbers.ll
@@ -6,194 +6,104 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %.not1 = icmp slt i32 %0, 1
-  br i1 %.not1, label %._crit_edge, label %iter.check
+  br i1 %.not1, label %._crit_edge, label %.lr.ph.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.preheader:                                 ; preds = %1
   %2 = add nsw i32 %0, -2147483647
-  %or.cond = icmp ult i32 %2, -2147483643
-  br i1 %or.cond, label %.lr.ph.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %2, -2147483627
+  br i1 %or.cond, label %.lr.ph.preheader7, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check5 = icmp ult i32 %0, 32
-  br i1 %min.iters.check5, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %0, 28
-  %n.vec = and i32 %0, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader
+  %n.vec = and i32 %0, 2147483640
   %3 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %4, %vector.body ]
-  %vec.phi6 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %5, %vector.body ]
-  %vec.phi7 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
-  %vec.phi8 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %4 = add <8 x i32> %vec.ind, %vec.phi
-  %5 = add <8 x i32> %step.add, %vec.phi6
-  %6 = add <8 x i32> %step.add.2, %vec.phi7
-  %7 = add <8 x i32> %step.add.3, %vec.phi8
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %8 = icmp eq i32 %index.next, %n.vec
-  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !1
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %4, %vector.body ]
+  %vec.phi5 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %5, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %4 = add <4 x i32> %vec.ind, %vec.phi
+  %5 = add <4 x i32> %step.add, %vec.phi5
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %6 = icmp eq i32 %index.next, %n.vec
+  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %5, %4
-  %bin.rdx9 = add <8 x i32> %6, %bin.rdx
-  %bin.rdx10 = add <8 x i32> %7, %bin.rdx9
-  %9 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx10)
+  %bin.rdx = add <4 x i32> %5, %4
+  %7 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %0, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader7
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %3, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %9, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec12 = and i32 %0, 2147483644
-  %10 = or disjoint i32 %n.vec12, 1
-  %11 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index13 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next16, %vec.epilog.vector.body ]
-  %vec.ind14 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next17, %vec.epilog.vector.body ]
-  %vec.phi15 = phi <4 x i32> [ %11, %vec.epilog.ph ], [ %12, %vec.epilog.vector.body ]
-  %12 = add <4 x i32> %vec.ind14, %vec.phi15
-  %index.next16 = add nuw i32 %index13, 4
-  %vec.ind.next17 = add <4 x i32> %vec.ind14, splat (i32 4)
-  %13 = icmp eq i32 %index.next16, %n.vec12
-  br i1 %13, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !5
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %14 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %12)
-  %cmp.n18 = icmp eq i32 %0, %n.vec12
-  br i1 %cmp.n18, label %._crit_edge, label %.lr.ph.preheader
-
-.lr.ph.preheader:                                 ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %10, %vec.epilog.middle.block ]
-  %.ph22 = phi i32 [ 0, %iter.check ], [ %9, %vec.epilog.iter.check ], [ %14, %vec.epilog.middle.block ]
+.lr.ph.preheader7:                                ; preds = %.lr.ph.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.preheader ], [ %3, %middle.block ]
+  %.ph8 = phi i32 [ 0, %.lr.ph.preheader ], [ %7, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader, %.lr.ph
-  %15 = phi i32 [ %18, %.lr.ph ], [ %.ph, %.lr.ph.preheader ]
-  %16 = phi i32 [ %17, %.lr.ph ], [ %.ph22, %.lr.ph.preheader ]
-  %17 = add i32 %15, %16
-  %18 = add i32 %15, 1
-  %.not = icmp sgt i32 %18, %0
-  br i1 %.not, label %._crit_edge, label %.lr.ph, !llvm.loop !6
+.lr.ph:                                           ; preds = %.lr.ph.preheader7, %.lr.ph
+  %8 = phi i32 [ %11, %.lr.ph ], [ %.ph, %.lr.ph.preheader7 ]
+  %9 = phi i32 [ %10, %.lr.ph ], [ %.ph8, %.lr.ph.preheader7 ]
+  %10 = add i32 %8, %9
+  %11 = add i32 %8, 1
+  %.not = icmp sgt i32 %11, %0
+  br i1 %.not, label %._crit_edge, label %.lr.ph, !llvm.loop !4
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa = phi i32 [ 0, %1 ], [ %14, %vec.epilog.middle.block ], [ %9, %middle.block ], [ %17, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %1
+  %.lcssa = phi i32 [ 0, %1 ], [ %7, %middle.block ], [ %10, %.lr.ph ]
   ret i32 %.lcssa
 }
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %.not1.i = icmp slt i32 %0, 1
-  br i1 %.not1.i, label %execute.exit, label %iter.check
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.preheader:                               ; preds = %1
   %2 = add nsw i32 %0, -2147483647
-  %or.cond = icmp ult i32 %2, -2147483643
-  br i1 %or.cond, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %2, -2147483627
+  br i1 %or.cond, label %.lr.ph.i.preheader3, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %0, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %0, 28
-  %n.vec = and i32 %0, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %0, 2147483640
   %3 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %4, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %5, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %4 = add <8 x i32> %vec.phi, %vec.ind
-  %5 = add <8 x i32> %vec.phi2, %step.add
-  %6 = add <8 x i32> %vec.phi3, %step.add.2
-  %7 = add <8 x i32> %vec.phi4, %step.add.3
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %8 = icmp eq i32 %index.next, %n.vec
-  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !7
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %4, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %5, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %4 = add <4 x i32> %vec.phi, %vec.ind
+  %5 = add <4 x i32> %vec.phi1, %step.add
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %6 = icmp eq i32 %index.next, %n.vec
+  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !5
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %5, %4
-  %bin.rdx5 = add <8 x i32> %6, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %7, %bin.rdx5
-  %9 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %5, %4
+  %7 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %0, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader3
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %3, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %9, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %0, 2147483644
-  %10 = or disjoint i32 %n.vec8, 1
-  %11 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %11, %vec.epilog.ph ], [ %12, %vec.epilog.vector.body ]
-  %12 = add <4 x i32> %vec.phi11, %vec.ind10
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add <4 x i32> %vec.ind10, splat (i32 4)
-  %13 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %13, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !8
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %14 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %12)
-  %cmp.n14 = icmp eq i32 %0, %n.vec8
-  br i1 %cmp.n14, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %10, %vec.epilog.middle.block ]
-  %.ph18 = phi i32 [ 0, %iter.check ], [ %9, %vec.epilog.iter.check ], [ %14, %vec.epilog.middle.block ]
+.lr.ph.i.preheader3:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.i.preheader ], [ %3, %middle.block ]
+  %.ph4 = phi i32 [ 0, %.lr.ph.i.preheader ], [ %7, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %15 = phi i32 [ %18, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %16 = phi i32 [ %17, %.lr.ph.i ], [ %.ph18, %.lr.ph.i.preheader ]
-  %17 = add i32 %16, %15
-  %18 = add i32 %15, 1
-  %.not.i = icmp sgt i32 %18, %0
-  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !9
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader3, %.lr.ph.i
+  %8 = phi i32 [ %11, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader3 ]
+  %9 = phi i32 [ %10, %.lr.ph.i ], [ %.ph4, %.lr.ph.i.preheader3 ]
+  %10 = add i32 %9, %8
+  %11 = add i32 %8, 1
+  %.not.i = icmp sgt i32 %11, %0
+  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !6
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %14, %vec.epilog.middle.block ], [ %9, %middle.block ], [ %17, %.lr.ph.i ]
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %7, %middle.block ], [ %10, %.lr.ph.i ]
   ret i32 %.lcssa.i
 }
 
@@ -202,100 +112,55 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %.not1.i = icmp slt i32 %3, 1
-  br i1 %.not1.i, label %execute.exit, label %iter.check
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.preheader:                               ; preds = %1
   %4 = add nsw i32 %3, -2147483647
-  %or.cond = icmp ult i32 %4, -2147483643
-  br i1 %or.cond, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %4, -2147483627
+  br i1 %or.cond, label %.lr.ph.i.preheader3, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %3, 2147483640
   %5 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %6 = add <8 x i32> %vec.phi, %vec.ind
-  %7 = add <8 x i32> %vec.phi2, %step.add
-  %8 = add <8 x i32> %vec.phi3, %step.add.2
-  %9 = add <8 x i32> %vec.phi4, %step.add.3
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %10 = icmp eq i32 %index.next, %n.vec
-  br i1 %10, label %middle.block, label %vector.body, !llvm.loop !10
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %6 = add <4 x i32> %vec.phi, %vec.ind
+  %7 = add <4 x i32> %vec.phi1, %step.add
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %8 = icmp eq i32 %index.next, %n.vec
+  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !7
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %7, %6
-  %bin.rdx5 = add <8 x i32> %8, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %9, %bin.rdx5
-  %11 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %7, %6
+  %9 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader3
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %5, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %11, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, 2147483644
-  %12 = or disjoint i32 %n.vec8, 1
-  %13 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %13, %vec.epilog.ph ], [ %14, %vec.epilog.vector.body ]
-  %14 = add <4 x i32> %vec.phi11, %vec.ind10
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add <4 x i32> %vec.ind10, splat (i32 4)
-  %15 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %15, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !11
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %16 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %14)
-  %cmp.n14 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n14, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %12, %vec.epilog.middle.block ]
-  %.ph18 = phi i32 [ 0, %iter.check ], [ %11, %vec.epilog.iter.check ], [ %16, %vec.epilog.middle.block ]
+.lr.ph.i.preheader3:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.i.preheader ], [ %5, %middle.block ]
+  %.ph4 = phi i32 [ 0, %.lr.ph.i.preheader ], [ %9, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %17 = phi i32 [ %20, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %18 = phi i32 [ %19, %.lr.ph.i ], [ %.ph18, %.lr.ph.i.preheader ]
-  %19 = add i32 %18, %17
-  %20 = add i32 %17, 1
-  %.not.i = icmp sgt i32 %20, %3
-  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !12
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader3, %.lr.ph.i
+  %10 = phi i32 [ %13, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader3 ]
+  %11 = phi i32 [ %12, %.lr.ph.i ], [ %.ph4, %.lr.ph.i.preheader3 ]
+  %12 = add i32 %11, %10
+  %13 = add i32 %10, 1
+  %.not.i = icmp sgt i32 %13, %3
+  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !8
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %16, %vec.epilog.middle.block ], [ %11, %middle.block ], [ %19, %.lr.ph.i ]
-  %21 = getelementptr i8, ptr %0, i64 8
-  %22 = load ptr, ptr %21, align 8
-  store i32 %.lcssa.i, ptr %22, align 4
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %9, %middle.block ], [ %12, %.lr.ph.i ]
+  %14 = getelementptr i8, ptr %0, i64 8
+  %15 = load ptr, ptr %14, align 8
+  store i32 %.lcssa.i, ptr %15, align 4
   ret void
 }
 
@@ -304,105 +169,57 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %.not1.i.i = icmp slt i32 %3, 1
-  br i1 %.not1.i.i, label %_mlir_ciface_execute.exit, label %iter.check
+  br i1 %.not1.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.i.preheader:                             ; preds = %1
   %4 = add nsw i32 %3, -2147483647
-  %or.cond = icmp ult i32 %4, -2147483643
-  br i1 %or.cond, label %.lr.ph.i.i.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %4, -2147483627
+  br i1 %or.cond, label %.lr.ph.i.i.preheader3, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.i.preheader
+  %n.vec = and i32 %3, 2147483640
   %5 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %6 = add <8 x i32> %vec.phi, %vec.ind
-  %7 = add <8 x i32> %vec.phi2, %step.add
-  %8 = add <8 x i32> %vec.phi3, %step.add.2
-  %9 = add <8 x i32> %vec.phi4, %step.add.3
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %10 = icmp eq i32 %index.next, %n.vec
-  br i1 %10, label %middle.block, label %vector.body, !llvm.loop !13
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %6 = add <4 x i32> %vec.phi, %vec.ind
+  %7 = add <4 x i32> %vec.phi1, %step.add
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %8 = icmp eq i32 %index.next, %n.vec
+  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !9
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %7, %6
-  %bin.rdx5 = add <8 x i32> %8, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %9, %bin.rdx5
-  %11 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %7, %6
+  %9 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader3
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %5, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %11, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, 2147483644
-  %12 = or disjoint i32 %n.vec8, 1
-  %13 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %13, %vec.epilog.ph ], [ %14, %vec.epilog.vector.body ]
-  %14 = add <4 x i32> %vec.phi11, %vec.ind10
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add <4 x i32> %vec.ind10, splat (i32 4)
-  %15 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %15, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !14
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %16 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %14)
-  %cmp.n14 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n14, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
-
-.lr.ph.i.i.preheader:                             ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %12, %vec.epilog.middle.block ]
-  %.ph18 = phi i32 [ 0, %iter.check ], [ %11, %vec.epilog.iter.check ], [ %16, %vec.epilog.middle.block ]
+.lr.ph.i.i.preheader3:                            ; preds = %.lr.ph.i.i.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.i.i.preheader ], [ %5, %middle.block ]
+  %.ph4 = phi i32 [ 0, %.lr.ph.i.i.preheader ], [ %9, %middle.block ]
   br label %.lr.ph.i.i
 
-.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader, %.lr.ph.i.i
-  %17 = phi i32 [ %20, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader ]
-  %18 = phi i32 [ %19, %.lr.ph.i.i ], [ %.ph18, %.lr.ph.i.i.preheader ]
-  %19 = add i32 %18, %17
-  %20 = add i32 %17, 1
-  %.not.i.i = icmp sgt i32 %20, %3
-  br i1 %.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !15
+.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader3, %.lr.ph.i.i
+  %10 = phi i32 [ %13, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader3 ]
+  %11 = phi i32 [ %12, %.lr.ph.i.i ], [ %.ph4, %.lr.ph.i.i.preheader3 ]
+  %12 = add i32 %11, %10
+  %13 = add i32 %10, 1
+  %.not.i.i = icmp sgt i32 %13, %3
+  br i1 %.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !10
 
-_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %16, %vec.epilog.middle.block ], [ %11, %middle.block ], [ %19, %.lr.ph.i.i ]
-  %21 = getelementptr i8, ptr %0, i64 8
-  %22 = load ptr, ptr %21, align 8
-  store i32 %.lcssa.i.i, ptr %22, align 4
+_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %1
+  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %9, %middle.block ], [ %12, %.lr.ph.i.i ]
+  %14 = getelementptr i8, ptr %0, i64 8
+  %15 = load ptr, ptr %14, align 8
+  store i32 %.lcssa.i.i, ptr %15, align 4
   ret void
 }
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #2
@@ -417,15 +234,10 @@ attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !1 = distinct !{!1, !2, !3}
 !2 = !{!"llvm.loop.isvectorized", i32 1}
 !3 = !{!"llvm.loop.unroll.runtime.disable"}
-!4 = !{!"branch_weights", i32 4, i32 28}
+!4 = distinct !{!4, !2}
 !5 = distinct !{!5, !2, !3}
 !6 = distinct !{!6, !2}
 !7 = distinct !{!7, !2, !3}
-!8 = distinct !{!8, !2, !3}
-!9 = distinct !{!9, !2}
-!10 = distinct !{!10, !2, !3}
-!11 = distinct !{!11, !2, !3}
-!12 = distinct !{!12, !2}
-!13 = distinct !{!13, !2, !3}
-!14 = distinct !{!14, !2, !3}
-!15 = distinct !{!15, !2}
+!8 = distinct !{!8, !2}
+!9 = distinct !{!9, !2, !3}
+!10 = distinct !{!10, !2}

--- a/nautilus/test/llvm-ir-test/reference-ir/sumOfSquares.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/sumOfSquares.ll
@@ -6,206 +6,110 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %.not1 = icmp slt i32 %0, 1
-  br i1 %.not1, label %._crit_edge, label %iter.check
+  br i1 %.not1, label %._crit_edge, label %.lr.ph.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.preheader:                                 ; preds = %1
   %2 = add nsw i32 %0, -2147483647
-  %or.cond = icmp ult i32 %2, -2147483643
-  br i1 %or.cond, label %.lr.ph.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %2, -2147483631
+  br i1 %or.cond, label %.lr.ph.preheader7, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check5 = icmp ult i32 %0, 32
-  br i1 %min.iters.check5, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %0, 28
-  %n.vec = and i32 %0, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.preheader
+  %n.vec = and i32 %0, 2147483640
   %3 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
-  %vec.phi6 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
-  %vec.phi7 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
-  %vec.phi8 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %4 = mul <8 x i32> %vec.ind, %vec.ind
-  %5 = mul <8 x i32> %step.add, %step.add
-  %6 = mul <8 x i32> %step.add.2, %step.add.2
-  %7 = mul <8 x i32> %step.add.3, %step.add.3
-  %8 = add <8 x i32> %4, %vec.phi
-  %9 = add <8 x i32> %5, %vec.phi6
-  %10 = add <8 x i32> %6, %vec.phi7
-  %11 = add <8 x i32> %7, %vec.phi8
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %12 = icmp eq i32 %index.next, %n.vec
-  br i1 %12, label %middle.block, label %vector.body, !llvm.loop !1
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
+  %vec.phi5 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %4 = mul <4 x i32> %vec.ind, %vec.ind
+  %5 = mul <4 x i32> %step.add, %step.add
+  %6 = add <4 x i32> %4, %vec.phi
+  %7 = add <4 x i32> %5, %vec.phi5
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %8 = icmp eq i32 %index.next, %n.vec
+  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !1
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %9, %8
-  %bin.rdx9 = add <8 x i32> %10, %bin.rdx
-  %bin.rdx10 = add <8 x i32> %11, %bin.rdx9
-  %13 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx10)
+  %bin.rdx = add <4 x i32> %7, %6
+  %9 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %0, %n.vec
-  br i1 %cmp.n, label %._crit_edge, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %._crit_edge, label %.lr.ph.preheader7
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %3, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %13, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec12 = and i32 %0, 2147483644
-  %14 = or disjoint i32 %n.vec12, 1
-  %15 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index13 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next16, %vec.epilog.vector.body ]
-  %vec.ind14 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next17, %vec.epilog.vector.body ]
-  %vec.phi15 = phi <4 x i32> [ %15, %vec.epilog.ph ], [ %17, %vec.epilog.vector.body ]
-  %16 = mul <4 x i32> %vec.ind14, %vec.ind14
-  %17 = add <4 x i32> %16, %vec.phi15
-  %index.next16 = add nuw i32 %index13, 4
-  %vec.ind.next17 = add <4 x i32> %vec.ind14, splat (i32 4)
-  %18 = icmp eq i32 %index.next16, %n.vec12
-  br i1 %18, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !5
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %19 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %17)
-  %cmp.n18 = icmp eq i32 %0, %n.vec12
-  br i1 %cmp.n18, label %._crit_edge, label %.lr.ph.preheader
-
-.lr.ph.preheader:                                 ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %14, %vec.epilog.middle.block ]
-  %.ph22 = phi i32 [ 0, %iter.check ], [ %13, %vec.epilog.iter.check ], [ %19, %vec.epilog.middle.block ]
+.lr.ph.preheader7:                                ; preds = %.lr.ph.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.preheader ], [ %3, %middle.block ]
+  %.ph8 = phi i32 [ 0, %.lr.ph.preheader ], [ %9, %middle.block ]
   br label %.lr.ph
 
-.lr.ph:                                           ; preds = %.lr.ph.preheader, %.lr.ph
-  %20 = phi i32 [ %24, %.lr.ph ], [ %.ph, %.lr.ph.preheader ]
-  %21 = phi i32 [ %23, %.lr.ph ], [ %.ph22, %.lr.ph.preheader ]
-  %22 = mul i32 %20, %20
-  %23 = add i32 %22, %21
-  %24 = add i32 %20, 1
-  %.not = icmp sgt i32 %24, %0
-  br i1 %.not, label %._crit_edge, label %.lr.ph, !llvm.loop !6
+.lr.ph:                                           ; preds = %.lr.ph.preheader7, %.lr.ph
+  %10 = phi i32 [ %14, %.lr.ph ], [ %.ph, %.lr.ph.preheader7 ]
+  %11 = phi i32 [ %13, %.lr.ph ], [ %.ph8, %.lr.ph.preheader7 ]
+  %12 = mul i32 %10, %10
+  %13 = add i32 %12, %11
+  %14 = add i32 %10, 1
+  %.not = icmp sgt i32 %14, %0
+  br i1 %.not, label %._crit_edge, label %.lr.ph, !llvm.loop !4
 
-._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa = phi i32 [ 0, %1 ], [ %19, %vec.epilog.middle.block ], [ %13, %middle.block ], [ %23, %.lr.ph ]
+._crit_edge:                                      ; preds = %.lr.ph, %middle.block, %1
+  %.lcssa = phi i32 [ 0, %1 ], [ %9, %middle.block ], [ %13, %.lr.ph ]
   ret i32 %.lcssa
 }
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(none)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %.not1.i = icmp slt i32 %0, 1
-  br i1 %.not1.i, label %execute.exit, label %iter.check
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.preheader:                               ; preds = %1
   %2 = add nsw i32 %0, -2147483647
-  %or.cond = icmp ult i32 %2, -2147483643
-  br i1 %or.cond, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %2, -2147483631
+  br i1 %or.cond, label %.lr.ph.i.preheader3, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %0, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %0, 28
-  %n.vec = and i32 %0, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %0, 2147483640
   %3 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %4 = mul <8 x i32> %vec.ind, %vec.ind
-  %5 = mul <8 x i32> %step.add, %step.add
-  %6 = mul <8 x i32> %step.add.2, %step.add.2
-  %7 = mul <8 x i32> %step.add.3, %step.add.3
-  %8 = add <8 x i32> %4, %vec.phi
-  %9 = add <8 x i32> %5, %vec.phi2
-  %10 = add <8 x i32> %6, %vec.phi3
-  %11 = add <8 x i32> %7, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %12 = icmp eq i32 %index.next, %n.vec
-  br i1 %12, label %middle.block, label %vector.body, !llvm.loop !7
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %6, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %7, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %4 = mul <4 x i32> %vec.ind, %vec.ind
+  %5 = mul <4 x i32> %step.add, %step.add
+  %6 = add <4 x i32> %4, %vec.phi
+  %7 = add <4 x i32> %5, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %8 = icmp eq i32 %index.next, %n.vec
+  br i1 %8, label %middle.block, label %vector.body, !llvm.loop !5
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %9, %8
-  %bin.rdx5 = add <8 x i32> %10, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %11, %bin.rdx5
-  %13 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %7, %6
+  %9 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %0, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader3
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %3, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %13, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %0, 2147483644
-  %14 = or disjoint i32 %n.vec8, 1
-  %15 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %15, %vec.epilog.ph ], [ %17, %vec.epilog.vector.body ]
-  %16 = mul <4 x i32> %vec.ind10, %vec.ind10
-  %17 = add <4 x i32> %16, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add <4 x i32> %vec.ind10, splat (i32 4)
-  %18 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %18, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !8
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %19 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %17)
-  %cmp.n14 = icmp eq i32 %0, %n.vec8
-  br i1 %cmp.n14, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %14, %vec.epilog.middle.block ]
-  %.ph18 = phi i32 [ 0, %iter.check ], [ %13, %vec.epilog.iter.check ], [ %19, %vec.epilog.middle.block ]
+.lr.ph.i.preheader3:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.i.preheader ], [ %3, %middle.block ]
+  %.ph4 = phi i32 [ 0, %.lr.ph.i.preheader ], [ %9, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %20 = phi i32 [ %24, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %21 = phi i32 [ %23, %.lr.ph.i ], [ %.ph18, %.lr.ph.i.preheader ]
-  %22 = mul i32 %20, %20
-  %23 = add i32 %22, %21
-  %24 = add i32 %20, 1
-  %.not.i = icmp sgt i32 %24, %0
-  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !9
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader3, %.lr.ph.i
+  %10 = phi i32 [ %14, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader3 ]
+  %11 = phi i32 [ %13, %.lr.ph.i ], [ %.ph4, %.lr.ph.i.preheader3 ]
+  %12 = mul i32 %10, %10
+  %13 = add i32 %12, %11
+  %14 = add i32 %10, 1
+  %.not.i = icmp sgt i32 %14, %0
+  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !6
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %19, %vec.epilog.middle.block ], [ %13, %middle.block ], [ %23, %.lr.ph.i ]
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %9, %middle.block ], [ %13, %.lr.ph.i ]
   ret i32 %.lcssa.i
 }
 
@@ -214,106 +118,58 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %.not1.i = icmp slt i32 %3, 1
-  br i1 %.not1.i, label %execute.exit, label %iter.check
+  br i1 %.not1.i, label %execute.exit, label %.lr.ph.i.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.preheader:                               ; preds = %1
   %4 = add nsw i32 %3, -2147483647
-  %or.cond = icmp ult i32 %4, -2147483643
-  br i1 %or.cond, label %.lr.ph.i.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %4, -2147483631
+  br i1 %or.cond, label %.lr.ph.i.preheader3, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.preheader
+  %n.vec = and i32 %3, 2147483640
   %5 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %6 = mul <8 x i32> %vec.ind, %vec.ind
-  %7 = mul <8 x i32> %step.add, %step.add
-  %8 = mul <8 x i32> %step.add.2, %step.add.2
-  %9 = mul <8 x i32> %step.add.3, %step.add.3
-  %10 = add <8 x i32> %6, %vec.phi
-  %11 = add <8 x i32> %7, %vec.phi2
-  %12 = add <8 x i32> %8, %vec.phi3
-  %13 = add <8 x i32> %9, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %14 = icmp eq i32 %index.next, %n.vec
-  br i1 %14, label %middle.block, label %vector.body, !llvm.loop !10
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %6 = mul <4 x i32> %vec.ind, %vec.ind
+  %7 = mul <4 x i32> %step.add, %step.add
+  %8 = add <4 x i32> %6, %vec.phi
+  %9 = add <4 x i32> %7, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %10 = icmp eq i32 %index.next, %n.vec
+  br i1 %10, label %middle.block, label %vector.body, !llvm.loop !7
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %11, %10
-  %bin.rdx5 = add <8 x i32> %12, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %13, %bin.rdx5
-  %15 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %9, %8
+  %11 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %execute.exit, label %.lr.ph.i.preheader3
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %5, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %15, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, 2147483644
-  %16 = or disjoint i32 %n.vec8, 1
-  %17 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %17, %vec.epilog.ph ], [ %19, %vec.epilog.vector.body ]
-  %18 = mul <4 x i32> %vec.ind10, %vec.ind10
-  %19 = add <4 x i32> %18, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add <4 x i32> %vec.ind10, splat (i32 4)
-  %20 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %20, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !11
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %21 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %19)
-  %cmp.n14 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n14, label %execute.exit, label %.lr.ph.i.preheader
-
-.lr.ph.i.preheader:                               ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %16, %vec.epilog.middle.block ]
-  %.ph18 = phi i32 [ 0, %iter.check ], [ %15, %vec.epilog.iter.check ], [ %21, %vec.epilog.middle.block ]
+.lr.ph.i.preheader3:                              ; preds = %.lr.ph.i.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.i.preheader ], [ %5, %middle.block ]
+  %.ph4 = phi i32 [ 0, %.lr.ph.i.preheader ], [ %11, %middle.block ]
   br label %.lr.ph.i
 
-.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader, %.lr.ph.i
-  %22 = phi i32 [ %26, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader ]
-  %23 = phi i32 [ %25, %.lr.ph.i ], [ %.ph18, %.lr.ph.i.preheader ]
-  %24 = mul i32 %22, %22
-  %25 = add i32 %24, %23
-  %26 = add i32 %22, 1
-  %.not.i = icmp sgt i32 %26, %3
-  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !12
+.lr.ph.i:                                         ; preds = %.lr.ph.i.preheader3, %.lr.ph.i
+  %12 = phi i32 [ %16, %.lr.ph.i ], [ %.ph, %.lr.ph.i.preheader3 ]
+  %13 = phi i32 [ %15, %.lr.ph.i ], [ %.ph4, %.lr.ph.i.preheader3 ]
+  %14 = mul i32 %12, %12
+  %15 = add i32 %14, %13
+  %16 = add i32 %12, 1
+  %.not.i = icmp sgt i32 %16, %3
+  br i1 %.not.i, label %execute.exit, label %.lr.ph.i, !llvm.loop !8
 
-execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i = phi i32 [ 0, %1 ], [ %21, %vec.epilog.middle.block ], [ %15, %middle.block ], [ %25, %.lr.ph.i ]
-  %27 = getelementptr i8, ptr %0, i64 8
-  %28 = load ptr, ptr %27, align 8
-  store i32 %.lcssa.i, ptr %28, align 4
+execute.exit:                                     ; preds = %.lr.ph.i, %middle.block, %1
+  %.lcssa.i = phi i32 [ 0, %1 ], [ %11, %middle.block ], [ %15, %.lr.ph.i ]
+  %17 = getelementptr i8, ptr %0, i64 8
+  %18 = load ptr, ptr %17, align 8
+  store i32 %.lcssa.i, ptr %18, align 4
   ret void
 }
 
@@ -322,111 +178,60 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %.not1.i.i = icmp slt i32 %3, 1
-  br i1 %.not1.i.i, label %_mlir_ciface_execute.exit, label %iter.check
+  br i1 %.not1.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
 
-iter.check:                                       ; preds = %1
+.lr.ph.i.i.preheader:                             ; preds = %1
   %4 = add nsw i32 %3, -2147483647
-  %or.cond = icmp ult i32 %4, -2147483643
-  br i1 %or.cond, label %.lr.ph.i.i.preheader, label %vector.main.loop.iter.check
+  %or.cond = icmp ult i32 %4, -2147483631
+  br i1 %or.cond, label %.lr.ph.i.i.preheader3, label %vector.ph
 
-vector.main.loop.iter.check:                      ; preds = %iter.check
-  %min.iters.check1 = icmp ult i32 %3, 32
-  br i1 %min.iters.check1, label %vec.epilog.ph, label %vector.ph
-
-vector.ph:                                        ; preds = %vector.main.loop.iter.check
-  %n.mod.vf = and i32 %3, 28
-  %n.vec = and i32 %3, 2147483616
+vector.ph:                                        ; preds = %.lr.ph.i.i.preheader
+  %n.vec = and i32 %3, 2147483640
   %5 = or disjoint i32 %n.vec, 1
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
   %index = phi i32 [ 0, %vector.ph ], [ %index.next, %vector.body ]
-  %vec.ind = phi <8 x i32> [ <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>, %vector.ph ], [ %vec.ind.next, %vector.body ]
-  %vec.phi = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %10, %vector.body ]
-  %vec.phi2 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %11, %vector.body ]
-  %vec.phi3 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %12, %vector.body ]
-  %vec.phi4 = phi <8 x i32> [ zeroinitializer, %vector.ph ], [ %13, %vector.body ]
-  %step.add = add <8 x i32> %vec.ind, splat (i32 8)
-  %step.add.2 = add <8 x i32> %vec.ind, splat (i32 16)
-  %step.add.3 = add <8 x i32> %vec.ind, splat (i32 24)
-  %6 = mul <8 x i32> %vec.ind, %vec.ind
-  %7 = mul <8 x i32> %step.add, %step.add
-  %8 = mul <8 x i32> %step.add.2, %step.add.2
-  %9 = mul <8 x i32> %step.add.3, %step.add.3
-  %10 = add <8 x i32> %6, %vec.phi
-  %11 = add <8 x i32> %7, %vec.phi2
-  %12 = add <8 x i32> %8, %vec.phi3
-  %13 = add <8 x i32> %9, %vec.phi4
-  %index.next = add nuw i32 %index, 32
-  %vec.ind.next = add <8 x i32> %vec.ind, splat (i32 32)
-  %14 = icmp eq i32 %index.next, %n.vec
-  br i1 %14, label %middle.block, label %vector.body, !llvm.loop !13
+  %vec.ind = phi <4 x i32> [ <i32 1, i32 2, i32 3, i32 4>, %vector.ph ], [ %vec.ind.next, %vector.body ]
+  %vec.phi = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %8, %vector.body ]
+  %vec.phi1 = phi <4 x i32> [ zeroinitializer, %vector.ph ], [ %9, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, splat (i32 4)
+  %6 = mul <4 x i32> %vec.ind, %vec.ind
+  %7 = mul <4 x i32> %step.add, %step.add
+  %8 = add <4 x i32> %6, %vec.phi
+  %9 = add <4 x i32> %7, %vec.phi1
+  %index.next = add nuw i32 %index, 8
+  %vec.ind.next = add <4 x i32> %vec.ind, splat (i32 8)
+  %10 = icmp eq i32 %index.next, %n.vec
+  br i1 %10, label %middle.block, label %vector.body, !llvm.loop !9
 
 middle.block:                                     ; preds = %vector.body
-  %bin.rdx = add <8 x i32> %11, %10
-  %bin.rdx5 = add <8 x i32> %12, %bin.rdx
-  %bin.rdx6 = add <8 x i32> %13, %bin.rdx5
-  %15 = tail call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %bin.rdx6)
+  %bin.rdx = add <4 x i32> %9, %8
+  %11 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %bin.rdx)
   %cmp.n = icmp eq i32 %3, %n.vec
-  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %vec.epilog.iter.check
+  br i1 %cmp.n, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader3
 
-vec.epilog.iter.check:                            ; preds = %middle.block
-  %ind.end = or disjoint i32 %n.vec, 1
-  %min.epilog.iters.check = icmp eq i32 %n.mod.vf, 0
-  br i1 %min.epilog.iters.check, label %.lr.ph.i.i.preheader, label %vec.epilog.ph, !prof !4
-
-vec.epilog.ph:                                    ; preds = %vector.main.loop.iter.check, %vec.epilog.iter.check
-  %vec.epilog.resume.val = phi i32 [ %n.vec, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %bc.resume.val = phi i32 [ %5, %vec.epilog.iter.check ], [ 1, %vector.main.loop.iter.check ]
-  %bc.merge.rdx = phi i32 [ %15, %vec.epilog.iter.check ], [ 0, %vector.main.loop.iter.check ]
-  %n.vec8 = and i32 %3, 2147483644
-  %16 = or disjoint i32 %n.vec8, 1
-  %17 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %bc.merge.rdx, i64 0
-  %broadcast.splatinsert = insertelement <4 x i32> poison, i32 %bc.resume.val, i64 0
-  %broadcast.splat = shufflevector <4 x i32> %broadcast.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
-  %induction = add <4 x i32> %broadcast.splat, <i32 0, i32 1, i32 2, i32 3>
-  br label %vec.epilog.vector.body
-
-vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %vec.epilog.ph
-  %index9 = phi i32 [ %vec.epilog.resume.val, %vec.epilog.ph ], [ %index.next12, %vec.epilog.vector.body ]
-  %vec.ind10 = phi <4 x i32> [ %induction, %vec.epilog.ph ], [ %vec.ind.next13, %vec.epilog.vector.body ]
-  %vec.phi11 = phi <4 x i32> [ %17, %vec.epilog.ph ], [ %19, %vec.epilog.vector.body ]
-  %18 = mul <4 x i32> %vec.ind10, %vec.ind10
-  %19 = add <4 x i32> %18, %vec.phi11
-  %index.next12 = add nuw i32 %index9, 4
-  %vec.ind.next13 = add <4 x i32> %vec.ind10, splat (i32 4)
-  %20 = icmp eq i32 %index.next12, %n.vec8
-  br i1 %20, label %vec.epilog.middle.block, label %vec.epilog.vector.body, !llvm.loop !14
-
-vec.epilog.middle.block:                          ; preds = %vec.epilog.vector.body
-  %21 = tail call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %19)
-  %cmp.n14 = icmp eq i32 %3, %n.vec8
-  br i1 %cmp.n14, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i.preheader
-
-.lr.ph.i.i.preheader:                             ; preds = %iter.check, %vec.epilog.iter.check, %vec.epilog.middle.block
-  %.ph = phi i32 [ 1, %iter.check ], [ %ind.end, %vec.epilog.iter.check ], [ %16, %vec.epilog.middle.block ]
-  %.ph18 = phi i32 [ 0, %iter.check ], [ %15, %vec.epilog.iter.check ], [ %21, %vec.epilog.middle.block ]
+.lr.ph.i.i.preheader3:                            ; preds = %.lr.ph.i.i.preheader, %middle.block
+  %.ph = phi i32 [ 1, %.lr.ph.i.i.preheader ], [ %5, %middle.block ]
+  %.ph4 = phi i32 [ 0, %.lr.ph.i.i.preheader ], [ %11, %middle.block ]
   br label %.lr.ph.i.i
 
-.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader, %.lr.ph.i.i
-  %22 = phi i32 [ %26, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader ]
-  %23 = phi i32 [ %25, %.lr.ph.i.i ], [ %.ph18, %.lr.ph.i.i.preheader ]
-  %24 = mul i32 %22, %22
-  %25 = add i32 %24, %23
-  %26 = add i32 %22, 1
-  %.not.i.i = icmp sgt i32 %26, %3
-  br i1 %.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !15
+.lr.ph.i.i:                                       ; preds = %.lr.ph.i.i.preheader3, %.lr.ph.i.i
+  %12 = phi i32 [ %16, %.lr.ph.i.i ], [ %.ph, %.lr.ph.i.i.preheader3 ]
+  %13 = phi i32 [ %15, %.lr.ph.i.i ], [ %.ph4, %.lr.ph.i.i.preheader3 ]
+  %14 = mul i32 %12, %12
+  %15 = add i32 %14, %13
+  %16 = add i32 %12, 1
+  %.not.i.i = icmp sgt i32 %16, %3
+  br i1 %.not.i.i, label %_mlir_ciface_execute.exit, label %.lr.ph.i.i, !llvm.loop !10
 
-_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %vec.epilog.middle.block, %1
-  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %21, %vec.epilog.middle.block ], [ %15, %middle.block ], [ %25, %.lr.ph.i.i ]
-  %27 = getelementptr i8, ptr %0, i64 8
-  %28 = load ptr, ptr %27, align 8
-  store i32 %.lcssa.i.i, ptr %28, align 4
+_mlir_ciface_execute.exit:                        ; preds = %.lr.ph.i.i, %middle.block, %1
+  %.lcssa.i.i = phi i32 [ 0, %1 ], [ %11, %middle.block ], [ %15, %.lr.ph.i.i ]
+  %17 = getelementptr i8, ptr %0, i64 8
+  %18 = load ptr, ptr %17, align 8
+  store i32 %.lcssa.i.i, ptr %18, align 4
   ret void
 }
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.vector.reduce.add.v4i32(<4 x i32>) #2
@@ -441,15 +246,10 @@ attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !1 = distinct !{!1, !2, !3}
 !2 = !{!"llvm.loop.isvectorized", i32 1}
 !3 = !{!"llvm.loop.unroll.runtime.disable"}
-!4 = !{!"branch_weights", i32 4, i32 28}
+!4 = distinct !{!4, !2}
 !5 = distinct !{!5, !2, !3}
 !6 = distinct !{!6, !2}
 !7 = distinct !{!7, !2, !3}
-!8 = distinct !{!8, !2, !3}
-!9 = distinct !{!9, !2}
-!10 = distinct !{!10, !2, !3}
-!11 = distinct !{!11, !2, !3}
-!12 = distinct !{!12, !2}
-!13 = distinct !{!13, !2, !3}
-!14 = distinct !{!14, !2, !3}
-!15 = distinct !{!15, !2}
+!8 = distinct !{!8, !2}
+!9 = distinct !{!9, !2, !3}
+!10 = distinct !{!10, !2}

--- a/nautilus/test/llvm-ir-test/reference-ir/useWrapper.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/useWrapper.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(ptr %0)
   %4 = tail call i32 @runtimeFunc0(ptr %1)
@@ -11,7 +10,6 @@ define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
   ret i32 %5
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(ptr %0)
   %4 = tail call i32 @runtimeFunc0(ptr %1)
@@ -22,7 +20,7 @@ define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(ptr) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -37,7 +35,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -52,7 +50,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/voidFuncCall.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/voidFuncCall.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 returned %0, i32 %1) local_unnamed_addr #0 {
   tail call void @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %0
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 returned %0, i32 %1) local_unnamed_addr #0 {
   tail call void @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %0
@@ -18,7 +16,7 @@ define signext i32 @_mlir_ciface_execute(i32 returned %0, i32 %1) local_unnamed_
 ; Function Attrs: memory(readwrite)
 declare void @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/nautilus/test/llvm-ir-test/reference-ir/withBranchProbability.ll
+++ b/nautilus/test/llvm-ir-test/reference-ir/withBranchProbability.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 1
   br i1 %2, label %3, label %5, !prof !1
@@ -17,7 +16,6 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   br label %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp eq i32 %0, 1
   br i1 %2, label %execute.exit, label %3, !prof !1
@@ -34,7 +32,7 @@ execute.exit:                                     ; preds = %1, %3
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 1
@@ -52,7 +50,7 @@ execute.exit:                                     ; preds = %1, %5
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 1
@@ -70,7 +68,6 @@ _mlir_ciface_execute.exit:                        ; preds = %1, %5
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/inlining/test/inlining-ir/callTwoFunctions_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/callTwoFunctions_inlined.ll
@@ -54,7 +54,7 @@ attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memor
 attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 
 !llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
-!llvm.ident = !{!6, !6}
+!llvm.ident = !{!6}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = !{i32 1, !"wchar_size", i32 4}
@@ -62,4 +62,4 @@ attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind wil
 !3 = !{i32 7, !"PIE Level", i32 2}
 !4 = !{i32 7, !"uwtable", i32 2}
 !5 = !{i32 7, !"frame-pointer", i32 2}
-!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}
+!6 = !{!"Debian clang version 21.1.8 (++20251221033036+2078da43e25a-1~exp1~20251221153213.50)"}

--- a/plugins/inlining/test/inlining-ir/directCallWithNestedCalls_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/directCallWithNestedCalls_inlined.ll
@@ -56,4 +56,4 @@ attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind wil
 !3 = !{i32 7, !"PIE Level", i32 2}
 !4 = !{i32 7, !"uwtable", i32 2}
 !5 = !{i32 7, !"frame-pointer", i32 2}
-!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}
+!6 = !{!"Debian clang version 21.1.8 (++20251221033036+2078da43e25a-1~exp1~20251221153213.50)"}

--- a/plugins/inlining/test/inlining-ir/loopDirectCall2_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/loopDirectCall2_inlined.ll
@@ -53,7 +53,7 @@ attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memor
 attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(none) uwtable "frame-pointer"="all" "is_target" "min-legal-vector-width"="0" "nautilus_inline_v0001" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 
 !llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
-!llvm.ident = !{!6, !6}
+!llvm.ident = !{!6}
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = !{i32 1, !"wchar_size", i32 4}
@@ -61,4 +61,4 @@ attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind wil
 !3 = !{i32 7, !"PIE Level", i32 2}
 !4 = !{i32 7, !"uwtable", i32 2}
 !5 = !{i32 7, !"frame-pointer", i32 2}
-!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}
+!6 = !{!"Debian clang version 21.1.8 (++20251221033036+2078da43e25a-1~exp1~20251221153213.50)"}

--- a/plugins/inlining/test/inlining-ir/loopDirectCall_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/loopDirectCall_inlined.ll
@@ -71,4 +71,4 @@ attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind wil
 !3 = !{i32 7, !"PIE Level", i32 2}
 !4 = !{i32 7, !"uwtable", i32 2}
 !5 = !{i32 7, !"frame-pointer", i32 2}
-!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}
+!6 = !{!"Debian clang version 21.1.8 (++20251221033036+2078da43e25a-1~exp1~20251221153213.50)"}

--- a/plugins/inlining/test/inlining-ir/simpleDirectCall_inlined.ll
+++ b/plugins/inlining/test/inlining-ir/simpleDirectCall_inlined.ll
@@ -62,4 +62,4 @@ attributes #2 = { alwaysinline mustprogress nofree norecurse nosync nounwind wil
 !3 = !{i32 7, !"PIE Level", i32 2}
 !4 = !{i32 7, !"uwtable", i32 2}
 !5 = !{i32 7, !"frame-pointer", i32 2}
-!6 = !{!"Ubuntu clang version 21.1.8 (++20251221032922+2078da43e25a-1~exp1~20251221153059.70)"}
+!6 = !{!"Debian clang version 21.1.8 (++20251221033036+2078da43e25a-1~exp1~20251221153213.50)"}

--- a/plugins/simd/test/reference-ir/vectorAddDouble.ll
+++ b/plugins/simd/test/reference-ir/vectorAddDouble.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <8 x double>, ptr %0, align 64
-  %5 = load <8 x double>, ptr %1, align 64
+  %4 = load <8 x double>, ptr %0, align 8
+  %5 = load <8 x double>, ptr %1, align 8
   %6 = fadd <8 x double> %4, %5
-  store <8 x double> %6, ptr %2, align 64
+  store <8 x double> %6, ptr %2, align 8
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <8 x double>, ptr %0, align 64
-  %5 = load <8 x double>, ptr %1, align 64
+  %4 = load <8 x double>, ptr %0, align 8
+  %5 = load <8 x double>, ptr %1, align 8
   %6 = fadd <8 x double> %4, %5
-  store <8 x double> %6, ptr %2, align 64
+  store <8 x double> %6, ptr %2, align 8
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <8 x double>, ptr %3, align 64
-  %11 = load <8 x double>, ptr %6, align 64
+  %10 = load <8 x double>, ptr %3, align 8
+  %11 = load <8 x double>, ptr %6, align 8
   %12 = fadd <8 x double> %10, %11
-  store <8 x double> %12, ptr %9, align 64
+  store <8 x double> %12, ptr %9, align 8
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <8 x double>, ptr %3, align 64
-  %11 = load <8 x double>, ptr %6, align 64
+  %10 = load <8 x double>, ptr %3, align 8
+  %11 = load <8 x double>, ptr %6, align 8
   %12 = fadd <8 x double> %10, %11
-  store <8 x double> %12, ptr %9, align 64
+  store <8 x double> %12, ptr %9, align 8
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorAddFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorAddFloat.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fadd <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fadd <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fadd <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fadd <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorAddInt.ll
+++ b/plugins/simd/test/reference-ir/vectorAddInt.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = add <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = add <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = add <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = add <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorAndInt.ll
+++ b/plugins/simd/test/reference-ir/vectorAndInt.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = and <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = and <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = and <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = and <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorBlendFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorBlendFloat.ll
@@ -5,23 +5,23 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr readonly %2, ptr writeonly %3) local_unnamed_addr #0 {
-  %5 = load <16 x float>, ptr %0, align 64
-  %6 = load <16 x float>, ptr %1, align 64
-  %7 = load <16 x i32>, ptr %2, align 64
+  %5 = load <16 x float>, ptr %0, align 4
+  %6 = load <16 x float>, ptr %1, align 4
+  %7 = load <16 x i32>, ptr %2, align 4
   %.not = icmp eq <16 x i32> %7, zeroinitializer
   %8 = select <16 x i1> %.not, <16 x float> %6, <16 x float> %5
-  store <16 x float> %8, ptr %3, align 64
+  store <16 x float> %8, ptr %3, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr readonly %2, ptr writeonly %3) local_unnamed_addr #0 {
-  %5 = load <16 x float>, ptr %0, align 64
-  %6 = load <16 x float>, ptr %1, align 64
-  %7 = load <16 x i32>, ptr %2, align 64
+  %5 = load <16 x float>, ptr %0, align 4
+  %6 = load <16 x float>, ptr %1, align 4
+  %7 = load <16 x i32>, ptr %2, align 4
   %.not.i = icmp eq <16 x i32> %7, zeroinitializer
   %8 = select <16 x i1> %.not.i, <16 x float> %6, <16 x float> %5
-  store <16 x float> %8, ptr %3, align 64
+  store <16 x float> %8, ptr %3, align 4
   ret void
 }
 
@@ -38,12 +38,12 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %10 = getelementptr i8, ptr %0, i64 24
   %11 = load ptr, ptr %10, align 8
   %12 = load ptr, ptr %11, align 8
-  %13 = load <16 x float>, ptr %3, align 64
-  %14 = load <16 x float>, ptr %6, align 64
-  %15 = load <16 x i32>, ptr %9, align 64
+  %13 = load <16 x float>, ptr %3, align 4
+  %14 = load <16 x float>, ptr %6, align 4
+  %15 = load <16 x i32>, ptr %9, align 4
   %.not.i = icmp eq <16 x i32> %15, zeroinitializer
   %16 = select <16 x i1> %.not.i, <16 x float> %14, <16 x float> %13
-  store <16 x float> %16, ptr %12, align 64
+  store <16 x float> %16, ptr %12, align 4
   ret void
 }
 
@@ -60,12 +60,12 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %10 = getelementptr i8, ptr %0, i64 24
   %11 = load ptr, ptr %10, align 8
   %12 = load ptr, ptr %11, align 8
-  %13 = load <16 x float>, ptr %3, align 64
-  %14 = load <16 x float>, ptr %6, align 64
-  %15 = load <16 x i32>, ptr %9, align 64
+  %13 = load <16 x float>, ptr %3, align 4
+  %14 = load <16 x float>, ptr %6, align 4
+  %15 = load <16 x i32>, ptr %9, align 4
   %.not.i.i = icmp eq <16 x i32> %15, zeroinitializer
   %16 = select <16 x i1> %.not.i.i, <16 x float> %14, <16 x float> %13
-  store <16 x float> %16, ptr %12, align 64
+  store <16 x float> %16, ptr %12, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorBlendInt.ll
+++ b/plugins/simd/test/reference-ir/vectorBlendInt.ll
@@ -5,23 +5,23 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr readonly %2, ptr writeonly %3) local_unnamed_addr #0 {
-  %5 = load <16 x i32>, ptr %0, align 64
-  %6 = load <16 x i32>, ptr %1, align 64
-  %7 = load <16 x i32>, ptr %2, align 64
+  %5 = load <16 x i32>, ptr %0, align 4
+  %6 = load <16 x i32>, ptr %1, align 4
+  %7 = load <16 x i32>, ptr %2, align 4
   %.not = icmp eq <16 x i32> %7, zeroinitializer
   %8 = select <16 x i1> %.not, <16 x i32> %6, <16 x i32> %5
-  store <16 x i32> %8, ptr %3, align 64
+  store <16 x i32> %8, ptr %3, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr readonly %2, ptr writeonly %3) local_unnamed_addr #0 {
-  %5 = load <16 x i32>, ptr %0, align 64
-  %6 = load <16 x i32>, ptr %1, align 64
-  %7 = load <16 x i32>, ptr %2, align 64
+  %5 = load <16 x i32>, ptr %0, align 4
+  %6 = load <16 x i32>, ptr %1, align 4
+  %7 = load <16 x i32>, ptr %2, align 4
   %.not.i = icmp eq <16 x i32> %7, zeroinitializer
   %8 = select <16 x i1> %.not.i, <16 x i32> %6, <16 x i32> %5
-  store <16 x i32> %8, ptr %3, align 64
+  store <16 x i32> %8, ptr %3, align 4
   ret void
 }
 
@@ -38,12 +38,12 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %10 = getelementptr i8, ptr %0, i64 24
   %11 = load ptr, ptr %10, align 8
   %12 = load ptr, ptr %11, align 8
-  %13 = load <16 x i32>, ptr %3, align 64
-  %14 = load <16 x i32>, ptr %6, align 64
-  %15 = load <16 x i32>, ptr %9, align 64
+  %13 = load <16 x i32>, ptr %3, align 4
+  %14 = load <16 x i32>, ptr %6, align 4
+  %15 = load <16 x i32>, ptr %9, align 4
   %.not.i = icmp eq <16 x i32> %15, zeroinitializer
   %16 = select <16 x i1> %.not.i, <16 x i32> %14, <16 x i32> %13
-  store <16 x i32> %16, ptr %12, align 64
+  store <16 x i32> %16, ptr %12, align 4
   ret void
 }
 
@@ -60,12 +60,12 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %10 = getelementptr i8, ptr %0, i64 24
   %11 = load ptr, ptr %10, align 8
   %12 = load ptr, ptr %11, align 8
-  %13 = load <16 x i32>, ptr %3, align 64
-  %14 = load <16 x i32>, ptr %6, align 64
-  %15 = load <16 x i32>, ptr %9, align 64
+  %13 = load <16 x i32>, ptr %3, align 4
+  %14 = load <16 x i32>, ptr %6, align 4
+  %15 = load <16 x i32>, ptr %9, align 4
   %.not.i.i = icmp eq <16 x i32> %15, zeroinitializer
   %16 = select <16 x i1> %.not.i.i, <16 x i32> %14, <16 x i32> %13
-  store <16 x i32> %16, ptr %12, align 64
+  store <16 x i32> %16, ptr %12, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorCmpBlendFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorCmpBlendFloat.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp ogt <16 x float> %4, %5
   %7 = select <16 x i1> %6, <16 x float> %4, <16 x float> %5
-  store <16 x float> %7, ptr %2, align 64
+  store <16 x float> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp ogt <16 x float> %4, %5
   %7 = select <16 x i1> %6, <16 x float> %4, <16 x float> %5
-  store <16 x float> %7, ptr %2, align 64
+  store <16 x float> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp ogt <16 x float> %10, %11
   %13 = select <16 x i1> %12, <16 x float> %10, <16 x float> %11
-  store <16 x float> %13, ptr %9, align 64
+  store <16 x float> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp ogt <16 x float> %10, %11
   %13 = select <16 x i1> %12, <16 x float> %10, <16 x float> %11
-  store <16 x float> %13, ptr %9, align 64
+  store <16 x float> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorDistanceSquaredFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorDistanceSquaredFloat.ll
@@ -5,8 +5,8 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x float>, ptr %0, align 64
-  %4 = load <16 x float>, ptr %1, align 64
+  %3 = load <16 x float>, ptr %0, align 4
+  %4 = load <16 x float>, ptr %1, align 4
   %5 = fsub <16 x float> %3, %4
   %6 = fmul <16 x float> %5, %5
   %7 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %6)
@@ -15,8 +15,8 @@ define float @execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x float>, ptr %0, align 64
-  %4 = load <16 x float>, ptr %1, align 64
+  %3 = load <16 x float>, ptr %0, align 4
+  %4 = load <16 x float>, ptr %1, align 4
   %5 = fsub <16 x float> %3, %4
   %6 = fmul <16 x float> %5, %5
   %7 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %6)
@@ -33,8 +33,8 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x float>, ptr %3, align 64
-  %8 = load <16 x float>, ptr %6, align 64
+  %7 = load <16 x float>, ptr %3, align 4
+  %8 = load <16 x float>, ptr %6, align 4
   %9 = fsub <16 x float> %7, %8
   %10 = fmul <16 x float> %9, %9
   %11 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %10)
@@ -51,8 +51,8 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x float>, ptr %3, align 64
-  %8 = load <16 x float>, ptr %6, align 64
+  %7 = load <16 x float>, ptr %3, align 4
+  %8 = load <16 x float>, ptr %6, align 4
   %9 = fsub <16 x float> %7, %8
   %10 = fmul <16 x float> %9, %9
   %11 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %10)

--- a/plugins/simd/test/reference-ir/vectorDivFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorDivFloat.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fdiv <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fdiv <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fdiv <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fdiv <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorDotProductFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorDotProductFloat.ll
@@ -5,8 +5,8 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x float>, ptr %0, align 64
-  %4 = load <16 x float>, ptr %1, align 64
+  %3 = load <16 x float>, ptr %0, align 4
+  %4 = load <16 x float>, ptr %1, align 4
   %5 = fmul <16 x float> %3, %4
   %6 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %5)
   ret float %6
@@ -14,8 +14,8 @@ define float @execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x float>, ptr %0, align 64
-  %4 = load <16 x float>, ptr %1, align 64
+  %3 = load <16 x float>, ptr %0, align 4
+  %4 = load <16 x float>, ptr %1, align 4
   %5 = fmul <16 x float> %3, %4
   %6 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %5)
   ret float %6
@@ -31,8 +31,8 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x float>, ptr %3, align 64
-  %8 = load <16 x float>, ptr %6, align 64
+  %7 = load <16 x float>, ptr %3, align 4
+  %8 = load <16 x float>, ptr %6, align 4
   %9 = fmul <16 x float> %7, %8
   %10 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %9)
   %11 = getelementptr i8, ptr %0, i64 16
@@ -48,8 +48,8 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x float>, ptr %3, align 64
-  %8 = load <16 x float>, ptr %6, align 64
+  %7 = load <16 x float>, ptr %3, align 4
+  %8 = load <16 x float>, ptr %6, align 4
   %9 = fmul <16 x float> %7, %8
   %10 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %9)
   %11 = getelementptr i8, ptr %0, i64 16

--- a/plugins/simd/test/reference-ir/vectorDotProductInt.ll
+++ b/plugins/simd/test/reference-ir/vectorDotProductInt.ll
@@ -5,8 +5,8 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define signext i32 @execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x i32>, ptr %0, align 64
-  %4 = load <16 x i32>, ptr %1, align 64
+  %3 = load <16 x i32>, ptr %0, align 4
+  %4 = load <16 x i32>, ptr %1, align 4
   %5 = mul <16 x i32> %4, %3
   %6 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %5)
   ret i32 %6
@@ -14,8 +14,8 @@ define signext i32 @execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define signext i32 @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x i32>, ptr %0, align 64
-  %4 = load <16 x i32>, ptr %1, align 64
+  %3 = load <16 x i32>, ptr %0, align 4
+  %4 = load <16 x i32>, ptr %1, align 4
   %5 = mul <16 x i32> %4, %3
   %6 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %5)
   ret i32 %6
@@ -31,8 +31,8 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x i32>, ptr %3, align 64
-  %8 = load <16 x i32>, ptr %6, align 64
+  %7 = load <16 x i32>, ptr %3, align 4
+  %8 = load <16 x i32>, ptr %6, align 4
   %9 = mul <16 x i32> %8, %7
   %10 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %9)
   %11 = getelementptr i8, ptr %0, i64 16
@@ -48,8 +48,8 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x i32>, ptr %3, align 64
-  %8 = load <16 x i32>, ptr %6, align 64
+  %7 = load <16 x i32>, ptr %3, align 4
+  %8 = load <16 x i32>, ptr %6, align 4
   %9 = mul <16 x i32> %8, %7
   %10 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %9)
   %11 = getelementptr i8, ptr %0, i64 16

--- a/plugins/simd/test/reference-ir/vectorEqFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorEqFloat.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp oeq <16 x float> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp oeq <16 x float> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp oeq <16 x float> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp oeq <16 x float> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorEqInt.ll
+++ b/plugins/simd/test/reference-ir/vectorEqInt.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = icmp eq <16 x i32> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = icmp eq <16 x i32> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = icmp eq <16 x i32> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = icmp eq <16 x i32> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorGeFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorGeFloat.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp oge <16 x float> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp oge <16 x float> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp oge <16 x float> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp oge <16 x float> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorLtFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorLtFloat.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp olt <16 x float> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp olt <16 x float> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp olt <16 x float> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp olt <16 x float> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorLtInt.ll
+++ b/plugins/simd/test/reference-ir/vectorLtInt.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = icmp slt <16 x i32> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = icmp slt <16 x i32> %4, %5
   %7 = sext <16 x i1> %6 to <16 x i32>
-  store <16 x i32> %7, ptr %2, align 64
+  store <16 x i32> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = icmp slt <16 x i32> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = icmp slt <16 x i32> %10, %11
   %13 = sext <16 x i1> %12 to <16 x i32>
-  store <16 x i32> %13, ptr %9, align 64
+  store <16 x i32> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorMulAccFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorMulAccFloat.ll
@@ -5,27 +5,27 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr readonly %2, ptr readonly %3, ptr writeonly %4) local_unnamed_addr #0 {
-  %6 = load <16 x float>, ptr %0, align 64
-  %7 = load <16 x float>, ptr %1, align 64
+  %6 = load <16 x float>, ptr %0, align 4
+  %7 = load <16 x float>, ptr %1, align 4
   %8 = fmul <16 x float> %6, %7
-  %9 = load <16 x float>, ptr %2, align 64
-  %10 = load <16 x float>, ptr %3, align 64
+  %9 = load <16 x float>, ptr %2, align 4
+  %10 = load <16 x float>, ptr %3, align 4
   %11 = fmul <16 x float> %9, %10
   %12 = fadd <16 x float> %8, %11
-  store <16 x float> %12, ptr %4, align 64
+  store <16 x float> %12, ptr %4, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr readonly %2, ptr readonly %3, ptr writeonly %4) local_unnamed_addr #0 {
-  %6 = load <16 x float>, ptr %0, align 64
-  %7 = load <16 x float>, ptr %1, align 64
+  %6 = load <16 x float>, ptr %0, align 4
+  %7 = load <16 x float>, ptr %1, align 4
   %8 = fmul <16 x float> %6, %7
-  %9 = load <16 x float>, ptr %2, align 64
-  %10 = load <16 x float>, ptr %3, align 64
+  %9 = load <16 x float>, ptr %2, align 4
+  %10 = load <16 x float>, ptr %3, align 4
   %11 = fmul <16 x float> %9, %10
   %12 = fadd <16 x float> %8, %11
-  store <16 x float> %12, ptr %4, align 64
+  store <16 x float> %12, ptr %4, align 4
   ret void
 }
 
@@ -45,14 +45,14 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %13 = getelementptr i8, ptr %0, i64 32
   %14 = load ptr, ptr %13, align 8
   %15 = load ptr, ptr %14, align 8
-  %16 = load <16 x float>, ptr %3, align 64
-  %17 = load <16 x float>, ptr %6, align 64
+  %16 = load <16 x float>, ptr %3, align 4
+  %17 = load <16 x float>, ptr %6, align 4
   %18 = fmul <16 x float> %16, %17
-  %19 = load <16 x float>, ptr %9, align 64
-  %20 = load <16 x float>, ptr %12, align 64
+  %19 = load <16 x float>, ptr %9, align 4
+  %20 = load <16 x float>, ptr %12, align 4
   %21 = fmul <16 x float> %19, %20
   %22 = fadd <16 x float> %18, %21
-  store <16 x float> %22, ptr %15, align 64
+  store <16 x float> %22, ptr %15, align 4
   ret void
 }
 
@@ -72,14 +72,14 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %13 = getelementptr i8, ptr %0, i64 32
   %14 = load ptr, ptr %13, align 8
   %15 = load ptr, ptr %14, align 8
-  %16 = load <16 x float>, ptr %3, align 64
-  %17 = load <16 x float>, ptr %6, align 64
+  %16 = load <16 x float>, ptr %3, align 4
+  %17 = load <16 x float>, ptr %6, align 4
   %18 = fmul <16 x float> %16, %17
-  %19 = load <16 x float>, ptr %9, align 64
-  %20 = load <16 x float>, ptr %12, align 64
+  %19 = load <16 x float>, ptr %9, align 4
+  %20 = load <16 x float>, ptr %12, align 4
   %21 = fmul <16 x float> %19, %20
   %22 = fadd <16 x float> %18, %21
-  store <16 x float> %22, ptr %15, align 64
+  store <16 x float> %22, ptr %15, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorMulFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorMulFloat.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fmul <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fmul <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fmul <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fmul <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorMulInt.ll
+++ b/plugins/simd/test/reference-ir/vectorMulInt.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = mul <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = mul <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = mul <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = mul <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorNegFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorNegFloat.ll
@@ -5,17 +5,17 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr writeonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x float>, ptr %0, align 64
+  %3 = load <16 x float>, ptr %0, align 4
   %4 = fneg <16 x float> %3
-  store <16 x float> %4, ptr %1, align 64
+  store <16 x float> %4, ptr %1, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr writeonly %1) local_unnamed_addr #0 {
-  %3 = load <16 x float>, ptr %0, align 64
+  %3 = load <16 x float>, ptr %0, align 4
   %4 = fneg <16 x float> %3
-  store <16 x float> %4, ptr %1, align 64
+  store <16 x float> %4, ptr %1, align 4
   ret void
 }
 
@@ -26,9 +26,9 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x float>, ptr %3, align 64
+  %7 = load <16 x float>, ptr %3, align 4
   %8 = fneg <16 x float> %7
-  store <16 x float> %8, ptr %6, align 64
+  store <16 x float> %8, ptr %6, align 4
   ret void
 }
 
@@ -39,9 +39,9 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %4 = getelementptr i8, ptr %0, i64 8
   %5 = load ptr, ptr %4, align 8
   %6 = load ptr, ptr %5, align 8
-  %7 = load <16 x float>, ptr %3, align 64
+  %7 = load <16 x float>, ptr %3, align 4
   %8 = fneg <16 x float> %7
-  store <16 x float> %8, ptr %6, align 64
+  store <16 x float> %8, ptr %6, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorOrInt.ll
+++ b/plugins/simd/test/reference-ir/vectorOrInt.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = or <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = or <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = or <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = or <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorReduceAddFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorReduceAddFloat.ll
@@ -5,14 +5,14 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %2)
   ret float %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @_mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %2)
   ret float %3
 }
@@ -24,7 +24,7 @@ declare float @llvm.vector.reduce.fadd.v16f32(float, <16 x float>) #1
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
@@ -36,7 +36,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8

--- a/plugins/simd/test/reference-ir/vectorReduceAddInt.ll
+++ b/plugins/simd/test/reference-ir/vectorReduceAddInt.ll
@@ -5,14 +5,14 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define signext i32 @execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x i32>, ptr %0, align 64
+  %2 = load <16 x i32>, ptr %0, align 4
   %3 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %2)
   ret i32 %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define signext i32 @_mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x i32>, ptr %0, align 64
+  %2 = load <16 x i32>, ptr %0, align 4
   %3 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %2)
   ret i32 %3
 }
@@ -24,7 +24,7 @@ declare i32 @llvm.vector.reduce.add.v16i32(<16 x i32>) #1
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x i32>, ptr %3, align 64
+  %4 = load <16 x i32>, ptr %3, align 4
   %5 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
@@ -36,7 +36,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x i32>, ptr %3, align 64
+  %4 = load <16 x i32>, ptr %3, align 4
   %5 = tail call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8

--- a/plugins/simd/test/reference-ir/vectorReduceMaxFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorReduceMaxFloat.ll
@@ -5,14 +5,14 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = tail call nnan float @llvm.vector.reduce.fmax.v16f32(<16 x float> %2)
   ret float %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @_mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = tail call nnan float @llvm.vector.reduce.fmax.v16f32(<16 x float> %2)
   ret float %3
 }
@@ -24,7 +24,7 @@ declare float @llvm.vector.reduce.fmax.v16f32(<16 x float>) #1
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = tail call nnan float @llvm.vector.reduce.fmax.v16f32(<16 x float> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
@@ -36,7 +36,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = tail call nnan float @llvm.vector.reduce.fmax.v16f32(<16 x float> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8

--- a/plugins/simd/test/reference-ir/vectorReduceMinFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorReduceMinFloat.ll
@@ -5,14 +5,14 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = tail call nnan float @llvm.vector.reduce.fmin.v16f32(<16 x float> %2)
   ret float %3
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @_mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = tail call nnan float @llvm.vector.reduce.fmin.v16f32(<16 x float> %2)
   ret float %3
 }
@@ -24,7 +24,7 @@ declare float @llvm.vector.reduce.fmin.v16f32(<16 x float>) #1
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = tail call nnan float @llvm.vector.reduce.fmin.v16f32(<16 x float> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8
@@ -36,7 +36,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = tail call nnan float @llvm.vector.reduce.fmin.v16f32(<16 x float> %4)
   %6 = getelementptr i8, ptr %0, i64 8
   %7 = load ptr, ptr %6, align 8

--- a/plugins/simd/test/reference-ir/vectorReluFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorReluFloat.ll
@@ -5,21 +5,21 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp ogt <16 x float> %4, %5
   %7 = select <16 x i1> %6, <16 x float> %4, <16 x float> %5
-  store <16 x float> %7, ptr %2, align 64
+  store <16 x float> %7, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fcmp ogt <16 x float> %4, %5
   %7 = select <16 x i1> %6, <16 x float> %4, <16 x float> %5
-  store <16 x float> %7, ptr %2, align 64
+  store <16 x float> %7, ptr %2, align 4
   ret void
 }
 
@@ -33,11 +33,11 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp ogt <16 x float> %10, %11
   %13 = select <16 x i1> %12, <16 x float> %10, <16 x float> %11
-  store <16 x float> %13, ptr %9, align 64
+  store <16 x float> %13, ptr %9, align 4
   ret void
 }
 
@@ -51,11 +51,11 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fcmp ogt <16 x float> %10, %11
   %13 = select <16 x i1> %12, <16 x float> %10, <16 x float> %11
-  store <16 x float> %13, ptr %9, align 64
+  store <16 x float> %13, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorSquaredNormFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorSquaredNormFloat.ll
@@ -5,7 +5,7 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = fmul <16 x float> %2, %2
   %4 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %3)
   ret float %4
@@ -13,7 +13,7 @@ define float @execute(ptr readonly %0) local_unnamed_addr #0 {
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define float @_mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
-  %2 = load <16 x float>, ptr %0, align 64
+  %2 = load <16 x float>, ptr %0, align 4
   %3 = fmul <16 x float> %2, %2
   %4 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %3)
   ret float %4
@@ -26,7 +26,7 @@ declare float @llvm.vector.reduce.fadd.v16f32(float, <16 x float>) #1
 define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = fmul <16 x float> %4, %4
   %6 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %5)
   %7 = getelementptr i8, ptr %0, i64 8
@@ -39,7 +39,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
 define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
-  %4 = load <16 x float>, ptr %3, align 64
+  %4 = load <16 x float>, ptr %3, align 4
   %5 = fmul <16 x float> %4, %4
   %6 = tail call reassoc float @llvm.vector.reduce.fadd.v16f32(float 0.000000e+00, <16 x float> %5)
   %7 = getelementptr i8, ptr %0, i64 8

--- a/plugins/simd/test/reference-ir/vectorSubFloat.ll
+++ b/plugins/simd/test/reference-ir/vectorSubFloat.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fsub <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x float>, ptr %0, align 64
-  %5 = load <16 x float>, ptr %1, align 64
+  %4 = load <16 x float>, ptr %0, align 4
+  %5 = load <16 x float>, ptr %1, align 4
   %6 = fsub <16 x float> %4, %5
-  store <16 x float> %6, ptr %2, align 64
+  store <16 x float> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fsub <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x float>, ptr %3, align 64
-  %11 = load <16 x float>, ptr %6, align 64
+  %10 = load <16 x float>, ptr %3, align 4
+  %11 = load <16 x float>, ptr %6, align 4
   %12 = fsub <16 x float> %10, %11
-  store <16 x float> %12, ptr %9, align 64
+  store <16 x float> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/simd/test/reference-ir/vectorXorInt.ll
+++ b/plugins/simd/test/reference-ir/vectorXorInt.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = xor <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
 define void @_mlir_ciface_execute(ptr readonly %0, ptr readonly %1, ptr writeonly %2) local_unnamed_addr #0 {
-  %4 = load <16 x i32>, ptr %0, align 64
-  %5 = load <16 x i32>, ptr %1, align 64
+  %4 = load <16 x i32>, ptr %0, align 4
+  %5 = load <16 x i32>, ptr %1, align 4
   %6 = xor <16 x i32> %5, %4
-  store <16 x i32> %6, ptr %2, align 64
+  store <16 x i32> %6, ptr %2, align 4
   ret void
 }
 
@@ -31,10 +31,10 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = xor <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 
@@ -48,10 +48,10 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #1 {
   %7 = getelementptr i8, ptr %0, i64 16
   %8 = load ptr, ptr %7, align 8
   %9 = load ptr, ptr %8, align 8
-  %10 = load <16 x i32>, ptr %3, align 64
-  %11 = load <16 x i32>, ptr %6, align 64
+  %10 = load <16 x i32>, ptr %3, align 4
+  %11 = load <16 x i32>, ptr %6, align 4
   %12 = xor <16 x i32> %11, %10
-  store <16 x i32> %12, ptr %9, align 64
+  store <16 x i32> %12, ptr %9, align 4
   ret void
 }
 

--- a/plugins/specialization/test/intrinsic-ir/assumeAlignedFunction_with_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/assumeAlignedFunction_with_intrinsics.ll
@@ -4,14 +4,14 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read, inaccessiblemem: write)
-define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
+define signext i32 @execute(ptr readonly %0) local_unnamed_addr #0 {
   call void @llvm.assume(i1 true) [ "align"(ptr %0, i8 16) ]
   %2 = load i32, ptr %0, align 16
   ret i32 %2
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read, inaccessiblemem: write)
-define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
+define signext i32 @_mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   call void @llvm.assume(i1 true) [ "align"(ptr %0, i8 16) ]
   %2 = load i32, ptr %0, align 16
   ret i32 %2

--- a/plugins/specialization/test/intrinsic-ir/assumeAlignedFunction_without_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/assumeAlignedFunction_without_intrinsics.ll
@@ -3,14 +3,12 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0) local_unnamed_addr #0 {
   tail call void @runtimeFunc0(ptr %0, i8 16)
   %2 = load i32, ptr %0, align 4
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
   tail call void @runtimeFunc0(ptr %0, i8 16)
   %2 = load i32, ptr %0, align 4
@@ -18,9 +16,9 @@ define signext i32 @_mlir_ciface_execute(ptr %0) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: memory(readwrite)
-declare void @runtimeFunc0(ptr, i8) local_unnamed_addr #1
+declare void @runtimeFunc0(ptr, i8 signext) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   tail call void @runtimeFunc0(ptr %3, i8 16)
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   tail call void @runtimeFunc0(ptr %3, i8 16)
@@ -42,7 +40,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/specialization/test/intrinsic-ir/assumeComplexCondition_without_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/assumeComplexCondition_without_intrinsics.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %0, 0
   %4 = icmp sgt i32 %1, 0
@@ -13,7 +12,6 @@ define signext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   ret i32 %6
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = icmp sgt i32 %0, 0
   %4 = icmp sgt i32 %1, 0
@@ -24,9 +22,9 @@ define signext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: memory(readwrite)
-declare void @runtimeFunc0(i1) local_unnamed_addr #1
+declare void @runtimeFunc0(i1 zeroext) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -43,7 +41,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -60,7 +58,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/specialization/test/intrinsic-ir/assumeFunction_without_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/assumeFunction_without_intrinsics.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 0
   tail call void @runtimeFunc0(i1 %2)
@@ -11,7 +10,6 @@ define signext i32 @execute(i32 %0) local_unnamed_addr #0 {
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = icmp sgt i32 %0, 0
   tail call void @runtimeFunc0(i1 %2)
@@ -20,9 +18,9 @@ define signext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: memory(readwrite)
-declare void @runtimeFunc0(i1) local_unnamed_addr #1
+declare void @runtimeFunc0(i1 zeroext) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 0
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp sgt i32 %3, 0
@@ -46,7 +44,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/specialization/test/intrinsic-ir/noaliasFunction_with_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/noaliasFunction_with_intrinsics.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: write)
-define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+define signext i32 @execute(ptr writeonly %0, ptr readonly %1) local_unnamed_addr #0 {
   call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
   store i32 1, ptr %0, align 4
   %3 = load i32, ptr %1, align 4
@@ -12,7 +12,7 @@ define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: write)
-define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
+define signext i32 @_mlir_ciface_execute(ptr writeonly %0, ptr readonly %1) local_unnamed_addr #0 {
   call void @llvm.assume(i1 true) [ "separate_storage"(ptr %0, ptr %1) ]
   store i32 1, ptr %0, align 4
   %3 = load i32, ptr %1, align 4

--- a/plugins/specialization/test/intrinsic-ir/noaliasFunction_without_intrinsics.ll
+++ b/plugins/specialization/test/intrinsic-ir/noaliasFunction_without_intrinsics.ll
@@ -3,7 +3,6 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
   tail call void @runtimeFunc0(ptr %0, ptr %1)
   store i32 1, ptr %0, align 4
@@ -11,7 +10,6 @@ define signext i32 @execute(ptr %0, ptr %1) local_unnamed_addr #0 {
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
   tail call void @runtimeFunc0(ptr %0, ptr %1)
   store i32 1, ptr %0, align 4
@@ -22,7 +20,7 @@ define signext i32 @_mlir_ciface_execute(ptr %0, ptr %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare void @runtimeFunc0(ptr, ptr) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -37,7 +35,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load ptr, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -52,7 +50,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/acosFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/acosFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/asinFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/asinFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/atan2Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/atan2Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/atanFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/atanFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/byteswap32Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/byteswap32Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/byteswap64Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/byteswap64Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
@@ -18,7 +16,7 @@ define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i64 @runtimeFunc0(i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/ceilFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/ceilFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/copysignFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/copysignFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/cosFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/cosFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/countlZero64Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/countlZero64Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
@@ -18,7 +16,7 @@ define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i64 @runtimeFunc0(i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/countlZeroFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/countlZeroFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/countrZero64Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/countrZero64Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
@@ -18,7 +16,7 @@ define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i64 @runtimeFunc0(i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/countrZeroFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/countrZeroFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/expFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/expFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/fabsFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/fabsFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/floorFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/floorFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/fmaFunction_with_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/fmaFunction_with_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1, float %2) local_unnamed_addr #0 {
   %4 = tail call float @runtimeFunc0(float %0, float %1, float %2)
   ret float %4
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1, float %2) local_unnamed_addr #0 {
   %4 = tail call float @runtimeFunc0(float %0, float %1, float %2)
   ret float %4
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1, float %2) local_unnamed_a
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/fmaFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/fmaFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1, float %2) local_unnamed_addr #0 {
   %4 = tail call float @runtimeFunc0(float %0, float %1, float %2)
   ret float %4
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1, float %2) local_unnamed_addr #0 {
   %4 = tail call float @runtimeFunc0(float %0, float %1, float %2)
   ret float %4
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1, float %2) local_unnamed_a
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -34,7 +32,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -50,7 +48,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/fmaxFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/fmaxFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/fminFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/fminFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/fmodFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/fmodFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/logFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/logFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/popcount64Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/popcount64Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
   %2 = tail call i64 @runtimeFunc0(i64 %0)
   ret i64 %2
@@ -18,7 +16,7 @@ define zeroext i64 @_mlir_ciface_execute(i64 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i64 @runtimeFunc0(i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = tail call i64 @runtimeFunc0(i64 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/popcountFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/popcountFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
   %2 = tail call i32 @runtimeFunc0(i32 %0)
   ret i32 %2
@@ -18,7 +16,7 @@ define zeroext i32 @_mlir_ciface_execute(i32 %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = tail call i32 @runtimeFunc0(i32 %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/powFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/powFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
   %3 = tail call float @runtimeFunc0(float %0, float %1)
   ret float %3
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0, float %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float, float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/rotl64Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/rotl64Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @execute(i64 %0, i64 %1) local_unnamed_addr #0 {
   %3 = tail call i64 @runtimeFunc0(i64 %0, i64 %1)
   ret i64 %3
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #0 {
   %3 = tail call i64 @runtimeFunc0(i64 %0, i64 %1)
   ret i64 %3
@@ -18,7 +16,7 @@ define zeroext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i64 @runtimeFunc0(i64, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/rotlFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/rotlFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
@@ -18,7 +16,7 @@ define zeroext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/rotr64Function_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/rotr64Function_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @execute(i64 %0, i64 %1) local_unnamed_addr #0 {
   %3 = tail call i64 @runtimeFunc0(i64 %0, i64 %1)
   ret i64 %3
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #0 {
   %3 = tail call i64 @runtimeFunc0(i64 %0, i64 %1)
   ret i64 %3
@@ -18,7 +16,7 @@ define zeroext i64 @_mlir_ciface_execute(i64 %0, i64 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i64 @runtimeFunc0(i64, i64) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i64, ptr %2, align 8
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/rotrFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/rotrFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
 }
 
-; Function Attrs: memory(readwrite)
 define zeroext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
   %3 = tail call i32 @runtimeFunc0(i32 %0, i32 %1)
   ret i32 %3
@@ -18,7 +16,7 @@ define zeroext i32 @_mlir_ciface_execute(i32 %0, i32 %1) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare i32 @runtimeFunc0(i32, i32) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -31,7 +29,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load i32, ptr %2, align 4
   %4 = getelementptr i8, ptr %0, i64 8
@@ -44,7 +42,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/sinFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/sinFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/sqrtFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/sqrtFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}

--- a/plugins/std/test/intrinsic-ir/tanFunction_without_intrinsics.ll
+++ b/plugins/std/test/intrinsic-ir/tanFunction_without_intrinsics.ll
@@ -3,13 +3,11 @@ source_filename = "LLVMDialectModule"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; Function Attrs: memory(readwrite)
 define float @execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
 }
 
-; Function Attrs: memory(readwrite)
 define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
   %2 = tail call float @runtimeFunc0(float %0)
   ret float %2
@@ -18,7 +16,7 @@ define float @_mlir_ciface_execute(float %0) local_unnamed_addr #0 {
 ; Function Attrs: memory(readwrite)
 declare float @runtimeFunc0(float) local_unnamed_addr #1
 
-define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -28,7 +26,7 @@ define void @_mlir_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
+define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #0 {
   %2 = load ptr, ptr %0, align 8
   %3 = load float, ptr %2, align 4
   %4 = tail call float @runtimeFunc0(float %3)
@@ -38,7 +36,6 @@ define void @_mlir__mlir_ciface_execute(ptr readonly %0) local_unnamed_addr #2 {
   ret void
 }
 
-attributes #0 = { memory(readwrite) }
 attributes #1 = { memory(readwrite) }
 
 !llvm.module.flags = !{!0}


### PR DESCRIPTION
Fixes the flaky LLVM IR tests.

The MLIR LLVM optimizer used JITTargetMachineBuilder::detectHost(), so the LLVM loop vectorizer's decisions (vector width, whether to vectorize) depended on the runner's CPU. Runners with AVX-512 vectorize 16-wide while AVX2 hosts use 8-wide, making the reference IR comparison intermittently fail.

- Add `mlir.targetCpu` option to pin a deterministic CPU + baseline feature set (+64bit,+sse2).
- The LLVM IR reference tests (core and std/simd/inlining/specialization plugins) set it to x86-64.
- Regenerate all LLVM IR reference files against the pinned baseline.