### PR TITLE
Playground: version footer + automated redeploy script

### DIFF
--- a/tools/playground/deploy/redeploy.sh
+++ b/tools/playground/deploy/redeploy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Nautilus Playground redeploy: fetches origin/main, and — only if it moved —
+# rebuilds the runner + API images and swaps the running container over.
+#
+# Runs on the host that owns the docker daemon serving the playground
+# (currently the nautilus-playground LXC), against a real git clone at
+# $REPO_DIR (not the plain source copy earlier deploys used). Intended to be
+# driven by cron every few hours:
+#   0 */4 * * * /opt/nautilus-playground/src/tools/playground/deploy/redeploy.sh >> /opt/nautilus-playground/deploy.log 2>&1
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/opt/nautilus-playground/src}"
+REMOTE="${REMOTE:-origin}"
+BRANCH="${BRANCH:-main}"
+LOCK_FILE="${LOCK_FILE:-/var/tmp/nautilus-playground-deploy.lock}"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+	echo "$(date -Is) redeploy already in progress, skipping"
+	exit 0
+fi
+
+cd "$REPO_DIR"
+git fetch "$REMOTE" "$BRANCH"
+local_sha="$(git rev-parse HEAD)"
+remote_sha="$(git rev-parse "$REMOTE/$BRANCH")"
+
+if [ "$local_sha" = "$remote_sha" ]; then
+	echo "$(date -Is) up to date at ${local_sha:0:8}, nothing to do"
+	exit 0
+fi
+
+echo "$(date -Is) deploying ${remote_sha:0:8} (was ${local_sha:0:8})"
+git reset --hard "$REMOTE/$BRANCH"
+
+# Every build here is a full nautilus+MLIR rebuild (the runner Dockerfile
+# COPies the whole tree before the cmake layer, so any source change busts
+# that cache) and image tags pile up one-per-deploy — prune first or the
+# disk fills up within a few redeploys.
+docker image prune -a -f
+docker builder prune -a -f
+
+short_sha="$(git rev-parse --short HEAD)"
+docker build -f tools/playground/runner/Dockerfile.runner \
+	-t "nautilus-playground-runner:${short_sha}" -t nautilus-playground-runner:latest .
+docker build -f tools/playground/server/Dockerfile \
+	--build-arg GIT_COMMIT="${short_sha}" \
+	-t "nautilus-playground-api:${short_sha}" -t nautilus-playground-api:latest .
+
+docker rm -f nautilus-playground >/dev/null 2>&1 || true
+docker run -d --name nautilus-playground --init --restart unless-stopped \
+	-p 8080:8080 \
+	-e RUNNER_IMAGE=nautilus-playground-runner \
+	-e TRUST_PROXY=1 \
+	-e JOB_ROOT=/var/tmp/nautilus-playground-jobs \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v /var/tmp/nautilus-playground-jobs:/var/tmp/nautilus-playground-jobs \
+	nautilus-playground-api:latest
+
+echo "$(date -Is) deployed ${short_sha}"

--- a/tools/playground/server/Dockerfile
+++ b/tools/playground/server/Dockerfile
@@ -29,7 +29,12 @@ COPY --from=server-build /app/package.json /app/package-lock.json* /app/
 RUN npm install --omit=dev
 COPY --from=server-build /app/dist /app/dist
 COPY --from=web-build /repo/tools/playground/web/dist /app/web-dist
-ENV WEB_DIST=/app/web-dist \
+# Short commit SHA the image was built from — the build context has no .git
+# (deploys copy a source tree, not a checkout), so this must be passed in:
+#   docker build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) ...
+ARG GIT_COMMIT=unknown
+ENV GIT_COMMIT=$GIT_COMMIT \
+    WEB_DIST=/app/web-dist \
     PORT=8080
 EXPOSE 8080
 CMD ["node", "dist/index.js"]

--- a/tools/playground/server/src/config.ts
+++ b/tools/playground/server/src/config.ts
@@ -35,4 +35,9 @@ export const config = {
 	examplesDir: process.env.EXAMPLES_DIR ?? path.join(import.meta.dirname, 'examples'),
 	/** Built web app; served statically when present. */
 	webDist: process.env.WEB_DIST ?? path.join(import.meta.dirname, '..', '..', 'web', 'dist'),
+
+	/** Short commit SHA baked in at image build time (see Dockerfile). */
+	gitCommit: process.env.GIT_COMMIT ?? 'unknown',
+	/** Process start time: a fresh container is created on every deploy, so this doubles as "last deployed". */
+	deployedAt: new Date().toISOString(),
 };

--- a/tools/playground/server/src/routes/compile.ts
+++ b/tools/playground/server/src/routes/compile.ts
@@ -99,6 +99,10 @@ export function registerRoutes(app: FastifyInstance, examples: Example[]): void 
 			sourceMaxBytes: config.sourceMaxBytes,
 			maxPipelineIterations: 8,
 		},
+		version: {
+			commit: config.gitCommit,
+			deployedAt: config.deployedAt,
+		},
 	}));
 }
 

--- a/tools/playground/web/src/App.tsx
+++ b/tools/playground/web/src/App.tsx
@@ -4,7 +4,17 @@ import { parse } from '@nautilus-ir/parser';
 import { makeTextDocument } from './lib/vscodeShim';
 import { splitTraceSections } from './lib/traceSections';
 import { decodeShareHash, encodeShareHash } from './lib/permalink';
-import { compile, fetchExamples, type Backend, type CompileOptions, type CompileResult, type Example, type Stage } from './api';
+import {
+	compile,
+	fetchExamples,
+	fetchMeta,
+	type Backend,
+	type CompileOptions,
+	type CompileResult,
+	type Example,
+	type Meta,
+	type Stage,
+} from './api';
 import { Editor, type EditorMarker } from './components/Editor';
 import { Toolbar, type StatusKind } from './components/Toolbar';
 import { StageTabs } from './components/StageTabs';
@@ -33,6 +43,7 @@ export function App() {
 	const [backend, setBackend] = useState<Backend>('mlir');
 	const [options, setOptions] = useState<CompileOptions>({});
 	const [examples, setExamples] = useState<Example[]>([]);
+	const [meta, setMeta] = useState<Meta | null>(null);
 	const [exampleId, setExampleId] = useState('');
 	const [result, setResult] = useState<CompileResult | null>(null);
 	const [status, setStatus] = useState('loading…');
@@ -94,6 +105,10 @@ export function App() {
 	// automatically so a visitor lands on a live pipeline. The server-side
 	// result cache makes this effectively free; the guard keeps user edits
 	// untouched.
+	useEffect(() => {
+		void fetchMeta().then(setMeta);
+	}, []);
+
 	useEffect(() => {
 		void fetchExamples().then((loaded) => {
 			setExamples(loaded);
@@ -233,6 +248,18 @@ export function App() {
 					)}
 				</section>
 			</main>
+			{meta && (
+				<footer className="footer">
+					<a
+						href={`https://github.com/nebulastream/nautilus/commit/${meta.version.commit}`}
+						target="_blank"
+						rel="noreferrer"
+					>
+						commit {meta.version.commit}
+					</a>
+					<span> · deployed {new Date(meta.version.deployedAt).toLocaleString()}</span>
+				</footer>
+			)}
 		</div>
 	);
 }

--- a/tools/playground/web/src/api.ts
+++ b/tools/playground/web/src/api.ts
@@ -64,12 +64,24 @@ export interface Example {
 	source: string;
 }
 
+export interface Meta {
+	version: { commit: string; deployedAt: string };
+}
+
 export async function fetchExamples(): Promise<Example[]> {
 	const response = await fetch('/api/examples');
 	if (!response.ok) {
 		return [];
 	}
 	return (await response.json()) as Example[];
+}
+
+export async function fetchMeta(): Promise<Meta | null> {
+	const response = await fetch('/api/meta');
+	if (!response.ok) {
+		return null;
+	}
+	return (await response.json()) as Meta;
 }
 
 export class ApiError extends Error {}

--- a/tools/playground/web/src/styles.css
+++ b/tools/playground/web/src/styles.css
@@ -55,6 +55,26 @@ body,
 	}
 }
 
+.footer {
+	flex: 0 0 auto;
+	display: flex;
+	gap: 4px;
+	align-items: center;
+	padding: 4px 16px;
+	font-size: 11px;
+	color: var(--text-400);
+	background: var(--paper);
+	border-top: 1px solid var(--line-100);
+}
+
+.footer a {
+	color: var(--text-400);
+}
+
+.footer a:hover {
+	color: var(--text-600);
+}
+
 /* --- panes --- */
 .panes {
 	display: flex;


### PR DESCRIPTION
## Summary
- `/api/meta` now reports the build's short commit SHA and the API process's start time (which doubles as "last deployed", since a redeploy always recreates the container); the web app shows both in a small footer.
- Adds `tools/playground/deploy/redeploy.sh`: fetches `origin/main` and only rebuilds + swaps the running container if it moved — meant to be driven by cron.

## Test plan
- [x] `tsc --noEmit` clean in `tools/playground/web` and `tools/playground/server`
- [x] Manually verified `/api/meta` and a full compile round trip against a locally built image
- [ ] Reviewer: confirm footer rendering/placement looks right once merged and auto-deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz3mRf86CuJgDLRvWYm8aQ