### PR TITLE
Arena-allocate TagRecorder's tag trie instead of per-node make_unique

### DIFF
--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -376,7 +376,7 @@ std::unique_ptr<ExecutionTrace> ExceptionBasedTraceContext::trace(std::function<
                                                                   const engine::Options& options, Arena& arena) {
 	log::debug("Initialize Tracing");
 	auto rootAddress = __builtin_return_address(0);
-	auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress);
+	auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress, arena);
 
 	// The ExecutionTrace borrows the caller-provided arena for all Block
 	// and TraceOperation allocations.  The arena must outlive the returned
@@ -463,7 +463,7 @@ std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<co
 		auto wrapperFunc = currentFunction.getFunction();
 
 		auto rootAddress = __builtin_return_address(0);
-		auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress);
+		auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress, arena);
 		SymbolicExecutionContext symbolicExecutionContext;
 		state.emplace(tr, executionTrace, symbolicExecutionContext, options);
 		auto traceIteration = 0;

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -385,7 +385,7 @@ std::unique_ptr<ExecutionTrace> LazyTraceContext::trace(std::function<void()>& t
                                                         const engine::Options& options, Arena& arena) {
 	log::debug("Initialize Completing Tracing");
 	auto rootAddress = __builtin_return_address(0);
-	auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress);
+	auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress, arena);
 
 	// The ExecutionTrace borrows the caller-provided arena for all
 	// allocations; the arena must outlive the returned trace.
@@ -470,7 +470,7 @@ std::unique_ptr<TraceModule> LazyTraceContext::startTrace(std::list<compiler::Co
 		auto wrapperFunc = currentFunction.getFunction();
 
 		auto rootAddress = __builtin_return_address(0);
-		auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress);
+		auto tr = tracing::TagRecorder((tracing::TagAddress) rootAddress, arena);
 		SymbolicExecutionContext symbolicExecutionContext;
 		state.emplace(tr, executionTrace, symbolicExecutionContext, options);
 		auto traceIteration = 0;

--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.cpp
@@ -9,7 +9,7 @@ namespace nautilus::tracing {
 
 #pragma GCC diagnostic ignored "-Wframe-address"
 
-TagRecorder::TagRecorder(TagAddress startAddress) : startAddress(startAddress) {
+TagRecorder::TagRecorder(TagAddress startAddress, common::Arena& arena) : startAddress(startAddress), arena(arena) {
 	useBuiltinTagCreation = __builtin_return_address(1) != nullptr;
 }
 
@@ -66,7 +66,7 @@ Tag* TagRecorder::createReferenceTagBacktrace() {
 		if (tagAddress == startAddress) {
 			return currentTagNode;
 		}
-		currentTagNode = currentTagNode->append(tagAddress);
+		currentTagNode = currentTagNode->append(tagAddress, arena);
 	}
 	throw TagCreationException("Stack is too deep. This could indicate the use "
 	                           "of recursive control-flow,"
@@ -88,7 +88,7 @@ __attribute__((noinline)) Tag* TagRecorder::createReferenceTagBuildin() {
 		if (tagAddress == startAddress) {
 			return currentTagNode;
 		}
-		currentTagNode = currentTagNode->append(tagAddress);
+		currentTagNode = currentTagNode->append(tagAddress, arena);
 		frame = static_cast<void**>(frame[0]);
 	}
 	throw TagCreationException("Stack is too deep. This could indicate the use "

--- a/nautilus/src/nautilus/tracing/tag/TagRecorder.hpp
+++ b/nautilus/src/nautilus/tracing/tag/TagRecorder.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Tag.hpp"
+#include "nautilus/common/Arena.hpp"
 
 namespace nautilus::tracing {
 
@@ -15,14 +16,18 @@ public:
 
 	/**
 	 * @brief Factory to create a new tag recorder.
+	 * @param arena Arena to allocate the trie's nodes from. Must be the same arena that backs the
+	 * ExecutionTrace the resulting tags are attached to (they are referenced by Operation::sourceTag
+	 * and compared by pointer identity), so tag node addresses stay valid for as long as that trace
+	 * -- not merely for the lifetime of this TagRecorder.
 	 * @return TagRecorder
 	 */
-	static inline __attribute__((always_inline)) TagRecorder createTagRecorder() {
+	static inline __attribute__((always_inline)) TagRecorder createTagRecorder(common::Arena& arena) {
 		// First we derive the base address, which is the first common address between two bracktraces.
 		auto referenceTag1 = createBaseTag();
 		auto referenceTag2 = createBaseTag();
 		auto baseAddress = getBaseAddress(referenceTag1, referenceTag2);
-		return TagRecorder(baseAddress);
+		return TagRecorder(baseAddress, arena);
 	}
 
 	/**
@@ -37,8 +42,10 @@ public:
 	/**
 	 * @brief Create a new tag recorder with a fixed start address.
 	 * @param startAddress
+	 * @param arena Arena to allocate the trie's nodes from (see @ref createTagRecorder for the lifetime
+	 * requirement).
 	 */
-	explicit TagRecorder(TagAddress startAddress);
+	explicit TagRecorder(TagAddress startAddress, common::Arena& arena);
 
 private:
 	static TagAddress getBaseAddress(TagVector& tag1, TagVector& tag2);
@@ -53,6 +60,8 @@ private:
 	const TagAddress startAddress;
 	// The tag recorder stores the individual tags in a trie of addresses, to minimize space consumption.
 	Tag rootTagThreeNode = Tag();
+	// Backing storage for trie nodes appended below the root; see the constructor's doc comment.
+	common::Arena& arena;
 	bool useBuiltinTagCreation;
 };
 } // namespace nautilus::tracing

--- a/nautilus/src/nautilus/tracing/tag/Trie.hpp
+++ b/nautilus/src/nautilus/tracing/tag/Trie.hpp
@@ -1,15 +1,23 @@
 
 #pragma once
 
-#include <algorithm>
+#include "nautilus/common/Arena.hpp"
+#include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <vector>
 
 namespace nautilus::tracing {
 
 /**
  * @brief A basic trie data structure, which stores sequences of values.
+ *
+ * Nodes and child-pointer storage are allocated from a caller-supplied Arena rather than
+ * individually via `make_unique`, so appending to the trie amortises to a bump-pointer
+ * allocation instead of a `malloc` per node. Callers must pass the same Arena that backs the
+ * data structure(s) the resulting node pointers end up referenced by (e.g. an ExecutionTrace's
+ * Operations), so that node addresses -- which are handed out and compared/hashed by identity --
+ * stay valid for as long as those references are needed, instead of only for the lifetime of the
+ * trie's owner.
+ *
  * @tparam T
  */
 template <typename T>
@@ -24,16 +32,28 @@ public:
 	/**
 	 * @brief Appends a value to the trie and returns a ptr to the element in the node in the trie.
 	 * @param value
+	 * @param arena Arena to allocate the new node (and child-storage growth) from.
 	 * @return TrieNode<T>*
 	 */
-	TrieNode<T>* append(T& value) {
-		auto found = std::find_if(children.begin(), children.end(),
-		                          [value](std::unique_ptr<TrieNode<T>>& x) { return x->content == value; });
-		if (found == children.end()) {
-			return children.emplace_back(std::make_unique<TrieNode<T>>(value, this)).get();
-		} else {
-			return found->get();
+	TrieNode<T>* append(T& value, common::Arena& arena) {
+		for (size_t i = 0; i < childCount; i++) {
+			if (children[i]->content == value) {
+				return children[i];
+			}
 		}
+		auto* child = arena.createUnmanaged<TrieNode<T>>(value, this);
+		if (childCount == childCapacity) {
+			const size_t newCapacity = childCapacity == 0 ? 4 : childCapacity * 2;
+			auto** newChildren =
+			    static_cast<TrieNode<T>**>(arena.allocate(newCapacity * sizeof(TrieNode<T>*), alignof(TrieNode<T>*)));
+			for (size_t i = 0; i < childCount; i++) {
+				newChildren[i] = children[i];
+			}
+			children = newChildren;
+			childCapacity = newCapacity;
+		}
+		children[childCount++] = child;
+		return child;
 	}
 
 	[[nodiscard]] const T& getContent() const noexcept {
@@ -47,7 +67,11 @@ public:
 
 private:
 	T content;
-	std::vector<std::unique_ptr<TrieNode<T>>> children;
+	// Arena-owned array of child pointers; never owns heap memory itself, so TrieNode stays
+	// trivially destructible and can be allocated via Arena::createUnmanaged.
+	TrieNode<T>** children = nullptr;
+	size_t childCount = 0;
+	size_t childCapacity = 0;
 	TrieNode<T>* parent;
 };
 } // namespace nautilus::tracing

--- a/nautilus/test/tracing-tests/CMakeLists.txt
+++ b/nautilus/test/tracing-tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(nautilus-tracing-unit-tests
         ArenaTest.cpp
         SSACreationPhaseTest.cpp
         SSAVerifierTest.cpp
+        TrieTest.cpp
 )
 
 target_link_libraries(nautilus-tracing-unit-tests PRIVATE nautilus Catch2::Catch2WithMain nautilus-sanitizer-suppressions)

--- a/nautilus/test/tracing-tests/TrieTest.cpp
+++ b/nautilus/test/tracing-tests/TrieTest.cpp
@@ -1,0 +1,77 @@
+#include "nautilus/common/Arena.hpp"
+#include "nautilus/tracing/tag/Trie.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+namespace nautilus::tracing {
+
+TEST_CASE("TrieNode::append deduplicates repeated values under the same parent", "[Trie]") {
+	common::Arena arena;
+	TrieNode<uint64_t> root;
+
+	uint64_t a = 1;
+	uint64_t aAgain = 1;
+	uint64_t b = 2;
+
+	auto* first = root.append(a, arena);
+	auto* second = root.append(aAgain, arena);
+	auto* third = root.append(b, arena);
+
+	REQUIRE(first == second);
+	REQUIRE(first != third);
+	REQUIRE(first->getContent() == 1);
+	REQUIRE(third->getContent() == 2);
+}
+
+TEST_CASE("TrieNode::append builds a stable parent chain", "[Trie]") {
+	common::Arena arena;
+	TrieNode<uint64_t> root;
+
+	uint64_t a = 10;
+	uint64_t b = 20;
+
+	auto* child = root.append(a, arena);
+	auto* grandchild = child->append(b, arena);
+
+	REQUIRE(grandchild->getParent() == child);
+	REQUIRE(child->getParent() == &root);
+	REQUIRE(root.getParent() == nullptr);
+}
+
+TEST_CASE("TrieNode::append grows past its initial inline capacity while keeping node identity", "[Trie]") {
+	// Exercise the child-array growth path (capacity starts at 0 and doubles from
+	// 4), verifying earlier-returned pointers stay valid and re-lookups still
+	// resolve to the same node after growth reallocates the pointer array.
+	common::Arena arena;
+	TrieNode<uint64_t> root;
+
+	constexpr int numChildren = 64;
+	std::vector<TrieNode<uint64_t>*> nodes;
+	for (uint64_t i = 0; i < numChildren; i++) {
+		nodes.push_back(root.append(i, arena));
+	}
+
+	for (uint64_t i = 0; i < numChildren; i++) {
+		auto* looked = root.append(i, arena);
+		REQUIRE(looked == nodes[i]);
+		REQUIRE(looked->getContent() == i);
+	}
+}
+
+TEST_CASE("TrieNode tries sharing one arena do not cross-contaminate", "[Trie]") {
+	// Mirrors LazyTraceContext::startTrace, which builds one TagRecorder (and
+	// therefore one trie) per traced function but hands all of them the same
+	// compile-scoped Arena. Independent tries in that arena must stay distinct.
+	common::Arena arena;
+	TrieNode<uint64_t> rootOne;
+	TrieNode<uint64_t> rootTwo;
+
+	uint64_t a = 1;
+	auto* childOfOne = rootOne.append(a, arena);
+	auto* childOfTwo = rootTwo.append(a, arena);
+
+	REQUIRE(childOfOne != childOfTwo);
+	REQUIRE(childOfOne->getParent() == &rootOne);
+	REQUIRE(childOfTwo->getParent() == &rootTwo);
+}
+
+} // namespace nautilus::tracing


### PR DESCRIPTION
Fixes #431.

## Summary

`TrieNode::append` (`nautilus/src/nautilus/tracing/tag/Trie.hpp`) heap-allocated a new node via `std::make_unique` on every miss and freed it individually on trie teardown. The profiling in #431 measured allocating/freeing trie nodes at roughly **12-13% of total tracing instructions**.

## Change

- `TrieNode<T>` now bump-allocates both nodes and its child-pointer array from a caller-supplied `common::Arena` instead of `std::make_unique`/`std::vector<std::unique_ptr<...>>`. The node no longer owns any heap memory, so it's trivially destructible and allocated via `Arena::createUnmanaged` — no per-node `free()` at all.
- `TagRecorder` now takes an `Arena&` and threads it through to every `append` call.
- Each of the four `TagRecorder` construction sites (`LazyTraceContext`/`ExceptionBasedTraceContext`, `trace()`/`startTrace()`) already had a `common::Arena&` in scope — the same arena that backs the `ExecutionTrace`/`Operation`s for that compile, drawn from `CompilationPipeline`'s trace `ArenaPool`.

## Why this arena and not a `thread_local` pool

`Operation::sourceTag` stores a raw `const Tag*` into the trie, dereferenced later (e.g. `IRGraph::toString` walking `getParent()` for source-location printing) — but only while `CompilationPipeline::compileToIR`'s trace arena handle is still alive; the codebase already documents that trace data (and therefore tag pointers) is dead once IR generation finishes. Allocating trie nodes from that same arena means:

- Tag node addresses stay valid for exactly as long as anything can still dereference them — no dangling-pointer risk from resetting/reusing trie storage while an `Operation` still points into it.
- The trie's memory is amortized across compiles "for free": `ArenaPool` already recycles this arena's chunks (`softReset` on release) across the many compiles a long-lived engine performs, which was the underlying goal of the issue.

This avoids the correctness risk called out in the issue's "things to get right" section (tag addresses must stay stable for as long as callers expect) without inventing a separate persistence/reset scheme for the trie.

## Testing

- Added `nautilus/test/tracing-tests/TrieTest.cpp`: dedup semantics, parent-chain stability, growth past the initial child-array capacity, and independent tries sharing one arena (mirroring `startTrace`'s per-function `TagRecorder`s).
- `clang-format-18 --dry-run --Werror` clean on all changed files.
- This sandbox has neither the pinned Clang 21 toolchain nor a pre-fetched MLIR checkout, so I verified the changed translation units with `g++-13 -std=c++20 -fsyntax-only` instead of a full CMake build; CI will run the full build/test matrix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7SbnUsKEcsmSXjg92ieUx)_