### PR TITLE
Fix O(depth^2) stack walk in TagRecorder::createReferenceTagBuildin

### DIFF
--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
@@ -78,19 +78,23 @@ Tag* TagRecorder::createReferenceTagBacktrace() {
 	                           " which is not supported in Nautilus code.");
 }
 
-Tag* TagRecorder::createReferenceTagBuildin() {
+// Walks the frame-pointer chain in a single linear pass instead of resolving each frame's return
+// address independently via __builtin_return_address(N), which re-walks N frames from the top every
+// call and makes a loop over depth 0..d cost O(d^2) frame dereferences in total (see issue #426).
+// This relies on the frame-pointer chain being intact, which the project guarantees globally via
+// -fno-omit-frame-pointer. The layout (frame[0] = saved/previous frame pointer, frame[1] = return
+// address) matches the frame-record convention used by both the x86-64 SysV and AArch64 AAPCS64 ABIs.
+__attribute__((noinline)) Tag* TagRecorder::createReferenceTagBuildin() {
 	auto* currentTagNode = &rootTagThreeNode;
 #pragma GCC diagnostic ignored "-Wframe-address"
-	[[maybe_unused]] auto tag1 = __builtin_return_address(0);
-	[[maybe_unused]] auto tag2 = __builtin_return_address(1);
-	[[maybe_unused]] auto tag3 = __builtin_return_address(1);
-
-	for (size_t i = 0; i <= MAX_TAG_SIZE; i++) {
-		auto tagAddress = (TagAddress) getReturnAddress(i);
+	auto** frame = static_cast<void**>(__builtin_frame_address(0));
+	for (size_t i = 0; i <= MAX_TAG_SIZE && frame != nullptr; i++) {
+		auto tagAddress = (TagAddress) frame[1];
 		if (tagAddress == startAddress) {
 			return currentTagNode;
 		}
 		currentTagNode = currentTagNode->append(tagAddress);
+		frame = static_cast<void**>(frame[0]);
 	}
 	throw TagCreationException("Stack is too deep. This could indicate the use "
 	                           "of recursive control-flow,"

--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
@@ -9,10 +9,8 @@ namespace nautilus::tracing {
 
 #pragma GCC diagnostic ignored "-Wframe-address"
 
-static void* getReturnAddress(uint32_t offset);
-
 TagRecorder::TagRecorder(TagAddress startAddress) : startAddress(startAddress) {
-	useBuiltinTagCreation = getReturnAddress(1) != nullptr;
+	useBuiltinTagCreation = __builtin_return_address(1) != nullptr;
 }
 
 // check if gnu backtrace is available.
@@ -28,17 +26,14 @@ TagVector TagRecorder::createBaseTag() {
 }
 #else
 
-static void* getReturnAddress(uint32_t offset);
-
-TagVector TagRecorder::createBaseTag() {
-	// throw NotImplementedException("No plugin registered that can handle this
-	// operation between");
-	[[maybe_unused]] void* root = __builtin_thread_pointer();
+// Walks the frame-pointer chain in a single linear pass; see the comment on createReferenceTagBuildin
+// below for why this replaces resolving each frame independently via __builtin_return_address(N).
+__attribute__((noinline)) TagVector TagRecorder::createBaseTag() {
 	std::vector<TagAddress> addresses;
-	for (size_t i = 0; i < MAX_TAG_SIZE; i++) {
-		auto address = getReturnAddress(i);
-		[[maybe_unused]] void* addr = __builtin_extract_return_addr(address);
-		addresses.emplace_back((TagAddress) address);
+	auto** frame = static_cast<void**>(__builtin_frame_address(0));
+	for (size_t i = 0; i < MAX_TAG_SIZE && frame != nullptr; i++) {
+		addresses.emplace_back((TagAddress) frame[1]);
+		frame = static_cast<void**>(frame[0]);
 	}
 	return addresses;
 }
@@ -106,22 +101,6 @@ Tag* TagRecorder::createReferenceTag() {
 		return createReferenceTagBuildin();
 	}
 	return createReferenceTagBacktrace();
-}
-
-template <size_t StackSize>
-__attribute__((noinline)) void* get_addr(size_t index) {
-	return [&]<std::size_t... ints>(std::index_sequence<ints...>) __attribute__((noinline)) {
-		void* addr = nullptr;
-		(void) ((index == ints &&
-		         (void(addr = __builtin_extract_return_addr(__builtin_return_address(ints + 2))), true)) ||
-		        ...);
-		return addr;
-	}
-	(std::make_index_sequence<StackSize> {});
-}
-
-static void* getReturnAddress(uint32_t offset) {
-	return get_addr<TagRecorder::MAX_TAG_SIZE>(offset);
 }
 
 } // namespace nautilus::tracing


### PR DESCRIPTION
## Summary

Fixes #426.

`TagRecorder::createReferenceTagBuildin()` computed each frame's return address independently via `getReturnAddress(i)` → `__builtin_return_address(i + 2)`. `__builtin_return_address(N)` walks `N` frames from the top on every call, so calling it for `i = 0..depth` in a loop summed to **O(depth²)** frame dereferences per tag — and every traced operation calls `recordSnapshot()` → `createTag()`, so this was the dominant per-operation cost of tracing (per the profiling in the issue, ~11.5% of total tracing instructions on a shallow kernel, growing quadratically with call depth).

This replaces that loop with a **single linear walk of the frame-pointer chain**:

```cpp
auto** frame = static_cast<void**>(__builtin_frame_address(0));
for (size_t i = 0; i <= MAX_TAG_SIZE && frame != nullptr; i++) {
    auto tagAddress = (TagAddress) frame[1];
    ...
    frame = static_cast<void**>(frame[0]);
}
```

making tag creation **O(depth)**. The function is marked `noinline` so it always has its own stack frame (making the frame-pointer offset stable regardless of inlining decisions elsewhere), and relies on `-fno-omit-frame-pointer`, which the project already sets globally for every target (`nautilus/CMakeLists.txt:20` and `CMakeLists.txt:94`). The frame-record layout (`frame[0]` = previous frame pointer, `frame[1]` = return address) matches both the x86-64 SysV and AArch64 AAPCS64 conventions, so no separate per-ABI code path is needed.

The portable `backtrace()`-based fallback (`createReferenceTagBacktrace()`, used when `useBuiltinTagCreation` is false) is untouched.

## Verification

- Full existing suite passes unchanged: `nautilus-tracing-tests` (4703 assertions), `nautilus-tracing-unit-tests` (10032 assertions), `nautilus-execution-tests` (15110 assertions) — all green, confirming tag identity/matching behavior (branch merging, loop detection, etc.) is unaffected.
- A standalone microbenchmark mirroring the issue's methodology (recursive call chains at depth 0, 1, 2, 4, 8, 16, 32, 64, 128, timing `TagRecorder::createTag()` in a tight loop at each depth) shows **flat ~10 ns/tag across all tested depths** with this fix, versus the quadratic growth reported in the issue for the old code (31 ns at depth 0 → 2417 ns at depth 64).

## Test plan

- [x] `ctest`-equivalent: built and ran `nautilus-tracing-tests`, `nautilus-tracing-unit-tests`, `nautilus-execution-tests` — all pass
- [x] `./format.sh` — no violations introduced (pre-existing violations in unrelated files under `plugins/gpu` and `tools/playground` are untouched by this change)
- [x] Standalone depth-scaling microbenchmark confirms O(depth) behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01TB9fAjUsD4UUEpRdCLNmTn)_