### PR TITLE
Move region name/src to a trailing legend in the trace text dump

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -196,10 +196,13 @@ jobs:
           out=$(./demo_regions)
           echo "$out"
           echo "$out" | grep -q "summarize(threshold=8) = 6503"
-          # the three nested regions, each named at the call site that opened it --
-          # "accumulate" through the stage() helper, which is the point of that overload
-          echo "$out" | grep -q 'region "scan" at .*DemoRegions.cpp:'
-          echo "$out" | grep -q 'region "classify" at .*DemoRegions.cpp:'
+          # the trace names a region by index where a block belongs to it, and defines
+          # the three nested regions -- each named at the call site that opened it,
+          # "accumulate" through the stage() helper, which is the point of that overload --
+          # once in a legend closing the trace
+          echo "$out" | grep -q ') ; region #0$'
+          echo "$out" | grep -q '; region #0 = "scan" at .*DemoRegions.cpp:'
+          echo "$out" | grep -q '; region #1 = "classify" at .*DemoRegions.cpp:'
           # the IR refers to regions by id and defines them in the legend closing the module
           echo "$out" | grep -q '): ; region #2$'
           echo "$out" | grep -q '; region #2 = "accumulate" at .*DemoRegions.cpp:.*, nested in #1'

--- a/docs/region.md
+++ b/docs/region.md
@@ -50,12 +50,12 @@ Invalid region() "accumulate" at src/Query.cpp:42:9: a value created inside the 
 body outlives it ($7). Carry the value out through a val<T> declared outside the region ...
 ```
 
-**The trace.** Each region traced under `lazyTracing` is recorded in the trace's region table (`ExecutionTrace::getRegions()`), which pairs the attributes with the two blocks that bound the body — the block the body starts in and the block the enclosing scope continues in — and with the region enclosing it. Every operation recorded inside the body points at that entry through `TraceOperation::regionIndex`, and so does every block created while the body was being traced (`Block::regionIndex`) — the body's own blocks and the blocks of any branch or loop inside it. The trace dump prints the attributes in front of the entry block:
+**The trace.** Each region traced under `lazyTracing` is recorded in the trace's region table (`ExecutionTrace::getRegions()`), which pairs the attributes with the two blocks that bound the body — the block the body starts in and the block the enclosing scope continues in — and with the region enclosing it. Every operation recorded inside the body points at that entry through `TraceOperation::regionIndex`, and so does every block created while the body was being traced (`Block::regionIndex`) — the body's own blocks and the blocks of any branch or loop inside it. The trace dump follows the same layout the IR dump uses (see below): a block names its region by index at the end of its header line, and the attributes those indices refer to are listed once in a legend at the end of the trace:
 
 ```
-; region "accumulate" at src/Query.cpp:42:9
-B1()
+B1() ; region #0
 	...
+; region #0 = "accumulate" at src/Query.cpp:42:9
 ```
 
 Under `exceptionBasedTracing` a region body is traced inline into the enclosing function (see below), so there are no bounding blocks to attach anything to and the region table stays empty. The attributes are still accepted and still cost nothing.

--- a/example/src/DemoRegions.cpp
+++ b/example/src/DemoRegions.cpp
@@ -82,12 +82,12 @@ int main(int, char*[]) {
 	          << ")\n\n";
 
 	std::cout << "What the dumps above show:\n"
-	          << "  * every block of the trace that belongs to a region is preceded by\n"
-	          << "      ; region \"name\" at DemoRegions.cpp:<line>:<column>\n"
-	          << "  * the IR names a region by id where the code is -- a block in its header,\n"
-	          << "    an operation only where it came from deeper in the nesting than its block:\n"
-	          << "      Block_N(...): ; region #2\n"
-	          << "  * and says once, in the legend closing the module, what each id means:\n"
+	          << "  * both the trace and the IR name a region by id where the code is -- a\n"
+	          << "    block in its header, an operation only where it came from deeper in the\n"
+	          << "    nesting than its block:\n"
+	          << "      B1() ; region #0            (trace)\n"
+	          << "      Block_N(...): ; region #2   (IR)\n"
+	          << "  * and each says once, in a legend closing it, what each id means:\n"
 	          << "      ; region #0 = \"scan\" at DemoRegions.cpp:<line>:<column>\n"
 	          << "      ; region #1 = \"classify\" at ..., nested in #0\n"
 	          << "      ; region #2 = \"accumulate\" at ..., nested in #1\n"

--- a/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
+++ b/nautilus/src/nautilus/tracing/ExecutionTrace.cpp
@@ -420,15 +420,20 @@ auto formatter<nautilus::tracing::ExecutionTrace>::format(const nautilus::tracin
                                                           fmt::format_context& ctx) -> format_context::iterator {
 	auto out = ctx.out();
 	for (size_t i = 0; i < trace.blocks.size(); i++) {
-		// A region owns no operation to print, so its attributes are printed as a comment
-		// line in front of the block its body starts in.
-		const auto regionIndex = trace.blocks[i]->regionIndex;
-		if (regionIndex < trace.regions.size()) {
-			fmt::format_to(
-			    out, "; region {}\n",
-			    trace.regions[regionIndex].attributes.toString(nautilus::log::options::getLogSourceLocations()));
-		}
 		fmt::format_to(out, "B{}{}", i, *trace.blocks[i]);
+	}
+	// The region legend: what each `; region #N` above refers to (docs/region.md), printed
+	// once at the end of the trace -- the same layout the nautilus IR dump uses for its
+	// region legend (see IRGraph.cpp), rather than repeating a region's name in line every
+	// time a block opens or re-enters it.
+	const bool withLocation = nautilus::log::options::getLogSourceLocations();
+	for (size_t i = 0; i < trace.regions.size(); i++) {
+		const auto& region = trace.regions[i];
+		fmt::format_to(out, "; region #{} = {}", i, region.attributes.toString(withLocation));
+		if (region.parent != nautilus::tracing::NO_REGION) {
+			fmt::format_to(out, ", nested in #{}", region.parent);
+		}
+		fmt::format_to(out, "\n");
 	}
 	return out;
 }
@@ -446,6 +451,11 @@ auto formatter<nautilus::tracing::Block>::format(const nautilus::tracing::Block&
 	fmt::format_to(out, ")");
 	if (block.type == nautilus::tracing::Block::Type::ControlFlowMerge) {
 		fmt::format_to(out, " ControlFlowMerge");
+	}
+	// Region reference: just the index, resolved against the legend the ExecutionTrace
+	// formatter prints once at the end of the trace (mirrors the nautilus IR block header).
+	if (block.regionIndex != nautilus::tracing::NO_REGION) {
+		fmt::format_to(out, " ; region #{}", block.regionIndex);
 	}
 	fmt::format_to(out, "\n");
 	for (const auto* operation : block.operations) {

--- a/nautilus/test/data/region-tests/after_ssa/regionBranch.trace
+++ b/nautilus/test/data/region-tests/after_ssa/regionBranch.trace
@@ -2,8 +2,7 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1($2,$1)	:void
-; region "branching"
-B1($2:i64,$1:i64)
+B1($2:i64,$1:i64) ; region #0
 	CONST	$3	0	:i32
 	CAST	$4	$3	:i64
 	GT	$5	$1	$4	:bool
@@ -13,19 +12,17 @@ B2($2:i64)
 	CAST	$14	$13	:i64
 	ADD	$15	$2	$14	:i64
 	RETURN	$0	$15	:i64
-; region "branching"
-B3($2:i64)
+B3($2:i64) ; region #0
 	CONST	$7	10	:i32
 	CAST	$8	$7	:i64
 	ADD	$9	$2	$8	:i64
 	JMP	$0	B5($9)	:void
-; region "branching"
-B4($2:i64)
+B4($2:i64) ; region #0
 	CONST	$10	20	:i32
 	CAST	$11	$10	:i64
 	ADD	$12	$2	$11	:i64
 	JMP	$0	B5($12)	:void
-; region "branching"
-B5($2:i64) ControlFlowMerge
+B5($2:i64) ControlFlowMerge ; region #0
 	JMP	$0	B2($2)	:void
+; region #0 = "branching"
 

--- a/nautilus/test/data/region-tests/after_ssa/regionNamed.trace
+++ b/nautilus/test/data/region-tests/after_ssa/regionNamed.trace
@@ -2,12 +2,12 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1($1)	:void
-; region "accumulate"
-B1($1:i64)
+B1($1:i64) ; region #0
 	CONST	$3	42	:i32
 	CAST	$4	$3	:i64
 	ADD	$5	$1	$4	:i64
 	JMP	$0	B2($5)	:void
 B2($2:i64)
 	RETURN	$0	$2	:i64
+; region #0 = "accumulate"
 

--- a/nautilus/test/data/region-tests/after_ssa/regionNested.trace
+++ b/nautilus/test/data/region-tests/after_ssa/regionNested.trace
@@ -2,21 +2,20 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1($1)	:void
-; region "outer"
-B1($1:i64)
+B1($1:i64) ; region #0
 	JMP	$0	B3($1)	:void
 B2($2:i64)
 	RETURN	$0	$2	:i64
-; region "inner"
-B3($1:i64)
+B3($1:i64) ; region #1
 	CONST	$3	1	:i32
 	CAST	$4	$3	:i64
 	ADD	$5	$1	$4	:i64
 	JMP	$0	B4($5)	:void
-; region "outer"
-B4($2:i64)
+B4($2:i64) ; region #0
 	CONST	$6	2	:i32
 	CAST	$7	$6	:i64
 	ADD	$8	$2	$7	:i64
 	JMP	$0	B2($8)	:void
+; region #0 = "outer"
+; region #1 = "inner", nested in #0
 

--- a/nautilus/test/data/region-tests/after_ssa/regionUnnamed.trace
+++ b/nautilus/test/data/region-tests/after_ssa/regionUnnamed.trace
@@ -2,12 +2,12 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1($1)	:void
-; region <unnamed>
-B1($1:i64)
+B1($1:i64) ; region #0
 	CONST	$3	42	:i32
 	CAST	$4	$3	:i64
 	ADD	$5	$1	$4	:i64
 	JMP	$0	B2($5)	:void
 B2($2:i64)
 	RETURN	$0	$2	:i64
+; region #0 = <unnamed>
 

--- a/nautilus/test/data/region-tests/tracing/regionBranch.trace
+++ b/nautilus/test/data/region-tests/tracing/regionBranch.trace
@@ -2,8 +2,7 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1()	:void
-; region "branching"
-B1()
+B1() ; region #0
 	CONST	$3	0	:i32
 	CAST	$4	$3	:i64
 	GT	$5	$1	$4	:bool
@@ -13,21 +12,19 @@ B2()
 	CAST	$14	$13	:i64
 	ADD	$15	$2	$14	:i64
 	RETURN	$0	$15	:i64
-; region "branching"
-B3()
+B3() ; region #0
 	CONST	$7	10	:i32
 	CAST	$8	$7	:i64
 	ADD	$9	$2	$8	:i64
 	ASSIGN	$2	$9	:i64
 	JMP	$0	B5()	:void
-; region "branching"
-B4()
+B4() ; region #0
 	CONST	$10	20	:i32
 	CAST	$11	$10	:i64
 	ADD	$12	$2	$11	:i64
 	ASSIGN	$2	$12	:i64
 	JMP	$0	B5()	:void
-; region "branching"
-B5() ControlFlowMerge
+B5() ControlFlowMerge ; region #0
 	JMP	$0	B2()	:void
+; region #0 = "branching"
 

--- a/nautilus/test/data/region-tests/tracing/regionNamed.trace
+++ b/nautilus/test/data/region-tests/tracing/regionNamed.trace
@@ -2,8 +2,7 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1()	:void
-; region "accumulate"
-B1()
+B1() ; region #0
 	CONST	$3	42	:i32
 	CAST	$4	$3	:i64
 	ADD	$5	$1	$4	:i64
@@ -11,4 +10,5 @@ B1()
 	JMP	$0	B2()	:void
 B2()
 	RETURN	$0	$2	:i64
+; region #0 = "accumulate"
 

--- a/nautilus/test/data/region-tests/tracing/regionNested.trace
+++ b/nautilus/test/data/region-tests/tracing/regionNested.trace
@@ -2,23 +2,22 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1()	:void
-; region "outer"
-B1()
+B1() ; region #0
 	JMP	$0	B3()	:void
 B2()
 	RETURN	$0	$2	:i64
-; region "inner"
-B3()
+B3() ; region #1
 	CONST	$3	1	:i32
 	CAST	$4	$3	:i64
 	ADD	$5	$1	$4	:i64
 	ASSIGN	$2	$5	:i64
 	JMP	$0	B4()	:void
-; region "outer"
-B4()
+B4() ; region #0
 	CONST	$6	2	:i32
 	CAST	$7	$6	:i64
 	ADD	$8	$2	$7	:i64
 	ASSIGN	$2	$8	:i64
 	JMP	$0	B2()	:void
+; region #0 = "outer"
+; region #1 = "inner", nested in #0
 

--- a/nautilus/test/data/region-tests/tracing/regionUnnamed.trace
+++ b/nautilus/test/data/region-tests/tracing/regionUnnamed.trace
@@ -2,8 +2,7 @@ EXECUTE:
 B0($1:i64)
 	CONST	$2	0	:i64
 	JMP	$0	B1()	:void
-; region <unnamed>
-B1()
+B1() ; region #0
 	CONST	$3	42	:i32
 	CAST	$4	$3	:i64
 	ADD	$5	$1	$4	:i64
@@ -11,4 +10,5 @@ B1()
 	JMP	$0	B2()	:void
 B2()
 	RETURN	$0	$2	:i64
+; region #0 = <unnamed>
 

--- a/nautilus/test/execution-tests/RegionTest.cpp
+++ b/nautilus/test/execution-tests/RegionTest.cpp
@@ -912,10 +912,11 @@ TEST_CASE("Region Attributes Are Recorded In The Trace", "[region]") {
 	REQUIRE(regions[1].parent == 0);
 	REQUIRE(trace->getBlock(0).regionIndex == tracing::NO_REGION);
 
-	// And they are visible in the trace dump.
+	// And they are visible in the trace dump, named once in the legend at the end (the
+	// same layout the IR dump uses), with each block naming its region by index.
 	const auto dump = trace->toString();
-	REQUIRE(dump.find("region \"accumulate\" at ") != std::string::npos);
-	REQUIRE(dump.find("region \"inner\" at ") != std::string::npos);
+	REQUIRE(dump.find("; region #0 = \"accumulate\" at ") != std::string::npos);
+	REQUIRE(dump.find("; region #1 = \"inner\" at ") != std::string::npos);
 }
 
 // What the attributes are for downstream: they survive the trace-to-IR conversion and the
@@ -1097,14 +1098,16 @@ TEST_CASE("Region Dumps Can Omit The Source Location", "[region]") {
 	REQUIRE(traceWithout.find(" at ") == std::string::npos);
 	REQUIRE(irWithout.find(" at ") == std::string::npos);
 
-	// What identifies a region does survive: its name everywhere, its id in the IR, and
-	// the nesting of the inner region inside the outer one.
-	REQUIRE(traceWithout.find("; region \"accumulate\"") != std::string::npos);
-	REQUIRE(traceWithout.find("; region \"inner\"") != std::string::npos);
+	// What identifies a region does survive: its name everywhere, its id in the trace and
+	// the IR, and the nesting of the inner region inside the outer one -- both dumps name
+	// a region by index where the code is and spell out what the index means once, in a
+	// legend at the end.
+	REQUIRE(traceWithout.find("; region #0 = \"accumulate\"\n") != std::string::npos);
+	REQUIRE(traceWithout.find("; region #1 = \"inner\", nested in #0") != std::string::npos);
 	REQUIRE(irWithout.find("; region #0 = \"accumulate\"\n") != std::string::npos);
 	REQUIRE(irWithout.find("; region #1 = \"inner\", nested in #0") != std::string::npos);
 	// An unnamed region has neither a name nor a location left, so it says so.
-	REQUIRE(traceWithout.find("; region <unnamed>") != std::string::npos);
+	REQUIRE(traceWithout.find("; region #2 = <unnamed>") != std::string::npos);
 
 	// The flag is a printing choice: the attributes themselves are untouched by it.
 	REQUIRE(std::string(trace->getRegions()[0].attributes.name) == "accumulate");


### PR DESCRIPTION
## Summary

- The trace text dump printed a region's name/source-location on a comment line in front of every block that opened or re-entered it, so the same description repeated once per block.
- The nautilus IR dump instead names a region by index at the end of a block's header line and spells out what each index means once, in a legend at the end of the module.
- This aligns the trace dump with that layout: a block header line now ends with `; region #N`, and the attributes (`; region #N = "name" [at file:line:column][, nested in #M]`) are printed once, in a legend after the last block — matching `IRGraph.cpp`'s region legend.

## Changes

- `nautilus/src/nautilus/tracing/ExecutionTrace.cpp`: moved the per-block region description into a trailing legend and made each block print only `; region #N`.
- `docs/region.md`: updated the trace-dump example to match the new layout.
- `nautilus/test/execution-tests/RegionTest.cpp`: updated string assertions against the trace dump to the new format.
- `nautilus/test/data/region-tests/{tracing,after_ssa}/*.trace`: regenerated golden fixtures for `regionNamed`, `regionUnnamed`, `regionNested`, `regionBranch`.

## Test plan

- [x] Built `libnautilus.a` and linked/ran the `[region]` Catch2 test suite (`RegionTest.cpp`) standalone — 109/109 assertions pass.
- [x] Built and ran a standalone driver reproducing `TracingTest.cpp`'s "Region Trace Test" cases (`tracing`/`after_ssa`/`ir` golden-file comparisons for `regionNamed`, `regionUnnamed`, `regionNested`, `regionBranch`, and the exception-based-tracing `regionNested_inlined` case) — 15/15 assertions pass, confirming the regenerated `.trace` fixtures byte-for-byte match the new formatter's output.
- Note: the full `nautilus-execution-tests`/`nautilus-tracing-tests` binaries could not be built end-to-end in this sandbox — Clang 18 (below the project's required Clang 19+/21) crashes compiling an unrelated header (`val_std.hpp`) pulled in by `ExecutionTest.cpp`/`TracingTest.cpp`; this is unrelated to this change. CI builds with the required compiler versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4WbMWNTvpxXzbdAXJcCGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4WbMWNTvpxXzbdAXJcCGR)_