### PR TITLE
Attach ABI extension attributes to entry function parameters

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -74,6 +74,34 @@ std::vector<mlir::Type> MLIRLoweringProvider::getMLIRType(std::span<ir::Operatio
 	return resultTypes;
 }
 
+/// Returns the LLVM ABI extension attribute that @p stamp requires when it
+/// crosses a native call boundary, or nullptr for stamps that need none.
+///
+/// Several C ABIs (Darwin AArch64, x86-64 SysV) make the *caller* responsible
+/// for widening a sub-32-bit integer argument, leaving the callee free to read
+/// the full register. Both ends of every boundary Nautilus generates are
+/// ABI-conforming compilers -- natively compiled C++ on one side, LLVM on the
+/// other -- so the two only agree if the generated signature spells the
+/// contract out. Types 32 bits and wider occupy a full register already and
+/// need no attribute.
+///
+/// Type::b is grouped with the unsigned types because C++ passes and returns
+/// `bool` zero-extended. It needs listing explicitly: isUnsignedInteger() does
+/// not cover it, as Type::b is a stamp of its own distinct from ui8.
+static const char* getNarrowIntExtensionAttr(Type stamp) {
+	switch (stamp) {
+	case Type::i8:
+	case Type::i16:
+		return "llvm.signext";
+	case Type::b:
+	case Type::ui8:
+	case Type::ui16:
+		return "llvm.zeroext";
+	default:
+		return nullptr;
+	}
+}
+
 mlir::Value MLIRLoweringProvider::getConstInt(const std::string& location, Type stamp, int64_t value) {
 	auto type = getMLIRType(stamp);
 	return mlir::arith::ConstantOp::create(*builder, getNameLoc(location), type, builder->getIntegerAttr(type, value));
@@ -449,18 +477,8 @@ mlir::FlatSymbolRefAttr MLIRLoweringProvider::insertExternalFunction(const std::
 	// (AAPCS64 does not), and an unattributed narrow result is always safe --
 	// LLVM re-extends it itself before any wider use.
 	for (size_t i = 0; i < argStamps.size() && i < argTypes.size(); ++i) {
-		switch (argStamps[i]) {
-		case Type::i8:
-		case Type::i16:
-			funcOp.setArgAttr(static_cast<unsigned>(i), "llvm.signext", mlir::UnitAttr::get(context));
-			break;
-		case Type::b:
-		case Type::ui8:
-		case Type::ui16:
-			funcOp.setArgAttr(static_cast<unsigned>(i), "llvm.zeroext", mlir::UnitAttr::get(context));
-			break;
-		default:
-			break;
+		if (const char* extensionAttr = getNarrowIntExtensionAttr(argStamps[i])) {
+			funcOp.setArgAttr(static_cast<unsigned>(i), extensionAttr, mlir::UnitAttr::get(context));
 		}
 	}
 
@@ -609,9 +627,14 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 	// This is a placeholder for future functionality.
 
 	// Generate execute function. Set input/output types and get its entry block.
+	// The stamps are collected alongside the types, from the same source, so the
+	// indices used for the argument attributes below cannot drift out of step
+	// with the signature they annotate.
 	llvm::SmallVector<mlir::Type> inputTypes(0);
+	llvm::SmallVector<Type> inputStamps(0);
 	for (auto& inputArg : functionOp.getFunctionBasicBlock().getArguments()) {
 		inputTypes.emplace_back(getMLIRType(inputArg->getStamp()));
+		inputStamps.emplace_back(inputArg->getStamp());
 	}
 
 	// Handle void vs non-void return types
@@ -652,6 +675,21 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 
 	// Avoid function name mangling.
 	mlirFunction->setAttr("llvm.emit_c_interface", mlir::UnitAttr::get(context));
+
+	// The entry function is not reached only through MLIR's packed `void**`
+	// interface: MLIRExecutable::getInvocableFunctionPtr resolves the bare
+	// symbol and Executable.hpp's Invocable calls it through a function pointer
+	// typed with the traced signature. Its parameters therefore sit on a real C
+	// ABI boundary, and the natively compiled caller on the other side extends
+	// narrow arguments as that ABI directs. Spelling the same contract out here
+	// makes the generated signature a faithful implementation of the C
+	// prototype it is invoked as, and lets LLVM drop the defensive re-extension
+	// it otherwise emits in the prologue for every narrow parameter.
+	for (size_t i = 0; i < inputStamps.size(); ++i) {
+		if (const char* extensionAttr = getNarrowIntExtensionAttr(inputStamps[i])) {
+			mlirFunction.setArgAttr(static_cast<unsigned>(i), extensionAttr, mlir::UnitAttr::get(context));
+		}
+	}
 
 	// Only set result attributes if the function returns a value
 	if (functionOp.getOutputArg() != Type::v) {


### PR DESCRIPTION
Closes #437. **Stacked on #436** — targets `lr/missing-zeroext-bool`, so the diff here is just the second commit. Retarget to `main` once #436 lands.

> ⚠️ **This PR currently has no CI and no local verification — see Testing.** `pr.yml` triggers only on `pull_request: branches: [main]`, so nothing runs while this targets `lr/missing-zeroext-bool`. Do not read the absence of red checks as a passing signal.

## Correction to #437 first

I filed #437 and characterised the argument side as "the same class of bug" as #436, latent and correctness-affecting. **That was wrong**, and I have since corrected the issue text. The two directions are not symmetric:

| | who must extend | missing attribute means |
|---|---|---|
| **Entry function result** (#436) | JIT callee | callee doesn't clean → native caller reads garbage → **real bug** |
| **Entry function args** (this PR) | native caller | callee doesn't trust → re-extends defensively → **correct, just implicit** |

Measured on x86-64 (`clang -O2`), callee codegen for the same body:

```
sel_noattr(i1 %x)          testb  $1, %dil     # masks to bit 0 — safe with garbage upper bits
sel_attr(i1 zeroext %x)    testl  %edi, %edi   # trusts the full register
ext_noattr(i8 %x)          movsbl %dil, %eax   # extends itself
ext_attr(i8 signext %x)    movl   %edi, %eax   # trusts the caller
```

So this PR is **ABI fidelity and codegen quality, not a bugfix**, and it moves the arg side from "correct regardless of caller" to "correct because the caller conforms". That is a real, if small, trade and the reason this is a draft — see Risk below.

## What changed

1. `getNarrowIntExtensionAttr(Type)` — factors out the classification `insertExternalFunction` already performed, now shared by both sites so they cannot drift apart. That drift is exactly what left `Type::b` unhandled on the result side until #436: `isUnsignedInteger()` does not cover `b`, since it is a stamp distinct from `ui8`.
2. `generateFunctionDefinitions` applies it to the entry function's parameters, which previously carried no extension attribute for any narrow stamp (`b`, `i8`, `ui8`, `i16`, `ui16`).
3. Argument stamps are collected alongside the MLIR types from the same source, so the attribute indices cannot fall out of step with the signature they annotate.

## Why the entry function's parameters are a real ABI boundary

`lookupPacked("execute")` is only an eager-compile warm-up whose result is discarded (`MLIRCompilationBackend.cpp:144`). The live path resolves the bare symbol and calls it natively:

`MLIRExecutable::getInvocableFunctionPtr` → `jit->lookup(member)` → `Invocable` → `fptr(std::forward(arguments)...)` (`Executable.hpp:225-231`), and `Module.hpp:88` via `reinterpret_cast`.

Clang emits `zeroext i1` for `bool`, `signext i8` for `int8_t`, `zeroext i8` for `uint8_t` on both params and results, so a conforming caller already extends; this makes the callee's declared signature say so.

## Risk

The change is only sound because every caller is a platform-ABI-conforming compiler. That holds for all four call paths above (the packed wrapper is LLVM-generated and conforms too). If any future caller reaches `execute` without going through a C prototype, the arg attributes would become an unchecked assumption — worth a maintainer's judgement on whether the redundant prologue extension is worth keeping for that margin. I am happy to drop this PR entirely on that basis; #436 stands alone.

## A gap this uncovered

`llvm-diff` **ignores parameter and result attributes**. Verified directly:

```
$ llvm-diff a.ll b.ll   # differ only by  zeroext i1  vs  i1
$ echo $?
0
```

That is why the 21 reference files containing `define i1 @execute` are unaffected by #436, and why the 24 with narrow params are unaffected here — neither PR needs reference regeneration, which is convenient but means **`llvm-ir-test` cannot detect ABI attribute regressions at all**. The bug #436 fixes is invisible to CI, and so is any future reversal of it. A direct string assertion over the dumped `after_llvm_generation` IR would close that, and seems more valuable than this PR; I did not add it here to keep the change reviewable, but can follow up.

## Testing

**Not built, not run, and not covered by CI.** Two independent gaps:

1. **No local build.** This container has clang 18 (the project requires 19+, default 21) and no MLIR, so I could not compile, run `ctest`, or execute the `format` target.
2. **No CI on this PR.** `pr.yml` is scoped to `pull_request: branches: [main]`; this PR targets `lr/missing-zeroext-bool`, so zero checks run. An earlier revision of this description said "treat CI as the first real verification" — that was wrong, and this corrects it.

So **this code has never been compiled by anything.** It should not merge until it has been. The fix is to retarget to `main` once #436 lands, which puts it back under the normal matrix; until then the absence of failures here means nothing.

What I did verify, none of it a substitute for a compile:

- `clang-format` config compliance checked by hand — no line over the 120-column limit, indentation is tabs
- ABI codegen claims above measured with real `clang -O2` runs, not asserted from memory
- `llvm-diff` attribute-blindness measured with `llvm-diff-18`
- `setArgAttr`'s `const char*` → `StringRef` conversion matches the existing call sites' string literals; `<llvm/ADT/SmallVector.h>` is already included for the added `SmallVector<Type>`