### PR TITLE
Use clang-22 and llvm-diff-22 for the LLVM IR test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -285,10 +285,10 @@ jobs:
           ./build/nautilus/test/fuzz/nautilus-fuzz-replay
   llvm-ir-test:
     runs-on: ubuntu-24.04
-    name: LLVM IR Test (clang-21)
+    name: LLVM IR Test (clang-22)
     env:
-      CC: clang-21
-      CXX: clang++-21
+      CC: clang-22
+      CXX: clang++-22
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -308,17 +308,18 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           key: ${{ github.job }}-llvm-ir-test
-      - name: Install clang 21 and llvm-diff-21
+      - name: Install clang 22 and llvm-diff-22
         run: |
           UBUNTU_CODENAME=$(lsb_release -cs)
           sudo apt-get update
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          echo "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 clang++-21 llvm-21
-          # Create symlinks for llvm-diff
-          sudo ln -sf /usr/bin/llvm-diff-21 /usr/local/bin/llvm-diff-19
+          sudo apt-get install -y clang-22 clang++-22 llvm-22
+          # Create symlinks for llvm-diff (LLVM 22 matches the bundled MLIR 22.1.8
+          # IR, which llvm-diff-21 cannot parse)
+          sudo ln -sf /usr/bin/llvm-diff-22 /usr/local/bin/llvm-diff-19
       - name: Cache MLIR binaries
         uses: actions/cache@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_WARNINGS "${CMAKE_CXX_WARNINGS} -Wpedantic-macros -Werror=integer-overflow -Werror=return-type -Werror=return-stack-address  -Werror=writable-strings")
+    # clang-22 flags Catch2's __COUNTER__ (used in the TEST_CASE macro) as a C2y
+    # extension; silence it under -Werror on clang 22+.
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+        set(CMAKE_CXX_WARNINGS "${CMAKE_CXX_WARNINGS} -Wno-c2y-extensions")
+    endif ()
 else ()
     set(CMAKE_CXX_WARNINGS "${CMAKE_CXX_WARNINGS} -Woverflow -Werror=return-type -Werror=return-local-addr  -Werror=write-strings -Wno-error=stringop-overflow")
 endif ()


### PR DESCRIPTION
The MLIR backend bundles LLVM 22 (mlir-22.1.8) and generates LLVM 22 IR, e.g. the ptr-only `llvm.lifetime.start/end` signature, which llvm-diff-21 rejects as a broken module. Switch the LLVM IR test job to clang-22 and install llvm-22 (llvm-diff-22) so the comparison tool matches the generated IR.