### PR TITLE
Attach ABI extension attributes to entry function parameters

### DIFF
--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -74,6 +74,34 @@ std::vector<mlir::Type> MLIRLoweringProvider::getMLIRType(std::span<ir::Operatio
 	return resultTypes;
 }
 
+/// Returns the LLVM ABI extension attribute that @p stamp requires when it
+/// crosses a native call boundary, or nullptr for stamps that need none.
+///
+/// Several C ABIs (Darwin AArch64, x86-64 SysV) make the *caller* responsible
+/// for widening a sub-32-bit integer argument, leaving the callee free to read
+/// the full register. Both ends of every boundary Nautilus generates are
+/// ABI-conforming compilers -- natively compiled C++ on one side, LLVM on the
+/// other -- so the two only agree if the generated signature spells the
+/// contract out. Types 32 bits and wider occupy a full register already and
+/// need no attribute.
+///
+/// Type::b is grouped with the unsigned types because C++ passes and returns
+/// `bool` zero-extended. It needs listing explicitly: isUnsignedInteger() does
+/// not cover it, as Type::b is a stamp of its own distinct from ui8.
+static const char* getNarrowIntExtensionAttr(Type stamp) {
+	switch (stamp) {
+	case Type::i8:
+	case Type::i16:
+		return "llvm.signext";
+	case Type::b:
+	case Type::ui8:
+	case Type::ui16:
+		return "llvm.zeroext";
+	default:
+		return nullptr;
+	}
+}
+
 mlir::Value MLIRLoweringProvider::getConstInt(const std::string& location, Type stamp, int64_t value) {
 	auto type = getMLIRType(stamp);
 	return mlir::arith::ConstantOp::create(*builder, getNameLoc(location), type, builder->getIntegerAttr(type, value));
@@ -449,18 +477,8 @@ mlir::FlatSymbolRefAttr MLIRLoweringProvider::insertExternalFunction(const std::
 	// (AAPCS64 does not), and an unattributed narrow result is always safe --
 	// LLVM re-extends it itself before any wider use.
 	for (size_t i = 0; i < argStamps.size() && i < argTypes.size(); ++i) {
-		switch (argStamps[i]) {
-		case Type::i8:
-		case Type::i16:
-			funcOp.setArgAttr(static_cast<unsigned>(i), "llvm.signext", mlir::UnitAttr::get(context));
-			break;
-		case Type::b:
-		case Type::ui8:
-		case Type::ui16:
-			funcOp.setArgAttr(static_cast<unsigned>(i), "llvm.zeroext", mlir::UnitAttr::get(context));
-			break;
-		default:
-			break;
+		if (const char* extensionAttr = getNarrowIntExtensionAttr(argStamps[i])) {
+			funcOp.setArgAttr(static_cast<unsigned>(i), extensionAttr, mlir::UnitAttr::get(context));
 		}
 	}
 
@@ -610,9 +628,14 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 	// This is a placeholder for future functionality.
 
 	// Generate execute function. Set input/output types and get its entry block.
+	// The stamps are collected alongside the types, from the same source, so the
+	// indices used for the argument attributes below cannot drift out of step
+	// with the signature they annotate.
 	llvm::SmallVector<mlir::Type> inputTypes(0);
+	llvm::SmallVector<Type> inputStamps(0);
 	for (auto& inputArg : functionOp.getFunctionBasicBlock().getArguments()) {
 		inputTypes.emplace_back(getMLIRType(inputArg->getStamp()));
+		inputStamps.emplace_back(inputArg->getStamp());
 	}
 
 	// Handle void vs non-void return types
@@ -653,6 +676,21 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 
 	// Avoid function name mangling.
 	mlirFunction->setAttr("llvm.emit_c_interface", mlir::UnitAttr::get(context));
+
+	// The entry function is not reached only through MLIR's packed `void**`
+	// interface: MLIRExecutable::getInvocableFunctionPtr resolves the bare
+	// symbol and Executable.hpp's Invocable calls it through a function pointer
+	// typed with the traced signature. Its parameters therefore sit on a real C
+	// ABI boundary, and the natively compiled caller on the other side extends
+	// narrow arguments as that ABI directs. Spelling the same contract out here
+	// makes the generated signature a faithful implementation of the C
+	// prototype it is invoked as, and lets LLVM drop the defensive re-extension
+	// it otherwise emits in the prologue for every narrow parameter.
+	for (size_t i = 0; i < inputStamps.size(); ++i) {
+		if (const char* extensionAttr = getNarrowIntExtensionAttr(inputStamps[i])) {
+			mlirFunction.setArgAttr(static_cast<unsigned>(i), extensionAttr, mlir::UnitAttr::get(context));
+		}
+	}
 
 	// Only set result attributes if the function returns a value
 	if (functionOp.getOutputArg() != Type::v) {

--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
@@ -102,6 +102,35 @@ static const char* getNarrowIntExtensionAttr(Type stamp) {
 	}
 }
 
+/// Whether the host C ABI makes the *caller* responsible for extending a narrow
+/// integer argument, so that a callee may read the full register.
+///
+/// This is the difference between the two directions an extension attribute can
+/// be used in, and it is not symmetric:
+///
+///   * On a *call* Nautilus emits (insertExternalFunction), the attribute makes
+///     the JIT extend before calling a natively compiled callee. Extending when
+///     the callee did not need it is merely redundant, so that site annotates
+///     unconditionally.
+///   * On the *entry function's parameters*, the attribute makes the JIT trust
+///     that its caller already extended. Where the ABI does not require the
+///     caller to, that trust is misplaced and the callee reads whatever the
+///     register's upper bits held.
+///
+/// AAPCS64 (Linux/AArch64) leaves the bits above a narrow argument unspecified
+/// and clang accordingly emits no attribute for one, so the entry function must
+/// keep extending defensively there. Darwin AArch64 and x86-64 SysV do require
+/// the caller to extend. The JIT always targets the host and its callers are
+/// compiled into this same process, so the host ABI is the one that governs and
+/// a compile-time answer is exact.
+static constexpr bool callerExtendsNarrowArguments() {
+#if defined(__aarch64__) && !defined(__APPLE__)
+	return false;
+#else
+	return true;
+#endif
+}
+
 mlir::Value MLIRLoweringProvider::getConstInt(const std::string& location, Type stamp, int64_t value) {
 	auto type = getMLIRType(stamp);
 	return mlir::arith::ConstantOp::create(*builder, getNameLoc(location), type, builder->getIntegerAttr(type, value));
@@ -681,14 +710,20 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame& 
 	// interface: MLIRExecutable::getInvocableFunctionPtr resolves the bare
 	// symbol and Executable.hpp's Invocable calls it through a function pointer
 	// typed with the traced signature. Its parameters therefore sit on a real C
-	// ABI boundary, and the natively compiled caller on the other side extends
-	// narrow arguments as that ABI directs. Spelling the same contract out here
-	// makes the generated signature a faithful implementation of the C
-	// prototype it is invoked as, and lets LLVM drop the defensive re-extension
-	// it otherwise emits in the prologue for every narrow parameter.
-	for (size_t i = 0; i < inputStamps.size(); ++i) {
-		if (const char* extensionAttr = getNarrowIntExtensionAttr(inputStamps[i])) {
-			mlirFunction.setArgAttr(static_cast<unsigned>(i), extensionAttr, mlir::UnitAttr::get(context));
+	// ABI boundary, so where that ABI has the caller extend narrow arguments,
+	// saying so here makes the generated signature a faithful implementation of
+	// the C prototype it is invoked as and lets LLVM drop the defensive
+	// re-extension it otherwise emits in the prologue.
+	//
+	// Only where the caller is actually required to extend, though: this
+	// attribute makes the callee *trust* its caller, and under AAPCS64 nothing
+	// extended the argument, so trusting it reads unspecified upper bits. The
+	// defensive prologue extension is the correct code there.
+	if (callerExtendsNarrowArguments()) {
+		for (size_t i = 0; i < inputStamps.size(); ++i) {
+			if (const char* extensionAttr = getNarrowIntExtensionAttr(inputStamps[i])) {
+				mlirFunction.setArgAttr(static_cast<unsigned>(i), extensionAttr, mlir::UnitAttr::get(context));
+			}
 		}
 	}
 

--- a/nautilus/test/execution-tests/ABIExtensionAttributeTest.cpp
+++ b/nautilus/test/execution-tests/ABIExtensionAttributeTest.cpp
@@ -22,6 +22,19 @@ namespace {
 // generated `define` line directly -- that is the only thing standing between
 // a dropped extension attribute and a silent ABI regression.
 
+// Whether the host ABI has the caller extend narrow integer arguments, and so
+// whether the entry function is entitled to trust that it did. AAPCS64 leaves
+// the bits above a narrow argument unspecified; Darwin AArch64 and x86-64 SysV
+// require the caller to extend. Mirrors callerExtendsNarrowArguments() in
+// MLIRLoweringProvider.cpp -- annotating parameters on AAPCS64 makes the callee
+// read register bits nothing ever set, which is a wrong-answer bug and not a
+// missed optimization.
+#if defined(__aarch64__) && !defined(__APPLE__)
+constexpr bool kCallerExtendsNarrowArguments = false;
+#else
+constexpr bool kCallerExtendsNarrowArguments = true;
+#endif
+
 val<bool> abiBoolIdentity(val<bool> x) {
 	return x;
 }
@@ -138,8 +151,15 @@ void checkIdentitySignature(const std::string& define, std::string_view type, st
 	const auto params = parameterList(define);
 	REQUIRE(params.size() == 1);
 	CHECK(params[0].find(type) != std::string::npos);
-	CHECK(params[0].find(attr) != std::string::npos);
+	if (kCallerExtendsNarrowArguments) {
+		CHECK(params[0].find(attr) != std::string::npos);
+	} else {
+		CHECK(params[0].find(attr) == std::string::npos);
+	}
 
+	// The result side is unconditional: an extension attribute there is a
+	// promise the callee makes and keeps, so a caller that re-extends anyway is
+	// merely redundant. That is why #436's fix is safe on every ABI.
 	CHECK(define.rfind("define " + std::string(attr) + " " + std::string(type) + " ", 0) == 0);
 }
 
@@ -202,15 +222,21 @@ TEST_CASE("ABI: mixed-width parameters are annotated positionally") {
 	REQUIRE(params.size() == 4);
 
 	CHECK(params[0].find("i1") != std::string::npos);
-	CHECK(params[0].find("zeroext") != std::string::npos);
-
 	CHECK(params[1].find("i8") != std::string::npos);
-	CHECK(params[1].find("signext") != std::string::npos);
-
 	CHECK(params[2].find("i16") != std::string::npos);
-	CHECK(params[2].find("zeroext") != std::string::npos);
-
 	CHECK(params[3].find("i32") != std::string::npos);
+
+	if (kCallerExtendsNarrowArguments) {
+		CHECK(params[0].find("zeroext") != std::string::npos);
+		CHECK(params[1].find("signext") != std::string::npos);
+		CHECK(params[2].find("zeroext") != std::string::npos);
+	} else {
+		CHECK_FALSE(hasExtensionAttr(params[0]));
+		CHECK_FALSE(hasExtensionAttr(params[1]));
+		CHECK_FALSE(hasExtensionAttr(params[2]));
+	}
+
+	// A 32-bit argument is unannotated on every ABI.
 	CHECK_FALSE(hasExtensionAttr(params[3]));
 }
 

--- a/nautilus/test/execution-tests/ABIExtensionAttributeTest.cpp
+++ b/nautilus/test/execution-tests/ABIExtensionAttributeTest.cpp
@@ -1,0 +1,255 @@
+#include "nautilus/config.hpp"
+
+#if defined(ENABLE_TRACING) && defined(ENABLE_MLIR_BACKEND)
+
+#include "nautilus/Engine.hpp"
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace nautilus::engine {
+
+namespace {
+
+// `llvm-diff` ignores parameter and result attributes, so the reference-IR
+// suite in test/llvm-ir-test cannot observe an ABI extension attribute
+// appearing or disappearing: two modules differing only by `zeroext i1` vs
+// `i1` compare equal there. These tests therefore assert on the text of the
+// generated `define` line directly -- that is the only thing standing between
+// a dropped extension attribute and a silent ABI regression.
+
+val<bool> abiBoolIdentity(val<bool> x) {
+	return x;
+}
+
+val<int8_t> abiInt8Identity(val<int8_t> x) {
+	return x;
+}
+
+val<uint8_t> abiUInt8Identity(val<uint8_t> x) {
+	return x;
+}
+
+val<int16_t> abiInt16Identity(val<int16_t> x) {
+	return x;
+}
+
+val<uint16_t> abiUInt16Identity(val<uint16_t> x) {
+	return x;
+}
+
+val<int32_t> abiInt32Identity(val<int32_t> x) {
+	return x;
+}
+
+val<int32_t> abiMixedNarrowArgs(val<bool> flag, val<int8_t> a, val<uint16_t> b, val<int32_t> c) {
+	val<int32_t> widened = c + static_cast<val<int32_t>>(a) + static_cast<val<int32_t>>(b);
+	return flag ? widened : val<int32_t>(0);
+}
+
+std::string readWholeFile(std::string_view path) {
+	std::ifstream in(std::string(path).c_str());
+	std::ostringstream buffer;
+	buffer << in.rdbuf();
+	return buffer.str();
+}
+
+/// Compiles @p func with the MLIR backend and returns the `define` line of the
+/// generated entry function from the `after_llvm_generation` dump.
+///
+/// The dump file is located through the executable's own record of what it
+/// wrote rather than by scanning the shared dump root, so a concurrently
+/// running test cannot hand this one another test's module.
+template <typename Func>
+std::string entryDefineLine(Func func) {
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	options.setOption("dump.after_llvm_generation", true);
+
+	NautilusEngine engine(options);
+	auto compiled = engine.registerFunction(func);
+
+	const auto generatedFile = compiled.getExecutable()->getGeneratedFile("after_llvm_generation");
+	REQUIRE(!generatedFile.empty());
+
+	const auto contents = readWholeFile(generatedFile);
+
+	// Drop this compilation's dump directory again now that it has been read,
+	// as the llvm-ir test helper does. Several debug-info tests locate their
+	// own output by diffing the shared dump root before and after compiling,
+	// so every directory left behind here is one more candidate they have to
+	// sift through.
+	const auto dumpDir = std::filesystem::path(std::string(generatedFile)).parent_path();
+	if (dumpDir.parent_path() == std::filesystem::temp_directory_path() / "dump") {
+		std::error_code ec;
+		std::filesystem::remove_all(dumpDir, ec);
+	}
+
+	std::istringstream iss(contents);
+	std::string line;
+	while (std::getline(iss, line)) {
+		// `llvm.emit_c_interface` also emits `_mlir_ciface_execute` plus the
+		// packed `_mlir_*` wrappers for the same function. The bare symbol is
+		// the one MLIRExecutable::getInvocableFunctionPtr resolves and
+		// Executable.hpp calls through a function pointer typed with the
+		// traced signature, so it is the one whose signature has to state the
+		// ABI contract.
+		if (line.rfind("define", 0) == 0 && line.find(" @execute(") != std::string::npos) {
+			return line;
+		}
+	}
+	return {};
+}
+
+/// Splits the parameter list out of a `define` line into one string per
+/// parameter, each of the shape `<type> [attrs...] %<n>`.
+std::vector<std::string> parameterList(const std::string& define) {
+	const auto open = define.find('(');
+	const auto close = define.find(')', open);
+	REQUIRE(open != std::string::npos);
+	REQUIRE(close != std::string::npos);
+
+	const auto params = define.substr(open + 1, close - open - 1);
+	std::vector<std::string> parts;
+	std::istringstream paramStream(params);
+	std::string part;
+	while (std::getline(paramStream, part, ',')) {
+		parts.push_back(part);
+	}
+	return parts;
+}
+
+bool hasExtensionAttr(const std::string& parameter) {
+	return parameter.find("signext") != std::string::npos || parameter.find("zeroext") != std::string::npos;
+}
+
+/// Asserts the single parameter and the result of an identity function both
+/// carry @p attr. LLVM prints a parameter's attributes *after* its type
+/// (`i8 signext %0`, sometimes with an optimizer-inserted `returned` in
+/// between) but a result's attribute *before* it (`define signext i8 @...`),
+/// so the two are matched differently on purpose.
+void checkIdentitySignature(const std::string& define, std::string_view type, std::string_view attr) {
+	INFO("define line: " << define);
+
+	const auto params = parameterList(define);
+	REQUIRE(params.size() == 1);
+	CHECK(params[0].find(type) != std::string::npos);
+	CHECK(params[0].find(attr) != std::string::npos);
+
+	CHECK(define.rfind("define " + std::string(attr) + " " + std::string(type) + " ", 0) == 0);
+}
+
+} // namespace
+
+TEST_CASE("ABI: entry function bool parameter and result carry zeroext") {
+	const auto define = entryDefineLine(abiBoolIdentity);
+	REQUIRE_FALSE(define.empty());
+	checkIdentitySignature(define, "i1", "zeroext");
+}
+
+TEST_CASE("ABI: entry function int8_t parameter and result carry signext") {
+	const auto define = entryDefineLine(abiInt8Identity);
+	REQUIRE_FALSE(define.empty());
+	checkIdentitySignature(define, "i8", "signext");
+}
+
+TEST_CASE("ABI: entry function uint8_t parameter and result carry zeroext") {
+	const auto define = entryDefineLine(abiUInt8Identity);
+	REQUIRE_FALSE(define.empty());
+	checkIdentitySignature(define, "i8", "zeroext");
+}
+
+TEST_CASE("ABI: entry function int16_t parameter and result carry signext") {
+	const auto define = entryDefineLine(abiInt16Identity);
+	REQUIRE_FALSE(define.empty());
+	checkIdentitySignature(define, "i16", "signext");
+}
+
+TEST_CASE("ABI: entry function uint16_t parameter and result carry zeroext") {
+	const auto define = entryDefineLine(abiUInt16Identity);
+	REQUIRE_FALSE(define.empty());
+	checkIdentitySignature(define, "i16", "zeroext");
+}
+
+TEST_CASE("ABI: entry function 32-bit parameter carries no extension attribute") {
+	// A 32-bit argument already occupies a full argument register on every
+	// target Nautilus builds for, so it needs no extension attribute; the
+	// classification must stop at 16 bits rather than annotating every
+	// integer stamp.
+	const auto define = entryDefineLine(abiInt32Identity);
+	REQUIRE_FALSE(define.empty());
+	INFO("define line: " << define);
+
+	const auto params = parameterList(define);
+	REQUIRE(params.size() == 1);
+	CHECK(params[0].find("i32") != std::string::npos);
+	CHECK_FALSE(hasExtensionAttr(params[0]));
+}
+
+TEST_CASE("ABI: mixed-width parameters are annotated positionally") {
+	// The attributes are keyed by argument index, so a signature mixing narrow
+	// and wide stamps is where an off-by-one would surface: `flag` must be
+	// zeroext, `a` signext, `b` zeroext, and `c` unannotated.
+	const auto define = entryDefineLine(abiMixedNarrowArgs);
+	REQUIRE_FALSE(define.empty());
+	INFO("define line: " << define);
+
+	const auto params = parameterList(define);
+	REQUIRE(params.size() == 4);
+
+	CHECK(params[0].find("i1") != std::string::npos);
+	CHECK(params[0].find("zeroext") != std::string::npos);
+
+	CHECK(params[1].find("i8") != std::string::npos);
+	CHECK(params[1].find("signext") != std::string::npos);
+
+	CHECK(params[2].find("i16") != std::string::npos);
+	CHECK(params[2].find("zeroext") != std::string::npos);
+
+	CHECK(params[3].find("i32") != std::string::npos);
+	CHECK_FALSE(hasExtensionAttr(params[3]));
+}
+
+TEST_CASE("ABI: narrow arguments round-trip through the native call boundary") {
+	// The attributes above move the entry function from "re-extends every
+	// narrow argument defensively" to "trusts the caller to have extended it".
+	// That is only sound if the caller on the other side of
+	// Executable.hpp's function pointer really does extend, so exercise the
+	// boundary with the values whose high bits differ between a zero- and a
+	// sign-extended register.
+	Options options;
+	options.setOption("engine.backend", std::string("mlir"));
+	NautilusEngine engine(options);
+
+	auto boolFn = engine.registerFunction(abiBoolIdentity);
+	CHECK(boolFn(true) == true);
+	CHECK(boolFn(false) == false);
+
+	auto int8Fn = engine.registerFunction(abiInt8Identity);
+	CHECK(int8Fn(int8_t(-1)) == int8_t(-1));
+	CHECK(int8Fn(int8_t(-128)) == int8_t(-128));
+	CHECK(int8Fn(int8_t(127)) == int8_t(127));
+
+	auto uint8Fn = engine.registerFunction(abiUInt8Identity);
+	CHECK(uint8Fn(uint8_t(255)) == uint8_t(255));
+	CHECK(uint8Fn(uint8_t(0)) == uint8_t(0));
+
+	auto int16Fn = engine.registerFunction(abiInt16Identity);
+	CHECK(int16Fn(int16_t(-1)) == int16_t(-1));
+	CHECK(int16Fn(int16_t(-32768)) == int16_t(-32768));
+
+	auto uint16Fn = engine.registerFunction(abiUInt16Identity);
+	CHECK(uint16Fn(uint16_t(65535)) == uint16_t(65535));
+
+	auto mixedFn = engine.registerFunction(abiMixedNarrowArgs);
+	CHECK(mixedFn(true, int8_t(-1), uint16_t(65535), 1) == 1 + (-1) + 65535);
+	CHECK(mixedFn(false, int8_t(-1), uint16_t(65535), 1) == 0);
+}
+
+} // namespace nautilus::engine
+
+#endif

--- a/nautilus/test/execution-tests/CMakeLists.txt
+++ b/nautilus/test/execution-tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(NAUTILUS_EXECUTION_TEST_SOURCES
 
 if (ENABLE_MLIR_BACKEND)
     list(APPEND NAUTILUS_EXECUTION_TEST_SOURCES
+            ABIExtensionAttributeTest.cpp
             DebugInfoExecutionTest.cpp)
 endif ()
 


### PR DESCRIPTION
Supersedes #438, which is stuck: it targets `lr/missing-zeroext-bool` (merged as #436), so `pr.yml` — scoped to `pull_request: branches: [main]` — never ran a single check on it. This branch is that change rebased onto `main`, plus the test coverage it was missing, plus a correctness fix that CI then found. Closes #437.

#438 said its code "has never been compiled by anything." It has now — and **it was wrong on Linux/AArch64.**

## The finding

#438's premise was that the change is safe because "every caller is a platform-ABI-conforming compiler." That is exactly backwards for AAPCS64: a *conforming* Linux/AArch64 caller does **not** extend narrow arguments. The first CI run on this branch failed three tests on `ubuntu-24.04-arm` — `Cast Compiler Test`, `Engine Compiler Test`, and the round-trip case added here — while every x86-64 leg and `macos-26` passed. `main`'s ARM leg is green, so this diff caused it.

The split is the ABI, not the ISA — same architecture, opposite outcome:

| target | caller extends narrow args? | result |
|---|---|---|
| x86-64 SysV | yes | passed |
| Darwin AArch64 (`macos-26`) | yes | passed |
| **Linux AAPCS64 (`ubuntu-24.04-arm`)** | **no** | **failed** |

The root cause is that the two directions an extension attribute can be used in are not symmetric, and #438 conflated them:

- On a **call Nautilus emits** (`insertExternalFunction`), the attribute makes the JIT *extend* before entering a natively compiled callee. Extending where the callee did not require it is redundant but harmless — so that site can annotate unconditionally, and does.
- On the **entry function's parameters**, the attribute makes the JIT *trust* that its caller already extended. Under AAPCS64 nothing did, so the callee read whatever the register happened to hold.

`insertExternalFunction`'s own comment already flagged that "AAPCS64 does not" — but only in respect of *results*. The argument side inherited the annotation without inheriting the caveat.

**Fix:** gate the entry-function parameter attributes on the host ABI. The JIT targets the host and its callers are compiled into this same process, so a compile-time answer is exact. The codegen win is kept on x86-64 and Darwin AArch64; AAPCS64 keeps the defensive prologue extension, which is the correct code there. The result side stays unconditional — an attribute there is a promise the callee makes and keeps, so a caller that re-extends is merely redundant. That is why #436 is safe everywhere.

## Commits

1. **`Attach ABI extension attributes to entry function parameters`** — #438's change, rebased. The stacked `lr/missing-zeroext-bool` commit dropped out automatically as already-applied (`500a5ba` on `main`). No conflicts against #418 or #441, both of which touched `MLIRLoweringProvider.cpp`.
2. **`Cover entry-function ABI extension attributes with a direct IR assertion`** — the follow-up #438 proposed but did not write.
3. **`Only trust caller-side extension where the ABI requires it`** — the AAPCS64 fix above.

## Verification

Built with clang-19 (a CI matrix leg) against MLIR 22.1.8, Release.

| | result |
|---|---|
| Test suite | **473/473** |
| Same, with the AAPCS64 branch forced on | **473/473** |
| `llvm-ir-test` leg | 11 failures, **identical set with and without the change** — pre-existing clang-19 vs. CI's pinned clang-22 drift |
| Reference IR churn | **none** |

Both sides of the new `#if` were exercised locally by forcing the condition, since this container is x86-64; the real AArch64 verification is CI's ARM leg.

Generated entry signature on an ABI where the caller extends:

```llvm
; before
define signext i32 @execute(i1 %0, i8 %1, i16 %2, i32 %3)
; after
define signext i32 @execute(i1 zeroext %0, i8 signext %1, i16 zeroext %2, i32 %3)
```

#438 claimed `llvm-diff` is blind to these attributes. That now has evidence beyond a synthetic two-file check: the whole 172-test `llvm-ir-test` leg produces an identical result before and after, despite 24 reference files having narrow parameters. **The corollary is that CI could not have caught the AArch64 bug through reference IR — only an execution test could**, which is why the tests below assert on text and on behaviour rather than on `llvm-diff`.

## The tests

- each narrow stamp (`b`, `i8`, `ui8`, `i16`, `ui16`) carries the extension its C prototype implies — on the parameter where the ABI warrants it, on the result unconditionally
- `i32` carries none, pinning the classification's upper bound
- a mixed-width signature is annotated positionally, where an off-by-one between the stamp list and the MLIR type list would surface
- a round-trip case calls each compiled function through the native function-pointer path with the boundary values whose high bits differ between a zero- and a sign-extended register

The IR cases fail on `main` (6 of 7) and pass here. The round-trip case is the one that caught the AArch64 bug. The test mirrors the same `#if` as the lowering rather than assuming one platform, so it documents the ABI split instead of encoding one side of it.

The parameter and result forms are matched differently on purpose: LLVM prints a parameter's attributes *after* its type (`i8 signext %0`, sometimes with an optimizer-inserted `returned` in between) but a result's *before* it.

## Other review notes

Checked and settled:

- **The `_mlir_ciface_` wrapper needs no matching call-site attributes.** `CallBase::paramHasAttr` falls back to the called function's attributes for a direct call, and `SelectionDAGBuilder` reads it through that path.
- **`getStamp()` vs `getOutputArg()`** on the result side are the same value — `FunctionOperation` passes `outputArg` to its `Operation` base.
- **The helper is exhaustive** for `Type`; everything ≥32 bits correctly falls through.

Worth a maintainer's eye:

- **The comment says "entry function", but the code annotates every function.** `generateFunctionDefinitions` runs in a loop over all `FunctionOperation`s. Harmless — intra-module direct calls agree via the same attribute fallback — but the comment describes a narrower scope than the code has.
- **The result side still annotates every integer width**, including `i32`/`i64`, while the argument side stops at 16 bits. A no-op at full register width on supported targets, but the two sides are not symmetric despite the shared helper. Left alone deliberately: it is #436's freshly-landed code.

## Unrelated pre-existing issues found

- **`Debug info: per-block DILexicalBlock scoping narrows variable visibility` is flaky on `main`.** Nine debug-info tests locate their output by snapshotting `/tmp/dump`, compiling, then scanning for new directories — under `ctest -j` a concurrent test's dump gets picked up instead, and the counters are overwritten rather than accumulated, so the assertion sees `0`. Reproduced on unmodified `main`: 2 of 5 stress runs failed. This PR's tests avoid the pattern and clean up after themselves, but the race deserves its own fix.
- **`DumpHandler::getRootPath` ignores its `Options` parameter**, so the `dump.path` option `LLVMIRTestUtil` sets is silently a no-op.

Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpZCvZCnCGSMqwnudsiGPi