### PR TITLE
Upgrade macOS CI runner to macos-26

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
             cc: 'clang-21'
             cxx: 'clang++-21'
             flags: '-DENABLE_GPU_PLUGIN=ON'
-          - os: 'macos-15'
+          - os: 'macos-26'
             cc: 'clang'
             cxx: 'clang++'
             flags: '-DENABLE_GPU_PLUGIN=ON'


### PR DESCRIPTION
Upgrades the macOS build matrix runner in `.github/workflows/pr.yml` from `macos-15` to `macos-26`.