### PR TITLE
CI: bound ctest/job duration so a hung test fails fast

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,11 @@ jobs:
   build-test:
     runs-on: ${{matrix.os}}
     name: ${{ matrix.os }} ${{ matrix.cc }} ${{ matrix.flags }}
+    # Backstop against a hung test: a single ctest case hanging on macos-26
+    # once ran for ~6h before hitting GitHub's default 360m job timeout. The
+    # per-test `ctest --timeout` below should catch this first; this is the
+    # second line of defense.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -98,25 +103,25 @@ jobs:
       - name: test
         shell: bash
         run: |
-          ctest --test-dir build/nautilus --output-on-failure
+          ctest --test-dir build/nautilus --output-on-failure --timeout 300
       - name: test std plugin
         shell: bash
         run: |
-          ctest --test-dir build/plugins/std/test --output-on-failure
+          ctest --test-dir build/plugins/std/test --output-on-failure --timeout 300
       - name: test simd plugin
         shell: bash
         run: |
-          ctest --test-dir build/plugins/simd/test --output-on-failure
+          ctest --test-dir build/plugins/simd/test --output-on-failure --timeout 300
       - name: test inlining plugin
         if: startsWith(matrix.cc, 'clang-19') || startsWith(matrix.cc, 'clang-20') || startsWith(matrix.cc, 'clang-21')
         shell: bash
         run: |
-          ctest --test-dir build/plugins/inlining/test --output-on-failure
+          ctest --test-dir build/plugins/inlining/test --output-on-failure --timeout 300
       - name: test gpu plugin
         if: contains(matrix.flags, 'ENABLE_GPU_PLUGIN=ON')
         shell: bash
         run: |
-          ctest --test-dir build/plugins/gpu/test --output-on-failure
+          ctest --test-dir build/plugins/gpu/test --output-on-failure --timeout 300
   example-demos:
     runs-on: ubuntu-24.04
     name: Example demos (clang-18)


### PR DESCRIPTION
## Summary

The `macos-26 clang -DENABLE_GPU_PLUGIN=ON` job on main got stuck. Investigation of the [workflow run](https://github.com/nebulastream/nautilus/actions/runs/32732515284/job/97447728990) shows:

- The `test` step (`ctest --test-dir build/nautilus --output-on-failure`) started test **#74: "Engine reused for many modules frees each module independently"** (`ModuleLifecycleTest.cpp`) at `13:31:59Z`.
- It never produced a pass/fail result. The job was only ended by GitHub Actions' default 360-minute job timeout at `19:25:35Z` (~5h54m later), and was reported as `cancelled`, not `failed`.
- The same test/job configuration passed in ~7 minutes total on an earlier commit ([run](https://github.com/nebulastream/nautilus/actions/runs/32287718074/job/96181103099)) on the same `macos-26` runner label, so this looks like a rare hang rather than a deterministic failure — most likely somewhere in LLVM's ORC/JITLink machinery on Darwin when repeatedly creating and tearing down 200 separate `LLJIT` instances (that test's loop), rather than in Nautilus's own code (the test path is single-threaded and doesn't use any Nautilus-level mutexes/threads).

Root-causing the exact LLVM/Darwin interaction needs a live macOS reproduction, which isn't available here. In the meantime, the CI had no test or job timeout at all, so a hang like this silently burns ~6 hours of CI time and blocks the queue instead of failing visibly.

## Changes

- Add `ctest --timeout 300` to every `ctest` invocation in the `build-test` job (300s is >2x the slowest known-good test, "Engine Compiler Test" at ~130s), so a hung test is killed and reported as a timeout instead of hanging indefinitely.
- Add `timeout-minutes: 30` to the `build-test` job as a second line of defense, well above the ~10 minute worst-case observed total job time.

## Test plan

- [ ] CI runs on this PR and the `macos-26 clang -DENABLE_GPU_PLUGIN=ON` job (and all other `build-test` matrix entries) complete within the new bounds.
- [ ] If the underlying hang reproduces again, it now surfaces as a ctest timeout failure pointing at the specific test within minutes instead of a silent multi-hour stall.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TeJeQq3yPJiS5V5WJc4Yyy)_