### PR TITLE
Fix region() tag collisions in unoptimized (Debug) builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,13 @@ jobs:
             cc: 'gcc-14'
             cxx: 'g++-14'
             flags: '-DENABLE_TRACING=OFF -DENABLE_LOGGING=OFF'
+          # Tag identity is derived from a frame-pointer walk, so -O0 vs -O3 is an axis
+          # tracing can legitimately behave differently on; every other leg above builds
+          # Release, which left a whole class of Debug-only tracing bugs uncaught (#450).
+          - os: 'ubuntu-24.04'
+            cc: 'gcc-14'
+            cxx: 'g++-14'
+            flags: '-DCMAKE_BUILD_TYPE=Debug'
           - os: 'ubuntu-24.04'
             cc: 'clang-19'
             cxx: 'clang++-19'

--- a/nautilus/include/nautilus/tracing/TracingUtil.hpp
+++ b/nautilus/include/nautilus/tracing/TracingUtil.hpp
@@ -100,7 +100,25 @@ void traceReturnOperation(Type type, const TypedValueRef& ref);
 
 /// Traces @p regionFunction as an isolated tracing region described by @p attributes;
 /// see docs/region.md.
-void traceRegion(std::function<void()>& regionFunction, const RegionAttributes& attributes);
+///
+/// Forced inline (like TagRecorder::createTag(), for the same reason) so this dispatch never
+/// shows up as its own stack frame: LazyTraceContext::traceRegion roots a new region scope's
+/// tags at __builtin_return_address(0), which is only call-site-specific if its immediate
+/// caller is region()'s own (per-lambda) instantiation. A real, out-of-line frame for this
+/// forwarder sits at the exact same address for every region() call in the program regardless
+/// of optimization level, since it is not templated on the region body -- and since whether
+/// the compiler collapses that frame away is otherwise optimization-level-dependent, two
+/// sibling region() calls opened directly inside another region's body could root their tags
+/// at that one shared address and collide (issue #450), which only surfaced in unoptimized
+/// builds.
+[[gnu::always_inline]] inline void traceRegion(std::function<void()>& regionFunction,
+                                               const RegionAttributes& attributes) {
+	if (auto* tracer = getActiveTracer()) {
+		tracer->traceRegion(regionFunction, attributes);
+	} else {
+		regionFunction();
+	}
+}
 
 void pushStaticVal(void* ptr, size_t size);
 void popStaticVal();

--- a/nautilus/src/nautilus/tracing/TracingUtil.cpp
+++ b/nautilus/src/nautilus/tracing/TracingUtil.cpp
@@ -36,14 +36,6 @@ void traceAssignment(const TypedValueRef& target, const TypedValueRef& source, T
 	}
 }
 
-void traceRegion(std::function<void()>& regionFunction, const RegionAttributes& attributes) {
-	if (activeTracer) {
-		activeTracer->traceRegion(regionFunction, attributes);
-	} else {
-		regionFunction();
-	}
-}
-
 TypedValueRef traceCopy(const TypedValueRef& ref) {
 	if (activeTracer) {
 		return activeTracer->traceCopy(ref);


### PR DESCRIPTION
## Summary

Fixes #450: `regionBranchBetweenInnerRegions` (an inner region, then a branch whose one arm opens a second inner region, then a third inner region) failed to trace in Debug builds with:

```
Invalid region() ...: no path through the region body reached its end, so the enclosing function cannot continue after it.
```

### Root cause

Tag identity in the tracer is derived from walking the frame-pointer chain up to a recorded `startAddress`. When `LazyTraceContext::traceRegion` opens a *new* region scope, it roots that scope's `TagRecorder` at `__builtin_return_address(0)`, which is only call-site-specific (i.e. distinguishes `region()` call site A from call site B) if `traceRegion`'s immediate caller is `region()`'s own per-lambda template instantiation.

But `region()` doesn't call `LazyTraceContext::traceRegion` directly — it goes through `nautilus::tracing::traceRegion`, a small **non-template free-function dispatcher** (`activeTracer->traceRegion(...)`) that had no inlining annotation. Whether that dispatcher shows up as its own stack frame is therefore optimization-level-dependent: at `-O3` it typically gets inlined away, but at `-O0` (Debug) it reliably survives as a real frame.

When it survives, *every* `region()` call in the whole program shares that one dispatcher frame's return address. For a region opened directly inside another region's body, the frame-pointer walk for the inner region's tag terminates as soon as it reaches that shared frame — before ever reaching the frame that would actually distinguish which `region()` call site triggered it. Two sibling regions opened inside the same enclosing region body (e.g. one before a branch, one inside it) then collide on the exact same tag, which the tracer interprets as a spurious control-flow merge, corrupting the trace instead of tracing the second region's body.

Reproduced locally by building `nautilus-execution-tests` with `-DCMAKE_BUILD_TYPE=Debug` under GCC 13 (the closest available system compiler in this environment to the issue's `g++-14`) and instrumenting the frame-pointer walk — confirmed that all three sibling `region()` calls in the fixture rooted at the exact same 3-frame chain before the fix, and that they resolve to distinct chains after it.

### Fix

Force `nautilus::tracing::traceRegion` inline (`[[gnu::always_inline]] inline`, moved into the header), mirroring the existing `TagRecorder::createTag()`/`createTagRecorder()` treatment that exists for the identical reason. This makes the dispatcher's frame disappear in every build, so `__builtin_return_address(0)` inside `LazyTraceContext::traceRegion` always lands on the call-site-specific frame, regardless of optimization level.

The exit-block-has-no-predecessors check in `traceRegion` (the actual diagnostic the issue's fixture triggers) is left untouched, per the issue's own guidance — the fix addresses the tag identity, not the check.

### CI

Also added a `-DCMAKE_BUILD_TYPE=Debug` leg (`gcc-14`) to the PR build matrix, since tag identity being derived from a frame-pointer walk makes `-O0` vs `-O3` an axis tracing can legitimately diverge on, and no existing leg built Debug.

## Test plan

- [x] `regionBranchBetweenInnerRegions` (the issue's fixture, already present in `RegionTest.cpp`) reproduced the failure in a local Debug/GCC13 build before the fix, and passes after it, across all backends exercised by that test (`bc`, `tbc`, `cpp`, `asmjit` — MLIR/`cpp` backends were not buildable in this sandboxed environment, so verified with the buildable subset: `bc`/`tbc`, plus a standalone repro harness driving `LazyTraceContext` directly).
- [x] Full `ctest --test-dir nautilus` suite passes in both Debug and Release local builds (GCC 13), aside from 7 pre-existing failures unrelated to this change (confirmed present on `main` without this fix too — they fail because this sandboxed environment has no MLIR/C backend built, not because of anything region-related).
- [x] `clang-format-18 --dry-run --Werror` clean on the changed files.
- [x] New CI matrix entry validated to actually select Debug (`-DCMAKE_BUILD_TYPE=Debug` placed after the job's default `-DCMAKE_BUILD_TYPE=Release` in the `cmake` invocation — confirmed CMake's last `-D` for a given variable wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uNPcaQvTVVBMKskNrbZ1s


---
_Generated by [Claude Code](https://claude.ai/code/session_018uNPcaQvTVVBMKskNrbZ1s)_