### PR TITLE
Inline ExecutionTrace's hot accessors to enable cross-TU inlining

### DIFF
--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -109,21 +109,6 @@ uint32_t ExecutionTrace::getCurrentBlockIndex() const {
 	return currentBlockIndex;
 }
 
-Block& ExecutionTrace::getCurrentBlock() {
-	if (currentBlockIndex >= blocks.size()) {
-		throw RuntimeException("Current block index out of bounds: " + std::to_string(currentBlockIndex));
-	}
-	return *blocks[currentBlockIndex];
-}
-
-void ExecutionTrace::setCurrentBlock(uint32_t index) {
-	if (index >= blocks.size()) {
-		throw RuntimeException("Cannot set current block to out of bounds index: " + std::to_string(index));
-	}
-	currentOperationIndex = 0;
-	currentBlockIndex = index;
-}
-
 std::vector<Block*>& ExecutionTrace::getBlocks() {
 	return blocks;
 }
@@ -223,34 +208,6 @@ void ExecutionTrace::addCmpOperation(Snapshot& snapshot, const TypedValueRef& co
 	operations.push_back(cmpOp);
 	auto operationIdentifier = getNextOperationIdentifier();
 	addTag(snapshot, operationIdentifier);
-}
-
-void ExecutionTrace::nextOperation() {
-	this->currentOperationIndex++;
-	auto& block = getCurrentBlock();
-	if (currentOperationIndex >= block.operations.size()) {
-		throw RuntimeException("Operation index out of bounds: " + std::to_string(currentOperationIndex));
-	}
-	auto* currentOp = block.operations[currentOperationIndex];
-	if (currentOp->op == JMP) {
-		auto* nextBlock = std::get<BlockRef*>(currentOp->input[0]);
-		setCurrentBlock(nextBlock->block);
-	}
-}
-
-TraceOperation& ExecutionTrace::getCurrentOperation() {
-	if (currentOperationIndex >= getCurrentBlock().operations.size()) {
-		throw RuntimeException("Current operation index out of bounds: " + std::to_string(currentOperationIndex));
-	}
-	while (getCurrentBlock().operations[currentOperationIndex]->op == JMP) {
-		auto* nextBlock = std::get<BlockRef*>(getCurrentBlock().operations[currentOperationIndex]->input[0]);
-		setCurrentBlock(nextBlock->block);
-		if (currentOperationIndex >= getCurrentBlock().operations.size()) {
-			throw RuntimeException("Current operation index out of bounds after JMP: " +
-			                       std::to_string(currentOperationIndex));
-		}
-	}
-	return *getCurrentBlock().operations[currentOperationIndex];
 }
 
 uint32_t ExecutionTrace::createBlock() {

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
@@ -4,9 +4,11 @@
 #include "Block.hpp"
 #include "TraceOperation.hpp"
 #include "nautilus/common/Arena.hpp"
+#include "nautilus/exceptions/RuntimeException.hpp"
 #include "tag/TagRecorder.hpp"
 #include <initializer_list>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -323,5 +325,51 @@ public:
 	 */
 	operation_identifier getNextOperationIdentifier();
 };
+
+// Defined inline (rather than in ExecutionTrace.cpp) so that callers in other
+// translation units (LazyTraceContext.cpp, ExceptionBasedTraceContext.cpp) can
+// inline these accessors at their many hot call sites. See issue #432.
+inline Block& ExecutionTrace::getCurrentBlock() {
+	if (currentBlockIndex >= blocks.size()) {
+		throw RuntimeException("Current block index out of bounds: " + std::to_string(currentBlockIndex));
+	}
+	return *blocks[currentBlockIndex];
+}
+
+inline void ExecutionTrace::setCurrentBlock(uint32_t index) {
+	if (index >= blocks.size()) {
+		throw RuntimeException("Cannot set current block to out of bounds index: " + std::to_string(index));
+	}
+	currentOperationIndex = 0;
+	currentBlockIndex = index;
+}
+
+inline void ExecutionTrace::nextOperation() {
+	this->currentOperationIndex++;
+	auto& block = getCurrentBlock();
+	if (currentOperationIndex >= block.operations.size()) {
+		throw RuntimeException("Operation index out of bounds: " + std::to_string(currentOperationIndex));
+	}
+	auto* currentOp = block.operations[currentOperationIndex];
+	if (currentOp->op == JMP) {
+		auto* nextBlock = std::get<BlockRef*>(currentOp->input[0]);
+		setCurrentBlock(nextBlock->block);
+	}
+}
+
+inline TraceOperation& ExecutionTrace::getCurrentOperation() {
+	if (currentOperationIndex >= getCurrentBlock().operations.size()) {
+		throw RuntimeException("Current operation index out of bounds: " + std::to_string(currentOperationIndex));
+	}
+	while (getCurrentBlock().operations[currentOperationIndex]->op == JMP) {
+		auto* nextBlock = std::get<BlockRef*>(getCurrentBlock().operations[currentOperationIndex]->input[0]);
+		setCurrentBlock(nextBlock->block);
+		if (currentOperationIndex >= getCurrentBlock().operations.size()) {
+			throw RuntimeException("Current operation index out of bounds after JMP: " +
+			                       std::to_string(currentOperationIndex));
+		}
+	}
+	return *getCurrentBlock().operations[currentOperationIndex];
+}
 
 } // namespace nautilus::tracing


### PR DESCRIPTION
## Summary

Fixes #432.

`ExecutionTrace::getCurrentBlock()`, `getCurrentOperation()`, `nextOperation()`, and `setCurrentBlock()` were defined out-of-line in `ExecutionTrace.cpp`, but called from `LazyTraceContext.cpp` / `ExceptionBasedTraceContext.cpp` — a different translation unit. Since the project builds without LTO, these calls were real, non-inlinable function calls at every one of their (extremely hot) per-operation call sites, even though each is just a bounds check plus a `blocks[currentBlockIndex]` dereference. Per the issue's profiling, `getCurrentBlock()` alone accounted for ~17% of self-cost when tracing `chainedIf100`.

This moves the four accessors' definitions into `ExecutionTrace.hpp` (marked `inline`), so callers in other translation units can inline them directly. No behavior change — bounds-check exceptions are preserved exactly as before.

## Changes

- `nautilus/src/nautilus/tracing/ExecutionTrace.hpp`: added inline definitions of `getCurrentBlock()`, `setCurrentBlock()`, `nextOperation()`, `getCurrentOperation()` after the class definition; added the `RuntimeException.hpp` and `<string>` includes needed by the moved bodies.
- `nautilus/src/nautilus/tracing/ExecutionTrace.cpp`: removed the now-relocated definitions (declarations remain in the header's class body, unchanged).

## Test plan

- [x] Configured and built `nautilus` (Clang 18, Release, MLIR/C/BC/TBC/AsmJit backends disabled to keep the build light in this sandbox) — builds cleanly with the project's strict warning flags.
- [x] Built and ran `nautilus-tracing-tests`, `nautilus-tracing-unit-tests`, `nautilus-value-tests`, `nautilus-ir-pass-tests`, `nautilus-execution-tests` — all pass (execution-test skips are due to the disabled backends, not this change).
- [x] Verified the moved code is clang-format clean (`ExecutionTrace.hpp` has zero violations under `clang-format-18`; the pre-existing `ExecutionTrace.cpp` violations elsewhere in the file predate this change and are due to the local clang-format-18 vs. the repo's clang-format-21 baseline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCfq3Y1Wz2LiJqAyYvq2pV)_