### PR TITLE
Record where each traced function was registered, and print it on the IR signature line

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -62,6 +62,16 @@ int32_t buffer = 0;
 compiled(&buffer, 42); // buffer is now 42
 ```
 
+### Registration Source Location
+
+`registerFunction` (and `NautilusFunction`, `NautilusModule::registerFunction`) captures the call site it was written at via a defaulted `std::source_location` parameter -- no cost to the caller, no debug info required. It is printed on the compiled function's signature line in the IR dump (`docs/graphs.md`), under the `log::options::setLogSourceLocations` flag, and named in diagnostics raised while tracing the function (e.g. a rejected `region()` body):
+
+```
+execute($1:i64) :i64  ; at src/Query.cpp:42:1 {
+```
+
+This is where the function was *registered*, not necessarily where its body is *defined*. For `NautilusFunction{"f", fBody}` the two usually coincide; for `engine.registerFunction(myKernel)` the location is the call site in setup code, which may be far from `myKernel`'s own definition. Symbolising the callee's address to recover the true definition site would need debug info and a resolver lookup; that is a separate, opt-in enrichment (see `dump.sourceLocations` and `SourceLocationResolver`), not what this parameter provides.
+
 ## Backend Selection
 
 Nautilus supports three compilation backends. Set the backend through the `engine.backend` option.

--- a/docs/region.md
+++ b/docs/region.md
@@ -100,6 +100,8 @@ It is on by default, because relating traced code back to the source is the poin
 
 The IR table holds one entry per region() call site per enclosing chain, not one per traced engagement: a region inside a statically unrolled loop is entered once per iteration, and all of those iterations are the same `region()` in the source. The one thing the IR does not keep is the region *boundary* — after the cleanup passes there is no block that starts a region, which is exactly the point of a region costing nothing in the generated code.
 
+The same flag governs a sibling piece of provenance: where the *function* around these regions was registered (`docs/engine.md#registration-source-location`), printed on its IR signature line and named in a rejected region's diagnostic alongside the region's own location.
+
 No backend reads any of this today; it is provenance for reading, verifying and debugging the IR.
 
 ### Naming a region from a helper

--- a/nautilus/include/nautilus/CompilableFunction.hpp
+++ b/nautilus/include/nautilus/CompilableFunction.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "nautilus/common/RegionAttributes.hpp"
 #include <functional>
 #include <string>
 #include <string_view>
@@ -11,8 +12,10 @@ class CompilableFunction {
 
 public:
 	CompilableFunction(std::string_view name, wrapper_function function,
-	                   std::unordered_map<std::string, std::string> attributes = {}, const void* definition = nullptr)
-	    : name(name), function(function), attributes(std::move(attributes)), definition(definition) {
+	                   std::unordered_map<std::string, std::string> attributes = {}, const void* definition = nullptr,
+	                   SourceLocation location = {})
+	    : name(name), function(function), attributes(std::move(attributes)), definition(definition),
+	      location(location) {
 	}
 
 	const std::string& getName() const {
@@ -39,11 +42,18 @@ public:
 		return definition;
 	}
 
+	/// Where this function was registered (docs/engine.md), or an unknown
+	/// location for a function queued without one.
+	const SourceLocation& getLocation() const {
+		return location;
+	}
+
 private:
 	std::string name;
 	wrapper_function function;
 	std::unordered_map<std::string, std::string> attributes;
 	const void* definition = nullptr;
+	SourceLocation location;
 };
 
 } // namespace nautilus::compiler

--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -4,12 +4,14 @@
 #include "nautilus/Executable.hpp"
 #include "nautilus/JITCompiler.hpp"
 #include "nautilus/Module.hpp"
+#include "nautilus/common/RegionAttributes.hpp"
 #include "nautilus/config.hpp"
 #include "nautilus/core.hpp"
 #include "nautilus/options.hpp"
 #include <any>
 #include <functional>
 #include <memory>
+#include <source_location>
 
 #ifdef ENABLE_TRACING
 #include "nautilus/CompilableFunction.hpp"
@@ -176,12 +178,19 @@ public:
 	NautilusEngine& operator=(NautilusEngine&&) noexcept = delete;
 
 	/// Register and compile a single function pointer. Defined after NautilusModule.
+	/// @param location Where this call was written; captured for free and shown on the
+	/// compiled function's IR signature line and in diagnostics raised while tracing it
+	/// (docs/engine.md). Note this is the registration call site, not @p fnptr's own
+	/// definition -- they usually coincide but need not.
 	template <typename R, is_val... FunctionArguments>
-	auto registerFunction(R (*fnptr)(val<FunctionArguments>...)) const;
+	auto registerFunction(R (*fnptr)(val<FunctionArguments>...),
+	                      std::source_location location = std::source_location::current()) const;
 
 	/// Register and compile a single std::function. Defined after NautilusModule.
+	/// @param location See the function-pointer overload above.
 	template <typename R, typename... FunctionArguments>
-	auto registerFunction(std::function<R(val<FunctionArguments>...)> func) const;
+	auto registerFunction(std::function<R(val<FunctionArguments>...)> func,
+	                      std::source_location location = std::source_location::current()) const;
 
 	/**
 	 * @brief Creates a new module for registering multiple functions to be compiled together.
@@ -288,26 +297,31 @@ public:
 	 * @tparam F Callable type (lambda, functor)
 	 * @param name Unique name for this function in the module
 	 * @param func The callable to register
+	 * @param location Where this call was written (docs/engine.md).
 	 */
 	template <typename Signature, typename F>
-	void registerFunction(const std::string& name, F&& func) {
+	void registerFunction(const std::string& name, F&& func,
+	                      std::source_location location = std::source_location::current()) {
 		using function_type = std::function<Signature>;
 		function_type stdFunc(std::forward<F>(func));
-		registerFunction(name, std::move(stdFunc));
+		registerFunction(name, std::move(stdFunc), location);
 	}
 
 	/**
 	 * @brief Register a function from a std::function.
 	 * @param name Unique name for this function in the module
 	 * @param func The std::function to register
+	 * @param location Where this call was written (docs/engine.md).
 	 */
 	template <typename R, typename... FunctionArguments>
-	void registerFunction(const std::string& name, std::function<R(val<FunctionArguments>...)> func) {
+	void registerFunction(const std::string& name, std::function<R(val<FunctionArguments>...)> func,
+	                      std::source_location location = std::source_location::current()) {
 		interpretedFunctions_[name] = func;
 #ifdef ENABLE_TRACING
 		if (compiled_) {
 			auto wrapper = details::createFunctionWrapper(std::move(func));
-			functions_.emplace_back(name, std::move(wrapper));
+			functions_.emplace_back(name, std::move(wrapper), std::unordered_map<std::string, std::string> {}, nullptr,
+			                        SourceLocation::from(location));
 		}
 #endif
 	}
@@ -316,15 +330,18 @@ public:
 	 * @brief Register a function from a function pointer.
 	 * @param name Unique name for this function in the module
 	 * @param fnptr The function pointer to register
+	 * @param location Where this call was written (docs/engine.md).
 	 */
 	template <typename R, is_val... FunctionArguments>
-	void registerFunction(const std::string& name, R (*fnptr)(val<FunctionArguments>...)) {
+	void registerFunction(const std::string& name, R (*fnptr)(val<FunctionArguments>...),
+	                      std::source_location location = std::source_location::current()) {
 		std::function<R(val<FunctionArguments>...)> func = fnptr;
 		interpretedFunctions_[name] = func;
 #ifdef ENABLE_TRACING
 		if (compiled_) {
 			auto wrapper = details::createFunctionWrapper(fnptr);
-			functions_.emplace_back(name, std::move(wrapper));
+			functions_.emplace_back(name, std::move(wrapper), std::unordered_map<std::string, std::string> {}, nullptr,
+			                        SourceLocation::from(location));
 		}
 #endif
 	}
@@ -389,18 +406,19 @@ using raw_return_type_t = typename raw_return_type<T>::type;
 } // namespace details
 
 template <typename R, is_val... FunctionArguments>
-auto NautilusEngine::registerFunction(R (*fnptr)(val<FunctionArguments>...)) const {
+auto NautilusEngine::registerFunction(R (*fnptr)(val<FunctionArguments>...), std::source_location location) const {
 	using RawR = details::raw_return_type_t<R>;
 	auto module = createModule();
-	module.registerFunction("execute", fnptr);
+	module.registerFunction("execute", fnptr, location);
 	return CompiledFunction<RawR(FunctionArguments...)>(module.compile());
 }
 
 template <typename R, typename... FunctionArguments>
-auto NautilusEngine::registerFunction(std::function<R(val<FunctionArguments>...)> func) const {
+auto NautilusEngine::registerFunction(std::function<R(val<FunctionArguments>...)> func,
+                                      std::source_location location) const {
 	using RawR = details::raw_return_type_t<R>;
 	auto module = createModule();
-	module.registerFunction("execute", std::move(func));
+	module.registerFunction("execute", std::move(func), location);
 	return CompiledFunction<RawR(FunctionArguments...)>(module.compile());
 }
 

--- a/nautilus/include/nautilus/Engine.hpp
+++ b/nautilus/include/nautilus/Engine.hpp
@@ -315,7 +315,7 @@ public:
 	 */
 	template <typename R, typename... FunctionArguments>
 	void registerFunction(const std::string& name, std::function<R(val<FunctionArguments>...)> func,
-	                      std::source_location location = std::source_location::current()) {
+	                      [[maybe_unused]] std::source_location location = std::source_location::current()) {
 		interpretedFunctions_[name] = func;
 #ifdef ENABLE_TRACING
 		if (compiled_) {
@@ -334,7 +334,7 @@ public:
 	 */
 	template <typename R, is_val... FunctionArguments>
 	void registerFunction(const std::string& name, R (*fnptr)(val<FunctionArguments>...),
-	                      std::source_location location = std::source_location::current()) {
+	                      [[maybe_unused]] std::source_location location = std::source_location::current()) {
 		std::function<R(val<FunctionArguments>...)> func = fnptr;
 		interpretedFunctions_[name] = func;
 #ifdef ENABLE_TRACING

--- a/nautilus/include/nautilus/nautilus_function.hpp
+++ b/nautilus/include/nautilus/nautilus_function.hpp
@@ -1,11 +1,13 @@
 // nautilus_function.hpp
 #pragma once
 
-#include "nautilus/Engine.hpp"   // engine::details::createFunctionWrapper
-#include "nautilus/function.hpp" // getArgumentReferences
-#include "nautilus/val_func.hpp" // val<R(*)(Args...)>
-#include <functional>            // std::invoke
+#include "nautilus/Engine.hpp"                  // engine::details::createFunctionWrapper
+#include "nautilus/common/RegionAttributes.hpp" // SourceLocation
+#include "nautilus/function.hpp"                // getArgumentReferences
+#include "nautilus/val_func.hpp"                // val<R(*)(Args...)>
+#include <functional>                           // std::invoke
 #include <optional>
+#include <source_location>
 #include <string>
 #include <type_traits> // std::is_void_v, std::invoke_result_t
 #include <unordered_map>
@@ -58,11 +60,21 @@ using nautilus_raw_func_ptr_t = typename detail::nautilus_function_traits<std::d
 
 class NautilusFunctionDefinition {
 public:
-	NautilusFunctionDefinition(std::string name) : name_(std::move(name)) {
+	/// @param location Where this function was registered. Defaulted so ordinary callers
+	/// get it for free; note this is where the NautilusFunctionDefinition was *constructed*,
+	/// which for `engine.registerFunction(myKernel)` is the call site in setup code, not
+	/// `myKernel`'s own definition -- see docs/engine.md.
+	NautilusFunctionDefinition(std::string name, std::source_location location = std::source_location::current())
+	    : name_(std::move(name)), location_(SourceLocation::from(location)) {
 	}
 
 	const std::string& name() const noexcept {
 		return name_;
+	}
+
+	/// Where this function was registered (see the constructor).
+	const SourceLocation& location() const noexcept {
+		return location_;
 	}
 
 	void setAttribute(const std::string& key, const std::string& value) {
@@ -87,6 +99,7 @@ public:
 
 private:
 	std::string name_;
+	SourceLocation location_;
 	std::unordered_map<std::string, std::string> attributes_;
 };
 
@@ -101,8 +114,8 @@ private:
 template <class F>
 class NautilusFunction {
 public:
-	NautilusFunction(std::string name, F f)
-	    : definition_(std::move(name)), f_(std::move(f))
+	NautilusFunction(std::string name, F f, std::source_location location = std::source_location::current())
+	    : definition_(std::move(name), location), f_(std::move(f))
 #ifdef ENABLE_TRACING
 	      ,
 	      fwrapper(engine::details::createFunctionWrapper(f_))

--- a/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
+++ b/nautilus/src/nautilus/compiler/ir/IRGraph.cpp
@@ -662,6 +662,14 @@ struct formatter<nautilus::compiler::ir::FunctionOperation> : formatter<std::str
 				                   nautilus::compiler::ir::currentPrintGraph->getFunctionTarget(id).getAttributes()));
 			}
 		}
+		// Where this function was registered (docs/engine.md), not where its body is
+		// defined -- for a NautilusFunction those usually coincide, for
+		// engine.registerFunction(myKernel) the location is the registration call site.
+		// Gated behind the same flag as the region legend below, so a dump that has to
+		// stay identical across machines and compilers can turn it off.
+		if (nautilus::log::options::getLogSourceLocations() && func.getLocation().isKnown()) {
+			fmt::format_to(out, "  ; at {}", func.getLocation().toString());
+		}
 		fmt::format_to(out, " {{");
 		{
 			nautilus::compiler::ir::PrintExceptionRegionScope exceptionScope(

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.cpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.cpp
@@ -10,11 +10,11 @@ FunctionOperation::FunctionOperation(std::string name, std::vector<BasicBlock*> 
                                      std::vector<Type> inputArgs, std::vector<std::string> inputArgNames,
                                      Type outputArg, std::vector<AllocaSpec> allocaSpecs,
                                      std::unordered_map<std::string, std::string> attributes,
-                                     std::vector<RegionSpec> regionSpecs)
+                                     std::vector<RegionSpec> regionSpecs, SourceLocation location)
     : Operation(OperationType::FunctionOp, outputArg), name(std::move(name)),
       functionBasicBlocks(std::move(functionBasicBlocks)), inputArgs(std::move(inputArgs)),
       inputArgNames(std::move(inputArgNames)), allocaSpecs(std::move(allocaSpecs)), attributes(std::move(attributes)),
-      regionSpecs(std::move(regionSpecs)) {
+      regionSpecs(std::move(regionSpecs)), location(location) {
 }
 
 const std::string& FunctionOperation::getName() const {
@@ -117,6 +117,10 @@ std::optional<std::string> FunctionOperation::getAttribute(const std::string& ke
 		return it->second;
 	}
 	return std::nullopt;
+}
+
+const SourceLocation& FunctionOperation::getLocation() const {
+	return location;
 }
 
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
+++ b/nautilus/src/nautilus/compiler/ir/operations/FunctionOperation.hpp
@@ -44,7 +44,7 @@ public:
 	                           std::vector<Type> inputArgs, std::vector<std::string> inputArgNames, Type outputArg,
 	                           std::vector<AllocaSpec> allocaSpecs = {},
 	                           std::unordered_map<std::string, std::string> attributes = {},
-	                           std::vector<RegionSpec> regionSpecs = {});
+	                           std::vector<RegionSpec> regionSpecs = {}, SourceLocation location = {});
 
 	~FunctionOperation() = default;
 
@@ -101,6 +101,10 @@ public:
 	[[nodiscard]] bool hasAttribute(const std::string& key) const;
 	[[nodiscard]] std::optional<std::string> getAttribute(const std::string& key) const;
 
+	/// Where this function was registered (docs/engine.md), or an unknown location for a
+	/// function traced without going through a registration entry point that captures one.
+	[[nodiscard]] const SourceLocation& getLocation() const;
+
 	/// Exception-region side table, populated by
 	/// ExceptionRegionPreparationPass (terminal pass). Empty until that pass
 	/// runs; `std::nullopt` means the pass has not yet visited this function.
@@ -116,5 +120,6 @@ private:
 	std::vector<AllocaSpec> allocaSpecs;
 	std::unordered_map<std::string, std::string> attributes;
 	std::vector<RegionSpec> regionSpecs;
+	SourceLocation location;
 };
 } // namespace nautilus::compiler::ir

--- a/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/ExceptionBasedTraceContext.cpp
@@ -290,8 +290,8 @@ const std::string& ExceptionBasedTraceContext::registerNautilusFunction(const Na
 	usedFunctionNames.insert(name);
 
 	const auto [inserted, _] = registeredFunctions.emplace(definition, std::move(name));
-	functionsToTrace.push_back(
-	    compiler::CompilableFunction(inserted->second, std::move(fwrapper), definition->attributes(), definition));
+	functionsToTrace.push_back(compiler::CompilableFunction(
+	    inserted->second, std::move(fwrapper), definition->attributes(), definition, definition->location()));
 	log::debug("Added function '{}' to functionsToTrace list. List now has {} functions", inserted->second,
 	           functionsToTrace.size());
 	return inserted->second;
@@ -576,6 +576,7 @@ std::unique_ptr<TraceModule> ExceptionBasedTraceContext::startTrace(std::list<co
 			isFirstFunction = false;
 		}
 		traceModule->setFunctionAttributes(currentFunction.getName(), attributes);
+		traceModule->setFunctionLocation(currentFunction.getName(), currentFunction.getLocation());
 		// Carry the definition identity through to IR conversion, which uses it
 		// to bind this body to the function-table id its call sites minted.
 		traceModule->addFunctionDefinition(currentFunction.getName(), currentFunction.getDefinition());

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -25,6 +25,13 @@ void TraceModule::setFunctionAttributes(const std::string& functionName,
 	}
 }
 
+void TraceModule::setFunctionLocation(const std::string& functionName, const SourceLocation& location) {
+	auto it = functions.find(functionName);
+	if (it != functions.end()) {
+		it->second.location = location;
+	}
+}
+
 void TraceModule::addFunctionDefinition(const std::string& functionName, const void* definition) {
 	if (definition == nullptr) {
 		return;
@@ -64,6 +71,11 @@ TraceModule::getFunctionAttributes(const std::string& functionName) const {
 	static const std::unordered_map<std::string, std::string> empty;
 	auto it = functions.find(functionName);
 	return it != functions.end() ? it->second.attributes : empty;
+}
+
+SourceLocation TraceModule::getFunctionLocation(const std::string& functionName) const {
+	auto it = functions.find(functionName);
+	return it != functions.end() ? it->second.location : SourceLocation {};
 }
 
 std::string TraceModule::toString() const {

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.hpp
@@ -42,6 +42,9 @@ struct TraceFunctionDefinition {
 	std::string name;
 	std::unique_ptr<ExecutionTrace> trace;
 	std::unordered_map<std::string, std::string> attributes;
+	/// Where this function was registered (docs/engine.md); unknown for a function traced
+	/// without going through a registration entry point that captures one.
+	SourceLocation location;
 	/// Every identity that denotes this body. Usually one: the
 	/// NautilusFunctionDefinition it was traced from, or nothing at all for a
 	/// module-registered entry function.
@@ -94,6 +97,9 @@ public:
 	void setFunctionAttributes(const std::string& functionName,
 	                           const std::unordered_map<std::string, std::string>& attrs);
 
+	/// Records where a previously added function was registered (docs/engine.md).
+	void setFunctionLocation(const std::string& functionName, const SourceLocation& location);
+
 	/// Records another identity that denotes @p functionName's body. Ignores
 	/// nullptr (a module-registered entry has no definition object) and
 	/// duplicates.
@@ -109,6 +115,10 @@ public:
 
 	/// Convenience: returns the attributes for a function (empty map if none).
 	const std::unordered_map<std::string, std::string>& getFunctionAttributes(const std::string& functionName) const;
+
+	/// Convenience: returns where a function was registered, or an unknown location if it
+	/// has none or the function does not exist.
+	SourceLocation getFunctionLocation(const std::string& functionName) const;
 
 	bool hasFunction(const std::string& functionName) const;
 

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.cpp
@@ -41,12 +41,24 @@ void LazyTraceContext::resume() {
 	paused_ = false;
 }
 
+std::string LazyTraceContext::describeCurrentFunction() const {
+	if (session_->currentFunctionName_.empty()) {
+		return {};
+	}
+	std::string description = " in function '" + session_->currentFunctionName_ + "'";
+	if (session_->currentFunctionLocation_.isKnown()) {
+		description += " (registered at " + session_->currentFunctionLocation_.toString() + ")";
+	}
+	return description;
+}
+
 TypedValueRef& LazyTraceContext::registerFunctionArgument(Type type, size_t index) {
 	if (paused_) {
 		return dummyRef_;
 	}
 	if (parent_ != nullptr) {
-		throw RuntimeException("Invalid region(): a region body has no arguments of its own.");
+		throw RuntimeException("Invalid region()" + describeCurrentFunction() +
+		                       ": a region body has no arguments of its own.");
 	}
 	return state->executionTrace.setArgument(type, index);
 }
@@ -283,8 +295,8 @@ const std::string& LazyTraceContext::registerNautilusFunction(const NautilusFunc
 	session_->usedFunctionNames.insert(name);
 
 	const auto [inserted, _] = session_->registeredFunctions.emplace(definition, std::move(name));
-	session_->functionsToTrace.push_back(
-	    compiler::CompilableFunction(inserted->second, std::move(fwrapper), definition->attributes(), definition));
+	session_->functionsToTrace.push_back(compiler::CompilableFunction(
+	    inserted->second, std::move(fwrapper), definition->attributes(), definition, definition->location()));
 	log::debug("Added function '{}' to functionsToTrace list. List now has {} functions", inserted->second,
 	           session_->functionsToTrace.size());
 	return inserted->second;
@@ -404,7 +416,8 @@ void LazyTraceContext::traceReturnOperation(Type resultType, const TypedValueRef
 		return;
 	}
 	if (parent_ != nullptr) {
-		throw RuntimeException("Invalid region(): a region body returns void and cannot return from the enclosing "
+		throw RuntimeException("Invalid region()" + describeCurrentFunction() +
+		                       ": a region body returns void and cannot return from the enclosing "
 		                       "function; assign to a val<T> captured by reference instead.");
 	}
 	if (isFollowing()) {
@@ -581,7 +594,7 @@ void LazyTraceContext::traceScopeExit() {
 			escaped += (escaped.empty() ? "" : ", ") + std::string("$") + std::to_string(ref);
 		});
 		throw RuntimeException(
-		    "Invalid region() " + region.attributes.toString() +
+		    "Invalid region() " + region.attributes.toString() + describeCurrentFunction() +
 		    ": a value created inside the region body outlives it (" + escaped +
 		    "). Carry the value out through a val<T> declared outside the region and assigned to inside it, or trace "
 		    "this function with engine.traceMode = \"exceptionBasedTracing\".");
@@ -594,7 +607,7 @@ void LazyTraceContext::traceScopeExit() {
 		// Same escape set, different snapshot: the remaining input to the hash is the
 		// static-variable stack, so a captured static_val was written inside the body.
 		throw RuntimeException(
-		    "Invalid region() " + region.attributes.toString() +
+		    "Invalid region() " + region.attributes.toString() + describeCurrentFunction() +
 		    ": the state alive at the end of the region body differs between the paths through it, so what escapes the "
 		    "region would depend on which path was explored last. Build the escaping value on every path (assigning to "
 		    "a val<T> declared outside the region merges across branches), or trace this function with "
@@ -627,7 +640,7 @@ void LazyTraceContext::traceRegion(std::function<void()>& regionFunction, const 
 		auto& memo = regionState().regionMemo;
 		auto memoized = memo.find(key);
 		if (memoized == memo.end()) {
-			throw RuntimeException("Invalid region() " + attributes.toString() +
+			throw RuntimeException("Invalid region() " + attributes.toString() + describeCurrentFunction() +
 			                       ": replaying a recorded path reached a region() call site that was not recorded "
 			                       "there. Trace this function with engine.traceMode = \"exceptionBasedTracing\", "
 			                       "which traces region bodies inline.");
@@ -680,7 +693,7 @@ void LazyTraceContext::traceRegion(std::function<void()>& regionFunction, const 
 		// No pass of the body ever ran to completion, so nothing reaches the block the
 		// enclosing scope is about to continue in. Diagnose it here rather than let a
 		// later phase fail on an unreachable block.
-		throw RuntimeException("Invalid region() " + attributes.toString() +
+		throw RuntimeException("Invalid region() " + attributes.toString() + describeCurrentFunction() +
 		                       ": no path through the region body reached its end, so the enclosing function cannot "
 		                       "continue after it.");
 	}
@@ -772,9 +785,12 @@ std::unique_ptr<TraceModule> LazyTraceContext::startTrace(std::list<compiler::Co
 			isFirstFunction = false;
 		}
 		traceModule->setFunctionAttributes(currentFunction.getName(), attributes);
+		traceModule->setFunctionLocation(currentFunction.getName(), currentFunction.getLocation());
 		// Carry the definition identity through to IR conversion, which uses it
 		// to bind this body to the function-table id its call sites minted.
 		traceModule->addFunctionDefinition(currentFunction.getName(), currentFunction.getDefinition());
+		session_->currentFunctionName_ = currentFunction.getName();
+		session_->currentFunctionLocation_ = currentFunction.getLocation();
 		auto wrapperFunc = currentFunction.getFunction();
 
 		auto rootAddress = __builtin_return_address(0);

--- a/nautilus/src/nautilus/tracing/LazyTraceContext.hpp
+++ b/nautilus/src/nautilus/tracing/LazyTraceContext.hpp
@@ -277,6 +277,18 @@ private:
 	std::unordered_map<const void*, std::string> registeredFunctions;
 	std::unordered_set<std::string> usedFunctionNames;
 
+	/// Name and registration site of the function whose body is currently being traced
+	/// (session-owned; see session_). Read by the "Invalid region()" diagnostics so a
+	/// rejected region body says which enclosing function it came from, not just where the
+	/// region() call site itself sits.
+	std::string currentFunctionName_;
+	SourceLocation currentFunctionLocation_;
+
+	/// " in function 'name' (registered at file:line:column)" for the function currently
+	/// being traced, or empty before any function has started. Used to extend an
+	/// "Invalid region()" diagnostic with the enclosing function's identity.
+	std::string describeCurrentFunction() const;
+
 	/// Returns the trace-unique name for @p definition, registering it for
 	/// tracing on first sight. @p newlyRegistered reports whether this call
 	/// was the first.

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.cpp
@@ -101,8 +101,9 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<TraceMo
 	for (const auto& functionName : traceModule->getFunctionNames()) {
 		auto* trace = traceModule->getFunction(functionName);
 		auto& attrs = traceModule->getFunctionAttributes(functionName);
+		auto location = traceModule->getFunctionLocation(functionName);
 		auto phaseContext = IRConversionContext(trace, ir, id);
-		auto* functionOperation = phaseContext.processFunction(functionName, attrs);
+		auto* functionOperation = phaseContext.processFunction(functionName, attrs, location);
 		ir->addFunctionOperation(functionOperation);
 		bindDefinition(*ir, *traceModule, functionName, functionOperation);
 	}
@@ -118,8 +119,9 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::apply(std::shared_ptr<TraceMo
 	for (const auto& functionName : traceModule->getFunctionNames()) {
 		auto* trace = traceModule->getFunction(functionName);
 		auto& attrs = traceModule->getFunctionAttributes(functionName);
+		auto location = traceModule->getFunctionLocation(functionName);
 		auto phaseContext = IRConversionContext(trace, ir, id);
-		auto* functionOperation = phaseContext.processFunction(functionName, attrs);
+		auto* functionOperation = phaseContext.processFunction(functionName, attrs, location);
 		ir->addFunctionOperation(functionOperation);
 		bindDefinition(*ir, *traceModule, functionName, functionOperation);
 	}
@@ -165,7 +167,8 @@ std::shared_ptr<IRGraph> TraceToIRConversionPhase::IRConversionContext::process(
 }
 
 FunctionOperation* TraceToIRConversionPhase::IRConversionContext::processFunction(
-    const std::string& functionName, const std::unordered_map<std::string, std::string>& attributes) {
+    const std::string& functionName, const std::unordered_map<std::string, std::string>& attributes,
+    const SourceLocation& location) {
 	// Clear state for this function
 	currentBasicBlocks.clear();
 	blockMap.clear();
@@ -180,7 +183,7 @@ FunctionOperation* TraceToIRConversionPhase::IRConversionContext::processFunctio
 	// Create and return the function operation
 	return ir->getArena().create<FunctionOperation>(functionName, std::move(currentBasicBlocks), std::vector<Type> {},
 	                                                std::vector<std::string> {}, returnType, collectAllocaSpecs(),
-	                                                attributes, std::move(currentRegionSpecs));
+	                                                attributes, std::move(currentRegionSpecs), location);
 }
 
 size_t TraceToIRConversionPhase::IRConversionContext::RegionKeyHash::operator()(const RegionKey& key) const noexcept {

--- a/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
+++ b/nautilus/src/nautilus/tracing/phases/TraceToIRConversionPhase.hpp
@@ -80,11 +80,13 @@ private:
 		 * @brief Processes a single function trace and returns a FunctionOperation
 		 * @param functionName The name of the function being processed
 		 * @param attributes Generic key-value attributes to attach to the FunctionOperation
+		 * @param location Where this function was registered (docs/engine.md)
 		 * @return Arena-allocated pointer to the generated FunctionOperation
 		 */
 		compiler::ir::FunctionOperation*
 		processFunction(const std::string& functionName,
-		                const std::unordered_map<std::string, std::string>& attributes = {});
+		                const std::unordered_map<std::string, std::string>& attributes = {},
+		                const SourceLocation& location = {});
 
 	private:
 		compiler::ir::BasicBlock* processBlock(Block& block);

--- a/plugins/gpu/test/GPUTracingTest.cpp
+++ b/plugins/gpu/test/GPUTracingTest.cpp
@@ -21,6 +21,7 @@
 namespace nautilus::log::options {
 bool getLogAddresses();
 void setLogAddresses(bool);
+void setLogSourceLocations(bool);
 } // namespace nautilus::log::options
 
 namespace nautilus::engine {
@@ -70,7 +71,11 @@ static auto traceContexts = std::vector<std::tuple<std::string, TraceFn>> {
 
 static void runTraceTests(const std::string& category,
                           std::vector<std::tuple<std::string, std::function<void()>>>& tests) {
+	// Disable logging of addresses and source locations so a checked-in dump does not
+	// depend on the machine or compiler it was generated on (see
+	// log::options::setLogSourceLocations and the equivalent guard in TracingTest.cpp).
 	nautilus::log::options::setLogAddresses(false);
+	nautilus::log::options::setLogSourceLocations(false);
 	for (auto& [ctxName, traceFn] : traceContexts) {
 		DYNAMIC_SECTION(ctxName) {
 			for (auto& [name, func] : tests) {


### PR DESCRIPTION
## Summary

Closes #451. After #448 every `region()` records the source location it was written at, but the *function* around those regions recorded nothing. A dump could say which region a block came from but not which source a compiled function came from, and a diagnostic raised inside a nested Nautilus function named the region without naming the function or where it was registered.

- `NautilusFunctionDefinition` now stores a `nautilus::SourceLocation`, captured via a defaulted `std::source_location::current()` parameter on `NautilusFunction`'s constructor, `NautilusEngine::registerFunction` (both overloads), and `NautilusModule::registerFunction` (all three overloads) — no runtime cost, no debug info, identical results on every compiler.
- The location is carried through `CompilableFunction` → `TraceFunctionDefinition` as a typed field (`SourceLocation`), alongside the existing generic string-attribute map rather than folded into it, mirroring how region attributes already reach `FunctionOperation`.
- `TraceToIRConversionPhase` threads it into `FunctionOperation`, which now exposes `getLocation()`.
- The IR dump prints it on the function's signature line:
  ```
  execute($1:i64) :i64  ; at src/Query.cpp:42:1 {
  ```
  gated behind the same `log::options::setLogSourceLocations` flag the region legend uses, so checked-in golden dumps (which run with the flag off) are unaffected.
- Every `Invalid region()` diagnostic raised while tracing (in `LazyTraceContext`) now also names the enclosing function and where it was registered, e.g.:
  ```
  Invalid region() "escaping" at src/Query.cpp:13:5 in function 'execute' (registered at src/Query.cpp:24:25): ...
  ```
- `docs/engine.md` and `docs/region.md` document the new "registration site, not necessarily definition site" semantics.

## Test plan

- [x] `cmake --build . --target nautilus` — core library builds cleanly.
- [x] `cmake --build . --target nautilus-ir-pass-tests` — 193/193 test cases, 1694 assertions pass.
- [x] `nautilus-execution-tests "[region]"` — 12/12 test cases, 465/465 assertions pass (covers the enriched `Invalid region()` diagnostics and the substring-based assertions in `RegionTest.cpp`, e.g. "Region Diagnostics Name The Region").
- [x] Full `nautilus-execution-tests` suite — 107/111 runnable cases pass; the 4 failures + 6 skips are pre-existing, caused by building locally with the MLIR backend disabled (`Backend not available` / `tbc-jit runtime unavailable`), not by this change.
- [x] Manual verification with a standalone program: confirmed the signature-line suffix appears with the flag on and disappears with it off, and confirmed the region-escape diagnostic names both the region's own location and the enclosing function's registration site.
- Not run: `nautilus-tracing-tests` (`TracingTest.cpp`, which owns the golden dumps under `test/data/nautilus-function-call-tests/` and `test/data/region-tests/`) — this file (and `ExecutionTest.cpp`) crashes the only available Clang (18.1.3, below the project's supported 19+) with an unrelated internal compiler error during template instantiation in `val_std.hpp`, reproduced identically on `main` before this change. Since `runTraceTests` sets `setLogSourceLocations(false)` process-wide before generating these dumps, the new signature-line suffix is inert there and no golden files should need regenerating — but this could not be executed directly in this environment and is worth double-checking in CI (which runs Clang 19/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgSWmE9cUeVufuKrX31e1E

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgSWmE9cUeVufuKrX31e1E)_