### PR TITLE
Install ccache via a shared composite action in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,15 +75,6 @@ jobs:
         with:
           path: build/mlir-*
           key: mlir-22.1.8-${{ runner.os }}-${{ runner.arch }}
-      - name: Install ccache (with retry)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          for i in 1 2 3 4 5; do
-            sudo apt-get update && sudo apt-get install -y ccache && exit 0
-            echo "apt-get install ccache failed (attempt $i/5), retrying in 15s..."
-            sleep 15
-          done
-          exit 1
       - name: get ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
@@ -147,14 +138,6 @@ jobs:
         with:
           path: example/build/mlir-*
           key: mlir-22.1.8-${{ runner.os }}-${{ runner.arch }}-example
-      - name: Install ccache (with retry)
-        run: |
-          for i in 1 2 3 4 5; do
-            sudo apt-get update && sudo apt-get install -y ccache && exit 0
-            echo "apt-get install ccache failed (attempt $i/5), retrying in 15s..."
-            sleep 15
-          done
-          exit 1
       - name: get ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
@@ -245,14 +228,6 @@ jobs:
         with:
           path: build/mlir-*
           key: mlir-22.1.8-${{ runner.os }}-${{ runner.arch }}
-      - name: Install ccache (with retry)
-        run: |
-          for i in 1 2 3 4 5; do
-            sudo apt-get update && sudo apt-get install -y ccache && exit 0
-            echo "apt-get install ccache failed (attempt $i/5), retrying in 15s..."
-            sleep 15
-          done
-          exit 1
       - name: get ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
@@ -296,14 +271,6 @@ jobs:
         run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
       - name: get cmake
         uses: lukka/get-cmake@latest
-      - name: Install ccache (with retry)
-        run: |
-          for i in 1 2 3 4 5; do
-            sudo apt-get update && sudo apt-get install -y ccache && exit 0
-            echo "apt-get install ccache failed (attempt $i/5), retrying in 15s..."
-            sleep 15
-          done
-          exit 1
       - name: get ccache
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:


### PR DESCRIPTION
The 'get ccache' step uses `hendrikmuhs/ccache-action`, which installs ccache when it isn't already present (per its README: *Ccache/sccache gets installed by this action if it is not installed yet*), configures the cache and saves/restores it. So the separate `Install ccache (with retry)` apt step was redundant in every job and only added the risk of a hung `apt-get update` stalling the workflow.

This drops the duplicated apt install step from all jobs; `get ccache` remains the single, sufficient setup step across the matrix, example demos, fuzz, and LLVM IR jobs.