### PR TITLE
Review follow-ups for #418: exception-region refactor + frame-guard groundwork

### DIFF
--- a/nautilus/include/nautilus/Executable.hpp
+++ b/nautilus/include/nautilus/Executable.hpp
@@ -300,7 +300,7 @@ public:
 	 */
 	template <typename R, typename... Args>
 	auto getInvocableMember(const std::string& member) {
-		auto mode = getExceptionPropagationMode();
+		auto mode = getExceptionPropagationMode(member);
 		if (hasInvocableFunctionPtr()) {
 			return Invocable<R, Args...>(getInvocableFunctionPtr(member), mode);
 		} else {
@@ -325,6 +325,24 @@ public:
 
 	[[nodiscard]] virtual ExceptionPropagationMode getExceptionPropagationMode() const {
 		return ExceptionPropagationMode::NativeUnwind;
+	}
+
+	/**
+	 * @brief Per-function refinement of getExceptionPropagationMode().
+	 *
+	 * A captured-host-rethrow backend (CPP/BC/TBC/AsmJit) still compiles most
+	 * functions with no exceptional call sites at all -- the common case, since
+	 * only a function that transitively invokes a non-noexcept call needs one.
+	 * Such a function never touches the ExceptionFrame machinery at runtime, so
+	 * it can be called through the raw function pointer with no frame active,
+	 * same as a NativeUnwind backend. Backends that track which of their
+	 * functions actually need capture (see
+	 * CapturedExceptionTransport::functionsNeedingCapture) override this to
+	 * answer per @p member instead of conservatively for the whole executable;
+	 * the default falls back to the executable-wide answer.
+	 */
+	[[nodiscard]] virtual ExceptionPropagationMode getExceptionPropagationMode(const std::string& /*member*/) const {
+		return getExceptionPropagationMode();
 	}
 
 	/**

--- a/nautilus/include/nautilus/Executable.hpp
+++ b/nautilus/include/nautilus/Executable.hpp
@@ -234,11 +234,12 @@ public:
 		 * @return returns the result of the function if any
 		 */
 		R operator()(Args... arguments) {
-			ExceptionFrame frame;
-			const bool useFrame = exceptionMode == ExceptionPropagationMode::CapturedHostRethrow;
-			if (useFrame) {
-				pushExceptionFrame(&frame);
-			}
+			// The guard pops on every exit path. Popping by hand after the call
+			// would be skipped whenever the call itself throws -- a bad_any_cast
+			// out of castGenericResult, or an interpreter propagating -- leaving
+			// the thread-local stack pointing at this destroyed frame for the
+			// rest of the thread's life.
+			ExceptionFrameScope frameScope(exceptionMode == ExceptionPropagationMode::CapturedHostRethrow);
 
 			auto doCall = [&]() -> R {
 				if (std::holds_alternative<FunctionType*>(func)) {
@@ -277,20 +278,14 @@ public:
 
 			if constexpr (!std::is_void_v<R>) {
 				R result = doCall();
-				if (useFrame) {
-					popExceptionFrame();
-					if (frame.pending) {
-						std::rethrow_exception(frame.pending);
-					}
+				if (frameScope.pending()) {
+					std::rethrow_exception(frameScope.pending());
 				}
 				return result;
 			} else {
 				doCall();
-				if (useFrame) {
-					popExceptionFrame();
-					if (frame.pending) {
-						std::rethrow_exception(frame.pending);
-					}
+				if (frameScope.pending()) {
+					std::rethrow_exception(frameScope.pending());
 				}
 			}
 		}

--- a/nautilus/include/nautilus/Module.hpp
+++ b/nautilus/include/nautilus/Module.hpp
@@ -84,13 +84,14 @@ class ModuleFunction<R(Args...)> {
 		}
 		std::shared_lock<std::shared_mutex> lock(state_->mutex);
 		if (state_->executable) {
-			// Native-unwind backends (MLIR) can be called through the raw
-			// function pointer: exceptions propagate natively. Captured-host-
-			// rethrow backends (CPP/BC/TBC/AsmJit) must go through the
-			// Invocable wrapper so the ExceptionFrame is pushed/rethrown around
-			// the call.
+			// A NativeUnwind backend (MLIR), or a captured-host-rethrow function
+			// with no exceptional call sites of its own, can be called through
+			// the raw function pointer: neither ever touches the ExceptionFrame
+			// machinery. Everything else must go through the Invocable wrapper
+			// so the frame is pushed/rethrown around the call.
 			if (state_->executable->hasInvocableFunctionPtr() &&
-			    state_->executable->getExceptionPropagationMode() == compiler::ExceptionPropagationMode::NativeUnwind) {
+			    state_->executable->getExceptionPropagationMode(name_) ==
+			        compiler::ExceptionPropagationMode::NativeUnwind) {
 				auto* fptr = reinterpret_cast<R (*)(Args...)>(state_->executable->getInvocableFunctionPtr(name_));
 				cache_->impl = fptr;
 			} else {

--- a/nautilus/include/nautilus/common/ExceptionTransport.hpp
+++ b/nautilus/include/nautilus/common/ExceptionTransport.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <exception>
 #include <type_traits>
 #include <utility>
@@ -14,27 +15,72 @@ struct ExceptionFrame {
 ExceptionFrame* currentExceptionFrame();
 void pushExceptionFrame(ExceptionFrame* frame);
 void popExceptionFrame();
+/// Pops back to @p frame's parent. Unlike the argument-less overload this
+/// cannot leave the thread-local stack pointing into a destroyed frame when
+/// pushes and pops got out of balance.
+void popExceptionFrame(ExceptionFrame* frame);
 bool hasPendingException();
+
+/// Stores the in-flight exception (i.e. the one currently being handled) in
+/// the innermost frame, if there is one and it is still empty.
+///
+/// Returns false when there is no frame to store it in. Callers running in a
+/// frame that can unwind must then rethrow rather than drop the exception;
+/// callers that cannot unwind (the capture thunk below, invoked from
+/// generated code without unwind tables) have no such option.
+[[nodiscard]] bool captureCurrentException() noexcept;
+
+/// RAII owner of an ExceptionFrame: pushes on construction and pops on
+/// destruction, so an exception escaping the guarded call cannot leave the
+/// thread-local stack pointing at a destroyed frame.
+class ExceptionFrameScope {
+public:
+	explicit ExceptionFrameScope(bool enabled) : enabled_(enabled) {
+		if (enabled_) {
+			pushExceptionFrame(&frame_);
+		}
+	}
+
+	~ExceptionFrameScope() {
+		if (enabled_) {
+			popExceptionFrame(&frame_);
+		}
+	}
+
+	ExceptionFrameScope(const ExceptionFrameScope&) = delete;
+	ExceptionFrameScope& operator=(const ExceptionFrameScope&) = delete;
+
+	/// The exception captured during the guarded call, or null.
+	[[nodiscard]] const std::exception_ptr& pending() const {
+		return frame_.pending;
+	}
+
+private:
+	ExceptionFrame frame_;
+	bool enabled_;
+};
 
 template <typename R, typename... Args>
 R captureThrowingCall(R (*target)(Args...), Args... args) noexcept {
+	// This thunk is invoked from generated/JIT-compiled frames that have no
+	// unwind tables, so it must not let an exception escape -- hence noexcept
+	// and the unconditional catch. Reaching it without a frame to capture into
+	// means the lowering emitted a capture site without pushing a frame, which
+	// is a bug on our side: assert loudly, and in release drop the exception
+	// rather than unwind through a frame that cannot be unwound.
 	if constexpr (std::is_void_v<R>) {
 		try {
 			target(std::forward<Args>(args)...);
 		} catch (...) {
-			auto* frame = currentExceptionFrame();
-			if (frame && !frame->pending) {
-				frame->pending = std::current_exception();
-			}
+			[[maybe_unused]] const bool captured = captureCurrentException();
+			assert(captured && "captureThrowingCall invoked without an active ExceptionFrame");
 		}
 	} else {
 		try {
 			return target(std::forward<Args>(args)...);
 		} catch (...) {
-			auto* frame = currentExceptionFrame();
-			if (frame && !frame->pending) {
-				frame->pending = std::current_exception();
-			}
+			[[maybe_unused]] const bool captured = captureCurrentException();
+			assert(captured && "captureThrowingCall invoked without an active ExceptionFrame");
 			return R {};
 		}
 	}

--- a/nautilus/include/nautilus/val_std.hpp
+++ b/nautilus/include/nautilus/val_std.hpp
@@ -279,11 +279,22 @@ public:
 	// SSA ref instead of going through val<T*>'s copy ctor, which would emit an
 	// extra traceCopy/ASSIGN op into the IR for what is logically just an alias.
 	// The source is left in a moved-from state and its destructor becomes a no-op.
+	//
+	// Deliberately does NOT touch the destructor registration: `value_ptr` is
+	// constructed directly from `other.value_ptr.getState()` (see above), so
+	// this object's state compares equal to other's -- same underlying address,
+	// same destructor function, since both are the same val<ValueType>
+	// instantiation. The registration made when the (possibly several moves
+	// back) original object was constructed already covers `this`; re-deriving
+	// it here would only remove and re-append that entry at the same address,
+	// reordering it after every other value currently live -- wrong when a
+	// throw during unwind must run destructors in reverse construction order,
+	// and, since register_destructor()/unregister_destructor() can allocate
+	// (activeDestructors is a std::vector), an avoidable way for an allocation
+	// to happen inside a noexcept move constructor.
 #ifdef ENABLE_TRACING
 	val(val<ValueType>&& other) noexcept : value_ptr(other.value_ptr.value, other.value_ptr.getState()) {
-		other.unregister_destructor();
 		other.moved_ = true;
-		register_destructor();
 	}
 #else
 	val(val<ValueType>&& other) noexcept : value_ptr(other.value_ptr.value) {

--- a/nautilus/src/nautilus/common/ExceptionTransport.cpp
+++ b/nautilus/src/nautilus/common/ExceptionTransport.cpp
@@ -1,4 +1,5 @@
 #include "nautilus/common/ExceptionTransport.hpp"
+#include <cassert>
 
 namespace nautilus::compiler {
 namespace {
@@ -20,6 +21,26 @@ void popExceptionFrame() {
 	if (tlsExceptionFrame) {
 		tlsExceptionFrame = tlsExceptionFrame->parent;
 	}
+}
+
+void popExceptionFrame(ExceptionFrame* frame) {
+	// Normally `frame` is the top of the stack. If it is not, an inner frame
+	// leaked (its owner was skipped by an exception); those frames are dead
+	// stack objects, so unwind past them rather than leaving the stack pointing
+	// at destroyed memory.
+	assert(tlsExceptionFrame == frame && "unbalanced ExceptionFrame push/pop");
+	tlsExceptionFrame = frame->parent;
+}
+
+bool captureCurrentException() noexcept {
+	auto* frame = currentExceptionFrame();
+	if (frame == nullptr) {
+		return false;
+	}
+	if (!frame->pending) {
+		frame->pending = std::current_exception();
+	}
+	return true;
 }
 
 bool hasPendingException() {

--- a/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.cpp
+++ b/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.cpp
@@ -3,30 +3,31 @@
 namespace nautilus::compiler {
 
 CapturedExceptionTransport::CapturedExceptionTransport(const ir::FunctionOperation& fn) {
-	if (fn.exceptionRegion) {
-		region_ = &*fn.exceptionRegion;
+	if (!fn.exceptionRegion) {
+		return;
+	}
+	region_ = &*fn.exceptionRegion;
+	siteIndex_.reserve(region_->callSites.size());
+	for (size_t i = 0; i < region_->callSites.size(); ++i) {
+		siteIndex_.emplace(region_->callSites[i].call, i);
 	}
 }
 
 bool CapturedExceptionTransport::callNeedsCapture(const ir::Operation* call) const {
-	return findCallSite(call) != nullptr;
+	return siteIndex_.contains(call);
+}
+
+size_t CapturedExceptionTransport::getPadIndexForCall(const ir::Operation* call) const {
+	const auto it = siteIndex_.find(call);
+	if (it == siteIndex_.end()) {
+		return ir::noLandingPad;
+	}
+	return region_->callSites[it->second].padIndex;
 }
 
 const ir::LandingPadBlock* CapturedExceptionTransport::getPadForCall(const ir::Operation* call) const {
-	const auto* callSite = findCallSite(call);
-	return callSite != nullptr ? callSite->pad : nullptr;
-}
-
-const ir::ExceptionalCallSite* CapturedExceptionTransport::findCallSite(const ir::Operation* call) const {
-	if (region_ == nullptr) {
-		return nullptr;
-	}
-	for (const auto& callSite : region_->callSites) {
-		if (callSite.call == call) {
-			return &callSite;
-		}
-	}
-	return nullptr;
+	const auto padIndex = getPadIndexForCall(call);
+	return padIndex == ir::noLandingPad ? nullptr : &region_->pads[padIndex];
 }
 
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.cpp
+++ b/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.cpp
@@ -1,4 +1,5 @@
 #include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
+#include "nautilus/compiler/ir/IRGraph.hpp"
 #include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
 #include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
 
@@ -40,6 +41,25 @@ void* CapturedExceptionTransport::captureThunkFor(const ir::Operation* call) {
 		return indirect->getCaptureFunc();
 	}
 	return nullptr;
+}
+
+std::unordered_set<std::string> CapturedExceptionTransport::functionsNeedingCapture(const ir::IRGraph& ir) {
+	std::unordered_set<std::string> names;
+	for (const auto* fn : ir.getFunctionOperations()) {
+		if (fn != nullptr && CapturedExceptionTransport(*fn).hasExceptionalCallSites()) {
+			names.insert(fn->getName());
+		}
+	}
+	return names;
+}
+
+bool CapturedExceptionTransport::anyFunctionNeedsCapture(const ir::IRGraph& ir) {
+	for (const auto* fn : ir.getFunctionOperations()) {
+		if (fn != nullptr && CapturedExceptionTransport(*fn).hasExceptionalCallSites()) {
+			return true;
+		}
+	}
+	return false;
 }
 
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.cpp
+++ b/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.cpp
@@ -1,4 +1,6 @@
 #include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
+#include "nautilus/compiler/ir/operations/IndirectCallOperation.hpp"
+#include "nautilus/compiler/ir/operations/ProxyCallOperation.hpp"
 
 namespace nautilus::compiler {
 
@@ -28,6 +30,16 @@ size_t CapturedExceptionTransport::getPadIndexForCall(const ir::Operation* call)
 const ir::LandingPadBlock* CapturedExceptionTransport::getPadForCall(const ir::Operation* call) const {
 	const auto padIndex = getPadIndexForCall(call);
 	return padIndex == ir::noLandingPad ? nullptr : &region_->pads[padIndex];
+}
+
+void* CapturedExceptionTransport::captureThunkFor(const ir::Operation* call) {
+	if (const auto* proxy = ir::dyn_cast<ir::ProxyCallOperation>(call)) {
+		return proxy->getCaptureFunc();
+	}
+	if (const auto* indirect = ir::dyn_cast<ir::IndirectCallOperation>(call)) {
+		return indirect->getCaptureFunc();
+	}
+	return nullptr;
 }
 
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.hpp
+++ b/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.hpp
@@ -44,6 +44,22 @@ public:
 	/// exceptional call site or has no destructors to run.
 	[[nodiscard]] const ir::LandingPadBlock* getPadForCall(const ir::Operation* call) const;
 
+	/// The recorded `captureThrowingCall<R, Args...>` thunk for @p call, or
+	/// nullptr when the call has none.
+	///
+	/// A capture site without a thunk must be lowered as a *direct* call plus
+	/// the pending-exception check. Routing it through a null thunk would call
+	/// address 0, with the argument list shifted by the thunk's extra target
+	/// parameter. Not every exceptional call site carries a thunk:
+	/// `traceNautilusCallWithExceptionHandling` records none, since a nested
+	/// Nautilus callee captures through its own transport.
+	[[nodiscard]] static void* captureThunkFor(const ir::Operation* call);
+
+	/// True when @p call both needs capture and has a thunk to capture through.
+	[[nodiscard]] bool callNeedsCaptureThunk(const ir::Operation* call) const {
+		return callNeedsCapture(call) && captureThunkFor(call) != nullptr;
+	}
+
 	/// The underlying side table, or nullptr when the function has none.
 	[[nodiscard]] const ir::FunctionExceptionRegion* getRegion() const {
 		return region_;

--- a/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.hpp
+++ b/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.hpp
@@ -3,7 +3,13 @@
 #include "nautilus/compiler/ir/ExceptionRegion.hpp"
 #include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
 #include <cstddef>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
+
+namespace nautilus::compiler::ir {
+class IRGraph;
+}
 
 namespace nautilus::compiler {
 
@@ -70,6 +76,22 @@ public:
 	[[nodiscard]] bool hasExceptionalCallSites() const {
 		return region_ != nullptr && !region_->callSites.empty();
 	}
+
+	/// Names of every function in @p ir whose compiled body actually touches
+	/// the captured-exception transport (i.e. `hasExceptionalCallSites()` is
+	/// true for it). A function whose name is absent from this set never
+	/// pushes/checks an ExceptionFrame at runtime, so it is safe to invoke
+	/// through the raw function pointer with no frame active -- see
+	/// `Executable::getExceptionPropagationMode(member)`, which backends use
+	/// this to answer per function instead of conservatively for the whole
+	/// executable.
+	[[nodiscard]] static std::unordered_set<std::string> functionsNeedingCapture(const ir::IRGraph& ir);
+
+	/// True when at least one function in @p ir has an exceptional call site.
+	/// Cheaper than checking `!functionsNeedingCapture(ir).empty()` when the
+	/// caller only needs a yes/no answer (e.g. deciding whether a generated
+	/// translation unit needs the captured-exception preamble at all).
+	[[nodiscard]] static bool anyFunctionNeedsCapture(const ir::IRGraph& ir);
 
 private:
 	const ir::FunctionExceptionRegion* region_ = nullptr;

--- a/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.hpp
+++ b/nautilus/src/nautilus/compiler/backends/CapturedExceptionTransport.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "nautilus/compiler/ir/ExceptionRegion.hpp"
 #include "nautilus/compiler/ir/operations/FunctionOperation.hpp"
-#include "nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.hpp"
-#include <span>
+#include <cstddef>
+#include <unordered_map>
 
 namespace nautilus::compiler {
 
@@ -15,6 +16,10 @@ namespace nautilus::compiler {
  * plus a branch to a landing pad, and which pad to branch to. It holds a
  * non-owning pointer to the region (or nullptr when the function has none).
  *
+ * Construct once per function and reuse across call sites: the constructor
+ * builds a call -> call-site index so each lookup is O(1). Constructing one
+ * per call site instead makes lowering quadratic in the number of calls.
+ *
  * The capture wrapper itself (`captureThrowingCall<R, Args...>`) is generated
  * at the typed invoke() site and recorded on the IR call operation
  * (`ProxyCallOperation::getCaptureFunc()` / `IndirectCallOperation::getCaptureFunc()`);
@@ -22,20 +27,38 @@ namespace nautilus::compiler {
  */
 class CapturedExceptionTransport {
 public:
+	CapturedExceptionTransport() = default;
 	explicit CapturedExceptionTransport(const ir::FunctionOperation& fn);
 
 	/// Returns true if @p call needs captured exception transport (a pending
 	/// check after the call plus a branch to its landing pad).
 	[[nodiscard]] bool callNeedsCapture(const ir::Operation* call) const;
 
+	/// Returns the index of @p call's landing pad within the region's pad list,
+	/// or `ir::noLandingPad` when the call is not an exceptional call site or
+	/// has no destructors to run. Backends that name pads (labels, block
+	/// indices) should key off this rather than the pad address.
+	[[nodiscard]] size_t getPadIndexForCall(const ir::Operation* call) const;
+
 	/// Returns the landing pad for @p call, or nullptr if the call is not an
 	/// exceptional call site or has no destructors to run.
 	[[nodiscard]] const ir::LandingPadBlock* getPadForCall(const ir::Operation* call) const;
 
-private:
-	const ir::ExceptionalCallSite* findCallSite(const ir::Operation* call) const;
+	/// The underlying side table, or nullptr when the function has none.
+	[[nodiscard]] const ir::FunctionExceptionRegion* getRegion() const {
+		return region_;
+	}
 
+	/// True when the function has at least one exceptional call site, i.e. it
+	/// needs landing pads, an exceptional exit and a pushed ExceptionFrame.
+	[[nodiscard]] bool hasExceptionalCallSites() const {
+		return region_ != nullptr && !region_->callSites.empty();
+	}
+
+private:
 	const ir::FunctionExceptionRegion* region_ = nullptr;
+	/// call operation -> index into `region_->callSites`.
+	std::unordered_map<const ir::Operation*, size_t> siteIndex_;
 };
 
 } // namespace nautilus::compiler

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -855,7 +855,7 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 	// calls need the capture thunk (mirrors X64's visitProxyCall).
 	auto it = funcNodes_.find(op->getFunctionName());
 	const bool isInternal = it != funcNodes_.end();
-	const bool needsCapture = !isInternal && callNeedsCapture(op);
+	const bool needsCapture = !isInternal && transport_.callNeedsCaptureThunk(op);
 	const bool needsCheck = callNeedsCapture(op);
 
 	FuncSignature sig;
@@ -926,7 +926,7 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 }
 
 void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame) {
-	const bool needsCapture = callNeedsCapture(op);
+	const bool needsCapture = transport_.callNeedsCaptureThunk(op);
 
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -253,6 +253,7 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 		processedBlocks.clear();
 		functionAllocaSlots_.clear();
 		currentFunction_ = funcOp;
+		transport_ = CapturedExceptionTransport(*funcOp);
 		padLabels_.clear();
 		exceptionalExitLabel_.reset();
 
@@ -1108,16 +1109,14 @@ bool AsmJitLoweringProvider::LoweringContext::callNeedsCapture(const ir::Operati
 	if (currentFunction_ == nullptr) {
 		return false;
 	}
-	CapturedExceptionTransport transport(*currentFunction_);
-	return transport.callNeedsCapture(call);
+	return transport_.callNeedsCapture(call);
 }
 
 const ir::LandingPadBlock* AsmJitLoweringProvider::LoweringContext::getPadForCall(const ir::Operation* call) const {
 	if (currentFunction_ == nullptr) {
 		return nullptr;
 	}
-	CapturedExceptionTransport transport(*currentFunction_);
-	return transport.getPadForCall(call);
+	return transport_.getPadForCall(call);
 }
 
 void* AsmJitLoweringProvider::LoweringContext::resolveCaptureThunk(const ir::Operation* call) const {
@@ -1131,8 +1130,8 @@ void* AsmJitLoweringProvider::LoweringContext::resolveCaptureThunk(const ir::Ope
 }
 
 void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir::Operation* call) {
-	const auto* pad = getPadForCall(call);
-	const Label target = pad != nullptr ? getPadLabel(pad) : getExceptionalExitLabel();
+	const auto padIndex = transport_.getPadIndexForCall(call);
+	const Label target = padIndex != ir::noLandingPad ? getPadLabel(padIndex) : getExceptionalExitLabel();
 
 	// frame = currentExceptionFrame()
 	FuncSignature frameSig;
@@ -1152,13 +1151,13 @@ void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir
 	cc.cbnz(pendingReg, target);
 }
 
-::asmjit::Label AsmJitLoweringProvider::LoweringContext::getPadLabel(const ir::LandingPadBlock* pad) {
-	auto it = padLabels_.find(pad);
+::asmjit::Label AsmJitLoweringProvider::LoweringContext::getPadLabel(size_t padIndex) {
+	auto it = padLabels_.find(padIndex);
 	if (it != padLabels_.end()) {
 		return it->second;
 	}
 	auto label = cc.newLabel();
-	padLabels_[pad] = label;
+	padLabels_[padIndex] = label;
 	return label;
 }
 
@@ -1176,8 +1175,9 @@ void AsmJitLoweringProvider::LoweringContext::lowerExceptionPads(RegisterFrame& 
 	}
 
 	const auto& pads = currentFunction_->exceptionRegion->pads;
-	for (const auto& pad : pads) {
-		cc.bind(getPadLabel(&pad));
+	for (size_t padIndex = 0; padIndex < pads.size(); ++padIndex) {
+		const auto& pad = pads[padIndex];
+		cc.bind(getPadLabel(padIndex));
 		// Pads contain only destructor ProxyCallOperations (all noUnwind), so
 		// lowering them through the normal dispatch emits plain external calls
 		// with no re-entrant capture.

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.cpp
@@ -1169,8 +1169,7 @@ void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir
 }
 
 void AsmJitLoweringProvider::LoweringContext::lowerExceptionPads(RegisterFrame& frame) {
-	if (currentFunction_ == nullptr || !currentFunction_->exceptionRegion.has_value() ||
-	    currentFunction_->exceptionRegion->callSites.empty()) {
+	if (currentFunction_ == nullptr || !transport_.hasExceptionalCallSites()) {
 		return;
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/A64LoweringProvider.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "nautilus/compiler/Frame.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #include "nautilus/compiler/backends/amsjit/A64PostRAPeepholePass.hpp"
 #include "nautilus/compiler/backends/amsjit/AsmJitRegister.hpp"
 #include "nautilus/compiler/backends/amsjit/intrinsics/AsmJitBackendIntrinsic.hpp"
@@ -98,8 +99,11 @@ private:
 		/// Function being lowered, used by the captured-exception transport to
 		/// find the call's landing pad. Cleared per function.
 		const ir::FunctionOperation* currentFunction_ = nullptr;
+		/// Captured-exception queries for `currentFunction_`, built once per
+		/// function rather than once per call site.
+		CapturedExceptionTransport transport_;
 		/// AsmJit labels for the current function's exception landing pads.
-		std::unordered_map<const ir::LandingPadBlock*, ::asmjit::Label> padLabels_;
+		std::unordered_map<size_t, ::asmjit::Label> padLabels_;
 		/// Shared exceptional-exit label for the current function (created on
 		/// first use, reset per function).
 		::asmjit::Label exceptionalExitLabel_;
@@ -198,7 +202,7 @@ private:
 		/// call's landing pad (or the exceptional-exit label) when set.
 		void emitCheckPendingException(const ir::Operation* call);
 		/// Returns the AsmJit label bound to @p pad (creating it on first use).
-		[[nodiscard]] ::asmjit::Label getPadLabel(const ir::LandingPadBlock* pad);
+		[[nodiscard]] ::asmjit::Label getPadLabel(size_t padIndex);
 		/// Returns the shared exceptional-exit label (creating it on first use).
 		[[nodiscard]] ::asmjit::Label getExceptionalExitLabel();
 		/// After the main CFG, emits the function's landing pads (each running

--- a/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitCompilationBackend.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/compiler/backends/amsjit/AsmJitCompilationBackend.hpp"
 #include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__)
 #include "nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp"
 #else
@@ -42,7 +43,8 @@ std::unique_ptr<Executable> AsmJitCompilationBackend::compile(const std::shared_
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
 
-	return std::make_unique<AsmJitExecutable>(std::move(runtime), result.basePtr, std::move(result.jitPtrs));
+	return std::make_unique<AsmJitExecutable>(std::move(runtime), result.basePtr, std::move(result.jitPtrs),
+	                                          CapturedExceptionTransport::functionsNeedingCapture(*ir));
 }
 
 } // namespace nautilus::compiler::asmjit

--- a/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitExecutable.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitExecutable.cpp
@@ -4,8 +4,10 @@
 namespace nautilus::compiler::asmjit {
 
 AsmJitExecutable::AsmJitExecutable(std::unique_ptr<::asmjit::JitRuntime> runtime, void* basePtr,
-                                   std::unordered_map<std::string, void*> jitPtrs)
-    : runtime_(std::move(runtime)), basePtr_(basePtr), jitPtrs_(std::move(jitPtrs)) {
+                                   std::unordered_map<std::string, void*> jitPtrs,
+                                   std::unordered_set<std::string> functionsNeedingCapture)
+    : runtime_(std::move(runtime)), basePtr_(basePtr), jitPtrs_(std::move(jitPtrs)),
+      functionsNeedingCapture_(std::move(functionsNeedingCapture)) {
 }
 
 AsmJitExecutable::~AsmJitExecutable() {

--- a/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitExecutable.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/AsmJitExecutable.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace nautilus::compiler::asmjit {
 
@@ -17,8 +18,14 @@ namespace nautilus::compiler::asmjit {
  */
 class AsmJitExecutable : public Executable {
 public:
+	/// @param functionsNeedingCapture names of the module's functions whose
+	///        compiled body has at least one captured-exception call site (see
+	///        CapturedExceptionTransport::functionsNeedingCapture). A function
+	///        not in this set is reported as NativeUnwind: it never touches
+	///        the ExceptionFrame machinery, so it is safe to call directly.
 	AsmJitExecutable(std::unique_ptr<::asmjit::JitRuntime> runtime, void* basePtr,
-	                 std::unordered_map<std::string, void*> jitPtrs);
+	                 std::unordered_map<std::string, void*> jitPtrs,
+	                 std::unordered_set<std::string> functionsNeedingCapture);
 	~AsmJitExecutable() override;
 
 	void* getInvocableFunctionPtr(const std::string& member) override;
@@ -28,12 +35,18 @@ public:
 		return ExceptionPropagationMode::CapturedHostRethrow;
 	}
 
+	[[nodiscard]] ExceptionPropagationMode getExceptionPropagationMode(const std::string& member) const override {
+		return functionsNeedingCapture_.contains(member) ? ExceptionPropagationMode::CapturedHostRethrow
+		                                                 : ExceptionPropagationMode::NativeUnwind;
+	}
+
 private:
 	std::unique_ptr<::asmjit::JitRuntime> runtime_;
 	/// Start of the single JIT memory block — released once in the destructor.
 	void* basePtr_;
 	/// Per-function pointers (offsets within the JIT block).
 	std::unordered_map<std::string, void*> jitPtrs_;
+	std::unordered_set<std::string> functionsNeedingCapture_;
 };
 
 } // namespace nautilus::compiler::asmjit

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -1385,7 +1385,7 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 	// calls need the capture thunk (mirrors TBC's visitProxyCall).
 	auto it = funcNodes_.find(op->getFunctionName());
 	const bool isInternal = it != funcNodes_.end();
-	const bool needsCapture = !isInternal && callNeedsCapture(op);
+	const bool needsCapture = !isInternal && transport_.callNeedsCaptureThunk(op);
 	const bool needsCheck = callNeedsCapture(op);
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));
@@ -1457,7 +1457,7 @@ void AsmJitLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperat
 
 void AsmJitLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOperation* op, RegisterFrame& frame) {
 	// Build callee signature from IR type information.
-	const bool needsCapture = callNeedsCapture(op);
+	const bool needsCapture = transport_.callNeedsCaptureThunk(op);
 	FuncSignature sig;
 	sig.setRet(getTypeId(op->getStamp()));
 	if (needsCapture) {
@@ -1708,13 +1708,11 @@ const ir::LandingPadBlock* AsmJitLoweringProvider::LoweringContext::getPadForCal
 }
 
 void* AsmJitLoweringProvider::LoweringContext::resolveCaptureThunk(const ir::Operation* call) const {
-	if (const auto* proxy = ir::dyn_cast<ir::ProxyCallOperation>(call)) {
-		return proxy->getCaptureFunc();
+	void* thunk = CapturedExceptionTransport::captureThunkFor(call);
+	if (thunk == nullptr) {
+		throw NotImplementedException("asmjit: captured-exception call has no recorded capture wrapper");
 	}
-	if (const auto* indirect = ir::dyn_cast<ir::IndirectCallOperation>(call)) {
-		return indirect->getCaptureFunc();
-	}
-	throw NotImplementedException("asmjit: captured-exception call has no recorded capture wrapper");
+	return thunk;
 }
 
 void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir::Operation* call) {

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -1754,8 +1754,7 @@ void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir
 }
 
 void AsmJitLoweringProvider::LoweringContext::lowerExceptionPads(RegisterFrame& frame) {
-	if (currentFunction_ == nullptr || !currentFunction_->exceptionRegion.has_value() ||
-	    currentFunction_->exceptionRegion->callSites.empty()) {
+	if (currentFunction_ == nullptr || !transport_.hasExceptionalCallSites()) {
 		return;
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.cpp
@@ -381,6 +381,7 @@ void AsmJitLoweringProvider::LoweringContext::processAll(std::string* asmjitIRDu
 		padLabels_.clear();
 		exceptionalExitLabel_.reset();
 		currentFunction_ = funcOp;
+		transport_ = CapturedExceptionTransport(*funcOp);
 
 		// Static usage counts feed the compare→branch fusion decision; only
 		// pay for the walk when the fusion is enabled.
@@ -1696,16 +1697,14 @@ bool AsmJitLoweringProvider::LoweringContext::callNeedsCapture(const ir::Operati
 	if (currentFunction_ == nullptr) {
 		return false;
 	}
-	CapturedExceptionTransport transport(*currentFunction_);
-	return transport.callNeedsCapture(call);
+	return transport_.callNeedsCapture(call);
 }
 
 const ir::LandingPadBlock* AsmJitLoweringProvider::LoweringContext::getPadForCall(const ir::Operation* call) const {
 	if (currentFunction_ == nullptr) {
 		return nullptr;
 	}
-	CapturedExceptionTransport transport(*currentFunction_);
-	return transport.getPadForCall(call);
+	return transport_.getPadForCall(call);
 }
 
 void* AsmJitLoweringProvider::LoweringContext::resolveCaptureThunk(const ir::Operation* call) const {
@@ -1719,8 +1718,8 @@ void* AsmJitLoweringProvider::LoweringContext::resolveCaptureThunk(const ir::Ope
 }
 
 void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir::Operation* call) {
-	const auto* pad = getPadForCall(call);
-	const Label target = pad != nullptr ? getPadLabel(pad) : getExceptionalExitLabel();
+	const auto padIndex = transport_.getPadIndexForCall(call);
+	const Label target = padIndex != ir::noLandingPad ? getPadLabel(padIndex) : getExceptionalExitLabel();
 
 	// frame = currentExceptionFrame()
 	FuncSignature frameSig;
@@ -1739,13 +1738,13 @@ void AsmJitLoweringProvider::LoweringContext::emitCheckPendingException(const ir
 	cc.jne(target);
 }
 
-::asmjit::Label AsmJitLoweringProvider::LoweringContext::getPadLabel(const ir::LandingPadBlock* pad) {
-	auto it = padLabels_.find(pad);
+::asmjit::Label AsmJitLoweringProvider::LoweringContext::getPadLabel(size_t padIndex) {
+	auto it = padLabels_.find(padIndex);
 	if (it != padLabels_.end()) {
 		return it->second;
 	}
 	auto label = cc.newLabel();
-	padLabels_[pad] = label;
+	padLabels_[padIndex] = label;
 	return label;
 }
 
@@ -1763,8 +1762,9 @@ void AsmJitLoweringProvider::LoweringContext::lowerExceptionPads(RegisterFrame& 
 	}
 
 	const auto& pads = currentFunction_->exceptionRegion->pads;
-	for (const auto& pad : pads) {
-		cc.bind(getPadLabel(&pad));
+	for (size_t padIndex = 0; padIndex < pads.size(); ++padIndex) {
+		const auto& pad = pads[padIndex];
+		cc.bind(getPadLabel(padIndex));
 		// Pads contain only destructor ProxyCallOperations (all noUnwind), so
 		// lowering them through the normal dispatch emits plain external calls
 		// with no re-entrant capture.

--- a/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/amsjit/X64LoweringProvider.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "nautilus/compiler/Frame.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #include "nautilus/compiler/backends/amsjit/AsmJitRegister.hpp"
 #include "nautilus/compiler/backends/amsjit/X64PostRAPeepholePass.hpp"
 #include "nautilus/compiler/backends/amsjit/intrinsics/AsmJitBackendIntrinsic.hpp"
@@ -125,10 +126,13 @@ private:
 		/// The function currently being lowered, or nullptr when lowering
 		/// outside a function body (pads are lowered within the active body).
 		const ir::FunctionOperation* currentFunction_ = nullptr;
+		/// Captured-exception queries for `currentFunction_`, built once per
+		/// function rather than once per call site.
+		CapturedExceptionTransport transport_;
 		/// Lazily-created AsmJit labels for the exception-region landing pads
 		/// of the current function, keyed by the pad's address. Cleared per
 		/// function.
-		std::unordered_map<const ir::LandingPadBlock*, ::asmjit::Label> padLabels_;
+		std::unordered_map<size_t, ::asmjit::Label> padLabels_;
 		/// Shared exceptional-exit label for the current function, created on
 		/// first use. All pads jump here after running destructors; it returns
 		/// the ABI default for the function's return type.
@@ -258,7 +262,7 @@ private:
 		/// call's landing pad (or the exceptional-exit label) when set.
 		void emitCheckPendingException(const ir::Operation* call);
 		/// Returns the AsmJit label bound to @p pad (creating it on first use).
-		[[nodiscard]] ::asmjit::Label getPadLabel(const ir::LandingPadBlock* pad);
+		[[nodiscard]] ::asmjit::Label getPadLabel(size_t padIndex);
 		/// Returns the shared exceptional-exit label (creating it on first use).
 		[[nodiscard]] ::asmjit::Label getExceptionalExitLabel();
 		/// After the main CFG, emits the function's landing pads (each running

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -693,8 +693,10 @@ void BCInterpreter::buildFlatCode() {
 
 BCExecutable::BCExecutable(std::unordered_map<std::string, void*> functionPtrs,
                            std::vector<std::unique_ptr<BCCallbackData>> callbackData,
-                           std::vector<BCClosureHandle> callbacks)
-    : functionPtrs_(std::move(functionPtrs)), callbackData_(std::move(callbackData)), callbacks_(std::move(callbacks)) {
+                           std::vector<BCClosureHandle> callbacks,
+                           std::unordered_set<std::string> functionsNeedingCapture)
+    : functionPtrs_(std::move(functionPtrs)), callbackData_(std::move(callbackData)), callbacks_(std::move(callbacks)),
+      functionsNeedingCapture_(std::move(functionsNeedingCapture)) {
 }
 
 BCExecutable::~BCExecutable() {

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -884,6 +884,35 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 		return executeThreaded(regs);
 	}
 #endif
+	// Dispatches a single non-terminator opcode through the inlined switch.
+	// Factored out so it can be shared, unchanged, between the two switch-path
+	// loop variants below (with and without the per-instruction pending-check
+	// test) instead of duplicating the macro-generated switch body.
+	auto dispatchSwitch = [&regs](const OpCode& c) {
+		switch (c.op) {
+#define NAUTILUS_BC_SWITCH_CASE(name, ...)                                                                             \
+	case ByteCode::name:                                                                                               \
+		__VA_ARGS__(c, regs);                                                                                          \
+		break;
+			NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_SWITCH_CASE)
+#undef NAUTILUS_BC_SWITCH_CASE
+		// Terminator pseudo-opcodes never appear in a block's operation stream in
+		// the call/switch paths (they keep the structured terminators); these
+		// cases exist only so the switch covers the whole ByteCode enum.
+		case ByteCode::JMP:
+		case ByteCode::CJMP:
+		case ByteCode::RET:
+		case ByteCode::CHECK_PENDING_EXCEPTION:
+#define NAUTILUS_BC_FUSED_SWITCH(fused, src, ctype, cmp) case ByteCode::fused:
+			NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_SWITCH)
+#undef NAUTILUS_BC_FUSED_SWITCH
+#define NAUTILUS_BC_IMM_SWITCH(immOp, src, ctype, oper) case ByteCode::immOp:
+			NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_SWITCH)
+#undef NAUTILUS_BC_IMM_SWITCH
+			break;
+		}
+	};
+
 	// first block is always the entrypoint
 	auto* currentBlock = &code.blocks[0];
 	// Threaded falls here when computed goto is unavailable, behaving as Switch.
@@ -893,54 +922,53 @@ int64_t BCInterpreter::execute(RegisterFile& regs) const {
 		// run, so this branch is perfectly predicted; it picks between the legacy
 		// indirect-call table and the inlined switch (which avoids a non-inlined
 		// call per instruction and lets the compiler keep the register base hot).
+		//
 		// CHECK_PENDING_EXCEPTION is a control-flow pseudo-opcode handled inline:
 		// when the captured-exception transport has a pending exception it jumps
-		// to the block in reg1 (the landing pad), otherwise it falls through.
+		// to the block in reg1 (the landing pad), otherwise it falls through. Most
+		// blocks -- everywhere in a function with no exceptional call sites, and
+		// most blocks even in one that has some -- never contain this opcode, so
+		// `hasPendingCheck` (set once by the lowering, not scanned here) picks
+		// between a loop that tests for it and a tight loop that doesn't. Folding
+		// that test into every iteration of the common loop would cost one extra
+		// compare-and-branch per instruction, in every program, whether or not it
+		// ever uses exceptions.
 		bool jumped = false;
 		if (useSwitch) {
-			for (const auto& c : currentBlock->code) {
-				if (c.op == ByteCode::CHECK_PENDING_EXCEPTION) {
-					if (hasPendingException()) {
-						currentBlock = &code.blocks[c.reg1];
-						jumped = true;
-						break;
+			if (currentBlock->hasPendingCheck) {
+				for (const auto& c : currentBlock->code) {
+					if (c.op == ByteCode::CHECK_PENDING_EXCEPTION) {
+						if (hasPendingException()) {
+							currentBlock = &code.blocks[c.reg1];
+							jumped = true;
+							break;
+						}
+						continue;
 					}
-					continue;
+					dispatchSwitch(c);
 				}
-				switch (c.op) {
-#define NAUTILUS_BC_SWITCH_CASE(name, ...)                                                                             \
-	case ByteCode::name:                                                                                               \
-		__VA_ARGS__(c, regs);                                                                                          \
-		break;
-					NAUTILUS_BC_OPCODE_LIST(NAUTILUS_BC_SWITCH_CASE)
-#undef NAUTILUS_BC_SWITCH_CASE
-				// Terminator pseudo-opcodes never appear in a block's operation stream
-				// in the call/switch paths (they keep the structured terminators); these
-				// cases exist only so the switch covers the whole ByteCode enum.
-				case ByteCode::JMP:
-				case ByteCode::CJMP:
-				case ByteCode::RET:
-				case ByteCode::CHECK_PENDING_EXCEPTION:
-#define NAUTILUS_BC_FUSED_SWITCH(fused, src, ctype, cmp) case ByteCode::fused:
-					NAUTILUS_BC_FUSED_BRANCH_LIST(NAUTILUS_BC_FUSED_SWITCH)
-#undef NAUTILUS_BC_FUSED_SWITCH
-#define NAUTILUS_BC_IMM_SWITCH(immOp, src, ctype, oper) case ByteCode::immOp:
-					NAUTILUS_BC_IMM_LIST(NAUTILUS_BC_IMM_SWITCH)
-#undef NAUTILUS_BC_IMM_SWITCH
-					break;
+			} else {
+				for (const auto& c : currentBlock->code) {
+					dispatchSwitch(c);
 				}
 			}
 		} else {
-			for (const auto& c : currentBlock->code) {
-				if (c.op == ByteCode::CHECK_PENDING_EXCEPTION) {
-					if (hasPendingException()) {
-						currentBlock = &code.blocks[c.reg1];
-						jumped = true;
-						break;
+			if (currentBlock->hasPendingCheck) {
+				for (const auto& c : currentBlock->code) {
+					if (c.op == ByteCode::CHECK_PENDING_EXCEPTION) {
+						if (hasPendingException()) {
+							currentBlock = &code.blocks[c.reg1];
+							jumped = true;
+							break;
+						}
+						continue;
 					}
-					continue;
+					OpTable[(int16_t) c.op](c, regs);
 				}
-				OpTable[(int16_t) c.op](c, regs);
+			} else {
+				for (const auto& c : currentBlock->code) {
+					OpTable[(int16_t) c.op](c, regs);
+				}
 			}
 		}
 		if (jumped) {

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.cpp
@@ -59,9 +59,12 @@ void dyncallCallV(const OpCode& op, RegisterFile& regs) {
 	try {
 		Dyncall::getVM().callVoid(value);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 }
@@ -72,9 +75,12 @@ void dyncallCallB(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callB(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<bool>(regs, op.output, returnValue);
@@ -86,9 +92,12 @@ void dyncallCallI8(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callI8(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<int8_t>(regs, op.output, returnValue);
@@ -100,9 +109,12 @@ void dyncallCallI16(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callI16(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<int16_t>(regs, op.output, returnValue);
@@ -114,9 +126,12 @@ void dyncallCallI32(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callI32(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<int32_t>(regs, op.output, returnValue);
@@ -128,9 +143,12 @@ void dyncallCallI64(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callI64(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<int64_t>(regs, op.output, returnValue);
@@ -142,9 +160,12 @@ void dyncallCallPtr(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callPtr(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<void*>(regs, op.output, returnValue);
@@ -156,9 +177,12 @@ void dyncallCallf(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callF(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<float>(regs, op.output, returnValue);
@@ -170,9 +194,12 @@ void dyncallCalld(const OpCode& op, RegisterFile& regs) {
 	try {
 		returnValue = Dyncall::getVM().callD(address);
 	} catch (...) {
-		auto* frame = currentExceptionFrame();
-		if (frame && !frame->pending) {
-			frame->pending = std::current_exception();
+		// No frame means nobody will rethrow this later, so let it propagate
+		// out of the interpreter rather than silently dropping it and handing
+		// back a zero result. Happens when the interpreter is driven directly
+		// (invokeGeneric, an embedder) instead of through Invocable.
+		if (!captureCurrentException()) {
+			throw;
 		}
 	}
 	writeReg<double>(regs, op.output, returnValue);

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreter.hpp
@@ -4,7 +4,9 @@
 #include "nautilus/compiler/backends/bc/ByteCode.hpp"
 #include "nautilus/config.hpp"
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // The bytecode backend hands each compiled function to its caller as a real C
@@ -141,8 +143,14 @@ private:
  */
 class BCExecutable : public Executable {
 public:
+	/// @param functionsNeedingCapture names of the module's functions whose
+	///        compiled body has at least one captured-exception call site (see
+	///        CapturedExceptionTransport::functionsNeedingCapture). A function
+	///        not in this set is reported as NativeUnwind: it never touches
+	///        the ExceptionFrame machinery, so it is safe to call directly.
 	BCExecutable(std::unordered_map<std::string, void*> functionPtrs,
-	             std::vector<std::unique_ptr<BCCallbackData>> callbackData, std::vector<BCClosureHandle> callbacks);
+	             std::vector<std::unique_ptr<BCCallbackData>> callbackData, std::vector<BCClosureHandle> callbacks,
+	             std::unordered_set<std::string> functionsNeedingCapture);
 
 	~BCExecutable() override;
 
@@ -154,10 +162,16 @@ public:
 		return ExceptionPropagationMode::CapturedHostRethrow;
 	}
 
+	[[nodiscard]] ExceptionPropagationMode getExceptionPropagationMode(const std::string& member) const override {
+		return functionsNeedingCapture_.contains(member) ? ExceptionPropagationMode::CapturedHostRethrow
+		                                                 : ExceptionPropagationMode::NativeUnwind;
+	}
+
 private:
 	std::unordered_map<std::string, void*> functionPtrs_;
 	std::vector<std::unique_ptr<BCCallbackData>> callbackData_;
 	std::vector<BCClosureHandle> callbacks_;
+	std::unordered_set<std::string> functionsNeedingCapture_;
 };
 
 } // namespace nautilus::compiler::bc

--- a/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCInterpreterBackend.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 #include <nautilus/CompilationStatistics.hpp>
+#include <nautilus/compiler/backends/CapturedExceptionTransport.hpp>
 #include <nautilus/compiler/backends/bc/BCInterpreter.hpp>
 #include <nautilus/compiler/backends/bc/BCInterpreterBackend.hpp>
 #include <nautilus/compiler/backends/bc/BCLoweringProvider.hpp>
@@ -355,7 +356,8 @@ std::unique_ptr<Executable> BCInterpreterBackend::compile(const std::shared_ptr<
 	}
 
 	return std::make_unique<BCExecutable>(std::move(functionPtrs), std::move(callbackDataStore),
-	                                      std::move(callbackPtrs));
+	                                      std::move(callbackPtrs),
+	                                      CapturedExceptionTransport::functionsNeedingCapture(*ir));
 }
 
 } // namespace nautilus::compiler::bc

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -1664,10 +1664,13 @@ void BCLoweringProvider::LoweringContext::emitCheckPendingException(const ir::Op
 	if (!callNeedsCapture(call)) {
 		return;
 	}
-	auto& code = program.blocks[block].code;
+	auto& codeBlock = program.blocks[block];
 	pendingExceptionPatches.emplace_back(
-	    PendingExceptionPatch {block, code.size(), transport_.getPadIndexForCall(call)});
-	code.emplace_back(ByteCode::CHECK_PENDING_EXCEPTION, -1, -1, -1);
+	    PendingExceptionPatch {block, codeBlock.code.size(), transport_.getPadIndexForCall(call)});
+	codeBlock.code.emplace_back(ByteCode::CHECK_PENDING_EXCEPTION, -1, -1, -1);
+	// Lets BCInterpreter::execute() skip the per-instruction pending check
+	// entirely for every block that never emits one -- the common case.
+	codeBlock.hasPendingCheck = true;
 }
 
 void BCLoweringProvider::LoweringContext::processDynamicCall(ir::ProxyCallOperation* opt, short block,

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -202,8 +202,7 @@ std::tuple<Code, RegisterFile> BCLoweringProvider::LoweringContext::process() {
 	// CHECK_PENDING_EXCEPTION opcodes emitted during the main CFG lowering carry
 	// a placeholder target (reg1 == -1) recorded in pendingExceptionPatches; the
 	// pad block indices are known only now, after the main CFG has been emitted.
-	const bool hasExceptionRegion =
-	    currentFunction_->exceptionRegion.has_value() && !currentFunction_->exceptionRegion->callSites.empty();
+	const bool hasExceptionRegion = transport_.hasExceptionalCallSites();
 	if (hasExceptionRegion) {
 		const auto& pads = currentFunction_->exceptionRegion->pads;
 		const short mainBlockCount = static_cast<short>(program.blocks.size());

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -195,6 +195,7 @@ std::tuple<Code, RegisterFile> BCLoweringProvider::LoweringContext::process() {
 		countAllUsages(&functionBasicBlock);
 	}
 	currentFunction_ = targetFunction;
+	transport_ = CapturedExceptionTransport(*targetFunction);
 	this->process(&functionBasicBlock, rootFrame);
 
 	// Lower the exception-region landing pads and the exceptional exit block.
@@ -227,15 +228,8 @@ std::tuple<Code, RegisterFile> BCLoweringProvider::LoweringContext::process() {
 		// index: the associated landing pad, or the exceptional exit when the call
 		// has no destructors.
 		for (const auto& patch : pendingExceptionPatches) {
-			short target = exceptionalExitBlock;
-			if (patch.pad != nullptr) {
-				for (size_t i = 0; i < pads.size(); ++i) {
-					if (&pads[i] == patch.pad) {
-						target = padBlockIndices[i];
-						break;
-					}
-				}
-			}
+			const short target =
+			    patch.padIndex == ir::noLandingPad ? exceptionalExitBlock : padBlockIndices[patch.padIndex];
 			program.blocks[patch.blockIndex].code[patch.opIndex].reg1 = target;
 		}
 	}
@@ -1664,21 +1658,16 @@ void BCLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOper
 }
 
 bool BCLoweringProvider::LoweringContext::callNeedsCapture(const ir::Operation* call) const {
-	if (currentFunction_ == nullptr) {
-		return false;
-	}
-	CapturedExceptionTransport transport(*currentFunction_);
-	return transport.callNeedsCapture(call);
+	return transport_.callNeedsCapture(call);
 }
 
 void BCLoweringProvider::LoweringContext::emitCheckPendingException(const ir::Operation* call, short block) {
 	if (!callNeedsCapture(call)) {
 		return;
 	}
-	CapturedExceptionTransport transport(*currentFunction_);
-	const auto* pad = transport.getPadForCall(call);
 	auto& code = program.blocks[block].code;
-	pendingExceptionPatches.emplace_back(PendingExceptionPatch {block, code.size(), pad});
+	pendingExceptionPatches.emplace_back(
+	    PendingExceptionPatch {block, code.size(), transport_.getPadIndexForCall(call)});
 	code.emplace_back(ByteCode::CHECK_PENDING_EXCEPTION, -1, -1, -1);
 }
 

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.cpp
@@ -1536,7 +1536,7 @@ void BCLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOper
 	// internalFunctionPtrs) are handled by the callee's own captured transport:
 	// no thunk here, the caller only runs the pending-exception check.
 	short calleeRegister = funcPtrRegister;
-	if (callNeedsCapture(opt) && opt->getCaptureFunc() != nullptr) {
+	if (transport_.callNeedsCaptureThunk(opt)) {
 		void* thunk = opt->getCaptureFunc();
 		code.emplace_back(ByteCode::DYNCALL_arg_ptr, funcPtrRegister, -1, -1);
 		calleeRegister = registerProvider.allocPinnedRegister();
@@ -1700,7 +1700,7 @@ void BCLoweringProvider::LoweringContext::processDynamicCall(ir::ProxyCallOperat
 	// internalFunctionPtrs) are handled by the callee's own captured transport:
 	// no thunk here, the caller only runs the pending-exception check.
 	short calleeRegister = funcInfoRegister;
-	if (callNeedsCapture(opt) && opt->getCaptureFunc() != nullptr) {
+	if (transport_.callNeedsCaptureThunk(opt)) {
 		void* thunk = opt->getCaptureFunc();
 		code.emplace_back(ByteCode::DYNCALL_arg_ptr, funcInfoRegister, -1, -1);
 		calleeRegister = registerProvider.allocPinnedRegister();

--- a/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/BCLoweringProvider.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nautilus/compiler/Frame.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #include "nautilus/compiler/backends/bc/ByteCode.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
 #include "nautilus/compiler/ir/OperationDispatcher.hpp"
@@ -158,16 +159,19 @@ private:
 		/// by visitProxyCall/visitIndirectCall via CapturedExceptionTransport to
 		/// decide whether a call site needs a pending-exception check.
 		const ir::FunctionOperation* currentFunction_ = nullptr;
+		/// Captured-exception queries for `currentFunction_`, built once per
+		/// function rather than once per call site.
+		CapturedExceptionTransport transport_;
 
 		/// Records the (block, op-index, pad) of every emitted
 		/// CHECK_PENDING_EXCEPTION whose target block index is resolved only
-		/// after the main CFG and landing pads have been lowered. `pad` is
-		/// nullptr when the call has no destructors (targets the exceptional
-		/// exit block directly).
+		/// after the main CFG and landing pads have been lowered. `padIndex` is
+		/// `ir::noLandingPad` when the call has no destructors (targets the
+		/// exceptional exit block directly).
 		struct PendingExceptionPatch {
 			short blockIndex;
 			size_t opIndex;
-			const ir::LandingPadBlock* pad;
+			size_t padIndex;
 		};
 		std::vector<PendingExceptionPatch> pendingExceptionPatches;
 

--- a/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
+++ b/nautilus/src/nautilus/compiler/backends/bc/ByteCode.hpp
@@ -824,6 +824,16 @@ public:
 	// when bc.immediates is enabled; call/switch ignore them.
 	std::vector<std::pair<uint32_t, int16_t>> foldableImmediates = {};
 
+	// True when this block's `code` contains a CHECK_PENDING_EXCEPTION opcode
+	// (set by the lowering when it emits one). The call/switch dispatch loops in
+	// BCInterpreter::execute() branch on this once per block, outside the
+	// per-instruction loop, so a block with no captured-exception call site pays
+	// no per-instruction cost at all -- only a block that actually needs the
+	// check runs the loop variant that tests for it. The threaded path is
+	// unaffected: CHECK_PENDING_EXCEPTION is already a distinct computed-goto
+	// label there, costing nothing extra either way.
+	bool hasPendingCheck = false;
+
 	friend std::ostream& operator<<(std::ostream& os, const CodeBlock& block);
 };
 

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPCompilationBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPCompilationBackend.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/compiler/backends/cpp/CPPCompilationBackend.hpp"
 #include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #include "nautilus/compiler/backends/cpp/CPPCompiler.hpp"
 #include "nautilus/compiler/backends/cpp/CPPExecutable.hpp"
 #include "nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp"
@@ -28,7 +29,7 @@ std::unique_ptr<Executable> CPPCompilationBackend::compile(const std::shared_ptr
 		statistics->recordTimingMs("cpp.compile.ms", compileStart);
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
-	return std::make_unique<CPPExecutable>(res);
+	return std::make_unique<CPPExecutable>(res, CapturedExceptionTransport::functionsNeedingCapture(*ir));
 }
 
 } // namespace nautilus::compiler::cpp

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPExecutable.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPExecutable.cpp
@@ -4,7 +4,9 @@
 #include <utility>
 namespace nautilus::compiler::cpp {
 
-CPPExecutable::CPPExecutable(std::shared_ptr<SharedLibrary> obj) : obj(std::move(obj)) {
+CPPExecutable::CPPExecutable(std::shared_ptr<SharedLibrary> obj,
+                             std::unordered_set<std::string> functionsNeedingCapture)
+    : obj(std::move(obj)), functionsNeedingCapture_(std::move(functionsNeedingCapture)) {
 }
 
 void* CPPExecutable::getInvocableFunctionPtr(const std::string& member) {

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPExecutable.hpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPExecutable.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <nautilus/Executable.hpp>
 #include <nautilus/compiler/backends/cpp/SharedLibrary.hpp>
+#include <string>
+#include <unordered_set>
 
 namespace nautilus::compiler::cpp {
 
@@ -14,8 +16,13 @@ public:
 	/**
 	 * Constructor to create a cpp executable.
 	 * @param obj the shared object, which we invoke at runtime.
+	 * @param functionsNeedingCapture names of the module's functions whose
+	 *        compiled body has at least one captured-exception call site (see
+	 *        CapturedExceptionTransport::functionsNeedingCapture). A function
+	 *        not in this set is reported as NativeUnwind: it never touches
+	 *        the ExceptionFrame machinery, so it is safe to call directly.
 	 */
-	explicit CPPExecutable(std::shared_ptr<SharedLibrary> obj);
+	CPPExecutable(std::shared_ptr<SharedLibrary> obj, std::unordered_set<std::string> functionsNeedingCapture);
 
 	~CPPExecutable() override = default;
 
@@ -28,7 +35,13 @@ public:
 		return ExceptionPropagationMode::CapturedHostRethrow;
 	}
 
+	[[nodiscard]] ExceptionPropagationMode getExceptionPropagationMode(const std::string& member) const override {
+		return functionsNeedingCapture_.contains(member) ? ExceptionPropagationMode::CapturedHostRethrow
+		                                                 : ExceptionPropagationMode::NativeUnwind;
+	}
+
 private:
 	std::shared_ptr<SharedLibrary> obj;
+	std::unordered_set<std::string> functionsNeedingCapture_;
 };
 } // namespace nautilus::compiler::cpp

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -71,23 +71,32 @@ std::stringstream CPPLoweringProvider::LoweringContext::process() {
 	std::stringstream pipelineCode;
 	pipelineCode << "\n";
 	pipelineCode << "#include <cstdint>\n";
-	pipelineCode << "#include <exception>\n\n";
-
-	// The generated shared library cannot link against nautilus, so the
-	// captured-exception transport helpers are baked in as raw function
-	// addresses resolved in the host process (same mechanism as the external
-	// function pointers emitted for ProxyCall/IndirectCall).
-	pipelineCode << "namespace nautilus { namespace compiler {\n";
-	pipelineCode << "struct ExceptionFrame { std::exception_ptr pending; ExceptionFrame* parent = nullptr; };\n";
-	pipelineCode << "}}\n\n";
-	pipelineCode << "static nautilus::compiler::ExceptionFrame* (*nautilus_current_exception_frame)() = "
-	             << "(nautilus::compiler::ExceptionFrame* (*)())(uintptr_t)"
-	             << reinterpret_cast<void*>(&nautilus::compiler::currentExceptionFrame) << ";\n";
-	pipelineCode << "static bool (*nautilus_has_pending_exception)() = (bool (*)())(uintptr_t)"
-	             << reinterpret_cast<void*>(&nautilus::compiler::hasPendingException) << ";\n\n";
 
 	// Process all function operations in the IR graph
 	const auto& functionOperations = ir->getFunctionOperations();
+
+	// The captured-exception preamble (the <exception> include, the mirrored
+	// ExceptionFrame layout, and the two helper-function-pointer globals) costs
+	// real compile time in the generated TU, so only pay for it when at least
+	// one function in the module actually has an exceptional call site -- the
+	// common case has none. The generated shared library cannot link against
+	// nautilus, so these helpers are baked in as raw function addresses
+	// resolved in the host process (same mechanism as the external function
+	// pointers emitted for ProxyCall/IndirectCall).
+	const bool moduleNeedsCapture = CapturedExceptionTransport::anyFunctionNeedsCapture(*ir);
+	if (moduleNeedsCapture) {
+		pipelineCode << "#include <exception>\n\n";
+		pipelineCode << "namespace nautilus { namespace compiler {\n";
+		pipelineCode << "struct ExceptionFrame { std::exception_ptr pending; ExceptionFrame* parent = nullptr; };\n";
+		pipelineCode << "}}\n\n";
+		pipelineCode << "static nautilus::compiler::ExceptionFrame* (*nautilus_current_exception_frame)() = "
+		             << "(nautilus::compiler::ExceptionFrame* (*)())(uintptr_t)"
+		             << reinterpret_cast<void*>(&nautilus::compiler::currentExceptionFrame) << ";\n";
+		pipelineCode << "static bool (*nautilus_has_pending_exception)() = (bool (*)())(uintptr_t)"
+		             << reinterpret_cast<void*>(&nautilus::compiler::hasPendingException) << ";\n\n";
+	} else {
+		pipelineCode << "\n";
+	}
 
 	// Helper lambda to process a single function
 	auto processFunction = [&](const ir::FunctionOperation& functionOperation) {
@@ -135,8 +144,7 @@ std::stringstream CPPLoweringProvider::LoweringContext::process() {
 		// Lower the exception-region landing pads into the block stream (before
 		// the variable/function declaration sections are emitted, so any
 		// declarations the pad's destructor calls introduce are captured).
-		const bool hasExceptionRegion =
-		    functionOperation.exceptionRegion.has_value() && !functionOperation.exceptionRegion->callSites.empty();
+		const bool hasExceptionRegion = transport_.hasExceptionalCallSites();
 		if (hasExceptionRegion) {
 			const auto& pads = functionOperation.exceptionRegion->pads;
 			for (size_t i = 0; i < pads.size(); ++i) {

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.cpp
@@ -93,6 +93,7 @@ std::stringstream CPPLoweringProvider::LoweringContext::process() {
 	auto processFunction = [&](const ir::FunctionOperation& functionOperation) {
 		// Reset state for each function
 		currentFunction_ = &functionOperation;
+		transport_ = CapturedExceptionTransport(functionOperation);
 		blocks.clear();
 		activeBlocks.clear();
 		blockArguments.str("");
@@ -240,19 +241,30 @@ void CPPLoweringProvider::LoweringContext::processPad(const ir::BasicBlock* bloc
 	blocks[blockIndex] << "goto exceptional_exit;\n";
 }
 
-std::string CPPLoweringProvider::LoweringContext::getPadLabel(const ir::LandingPadBlock* pad) {
-	if (pad == nullptr) {
+std::string CPPLoweringProvider::LoweringContext::getPadLabel(size_t padIndex) {
+	if (padIndex == ir::noLandingPad) {
 		return "exceptional_exit";
 	}
-	if (currentFunction_ != nullptr && currentFunction_->exceptionRegion.has_value()) {
-		const auto& pads = currentFunction_->exceptionRegion->pads;
-		for (size_t i = 0; i < pads.size(); ++i) {
-			if (&pads[i] == pad) {
-				return "cleanup_pad_" + std::to_string(i);
-			}
-		}
+	return "cleanup_pad_" + std::to_string(padIndex);
+}
+
+void CPPLoweringProvider::LoweringContext::emitCapturedCall(short blockIndex, const std::string& callExpr,
+                                                            const std::string& resultVar, const std::string& returnType,
+                                                            size_t padIndex) {
+	auto& out = blocks[blockIndex];
+	const bool hasResult = !resultVar.empty();
+	out << "try {\n";
+	out << (hasResult ? resultVar + " = " : "") << callExpr << ";\n";
+	out << "} catch (...) {\n";
+	out << "auto* __frame = nautilus_current_exception_frame();\n";
+	out << "if (__frame && !__frame->pending) { __frame->pending = std::current_exception(); }\n";
+	if (hasResult) {
+		out << resultVar << " = (" << returnType << ")0;\n";
 	}
-	return "exceptional_exit";
+	out << "}\n";
+	out << "if (nautilus_has_pending_exception()) {\n";
+	out << "goto " << getPadLabel(padIndex) << ";\n";
+	out << "}\n";
 }
 
 void CPPLoweringProvider::LoweringContext::visitCompare(ir::CompareOperation* cmpOp, short blockIndex,
@@ -508,46 +520,21 @@ void CPPLoweringProvider::LoweringContext::visitProxyCall(ir::ProxyCallOperation
 	callExpr += "(" + args.str() + ")";
 
 	// Does this call site need captured exception transport?
-	CapturedExceptionTransport transport(*currentFunction_);
-	const bool needsCapture = transport.callNeedsCapture(opt);
-	const auto* pad = needsCapture ? transport.getPadForCall(opt) : nullptr;
+	const bool needsCapture = transport_.callNeedsCapture(opt);
+	const auto padIndex = transport_.getPadIndexForCall(opt);
 
+	std::string resultVar;
 	if (opt->getStamp() != Type::v) {
-		auto resultVar = getVariable(opt->getIdentifier());
+		resultVar = getVariable(opt->getIdentifier());
 		if (!frame.contains(opt->getIdentifier())) {
 			blockArguments << getType(opt->getStamp()) << " " << resultVar << ";\n";
 			frame.setValue(opt->getIdentifier(), resultVar);
 		}
-		if (needsCapture) {
-			blocks[blockIndex] << "try {\n";
-			blocks[blockIndex] << resultVar << " = " << callExpr << ";\n";
-			blocks[blockIndex] << "} catch (...) {\n";
-			blocks[blockIndex] << "auto* __frame = nautilus_current_exception_frame();\n";
-			blocks[blockIndex]
-			    << "if (__frame && !__frame->pending) { __frame->pending = std::current_exception(); }\n";
-			blocks[blockIndex] << resultVar << " = (" << returnType << ")0;\n";
-			blocks[blockIndex] << "}\n";
-			blocks[blockIndex] << "if (nautilus_has_pending_exception()) {\n";
-			blocks[blockIndex] << "goto " << getPadLabel(pad) << ";\n";
-			blocks[blockIndex] << "}\n";
-		} else {
-			blocks[blockIndex] << resultVar << " = " << callExpr << ";\n";
-		}
+	}
+	if (needsCapture) {
+		emitCapturedCall(blockIndex, callExpr, resultVar, returnType, padIndex);
 	} else {
-		if (needsCapture) {
-			blocks[blockIndex] << "try {\n";
-			blocks[blockIndex] << callExpr << ";\n";
-			blocks[blockIndex] << "} catch (...) {\n";
-			blocks[blockIndex] << "auto* __frame = nautilus_current_exception_frame();\n";
-			blocks[blockIndex]
-			    << "if (__frame && !__frame->pending) { __frame->pending = std::current_exception(); }\n";
-			blocks[blockIndex] << "}\n";
-			blocks[blockIndex] << "if (nautilus_has_pending_exception()) {\n";
-			blocks[blockIndex] << "goto " << getPadLabel(pad) << ";\n";
-			blocks[blockIndex] << "}\n";
-		} else {
-			blocks[blockIndex] << callExpr << ";\n";
-		}
+		blocks[blockIndex] << (resultVar.empty() ? "" : resultVar + " = ") << callExpr << ";\n";
 	}
 }
 
@@ -572,46 +559,21 @@ void CPPLoweringProvider::LoweringContext::visitIndirectCall(ir::IndirectCallOpe
 	std::string callExpr = "((" + returnType + "(*)(" + argTypes.str() + "))" + fnPtrVar + ")(" + args.str() + ")";
 
 	// Does this call site need captured exception transport?
-	CapturedExceptionTransport transport(*currentFunction_);
-	const bool needsCapture = transport.callNeedsCapture(opt);
-	const auto* pad = needsCapture ? transport.getPadForCall(opt) : nullptr;
+	const bool needsCapture = transport_.callNeedsCapture(opt);
+	const auto padIndex = transport_.getPadIndexForCall(opt);
 
+	std::string resultVar;
 	if (opt->getStamp() != Type::v) {
-		auto resultVar = getVariable(opt->getIdentifier());
+		resultVar = getVariable(opt->getIdentifier());
 		if (!frame.contains(opt->getIdentifier())) {
 			blockArguments << getType(opt->getStamp()) << " " << resultVar << ";\n";
 			frame.setValue(opt->getIdentifier(), resultVar);
 		}
-		if (needsCapture) {
-			blocks[blockIndex] << "try {\n";
-			blocks[blockIndex] << resultVar << " = " << callExpr << ";\n";
-			blocks[blockIndex] << "} catch (...) {\n";
-			blocks[blockIndex] << "auto* __frame = nautilus_current_exception_frame();\n";
-			blocks[blockIndex]
-			    << "if (__frame && !__frame->pending) { __frame->pending = std::current_exception(); }\n";
-			blocks[blockIndex] << resultVar << " = (" << returnType << ")0;\n";
-			blocks[blockIndex] << "}\n";
-			blocks[blockIndex] << "if (nautilus_has_pending_exception()) {\n";
-			blocks[blockIndex] << "goto " << getPadLabel(pad) << ";\n";
-			blocks[blockIndex] << "}\n";
-		} else {
-			blocks[blockIndex] << resultVar << " = " << callExpr << ";\n";
-		}
+	}
+	if (needsCapture) {
+		emitCapturedCall(blockIndex, callExpr, resultVar, returnType, padIndex);
 	} else {
-		if (needsCapture) {
-			blocks[blockIndex] << "try {\n";
-			blocks[blockIndex] << callExpr << ";\n";
-			blocks[blockIndex] << "} catch (...) {\n";
-			blocks[blockIndex] << "auto* __frame = nautilus_current_exception_frame();\n";
-			blocks[blockIndex]
-			    << "if (__frame && !__frame->pending) { __frame->pending = std::current_exception(); }\n";
-			blocks[blockIndex] << "}\n";
-			blocks[blockIndex] << "if (nautilus_has_pending_exception()) {\n";
-			blocks[blockIndex] << "goto " << getPadLabel(pad) << ";\n";
-			blocks[blockIndex] << "}\n";
-		} else {
-			blocks[blockIndex] << callExpr << ";\n";
-		}
+		blocks[blockIndex] << (resultVar.empty() ? "" : resultVar + " = ") << callExpr << ";\n";
 	}
 }
 

--- a/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/cpp/CPPLoweringProvider.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "nautilus/compiler/Frame.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
+#include "nautilus/compiler/ir/ExceptionRegion.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
 #include "nautilus/compiler/ir/OperationDispatcher.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
-#include "nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.hpp"
 #include <cmath>
 #include <iomanip>
 #include <limits>
@@ -54,6 +55,9 @@ private:
 		/// dispatching its blocks). Provides access to the function's
 		/// exception-region side table from the per-call visit hooks.
 		const ir::FunctionOperation* currentFunction_ = nullptr;
+		/// Captured-exception queries for `currentFunction_`, rebuilt once per
+		/// function rather than once per call site.
+		CapturedExceptionTransport transport_;
 
 		std::string process(const ir::BasicBlock*, RegisterFrame& frame);
 
@@ -63,9 +67,15 @@ private:
 		/// ProxyCallOperations) into the block stream under @p label.
 		void processPad(const ir::BasicBlock* block, const std::string& label, RegisterFrame& frame);
 
-		/// Maps a landing pad to its generated label ("cleanup_pad_N"), or
-		/// "exceptional_exit" when @p pad is null.
-		std::string getPadLabel(const ir::LandingPadBlock* pad);
+		/// Maps a landing-pad index to its generated label ("cleanup_pad_N"), or
+		/// "exceptional_exit" when @p padIndex is `ir::noLandingPad`.
+		static std::string getPadLabel(size_t padIndex);
+
+		/// Emits the captured-call epilogue: store the in-flight exception into
+		/// the host frame and branch to @p padIndex's label. @p resultAssign is
+		/// the "var = " prefix for a value-returning call, empty for void.
+		void emitCapturedCall(short blockIndex, const std::string& callExpr, const std::string& resultVar,
+		                      const std::string& returnType, size_t padIndex);
 
 		// Per-operation hooks invoked by OperationDispatcher::dispatch.
 		void visitAdd(ir::AddOperation* opt, short block, RegisterFrame& frame);

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -679,6 +679,7 @@ void MLIRLoweringProvider::generateFunction(mlir::func::FuncOp& mlirFunction, co
 	debugAllocas_.clear();
 	functionAllocaSlots_.clear();
 	currentFunction_ = &functionOp;
+	transport_ = CapturedExceptionTransport(functionOp);
 	currentFunctionHeaderLine_ = 0;
 	currentFunctionLines_ = nullptr;
 	if (debugInfo_.enable && irSourceMap_ != nullptr) {
@@ -962,15 +963,7 @@ void MLIRLoweringProvider::visitProxyCall(ir::ProxyCallOperation* proxyCallOp, V
 	// exception propagates natively through this unwindable frame. Only calls
 	// with a landing pad need the invoke/landingpad and the personality
 	// function.
-	const ir::LandingPadBlock* pad = nullptr;
-	if (currentFunction_ && currentFunction_->exceptionRegion.has_value()) {
-		for (const auto& cs : currentFunction_->exceptionRegion->callSites) {
-			if (cs.call == proxyCallOp) {
-				pad = cs.pad;
-				break;
-			}
-		}
-	}
+	const ir::LandingPadBlock* pad = transport_.getPadForCall(proxyCallOp);
 
 	if (proxyCallOp->requiresExceptionHandling() && pad != nullptr && pad->block != nullptr) {
 		const auto location = getNameLoc("invoke");
@@ -1048,15 +1041,7 @@ void MLIRLoweringProvider::visitIndirectCall(ir::IndirectCallOperation* indirect
 	// destructors) need the invoke/landingpad machinery; pad-less calls fall
 	// through to the plain LLVM call below and the exception propagates
 	// natively through this unwindable frame.
-	const ir::LandingPadBlock* pad = nullptr;
-	if (currentFunction_ && currentFunction_->exceptionRegion.has_value()) {
-		for (const auto& cs : currentFunction_->exceptionRegion->callSites) {
-			if (cs.call == indirectCallOp) {
-				pad = cs.pad;
-				break;
-			}
-		}
-	}
+	const ir::LandingPadBlock* pad = transport_.getPadForCall(indirectCallOp);
 
 	if (indirectCallOp->requiresExceptionHandling() && pad != nullptr && pad->block != nullptr) {
 		auto* currentBlock = builder->getInsertionBlock();

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -1102,12 +1102,15 @@ void MLIRLoweringProvider::visitIndirectCall(ir::IndirectCallOperation* indirect
 		return;
 	}
 
-	// For indirect calls in the MLIR LLVM dialect, the callee pointer is the first element of the operands.
+	// For indirect calls in the MLIR LLVM dialect, the callee pointer is the
+	// first element of the operands. Reuses `callArgs` (resolved once above)
+	// instead of re-resolving every argument: resolveOperand can materialize
+	// conversion ops, so calling it twice per argument on this -- the common,
+	// no-landing-pad -- path would both waste work and risk duplicate ops.
 	std::vector<mlir::Value> allOperands;
+	allOperands.reserve(callArgs.size() + 1);
 	allOperands.push_back(calleePtr);
-	for (const auto& arg : indirectCallOp->getInputArguments()) {
-		allOperands.push_back(resolveOperand(arg, frame));
-	}
+	allOperands.insert(allOperands.end(), callArgs.begin(), callArgs.end());
 	if (indirectCallOp->getStamp() != Type::v) {
 		auto res = mlir::LLVM::CallOp::create(*builder, getNameLoc("indirectCall"), fnType, allOperands);
 		bind(frame, indirectCallOp, res.getResult());

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "nautilus/compiler/Frame.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #include "nautilus/compiler/backends/mlir/ProxyFunctions.hpp"
 #include "nautilus/compiler/backends/mlir/debug/DebugInfoOptions.hpp"
 #include "nautilus/compiler/backends/mlir/debug/IRSourceMap.hpp"
@@ -138,6 +139,10 @@ private:
 	/// generateFunction so visitProxyCall/visitIndirectCall can read the
 	/// exception-region side table.
 	const ir::FunctionOperation* currentFunction_ = nullptr;
+
+	/// Captured-exception queries for `currentFunction_`, built once per
+	/// function in generateFunction rather than once per call site.
+	CapturedExceptionTransport transport_;
 
 	/// Every SSA value produced so far for a Nautilus IR operation or block
 	/// argument, keyed by the operation's identity -- not its identifier: an

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCBackend.cpp
@@ -1,6 +1,7 @@
 
 #include "nautilus/compiler/backends/tbc/TBCBackend.hpp"
 #include "nautilus/CompilationStatistics.hpp"
+#include "nautilus/compiler/backends/CapturedExceptionTransport.hpp"
 #include "nautilus/compiler/backends/tbc/TBCExecutable.hpp"
 #include "nautilus/compiler/backends/tbc/TBCInterpreter.hpp"
 #include "nautilus/compiler/backends/tbc/TBCLoweringProvider.hpp"
@@ -156,7 +157,8 @@ std::unique_ptr<Executable> TBCBackend::compile(const std::shared_ptr<ir::IRGrap
 		statistics->recordTimingMs("backend.totalMs", backendStart);
 	}
 
-	return std::make_unique<TBCExecutable>(std::move(program));
+	return std::make_unique<TBCExecutable>(std::move(program),
+	                                       CapturedExceptionTransport::functionsNeedingCapture(*ir));
 }
 
 } // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.cpp
@@ -154,7 +154,9 @@ private:
 
 } // namespace
 
-TBCExecutable::TBCExecutable(std::shared_ptr<TBCProgram> program) : program(std::move(program)) {
+TBCExecutable::TBCExecutable(std::shared_ptr<TBCProgram> program,
+                             std::unordered_set<std::string> functionsNeedingCapture)
+    : program(std::move(program)), functionsNeedingCapture_(std::move(functionsNeedingCapture)) {
 }
 
 void* TBCExecutable::getInvocableFunctionPtr(const std::string&) {

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.hpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCExecutable.hpp
@@ -3,6 +3,8 @@
 #include "nautilus/Executable.hpp"
 #include "nautilus/compiler/backends/tbc/TBCCode.hpp"
 #include <memory>
+#include <string>
+#include <unordered_set>
 
 namespace nautilus::compiler::tbc {
 
@@ -17,7 +19,13 @@ namespace nautilus::compiler::tbc {
  */
 class TBCExecutable : public Executable {
 public:
-	explicit TBCExecutable(std::shared_ptr<TBCProgram> program);
+	/// @param functionsNeedingCapture names of the module's functions whose
+	///        compiled body has at least one captured-exception call site (see
+	///        CapturedExceptionTransport::functionsNeedingCapture). A function
+	///        not in this set is reported as NativeUnwind: it never touches
+	///        the ExceptionFrame machinery, so the generic Invocable skips
+	///        pushing one for it.
+	TBCExecutable(std::shared_ptr<TBCProgram> program, std::unordered_set<std::string> functionsNeedingCapture);
 
 	[[nodiscard]] void* getInvocableFunctionPtr(const std::string& member) override;
 	bool hasInvocableFunctionPtr() override;
@@ -27,8 +35,14 @@ public:
 		return ExceptionPropagationMode::CapturedHostRethrow;
 	}
 
+	[[nodiscard]] ExceptionPropagationMode getExceptionPropagationMode(const std::string& member) const override {
+		return functionsNeedingCapture_.contains(member) ? ExceptionPropagationMode::CapturedHostRethrow
+		                                                 : ExceptionPropagationMode::NativeUnwind;
+	}
+
 private:
 	std::shared_ptr<TBCProgram> program;
+	std::unordered_set<std::string> functionsNeedingCapture_;
 };
 
 } // namespace nautilus::compiler::tbc

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -226,7 +226,8 @@ class LoweringContext : public ir::OperationDispatcher<LoweringContext> {
 public:
 	LoweringContext(const ir::FunctionOperation* func, TBCProgram& program, TBCFunction& out,
 	                const TBCLoweringOptions& options)
-	    : func(func), program(program), out(out), options(options) {
+	    : func(func), transport(func != nullptr ? CapturedExceptionTransport(*func) : CapturedExceptionTransport {}),
+	      program(program), out(out), options(options) {
 	}
 
 	void process() {
@@ -272,6 +273,8 @@ private:
 	friend class ir::OperationDispatcher<LoweringContext>;
 
 	const ir::FunctionOperation* func;
+	/// Captured-exception queries for `func`, built once rather than per call site.
+	CapturedExceptionTransport transport;
 	TBCProgram& program;
 	TBCFunction& out;
 	TBCLoweringOptions options;
@@ -311,7 +314,7 @@ private:
 		int block = -1;
 		uint32_t codeIndex = 0;
 		int targetBlock = -1;
-		const ir::LandingPadBlock* pad = nullptr;
+		size_t padIndex = ir::noLandingPad;
 	};
 	std::vector<CheckPendingSite> checkPendingSites;
 
@@ -973,10 +976,6 @@ private:
 	/// Returns true if @p call is a captured-exception call site (i.e. it needs
 	/// the capture thunk and a pending-exception check after the call).
 	bool callNeedsCapture(const ir::Operation* call) const {
-		if (func == nullptr) {
-			return false;
-		}
-		CapturedExceptionTransport transport(*func);
 		return transport.callNeedsCapture(call);
 	}
 
@@ -987,10 +986,8 @@ private:
 		if (!callNeedsCapture(call)) {
 			return;
 		}
-		CapturedExceptionTransport transport(*func);
-		const auto* pad = transport.getPadForCall(call);
 		const uint32_t codeIndex = static_cast<uint32_t>(blocks[block].code.size());
-		checkPendingSites.push_back({block, codeIndex, -1, pad});
+		checkPendingSites.push_back({block, codeIndex, -1, transport.getPadIndexForCall(call)});
 		emit(block, Op::CHECK_PENDING, 0, 0, 0);
 	}
 
@@ -1112,23 +1109,20 @@ private:
 		const int mainBlockCount = static_cast<int>(blocks.size());
 		const int exceptionalExitBlock = mainBlockCount + static_cast<int>(pads.size());
 
-		std::unordered_map<const ir::LandingPadBlock*, int> padBlockIndices;
+		std::vector<int> padBlockIndices;
+		padBlockIndices.reserve(pads.size());
 		for (const auto& pad : pads) {
-			const int padIndex = processBlock(pad.block, rootFrame);
-			blocks[padIndex].term = Terminator {Terminator::Jump, kNoReg, exceptionalExitBlock, -1, kNoReg};
-			padBlockIndices[&pad] = padIndex;
+			const int blockIndex = processBlock(pad.block, rootFrame);
+			blocks[blockIndex].term = Terminator {Terminator::Jump, kNoReg, exceptionalExitBlock, -1, kNoReg};
+			padBlockIndices.push_back(blockIndex);
 		}
 
 		blocks.emplace_back();
 		blocks.back().term = Terminator {Terminator::Ret, kNoReg, -1, -1, kNoReg};
 
 		for (auto& site : checkPendingSites) {
-			if (site.pad != nullptr) {
-				const auto it = padBlockIndices.find(site.pad);
-				site.targetBlock = it != padBlockIndices.end() ? it->second : exceptionalExitBlock;
-			} else {
-				site.targetBlock = exceptionalExitBlock;
-			}
+			site.targetBlock =
+			    site.padIndex == ir::noLandingPad ? exceptionalExitBlock : padBlockIndices[site.padIndex];
 		}
 	}
 

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -1094,7 +1094,7 @@ private:
 	/// exceptional-exit block does a void return — the Invocable wrapper
 	/// rethrows the pending exception regardless of the return value.
 	void lowerExceptionPads(RegisterFrame& rootFrame) {
-		if (!func->exceptionRegion.has_value() || func->exceptionRegion->callSites.empty()) {
+		if (!transport.hasExceptionalCallSites()) {
 			return;
 		}
 		const auto& pads = func->exceptionRegion->pads;

--- a/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/tbc/TBCLoweringProvider.cpp
@@ -996,13 +996,7 @@ private:
 	/// wrapper is generated at the typed invoke() site and threaded through the
 	/// trace into the IR; backends simply read it.
 	void* resolveCaptureThunk(const ir::Operation* call) {
-		if (const auto* proxy = ir::dyn_cast<ir::ProxyCallOperation>(call)) {
-			return proxy->getCaptureFunc();
-		}
-		if (const auto* indirect = ir::dyn_cast<ir::IndirectCallOperation>(call)) {
-			return indirect->getCaptureFunc();
-		}
-		return nullptr;
+		return CapturedExceptionTransport::captureThunkFor(call);
 	}
 
 	void visitProxyCall(ir::ProxyCallOperation* opt, int block, RegisterFrame& frame) {
@@ -1030,8 +1024,7 @@ private:
 		// the raw target, so an exception is caught before it crosses dyncall's
 		// assembly trampoline. The raw target becomes the thunk's first argument
 		// (a pinned constant slot) and the thunk itself is the callee.
-		if (callNeedsCapture(opt)) {
-			void* thunk = resolveCaptureThunk(opt);
+		if (void* thunk = transport.callNeedsCaptureThunk(opt) ? resolveCaptureThunk(opt) : nullptr) {
 			const uint16_t targetReg = constSlot(reinterpret_cast<uint64_t>(opt->getFunctionPtr()));
 			site.argTypes.insert(site.argTypes.begin(), Type::ptr);
 			site.argRegs.insert(site.argRegs.begin(), targetReg);
@@ -1061,8 +1054,7 @@ private:
 		// the thunk's first argument and call the capture thunk via CALL_EXT
 		// (which reads site.target), so the exception is caught in a real C++
 		// frame before crossing dyncall's trampoline.
-		if (callNeedsCapture(opt)) {
-			void* thunk = resolveCaptureThunk(opt);
+		if (void* thunk = transport.callNeedsCaptureThunk(opt) ? resolveCaptureThunk(opt) : nullptr) {
 			site.argTypes.insert(site.argTypes.begin(), Type::ptr);
 			site.argRegs.insert(site.argRegs.begin(), functionReg);
 			site.target = thunk;

--- a/nautilus/src/nautilus/compiler/ir/ExceptionRegion.hpp
+++ b/nautilus/src/nautilus/compiler/ir/ExceptionRegion.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace nautilus::compiler::ir {
+
+class BasicBlock;
+class Operation;
+
+/// A shared landing-pad block. The block holds the ordered destructor calls
+/// (reverse of the construction order) that must run when the associated call
+/// unwinds. It is not part of the function's main CFG; it lives only in the
+/// `FunctionExceptionRegion` side table and is lowered by the backend.
+struct LandingPadBlock {
+	BasicBlock* block = nullptr;
+};
+
+/// Sentinel for `ExceptionalCallSite::padIndex`: the call is an exceptional
+/// call site, but has no destructors to run.
+inline constexpr size_t noLandingPad = static_cast<size_t>(-1);
+
+/// A call site that may unwind. `padIndex` is `noLandingPad` when the call has
+/// no destructors to run (the backend still needs the site to attach an
+/// exception handler to, but there is no cleanup to perform).
+///
+/// The pad is referenced by index rather than by pointer so that
+/// `FunctionExceptionRegion` stays a well-behaved value type: a copy of the
+/// region keeps its call sites pointing at the copy's own pads.
+struct ExceptionalCallSite {
+	Operation* call = nullptr;
+	size_t padIndex = noLandingPad;
+
+	[[nodiscard]] bool hasPad() const {
+		return padIndex != noLandingPad;
+	}
+};
+
+/// Per-function side table produced by ExceptionRegionPreparationPass:
+/// the landing pads keyed by the ordered destructor set, plus the call sites
+/// that reference them.
+struct FunctionExceptionRegion {
+	std::vector<LandingPadBlock> pads;
+	std::vector<ExceptionalCallSite> callSites;
+
+	/// The landing pad for @p site, or nullptr when the site has no cleanup.
+	[[nodiscard]] const LandingPadBlock* padFor(const ExceptionalCallSite& site) const {
+		return site.hasPad() ? &pads[site.padIndex] : nullptr;
+	}
+};
+
+} // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -157,8 +157,8 @@ struct formatter<nautilus::compiler::ir::Operation> : formatter<std::string_view
 
 template <>
 struct formatter<nautilus::compiler::ir::OperationIdentifier> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::OperationIdentifier& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::OperationIdentifier& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "${}", op.getId());
 		return out;
@@ -176,8 +176,8 @@ struct formatter<nautilus::compiler::ir::BlockIdentifier> : formatter<std::strin
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlockInvocation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlockInvocation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "Block_{}(", op.getBlock()->getIdentifier());
 		const auto args = op.getArguments();
@@ -204,8 +204,8 @@ struct formatter<nautilus::compiler::ir::IfOperation> : formatter<std::string_vi
 
 template <>
 struct formatter<nautilus::compiler::ir::ProxyCallOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::ProxyCallOperation& op,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 
 		if (op.getStamp() != nautilus::Type::v) {
@@ -358,8 +358,8 @@ auto fmt::formatter<nautilus::compiler::ir::Operation>::format(const nautilus::c
 
 template <>
 struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::BasicBlock& block, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::BasicBlock& block,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "\nBlock_{}(", block.getIdentifier());
 		const auto& args = block.getArguments();
@@ -380,8 +380,8 @@ struct formatter<nautilus::compiler::ir::BasicBlock> : formatter<std::string_vie
 
 template <>
 struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::string_view> {
-	static auto format(const nautilus::compiler::ir::FunctionOperation& func, format_context& ctx)
-	    -> format_context::iterator {
+	static auto format(const nautilus::compiler::ir::FunctionOperation& func,
+	                   format_context& ctx) -> format_context::iterator {
 		auto out = ctx.out();
 		fmt::format_to(out, "{}(", func.getName());
 		// The trace-to-IR conversion leaves `inputArgs`/`inputArgNames` empty;
@@ -426,9 +426,8 @@ struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::str
 				fmt::format_to(out, "\tcall_sites:\n");
 				for (const auto& site : region.callSites) {
 					fmt::format_to(out, "\t\t{} -> ", site.call->getIdentifier());
-					if (site.pad != nullptr) {
-						const auto index = static_cast<size_t>(site.pad - region.pads.data());
-						fmt::format_to(out, "pad_{}\n", index);
+					if (site.hasPad()) {
+						fmt::format_to(out, "pad_{}\n", site.padIndex);
 					} else {
 						fmt::format_to(out, "(no_pad)\n");
 					}

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
@@ -1,9 +1,9 @@
 
 #pragma once
 
+#include "nautilus/compiler/ir/ExceptionRegion.hpp"
 #include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
 #include "nautilus/compiler/ir/operations/Operation.hpp"
-#include "nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.hpp"
 #include <cstddef>
 #include <optional>
 #include <unordered_map>

--- a/nautilus/src/nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.cpp
@@ -108,13 +108,11 @@ bool applyToFunction(FunctionOperation& fn, common::Arena& arena) {
 	uint32_t nextBlockId = maxBlockId + 1;
 
 	FunctionExceptionRegion region;
-	// Upper bound on distinct pads: never reallocates, so `pad` pointers into
-	// `region.pads` stay stable while we intern.
 	region.pads.reserve(rawSites.size());
 
 	for (auto& site : rawSites) {
 		if (site.destructors.empty()) {
-			region.callSites.push_back({site.call, nullptr});
+			region.callSites.push_back({site.call, noLandingPad});
 			continue;
 		}
 
@@ -141,7 +139,7 @@ bool applyToFunction(FunctionOperation& fn, common::Arena& arena) {
 			}
 			region.pads.push_back({padBlock});
 		}
-		region.callSites.push_back({site.call, &region.pads[index]});
+		region.callSites.push_back({site.call, index});
 	}
 
 	fn.exceptionRegion = std::move(region);

--- a/nautilus/src/nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.cpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.cpp
@@ -51,12 +51,35 @@ std::vector<DestructorSpec> convertDestructors(const std::vector<IndirectCallOpe
 	return out;
 }
 
+/// One entry in the pad-identity key: the destructor's address operand plus
+/// which function is called on it. In practice the address alone already
+/// disambiguates -- an SSA value has one declared type, so its recorded
+/// destructor follows from that type -- but keying on the pair costs nothing
+/// and doesn't rely on that invariant holding.
+struct DestructorIdentity {
+	Operation* address;
+	void* functionPtr;
+
+	bool operator==(const DestructorIdentity& other) const {
+		return address == other.address && functionPtr == other.functionPtr;
+	}
+};
+
 /// Total-order comparison for the pad-identity key (an ordered sequence of
-/// address operands). Uses std::less so unrelated Operation* compare with a
+/// DestructorIdentity). Uses std::less so unrelated pointers compare with a
 /// strict total order rather than the built-in `<`.
+struct IdentityLess {
+	bool operator()(const DestructorIdentity& a, const DestructorIdentity& b) const {
+		if (a.address != b.address) {
+			return std::less<Operation*> {}(a.address, b.address);
+		}
+		return std::less<void*> {}(a.functionPtr, b.functionPtr);
+	}
+};
+
 struct VecLess {
-	bool operator()(const std::vector<Operation*>& a, const std::vector<Operation*>& b) const {
-		return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), std::less<Operation*> {});
+	bool operator()(const std::vector<DestructorIdentity>& a, const std::vector<DestructorIdentity>& b) const {
+		return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), IdentityLess {});
 	}
 };
 
@@ -92,7 +115,7 @@ bool applyToFunction(FunctionOperation& fn, common::Arena& arena) {
 
 	// 2. Intern pads by the ordered sequence of destructor address operands.
 	// Two calls sharing the same ordered set of address operands share a pad.
-	std::map<std::vector<Operation*>, size_t, VecLess> padIndex;
+	std::map<std::vector<DestructorIdentity>, size_t, VecLess> padIndex;
 
 	// Fresh-identifier baseline: never collide with the main CFG's op/block
 	// ids. The two identifier namespaces are distinct, so track each.
@@ -116,10 +139,10 @@ bool applyToFunction(FunctionOperation& fn, common::Arena& arena) {
 			continue;
 		}
 
-		std::vector<Operation*> identity;
+		std::vector<DestructorIdentity> identity;
 		identity.reserve(site.destructors.size());
 		for (const auto& d : site.destructors) {
-			identity.push_back(d.address);
+			identity.push_back({d.address, d.functionPtr});
 		}
 
 		auto [it, inserted] = padIndex.try_emplace(identity, region.pads.size());

--- a/nautilus/src/nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.hpp
+++ b/nautilus/src/nautilus/compiler/ir/passes/ExceptionRegionPreparationPass.hpp
@@ -1,39 +1,11 @@
-
 #pragma once
 
+#include "nautilus/compiler/ir/ExceptionRegion.hpp"
 #include "nautilus/compiler/ir/IRGraph.hpp"
-#include "nautilus/compiler/ir/blocks/BasicBlock.hpp"
-#include "nautilus/compiler/ir/operations/Operation.hpp"
 #include "nautilus/compiler/ir/passes/IRPass.hpp"
-#include <cstdint>
-#include <optional>
-#include <vector>
+#include <string>
 
 namespace nautilus::compiler::ir {
-
-/// A shared landing-pad block. The block holds the ordered destructor calls
-/// (reverse of the construction order) that must run when the associated call
-/// unwinds. It is not part of the function's main CFG; it lives only in the
-/// `FunctionExceptionRegion` side table and is lowered by the backend.
-struct LandingPadBlock {
-	BasicBlock* block = nullptr;
-};
-
-/// A call site that may unwind. `pad` is `nullptr` when the call has no
-/// destructors to run (the backend still needs the site to attach an
-/// exception handler to, but there is no cleanup to perform).
-struct ExceptionalCallSite {
-	Operation* call = nullptr;
-	LandingPadBlock* pad = nullptr;
-};
-
-/// Per-function side table produced by ExceptionRegionPreparationPass:
-/// the landing pads keyed by the ordered destructor set, plus the call sites
-/// that reference them.
-struct FunctionExceptionRegion {
-	std::vector<LandingPadBlock> pads;
-	std::vector<ExceptionalCallSite> callSites;
-};
 
 /**
  * @brief Terminal pass that materializes exception-handling regions.
@@ -42,9 +14,9 @@ struct FunctionExceptionRegion {
  * potentially-throwing call (ProxyCallOperation / IndirectCallOperation with
  * `noUnwind == false`), and interns each call's ordered destructor list into
  * a shared landing-pad block. The result is attached to the FunctionOperation
- * as a `FunctionExceptionRegion` side table. Pad blocks and their destructor
- * calls are arena-allocated and carry fresh identifiers that never collide
- * with the main CFG's.
+ * as a `FunctionExceptionRegion` side table (see ir/ExceptionRegion.hpp).
+ * Pad blocks and their destructor calls are arena-allocated and carry fresh
+ * identifiers that never collide with the main CFG's.
  *
  * Idempotent: a function whose `exceptionRegion` is already set is skipped.
  */

--- a/nautilus/test/common/ExceptionTransportTest.cpp
+++ b/nautilus/test/common/ExceptionTransportTest.cpp
@@ -4,9 +4,11 @@
 #include <string>
 #include <thread>
 
+using nautilus::compiler::captureCurrentException;
 using nautilus::compiler::captureThrowingCall;
 using nautilus::compiler::currentExceptionFrame;
 using nautilus::compiler::ExceptionFrame;
+using nautilus::compiler::ExceptionFrameScope;
 using nautilus::compiler::hasPendingException;
 using nautilus::compiler::popExceptionFrame;
 using nautilus::compiler::pushExceptionFrame;
@@ -107,4 +109,77 @@ TEST_CASE("concurrent invocations isolate frames", "[ExceptionTransport]") {
 	});
 	th1.join();
 	th2.join();
+}
+
+TEST_CASE("ExceptionFrameScope pops when the guarded call throws", "[ExceptionTransport]") {
+	// The hand-rolled push/call/pop this replaced skipped the pop whenever the
+	// call threw, leaving the TLS stack pointing at a destroyed stack frame.
+	REQUIRE(currentExceptionFrame() == nullptr);
+	REQUIRE_THROWS_AS(
+	    [] {
+		    ExceptionFrameScope scope(true);
+		    REQUIRE(currentExceptionFrame() != nullptr);
+		    throw std::runtime_error("escapes past the guard");
+	    }(),
+	    std::runtime_error);
+	REQUIRE(currentExceptionFrame() == nullptr);
+}
+
+TEST_CASE("ExceptionFrameScope nests and restores the parent", "[ExceptionTransport]") {
+	ExceptionFrameScope outer(true);
+	auto* outerFrame = currentExceptionFrame();
+	REQUIRE(outerFrame != nullptr);
+	{
+		ExceptionFrameScope inner(true);
+		REQUIRE(currentExceptionFrame() != outerFrame);
+		REQUIRE(currentExceptionFrame()->parent == outerFrame);
+	}
+	REQUIRE(currentExceptionFrame() == outerFrame);
+}
+
+TEST_CASE("disabled ExceptionFrameScope pushes nothing", "[ExceptionTransport]") {
+	REQUIRE(currentExceptionFrame() == nullptr);
+	{
+		ExceptionFrameScope scope(false);
+		REQUIRE(currentExceptionFrame() == nullptr);
+		REQUIRE_FALSE(scope.pending());
+	}
+	REQUIRE(currentExceptionFrame() == nullptr);
+}
+
+TEST_CASE("a frame is reusable after it captured an exception", "[ExceptionTransport]") {
+	// One invocation throwing must not poison the next one on the same thread.
+	{
+		ExceptionFrameScope first(true);
+		captureThrowingCall(+[]() { throw std::runtime_error("boom"); });
+		REQUIRE(first.pending());
+	}
+	REQUIRE(currentExceptionFrame() == nullptr);
+	{
+		ExceptionFrameScope second(true);
+		REQUIRE_FALSE(second.pending());
+		REQUIRE(captureThrowingCall(+[](int x) { return x + 1; }, 41) == 42);
+		REQUIRE_FALSE(second.pending());
+	}
+}
+
+TEST_CASE("captureCurrentException reports a missing frame", "[ExceptionTransport]") {
+	REQUIRE(currentExceptionFrame() == nullptr);
+	bool captured = true;
+	try {
+		throw std::runtime_error("nowhere to put this");
+	} catch (...) {
+		captured = captureCurrentException();
+	}
+	// False tells the caller to rethrow rather than silently drop it, which is
+	// what the BC dyncall handlers now do when driven without a frame.
+	REQUIRE_FALSE(captured);
+
+	ExceptionFrameScope scope(true);
+	try {
+		throw std::runtime_error("this one lands");
+	} catch (...) {
+		REQUIRE(captureCurrentException());
+	}
+	REQUIRE(scope.pending());
 }

--- a/nautilus/test/execution-tests/InvokeExceptionExecutionTest.cpp
+++ b/nautilus/test/execution-tests/InvokeExceptionExecutionTest.cpp
@@ -162,6 +162,22 @@ engine::NautilusEngine makeBcEngine(const std::string& traceMode) {
 	options.setOption("engine.traceMode", traceMode);
 	return engine::NautilusEngine {options};
 }
+
+// Same as makeBcEngine, but pins bc.dispatch instead of leaving it at the
+// "call" default. The interpreter's CHECK_PENDING_EXCEPTION handling differs
+// by dispatch mode (BCInterpreter::execute's switch-path loop vs. its
+// call-path loop, each gated by CodeBlock::hasPendingCheck; the threaded path
+// takes a separate computed-goto label entirely) -- exercise every mode
+// against a throwing call so all three are covered, not just the default.
+engine::NautilusEngine makeBcEngine(const std::string& traceMode, const std::string& dispatch) {
+	engine::Options options;
+	options.setOption("engine.Compilation", true);
+	options.setOption("engine.backend", std::string("bc"));
+	options.setOption("engine.compilationStrategy", std::string("legacy"));
+	options.setOption("engine.traceMode", traceMode);
+	options.setOption("bc.dispatch", dispatch);
+	return engine::NautilusEngine {options};
+}
 #endif // ENABLE_BC_BACKEND
 
 #ifdef ENABLE_TBC_BACKEND
@@ -273,6 +289,24 @@ TEST_CASE("BC backend exceptional cleanups run in reverse construction order") {
 	REQUIRE(destructorCalls == 2);
 	REQUIRE(destructorValues[0] == 2);
 	REQUIRE(destructorValues[1] == 1);
+}
+
+TEST_CASE("BC backend unwinds destructors under every dispatch mode") {
+	// BCInterpreter::execute() picks a loop variant per basic block based on
+	// CodeBlock::hasPendingCheck, nested inside the call/switch dispatch-mode
+	// branch; the threaded path handles the check as its own computed-goto
+	// label. All three need to actually take the pending-exception branch, not
+	// just agree on ordinary (non-throwing) results the way BCDispatchModeTest
+	// checks.
+	for (const auto& dispatch : {std::string("call"), std::string("switch"), std::string("threaded")}) {
+		DYNAMIC_SECTION(dispatch) {
+			auto engine = makeBcEngine("lazyTracing", dispatch);
+			auto function = engine.registerFunction(invokeThrowingWithStruct);
+			destructorCalls = 0;
+			REQUIRE_THROWS_AS(function(), std::runtime_error);
+			REQUIRE(destructorCalls == 1);
+		}
+	}
 }
 #endif // ENABLE_BC_BACKEND
 
@@ -543,14 +577,14 @@ TEST_CASE("indirect throwing invokes unwind destructors across backends") {
 		DYNAMIC_SECTION(backend.name) {
 			for (const auto& [traceMode, traceFn] : traceModes) {
 				DYNAMIC_SECTION(traceMode) {
-				auto ir = traceIndirectThrowIR(traceFn);
-				auto* compilationBackend =
-				    compiler::CompilationBackendRegistry::getInstance()->getBackend(backend.name);
-				// DumpHandler stores Options by reference, so the options must
-				// outlive the compile() call (no temporaries here).
-				engine::Options dumpOptions;
-				compiler::DumpHandler dumpHandler(dumpOptions, "indirect-throw-test");
-				auto executable = compilationBackend->compile(ir, dumpHandler, engine::Options {}, nullptr);
+					auto ir = traceIndirectThrowIR(traceFn);
+					auto* compilationBackend =
+					    compiler::CompilationBackendRegistry::getInstance()->getBackend(backend.name);
+					// DumpHandler stores Options by reference, so the options must
+					// outlive the compile() call (no temporaries here).
+					engine::Options dumpOptions;
+					compiler::DumpHandler dumpHandler(dumpOptions, "indirect-throw-test");
+					auto executable = compilationBackend->compile(ir, dumpHandler, engine::Options {}, nullptr);
 					auto function = executable->getInvocableMember<void>("execute");
 					destructorCalls = 0;
 					REQUIRE_THROWS_AS(function(), std::runtime_error);

--- a/nautilus/test/execution-tests/InvokeExceptionExecutionTest.cpp
+++ b/nautilus/test/execution-tests/InvokeExceptionExecutionTest.cpp
@@ -78,6 +78,44 @@ val<int32_t> invokeThrowingWithoutStruct() {
 	return 42;
 }
 
+void throwIfTrue(int32_t flag) {
+	if (flag != 0) {
+		throw std::runtime_error("conditional throw");
+	}
+}
+
+// Conditionally throws, so the same registered function object can be called
+// twice -- once throwing, once not -- to check the executable is reusable
+// after an exception. `result` is cleaned up on both paths: the exceptional
+// one via the landing pad, the normal one via the traced destructor call at
+// its natural scope exit.
+val<int32_t> invokeMaybeThrowingWithStruct(val<int32_t> shouldThrow) {
+	val<ExceptionResult> result;
+	invoke(writeResult, &result, val<int32_t> {7});
+	invoke(throwIfTrue, shouldThrow);
+	return result.get(&ExceptionResult::value);
+}
+
+// Move-constructs a val<Struct> while a sibling val<Struct> is already live,
+// then throws. Regression coverage for the move constructor's destructor
+// bookkeeping: val<T>'s move ctor must not remove-then-re-append the moved
+// value's landing-pad registration (same address, same destructor, so the
+// existing registration from the original -- pre-move -- construction already
+// covers it), or the destructor of the moved-into object would run out of
+// its correct reverse-construction-order position relative to a sibling
+// that's still alive. `first` moves into `movedInto` while `second` stays
+// where it was constructed; the throw must still run `second` before the
+// moved value, matching the order they were originally constructed in.
+val<int32_t> invokeThrowingAfterMove() {
+	val<ExceptionResult> first;
+	invoke(writeResult, &first, val<int32_t> {1});
+	val<ExceptionResult> second;
+	invoke(writeResult, &second, val<int32_t> {2});
+	val<ExceptionResult> movedInto = std::move(first);
+	invoke(throwWhileWriting, &movedInto, val<int32_t> {99});
+	return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Nested Nautilus function calls: the caller's live val<Struct> destructors
 // must be carried across the nested-call boundary so they run if the nested
@@ -626,6 +664,67 @@ TEST_CASE("noexcept nested Nautilus call stays on the direct path") {
 					nestedDtorCalls = 0;
 					REQUIRE(function(42) == 42);
 					REQUIRE(nestedDtorCalls == 1);
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// val<Struct> move construction must not disturb landing-pad destructor
+// order relative to still-live siblings (see invokeThrowingAfterMove above).
+// ---------------------------------------------------------------------------
+TEST_CASE("moving a live struct preserves reverse construction order") {
+	for (const auto& backend : exceptionBackends()) {
+		DYNAMIC_SECTION(backend.name) {
+			for (const auto& traceMode : {std::string("exceptionBasedTracing"), std::string("lazyTracing")}) {
+				DYNAMIC_SECTION(traceMode) {
+					auto engine = backend.makeEngine(traceMode);
+					auto function = engine.registerFunction(invokeThrowingAfterMove);
+					destructorCalls = 0;
+					REQUIRE_THROWS_AS(function(), std::runtime_error);
+					REQUIRE(destructorCalls == 2);
+					// `second` was constructed after `first`/`movedInto`'s storage, so
+					// it must be destroyed first; `movedInto` (== first's original
+					// storage) destructs second, in its original construction-order slot.
+					REQUIRE(destructorValues[0] == 2);
+					REQUIRE(destructorValues[1] == 1);
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The same compiled/registered function must remain callable after one
+// invocation throws: the pending exception must not leak into (or be
+// mistaken for one belonging to) the next call. Regression coverage for
+// Invocable::operator()'s ExceptionFrameScope -- each call pushes and pops
+// its own frame, so a throw on call N cannot affect call N+1's frame.
+// ---------------------------------------------------------------------------
+TEST_CASE("an executable is reusable after a call throws") {
+	for (const auto& backend : exceptionBackends()) {
+		DYNAMIC_SECTION(backend.name) {
+			for (const auto& traceMode : {std::string("exceptionBasedTracing"), std::string("lazyTracing")}) {
+				DYNAMIC_SECTION(traceMode) {
+					auto engine = backend.makeEngine(traceMode);
+					auto function = engine.registerFunction(invokeMaybeThrowingWithStruct);
+
+					destructorCalls = 0;
+					REQUIRE_THROWS_AS(function(1), std::runtime_error);
+					REQUIRE(destructorCalls == 1);
+
+					// Same function object, called again: must run normally, not
+					// inherit or rethrow anything left over from the first call.
+					destructorCalls = 0;
+					REQUIRE(function(0) == 7);
+					REQUIRE(destructorCalls == 1);
+
+					// And a third call confirms the second call's frame was popped
+					// cleanly too, not just the first's.
+					destructorCalls = 0;
+					REQUIRE_THROWS_AS(function(1), std::runtime_error);
+					REQUIRE(destructorCalls == 1);
 				}
 			}
 		}

--- a/nautilus/test/ir-pass-tests/ExceptionRegionPreparationTest.cpp
+++ b/nautilus/test/ir-pass-tests/ExceptionRegionPreparationTest.cpp
@@ -81,7 +81,7 @@ TEST_CASE("ExceptionRegionPreparation: one alloc, one throwing call -> one pad w
 	REQUIRE(region.pads[0].block->getOperations().size() == 1);
 	REQUIRE(region.callSites.size() == 1);
 	REQUIRE(region.callSites[0].call == call);
-	REQUIRE(region.callSites[0].pad == &region.pads[0]);
+	REQUIRE(region.callSites[0].padIndex == 0);
 
 	auto* dtorCall = compiler::ir::dyn_cast<ProxyCallOperation>(region.pads[0].block->getOperations().front());
 	REQUIRE(dtorCall != nullptr);
@@ -131,8 +131,8 @@ TEST_CASE("ExceptionRegionPreparation: two calls with same dtor set share a pad"
 	REQUIRE(region.callSites.size() == 2);
 	REQUIRE(region.callSites[0].call == call1);
 	REQUIRE(region.callSites[1].call == call2);
-	REQUIRE(region.callSites[0].pad == &region.pads[0]);
-	REQUIRE(region.callSites[1].pad == &region.pads[0]);
+	REQUIRE(region.callSites[0].padIndex == 0);
+	REQUIRE(region.callSites[1].padIndex == 0);
 }
 
 TEST_CASE("ExceptionRegionPreparation: two calls with different dtor sets use different pads") {
@@ -151,9 +151,9 @@ TEST_CASE("ExceptionRegionPreparation: two calls with different dtor sets use di
 	REQUIRE(region.callSites.size() == 2);
 	REQUIRE(region.callSites[0].call == call1);
 	REQUIRE(region.callSites[1].call == call2);
-	REQUIRE(region.callSites[0].pad == &region.pads[0]);
-	REQUIRE(region.callSites[1].pad == &region.pads[1]);
-	REQUIRE(region.callSites[0].pad != region.callSites[1].pad);
+	REQUIRE(region.callSites[0].padIndex == 0);
+	REQUIRE(region.callSites[1].padIndex == 1);
+	REQUIRE(region.callSites[0].padIndex != region.callSites[1].padIndex);
 }
 
 TEST_CASE("ExceptionRegionPreparation: throwing call without destructors maps to a null pad") {
@@ -168,7 +168,7 @@ TEST_CASE("ExceptionRegionPreparation: throwing call without destructors maps to
 	REQUIRE(region.pads.size() == 0);
 	REQUIRE(region.callSites.size() == 1);
 	REQUIRE(region.callSites[0].call == call);
-	REQUIRE(region.callSites[0].pad == nullptr);
+	REQUIRE_FALSE(region.callSites[0].hasPad());
 }
 
 TEST_CASE("ExceptionRegionPreparation: noUnwind call is absent from the region") {
@@ -284,7 +284,7 @@ TEST_CASE("ExceptionRegionPreparation: indirect call with a destructor is collec
 	REQUIRE(region.pads.size() == 1);
 	REQUIRE(region.callSites.size() == 1);
 	REQUIRE(region.callSites[0].call == call);
-	REQUIRE(region.callSites[0].pad == &region.pads[0]);
+	REQUIRE(region.callSites[0].padIndex == 0);
 	auto* dtorCall = compiler::ir::dyn_cast<ProxyCallOperation>(region.pads[0].block->getOperations().front());
 	REQUIRE(dtorCall != nullptr);
 	REQUIRE(dtorCall->getInputArguments()[0] == addr);


### PR DESCRIPTION
Stacked on `codex/unified-captured-exception-handling`, so it targets that branch rather than `main` and reads as a delta on top of #418.

Implements every item from the review on #418. All five commits, in order:

### `110e456` — Extract exception-region data, index pads, cache transport lookups

Three mechanical refactors, no behavior change, net −50 lines. `LandingPadBlock`/`ExceptionalCallSite`/`FunctionExceptionRegion` move to a new `ir/ExceptionRegion.hpp` (breaking a `FunctionOperation` ↔ pass ↔ `IRGraph` include cycle); `ExceptionalCallSite::pad` becomes an index instead of a pointer into a vector the region doesn't own after a copy; `CapturedExceptionTransport` builds an O(1) lookup once per function instead of scanning per call site.

### `b2e4e99` + `e8d195d` — RAII exception frame, stop swallowing, uniform thunk contract

`Invocable::operator()` now owns its `ExceptionFrame` through `ExceptionFrameScope` instead of a hand-rolled push/call/pop, so an exception escaping the call can no longer leave the thread-local frame stack pointing at destroyed memory. BC's `dyncallCall*` handlers rethrow instead of silently dropping the exception when there is no active frame. The null-capture-thunk guard that only BC had is now expressed once, in `CapturedExceptionTransport::callNeedsCaptureThunk`, and used uniformly by BC/TBC/X64/A64. Five new transport tests cover the guard directly.

### `f484e10` — Make exception-handling cost per-function instead of per-backend

Fixes the `exec_cpp_add` 2.52× / `exec_asmjit_add` 2.59× / ~1.6× `comp_cpp_*` regressions from the #418 benchmark. `Executable::getExceptionPropagationMode` gains a per-member overload; CPP/BC/TBC/AsmJit record which function names actually need capture and answer per function, so a function with no throwing calls gets the raw-fptr fast path and no `ExceptionFrame` push, same as a `NativeUnwind` backend.

### `5960293` — Move BC's pending-exception check out of the per-instruction loop

Fixes the other benchmark-visible cost: `exec_bc_*_switch` regressed 1.23–1.27× while `exec_bc_*_threaded` showed none. `CodeBlock` gains a `hasPendingCheck` flag set once by the lowering; `execute()` branches on it once per block instead of testing every instruction.

### `423582c` — Fix a real move-constructor bug, plus the remaining cleanups

While closing out the last two review items, found that `val_std.hpp`'s move constructor doesn't just do unneeded work — it's a genuine correctness bug: moving a `val<Struct>` while a sibling is live silently reorders the moved value's destructor to run *before* the sibling's on an exceptional unwind, violating the reverse-construction-order guarantee this whole PR exists to provide. Fixed, with a regression test that reproduces the bug against the pre-fix code (`1 == 2` failure) and passes against the fix, across all four available backends. Also: MLIR's indirect-call lowering resolved every argument twice on the common path (now reuses the first resolution); the landing-pad interning key now includes the destructor's function pointer, not just the address, for robustness. Plus a second new test, `"an executable is reusable after a call throws"`, closing the last flagged gap (throw → no-throw → throw on the same registered function, across all backends).

## Verification

**No CI runs on this PR** — `.github/workflows/pr.yml` only triggers for PRs targeting `main`; this one targets `codex/unified-captured-exception-handling`. These commits get CI once they land there and #418 re-runs.

What *was* verified, after every commit: the library builds (with and without `ENABLE_MLIR_BACKEND`), and 173 IR-pass, 12 transport, 15 tracing and 102 val assertion-suites pass.

**Beyond that**, this session found a workaround for the local toolchain gap flagged in earlier revisions: this box's clang 18 frontend crashes compiling one file (`ExecutionTest.cpp`) that shares a test binary with the rest of `nautilus-execution-tests`, including `InvokeExceptionExecutionTest.cpp` — the actual cross-backend exception suite. Temporarily excluding just that one file from the CMake target (verification-only, reverted before every commit — check the diffs, `CMakeLists.txt` never appears) unblocked the rest of the binary. Result, on the final commit: **97 test cases, 87 passed**, the other 4 failing only with `Backend not available` (expected — `ENABLE_MLIR_BACKEND` is off here), 6 skipped (tbc-jit runtime unavailable). That's real execution coverage — throw/unwind/destructor-ordering/nested-calls/reuse-after-throw — of every commit in this PR, across CPP/BC/TBC/AsmJit and both trace modes, not just build-level and IR-level checks.

Remaining gap: `TracingTest.cpp` and `plugins/std/test/VectorTest.cpp` are single-file executables that still crash the clang-18 frontend directly, with no equivalent workaround, so those two suites specifically were not run in this environment. Formatting used clang-format 18 rather than the project's 21, so a reformat may still be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ts1t2MKVB27GakWjoWC98A