### PR TITLE
Add missing llvm.zeroext to lowering of bools

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -655,7 +655,7 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 
 	// Only set result attributes if the function returns a value
 	if (functionOp.getOutputArg() != Type::v) {
-		if (isUnsignedInteger(functionOp.getStamp())) {
+		if (isUnsignedInteger(functionOp.getStamp()) || functionOp.getStamp() == Type::b) {
 			mlirFunction.setResultAttr(0, "llvm.zeroext", mlir::UnitAttr::get(context));
 		} else if (isSignedInteger(functionOp.getStamp())) {
 			mlirFunction.setResultAttr(0, "llvm.signext", mlir::UnitAttr::get(context));


### PR DESCRIPTION
When lowering bools, llvm.zeroext is not set, which allows LLVM to produce code that reads the upper bits which can contain garbage. We encountered this in https://github.com/nebulastream/nebulastream/pull/1960 on AVX512 where a null comparison between fields returned false, but because of the upper bits it read true.
AFAIK @alepping mentioned that he encountered this issue somewhere else as well already.

