### PR TITLE
Replace AliveVariableHash's map with a vector indexed by ValueRef

### DIFF
--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.hpp
@@ -9,6 +9,8 @@
 #include "nautilus/tracing/TracingInterface.hpp"
 #include "tag/Tag.hpp"
 #include "tag/TagRecorder.hpp"
+#include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -48,29 +50,35 @@ inline size_t getStaticVarValue(const StaticVarHolder& holder) {
 /**
  * @brief Efficiently tracks reference counts and computes an incremental hash of alive variables.
  *
- * This class maintains reference counts using a sparse hash map to support the full uint32_t range
- * of variable IDs while keeping memory usage reasonable. The hash reflects both which variables
- * are alive and their reference counts, updated incrementally in O(1) average time.
+ * ValueRefs are dense small integers (ExecutionTrace::getNextValueRef() is a plain incrementing
+ * counter), so reference counts are stored in a vector indexed by id rather than a hash map.
+ * The hash reflects both which variables are alive and their reference counts, updated
+ * incrementally in O(1) time.
  *
  * Implementation details:
  * - Uses XOR-based hashing for O(1) incremental updates
  * - Each variable ID is mixed with a constant multiplier for better hash distribution
  * - The hash incorporates both variable identity (ID) and reference count
- * - Uses unordered_map for sparse storage (only allocates for variables that exist)
- * - Entries are erased when their count reaches zero, so the map stays bounded by the
- *   peak number of alive variables instead of growing with every value ref ever seen
+ * - Uses a growable vector indexed by id - no allocation on increment/decrement beyond
+ *   the amortized growth needed to cover the highest id seen so far
+ * - A separate alive-count is maintained so size() stays O(1) even though zero-count
+ *   entries are not removed from the vector
  *
  * Performance characteristics:
- * - increment(): O(1) average - hash map lookup + two XOR operations, two multiplications
- * - decrement(): O(1) average - hash map lookup + two XOR operations, two multiplications
+ * - increment(): O(1) amortized - vector index + two XOR operations, two multiplications
+ * - decrement(): O(1) - vector index + two XOR operations, two multiplications
  * - hash(): O(1) - returns cached value
+ * - size(): O(1) - returns cached alive count
  *
- * @note Changed from fixed array to hash map to support uint32_t ValueRef (was uint16_t).
+ * @note Changed from a hash map (which erased entries to bound its size) to a vector indexed
+ * by ValueRef. This trades peak-alive-sized memory for maxRef-sized memory in exchange for
+ * removing the malloc/free pair that the map's insert/erase pair cost per traced value.
  */
 class AliveVariableHash {
 	static constexpr uint64_t HASH_MULTIPLIER = 0x9e3779b97f4a7c15; // Golden ratio constant for good mixing
 
-	std::unordered_map<uint32_t, uint32_t> counts;
+	std::vector<uint32_t> counts;
+	size_t aliveCount = 0;
 	uint64_t alive_hash = 0;
 
 public:
@@ -88,8 +96,14 @@ public:
 	 * @param id Variable identifier (32-bit value)
 	 */
 	inline void increment(uint32_t id) noexcept {
+		if (id >= counts.size()) {
+			counts.resize(id + 1, 0);
+		}
 		uint32_t& c = counts[id];
 		alive_hash ^= (id * HASH_MULTIPLIER) * c;
+		if (c == 0) {
+			++aliveCount;
+		}
 		++c;
 		alive_hash ^= (id * HASH_MULTIPLIER) * c;
 	}
@@ -100,22 +114,16 @@ public:
 	 * The hash is updated by XOR-ing out the old contribution ((id * HASH_MULTIPLIER) * old_count)
 	 * and XOR-ing in the new contribution ((id * HASH_MULTIPLIER) * new_count).
 	 *
-	 * Entries that reach a count of zero are erased. This is hash-neutral (a zero count
-	 * contributes 0 to the XOR hash, identical to an absent entry) and keeps the map size
-	 * proportional to the number of currently-alive variables. Without the erase, the map
-	 * grows with every value ref ever seen and — because the trace context is thread_local —
-	 * persists across trace iterations and across traced functions.
-	 *
-	 * @param id Variable identifier (32-bit value)
+	 * @param id Variable identifier (32-bit value), previously passed to increment()
 	 */
 	inline void decrement(uint32_t id) noexcept {
-		const auto it = counts.try_emplace(id, 0).first;
-		uint32_t& c = it->second;
+		assert(id < counts.size() && counts[id] > 0 && "decrement() on a variable that is not alive");
+		uint32_t& c = counts[id];
 		alive_hash ^= (id * HASH_MULTIPLIER) * c;
 		--c;
 		alive_hash ^= (id * HASH_MULTIPLIER) * c;
 		if (c == 0) {
-			counts.erase(it);
+			--aliveCount;
 		}
 	}
 
@@ -133,29 +141,23 @@ public:
 	}
 
 	/**
-	 * @brief Returns the number of tracked entries.
-	 *
-	 * Since zero-count entries are erased by decrement(), this is the number of
-	 * currently-alive variables (variables with a non-zero reference count).
-	 *
-	 * @return Number of entries in the underlying map
+	 * @brief Returns the number of currently-alive variables (non-zero reference count).
+	 * @return Number of currently-alive variables
 	 */
 	inline size_t size() const noexcept {
-		return counts.size();
+		return aliveCount;
 	}
 
 	/**
 	 * @brief Resets all reference counts and hash to initial state.
 	 *
-	 * This efficiently clears all counts without creating a temporary object.
-	 * Since decrement() erases entries when they reach zero, a balanced trace iteration
-	 * leaves the map empty and this is a no-op. The emptiness check (rather than a hash
-	 * check) also guards against the rare XOR collision where live entries hash to 0.
+	 * Zeroes every slot in the backing vector rather than shrinking it, so the vector's
+	 * capacity - and thus the highest id it can hold without reallocating - is retained
+	 * across trace iterations.
 	 */
 	inline void reset() noexcept {
-		if (!counts.empty()) {
-			counts.clear();
-		}
+		std::fill(counts.begin(), counts.end(), 0);
+		aliveCount = 0;
 		alive_hash = 0;
 	}
 };
@@ -328,7 +330,7 @@ private:
 
 	// Persistent state - reset between trace iterations via resume()
 	std::vector<StaticVarHolder> staticVars; // Tracks static variable states for snapshot hashing
-	AliveVariableHash aliveVars;             // Tracks alive variables with incremental hash (256KB)
+	AliveVariableHash aliveVars;             // Tracks alive variables with incremental hash
 	std::list<compiler::CompilableFunction> functionsToTrace = std::list<compiler::CompilableFunction> {};
 	std::unordered_set<std::string> registeredFunctions;
 };


### PR DESCRIPTION
## Summary

Fixes #427.

`AliveVariableHash` (`ExceptionBasedTraceContext.hpp`) tracked reference counts for alive `val`s using a `std::unordered_map` that erased entries when a count reached zero. Since every traced value is constructed and then destroyed, each value's lifetime cost one map insert **and** one map erase — a `malloc`/`free` pair per traced value, accounting for roughly 10% of tracing instructions per the issue's `callgrind` measurements.

`ValueRef`s are dense small integers (`ExecutionTrace::getNextValueRef()` is a plain incrementing counter), so this replaces the map with a growable `std::vector` indexed directly by ref:

- `increment`/`decrement` become a vector index + two XOR updates, with no allocation beyond the vector's own amortized growth to cover the highest id seen so far.
- A separate `aliveCount` member is maintained so `size()` stays O(1) even though zero-count slots are no longer removed from the vector (previously this was `counts.size()`, relying on the map only holding nonzero entries).
- `reset()` zeroes the vector's contents (`std::fill`) rather than clearing/erasing, so the vector's capacity — and thus the highest id it can hold without reallocating — is retained across trace iterations.
- Added an `assert` guarding the pre-existing underflow hazard called out in the issue: `decrement()` on an id that was never incremented (or already fully decremented) is now an assertion failure in debug builds rather than silently wrapping a counter to `0xFFFFFFFF`.

### Memory tradeoff

As noted in the issue, this trades a peak-alive-sized map for a vector sized to the highest `ValueRef` issued (`4 bytes × lastValueRef`), which is small in practice (a 900-op trace is ~3.6 KB) and is far outweighed by removing the allocator traffic.

## Measurement

Reproduced the issue's methodology locally: `chainedIf100` traced 5×, Release build (`-O3 -DNDEBUG`), `valgrind --tool=callgrind`, comparing this branch against the pre-fix commit (`3b5b583`).

| | Before | After | Δ |
|---|---|---|---|
| Total instructions (Ir) | 351,308,107 | 311,616,141 | **-11.3%** |

| symbol (inclusive) | before | after |
|---|---|---|
| `tracing::allocateValRef` | 7.13% | 2.29% |
| `tracing::freeValRef` | 7.19% | 1.48% |
| `AliveVariableHash::decrement` | 6.53% | inlined away (trivial, no longer separately visible) |
| `_Hashtable::_M_insert_unique_node` (the `counts` map insert) | 2.29% | gone |

The only remaining `_Hashtable` symbols in the post-fix profile belong to the unrelated `Snapshot`→tag-state dedup map, confirming the alive-variable bookkeeping path is now allocation-free. The measured 11.3% total-instruction reduction is in line with (and slightly exceeds) the issue's ~10.4% estimate.

## Test plan

- [x] `nautilus-tracing-unit-tests` (includes `AliveVariableHashTest.cpp`, unmodified) — all 15 test cases / 10032 assertions pass, exercising the erase-neutrality, re-increment, refcount-hash, id-churn, and reset behaviors the class documents.
- [x] `nautilus-execution-tests` (TBC/BC/AsmJit backends, MLIR disabled for a faster local build) — 36 passed / 22 skipped (skips are backend-availability skips unrelated to this change), 6762/6762 assertions pass.
- [x] `valgrind --tool=callgrind` before/after comparison on `chainedIf100` (see Measurement above).
- [x] Formatted with `clang-format-18 --style=file` (matching the repo's `.clang-format`; `clang-format-21` unavailable in this environment).

Built locally with `-DENABLE_MLIR_BACKEND=OFF -DENABLE_C_BACKEND=OFF -DENABLE_BC_BACKEND=OFF -DENABLE_ASMJIT_BACKEND=OFF` was not viable for execution tests (needed at least one backend), so execution tests were built with TBC/BC/AsmJit backends enabled and MLIR disabled to avoid the large MLIR download in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_014f6BhF9YzpVh4hTo3bY19Q)_
